### PR TITLE
[xdl] configure filenames/dirs for selfhosted apps to play well with …

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -56,6 +56,7 @@
     "glob-promise": "^3.3.0",
     "globby": "^6.1.0",
     "hasbin": "^1.2.3",
+    "hashids": "^1.1.4",
     "home-dir": "^1.0.0",
     "idx": "^2.1.0",
     "indent-string": "^3.1.0",


### PR DESCRIPTION
…OTA updates

# Why
This PR makes OTA updates play well with selfhosted apps.
OTA updates wont work unless the manifest has a new `revisionId` field and a different `bundleUrl`. Exported app directory is also rejiggered to avoid clutter. 
