### PR TITLE
[xdl] stop appending index.exp to manifest requests, add appropriate …

### DIFF
--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -564,11 +564,13 @@ export async function publishAsync(
         'Exponent-SDK-Version': exp.sdkVersion,
         'Exponent-Platform': 'android',
         'Expo-Release-Channel': options.releaseChannel,
+        Accept: 'application/expo+json,application/json',
       }),
       ExponentTools.getManifestAsync(response.url, {
         'Exponent-SDK-Version': exp.sdkVersion,
         'Exponent-Platform': 'ios',
         'Expo-Release-Channel': options.releaseChannel,
+        Accept: 'application/expo+json,application/json',
       }),
     ]);
 
@@ -999,6 +1001,7 @@ async function _handleKernelPublishedAsync({ projectRoot, user, exp, url }) {
     let manifest = await ExponentTools.getManifestAsync(url, {
       'Exponent-SDK-Version': exp.sdkVersion,
       'Exponent-Platform': 'android',
+      Accept: 'application/expo+json,application/json',
     });
     manifest.bundleUrl = kernelBundleUrl;
     manifest.sdkVersion = 'UNVERSIONED';
@@ -1012,6 +1015,7 @@ async function _handleKernelPublishedAsync({ projectRoot, user, exp, url }) {
     let manifest = await ExponentTools.getManifestAsync(url, {
       'Exponent-SDK-Version': exp.sdkVersion,
       'Exponent-Platform': 'ios',
+      Accept: 'application/expo+json,application/json',
     });
     manifest.bundleUrl = kernelBundleUrl;
     manifest.sdkVersion = 'UNVERSIONED';

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -56,9 +56,10 @@ exports.updateAndroidShellAppAsync = async function updateAndroidShellAppAsync(a
     'Exponent-SDK-Version': sdkVersion,
     'Exponent-Platform': 'android',
     'Expo-Release-Channel': releaseChannel,
+    Accept: 'application/expo+json,application/json',
   });
 
-  let fullManifestUrl = `${url.replace('exp://', 'https://')}/index.exp`;
+  let fullManifestUrl = url.replace('exp://', 'https://');
   let bundleUrl = manifest.bundleUrl;
 
   let shellPath = path.join(exponentDirectory(), 'android-shell-app');
@@ -288,6 +289,7 @@ exports.createAndroidShellAppAsync = async function createAndroidShellAppAsync(a
       'Exponent-SDK-Version': sdkVersion,
       'Exponent-Platform': 'android',
       'Expo-Release-Channel': releaseChannel,
+      Accept: 'application/expo+json,application/json',
     });
   }
 

--- a/packages/xdl/src/detach/ExponentTools.js
+++ b/packages/xdl/src/detach/ExponentTools.js
@@ -76,7 +76,7 @@ function saveImageToPathAsync(projectRoot, pathOrURL, outPath) {
 async function getManifestAsync(url, headers) {
   const buildPhaseLogger = logger.withFields({ buildPhase: 'reading manifest' });
   const requestOptions = {
-    url: url.replace('exp://', 'http://') + '/index.exp',
+    url: url.replace('exp://', 'http://'),
     headers,
   };
 

--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -111,6 +111,7 @@ async function _maybeLegacyPreloadKernelManifestAndBundleAsync(
     const kernelManifest = await getManifestAsync(KERNEL_URL, {
       'Exponent-SDK-Version': sdkVersionSupported,
       'Exponent-Platform': 'ios',
+      Accept: 'application/expo+json,application/json',
     });
     return _preloadManifestAndBundleAsync(
       kernelManifest,

--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -180,6 +180,7 @@ async function _createStandaloneContextAsync(args) {
       'Exponent-SDK-Version': sdkVersion,
       'Exponent-Platform': 'ios',
       'Expo-Release-Channel': releaseChannel ? releaseChannel : 'default',
+      Accept: 'application/expo+json,application/json',
     });
   }
 


### PR DESCRIPTION
…Accept headers

# Why
- Clients used to append index.exp to all urls (ie)` /@quinlanj/test19/index.exp`
- This constraint is lifted so users can host manifests at an arbitrary path.
- `www` is configured to serve manifests at `@user/app` path with the proper `Accept` HTTP headers now. When given an url like `exp.host/@quinlanj/test19` and by specifying the correct MIME types in the `Accept` header, clients will return the manifest as usual, allowing users to host their manifests at any path they want.
- www PR is at https://github.com/expo/universe/pull/3052

# Tests
- [x] using tools-public, build selfhosted standalones with urls like `https://quinlanj.github.io/self-hosting/android-index.exp`
- [ ]  using tools-public, build selfhosted standalones with the usual urls like `https://exp.host/@quinlanj/test19`