### PR TITLE
Adjust scrolling behavior of logs

### DIFF
--- a/common/data.js
+++ b/common/data.js
@@ -30,7 +30,7 @@ export const loggers = [
   {
     id: 2,
     type: 'process',
-    name: 'React Native Packager',
+    name: 'Metro Bundler',
     logs: [
       {
         status: 'success',
@@ -273,7 +273,7 @@ export const generateServerSideMockData = store => {
     device: {
       id: 1,
       type: 'process',
-      name: 'React Native Packager',
+      name: 'Metro Bundler',
       logs: [],
     },
   });

--- a/common/store.js
+++ b/common/store.js
@@ -20,10 +20,17 @@ const stateUpdateDeviceWithLog = (state, action) => {
   if (!state.devices[action.log.deviceIndex]) {
     return { ...state };
   }
-
-  state.devices[action.log.deviceIndex].logs.push(action.log);
-
-  return { ...state, ...{ devices: [...state.devices] } };
+  let devices = state.devices.map((device, i) => {
+    if (i === action.log.deviceIndex) {
+      return {
+        ...device,
+        logs: [...device.logs, action.log],
+      };
+    } else {
+      return device;
+    }
+  });
+  return { ...state, devices };
 };
 
 const stateConnectDevice = (state, action) => {

--- a/components/ProjectManagerSection.js
+++ b/components/ProjectManagerSection.js
@@ -85,14 +85,34 @@ class ProjectManagerSection extends React.Component {
     if (this.props.isOverCurrent && !nextProps.isOverCurrent) {
       console.log('isOverCurrent');
     }
-
-    if (this.refs.logs) {
-      this.refs.logs.scrollIntoView({});
-    }
   }
 
   componentDidMount() {
-    this.refs.logs.scrollIntoView({});
+    this.scrollToEnd();
+  }
+
+  // TODO: When upgrading to React 16.3, switch to getSnapshotBeforeUpdate
+  componentWillUpdate(nextProps) {
+    let prevProps = this.props;
+    if (this.refs.logContainer && prevProps.data.logs.length < nextProps.data.logs.length) {
+      let { scrollHeight, scrollTop, clientHeight } = this.refs.logContainer;
+      this.scrollOffsetFromBottom = scrollHeight - (scrollTop + clientHeight);
+    } else {
+      this.scrollOffsetFromBottom = null;
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.scrollOffsetFromBottom != null && this.scrollOffsetFromBottom < 20) {
+      this.scrollToEnd();
+    }
+  }
+
+  scrollToEnd() {
+    let element = this.refs.logContainer;
+    if (element) {
+      element.scrollTop = element.scrollHeight - element.clientHeight;
+    }
   }
 
   render() {
@@ -147,9 +167,10 @@ class ProjectManagerSection extends React.Component {
               ${STYLES_CONTAINER_SECTION_FRAME}
               ${this.props.isSelected ? STYLES_CONTAINER_SECTION_FRAME_SELECTED : ''}
               ${this.props.isOver ? STYLES_CONTAINER_SECTION_FRAME_HOVER : ''}
-            `}>
+            `}
+            ref="logContainer"
+            >
             {logElements}
-            <div ref="logs" />
           </div>
         </Boundary>
       </div>


### PR DESCRIPTION
* When new logs get added, scroll to bottom (Previously it lagged one log entry
  behind, because the scrolling happened in `componentWillReceiveProps` that
  gets called before the new logs have been rendered.

* Only scroll to the bottom for new log entries, when the user has not scrolled
  back. (Similar to terminal, chat apps etc.)

* Remove the mutation in the Redux store to allow comparing previous and next
  log array to see if new items were added.