### PR TITLE
[xdl] add sdkVersions to unimodules config

### DIFF
--- a/packages/xdl/CHANGELOG.md
+++ b/packages/xdl/CHANGELOG.md
@@ -10,6 +10,15 @@ For guidelines on how to update this file, visit http://keepachangelog.com/en/0.
 
 ### Removed
 
+## [51.1.0] - 2018-08-28
+
+### Changed
+
+* Allow for passsing workingdir for android shell app builder.
+* Allow for generating ios shell app with single sdk.
+
+## [51.0.0] - 2018-08-24
+
 ## [50.9.0] - 2018-08-23
 
 ## [50.8.0] - 2018-07-31

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdl",
-  "version": "51.0.0",
+  "version": "51.1.0",
   "description": "The Expo Development Library",
   "main": "build/xdl.js",
   "files": [

--- a/packages/xdl/src/detach/IosIPABuilder.js
+++ b/packages/xdl/src/detach/IosIPABuilder.js
@@ -11,14 +11,7 @@ import * as IosCodeSigning from './IosCodeSigning';
 const logger = _logger.withFields({ buildPhase: 'building and signing IPA' });
 
 export default function createIPABuilder(buildParams) {
-  const {
-    appUUID,
-    keychainPath,
-    bundleIdentifier,
-    teamID,
-    workingDir = process.env.TURTLE_WORKING_DIR_PATH,
-    manifest,
-  } = buildParams;
+  const { appUUID, keychainPath, bundleIdentifier, teamID, workingDir, manifest } = buildParams;
   const workspace = path.join(
     workingDir,
     'shellAppWorkspaces',

--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -147,6 +147,7 @@ async function _podInstallAsync(workspacePath, isRepoUpdateEnabled) {
 /**
  * @param workspacePath optionally provide a path for the unbuilt xcode workspace to create/use.
  * @param expoSourcePath path to expo client app sourcecode (/ios dir from expo/expo repo)
+ * @param shellAppSdkVersion sdk version for shell app
  */
 async function _createStandaloneContextAsync(args) {
   // right now we only ever build a single detached workspace for service contexts.
@@ -195,7 +196,8 @@ async function _createStandaloneContextAsync(args) {
     args.testEnvironment,
     buildFlags,
     args.url,
-    args.releaseChannel
+    args.releaseChannel,
+    args.shellAppSdkVersion
   );
   return context;
 }
@@ -297,6 +299,7 @@ async function createTurtleWorkspaceAsync(args) {
  *  @param verbose show all xcodebuild output (default false)
  *  @param reuseWorkspace if true, when building, assume a detached workspace already exists rather than creating a new one.
  *  @param type type of artifact to build (simulator or archive)
+ *  @param shellAppSdkVersion sdk version for shell app
  */
 async function buildAndCopyArtifactAsync(args) {
   args = _validateCLIArgs(args);

--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -182,7 +182,10 @@ async function _renderPodfileFromTemplateAsync(
     TARGET_NAME: projectName,
   };
   let reactNativeDependencyPath;
-  const detachableUniversalModules = Modules.getDetachableModulesForPlatform('ios');
+  const detachableUniversalModules = Modules.getDetachableModulesForPlatformAndSdkVersion(
+    'ios',
+    sdkVersion
+  );
   if (context.type === 'user') {
     invariant(iosClientVersion, `The iOS client version must be specified`);
     reactNativeDependencyPath = path.join(context.data.projectPath, 'node_modules', 'react-native');

--- a/packages/xdl/src/detach/StandaloneContext.js
+++ b/packages/xdl/src/detach/StandaloneContext.js
@@ -68,7 +68,8 @@ class StandaloneContext {
     testEnvironment: StandaloneContextTestEnvironment,
     build: StandaloneBuildFlags,
     publishedUrl: ?string,
-    releaseChannel: ?string
+    releaseChannel: ?string,
+    shellAppSdkVersion: ?string
   ): StandaloneContext => {
     let context = new StandaloneContext();
     context.type = 'service';
@@ -78,6 +79,7 @@ class StandaloneContext {
       manifest,
       privateConfig,
       testEnvironment,
+      shellAppSdkVersion,
     };
     context.config = manifest;
     context.build = build;

--- a/packages/xdl/src/modules/Modules.js
+++ b/packages/xdl/src/modules/Modules.js
@@ -2,6 +2,8 @@
  * @flow
  */
 
+import semver from 'semver';
+
 import { expoSdkUniversalModulesConfigs } from './config';
 
 type Platform = 'ios' | 'android';
@@ -9,6 +11,7 @@ type Platform = 'ios' | 'android';
 type ModuleConfig = {
   podName: string,
   libName: string,
+  sdkVersions: string,
   detachable: boolean,
   isNativeModule: boolean,
   subdirectory: string,
@@ -36,9 +39,16 @@ export function getVersionableModulesForPlatform(platform: Platform): Array<Modu
   });
 }
 
-export function getDetachableModulesForPlatform(platform: Platform): Array<ModuleConfig> {
+export function getDetachableModulesForPlatformAndSdkVersion(
+  platform: Platform,
+  sdkVersion: string
+): Array<ModuleConfig> {
   return getAllForPlatform(platform).filter(moduleConfig => {
-    return moduleConfig.isNativeModule && moduleConfig.detachable;
+    return (
+      moduleConfig.isNativeModule &&
+      moduleConfig.detachable &&
+      semver.satisfies(sdkVersion, moduleConfig.sdkVersions)
+    );
   });
 }
 

--- a/packages/xdl/src/modules/config.js
+++ b/packages/xdl/src/modules/config.js
@@ -30,40 +30,66 @@ const defaultUniversalModuleConfig = {
 
 const expoSdkUniversalModules = [
   // versioned modules
-  { podName: 'EXGL', libName: 'expo-gl' },
-  { podName: 'EXSMS', libName: 'expo-sms' },
-  { podName: 'EXCore', libName: 'expo-core' },
-  { podName: 'EXFont', libName: 'expo-font' },
-  { podName: 'EXPrint', libName: 'expo-print' },
-  { podName: 'EXCamera', libName: 'expo-camera' },
-  { podName: 'EXSensors', libName: 'expo-sensors' },
-  { podName: 'EXLocation', libName: 'expo-location' },
-  { podName: 'EXConstants', libName: 'expo-constants' },
-  { podName: 'EXFileSystem', libName: 'expo-file-system' },
-  { podName: 'EXPermissions', libName: 'expo-permissions' },
-  { podName: 'EXSegment', libName: 'expo-analytics-segment' },
-  { podName: 'EXMediaLibrary', libName: 'expo-media-library' },
-  { podName: 'EXFontInterface', libName: 'expo-font-interface' },
-  { podName: 'EXCameraInterface', libName: 'expo-camera-interface' },
-  { podName: 'EXSensorsInterface', libName: 'expo-sensors-interface' },
-  { podName: 'EXConstantsInterface', libName: 'expo-constants-interface' },
-  { podName: 'EXReactNativeAdapter', libName: 'expo-react-native-adapter' },
-  { podName: 'EXFileSystemInterface', libName: 'expo-file-system-interface' },
-  { podName: 'EXPermissionsInterface', libName: 'expo-permissions-interface' },
-  { podName: 'EXImageLoaderInterface', libName: 'expo-image-loader-interface' },
-  { podName: 'EXFaceDetectorInterface', libName: 'expo-face-detector-interface' },
+  { podName: 'EXGL', libName: 'expo-gl', sdkVersions: '>=29.0.0' },
+  { podName: 'EXSMS', libName: 'expo-sms', sdkVersions: '>=29.0.0' },
+  { podName: 'EXCore', libName: 'expo-core', sdkVersions: '>=29.0.0' },
+  { podName: 'EXFont', libName: 'expo-font', sdkVersions: '>=30.0.0' },
+  { podName: 'EXPrint', libName: 'expo-print', sdkVersions: '>=30.0.0' },
+  { podName: 'EXCamera', libName: 'expo-camera', sdkVersions: '>=29.0.0' },
+  { podName: 'EXSensors', libName: 'expo-sensors', sdkVersions: '>=29.0.0' },
+  { podName: 'EXLocation', libName: 'expo-location', sdkVersions: '>=30.0.0' },
+  { podName: 'EXConstants', libName: 'expo-constants', sdkVersions: '>=29.0.0' },
+  { podName: 'EXFileSystem', libName: 'expo-file-system', sdkVersions: '>=29.0.0' },
+  { podName: 'EXPermissions', libName: 'expo-permissions', sdkVersions: '>=29.0.0' },
+  { podName: 'EXSegment', libName: 'expo-analytics-segment', sdkVersions: '>=30.0.0' },
+  { podName: 'EXMediaLibrary', libName: 'expo-media-library', sdkVersions: '>=30.0.0' },
+  { podName: 'EXFontInterface', libName: 'expo-font-interface', sdkVersions: '>=30.0.0' },
+  { podName: 'EXCameraInterface', libName: 'expo-camera-interface', sdkVersions: '>=29.0.0' },
+  { podName: 'EXSensorsInterface', libName: 'expo-sensors-interface', sdkVersions: '>=29.0.0' },
+  { podName: 'EXConstantsInterface', libName: 'expo-constants-interface', sdkVersions: '>=29.0.0' },
+  {
+    podName: 'EXReactNativeAdapter',
+    libName: 'expo-react-native-adapter',
+    sdkVersions: '>=29.0.0',
+  },
+  {
+    podName: 'EXFileSystemInterface',
+    libName: 'expo-file-system-interface',
+    sdkVersions: '>=29.0.0',
+  },
+  {
+    podName: 'EXPermissionsInterface',
+    libName: 'expo-permissions-interface',
+    sdkVersions: '>=29.0.0',
+  },
+  {
+    podName: 'EXImageLoaderInterface',
+    libName: 'expo-image-loader-interface',
+    sdkVersions: '>=30.0.0',
+  },
+  {
+    podName: 'EXFaceDetectorInterface',
+    libName: 'expo-face-detector-interface',
+    sdkVersions: '>=29.0.0',
+  },
   {
     podName: 'EXFaceDetector',
     libName: 'expo-face-detector',
     detachable: false,
+    sdkVersions: '>=29.0.0',
   },
-  { podName: 'EXBarCodeScannerInterface', libName: 'expo-barcode-scanner-interface' },
-  { podName: 'EXBarCodeScanner', libName: 'expo-barcode-scanner' },
+  {
+    podName: 'EXBarCodeScannerInterface',
+    libName: 'expo-barcode-scanner-interface',
+    sdkVersions: '>=30.0.0',
+  },
+  { podName: 'EXBarCodeScanner', libName: 'expo-barcode-scanner', sdkVersions: '>=30.0.0' },
 
   // unversioned modules
   {
     podName: 'EXGL-CPP',
     libName: 'expo-gl-cpp',
+    sdkVersions: '>=29.0.0',
     versionable: false,
     config: {
       ios: {
@@ -75,10 +101,12 @@ const expoSdkUniversalModules = [
   // JS-only modules
   {
     libName: 'expo-asset',
+    sdkVersions: '>=29.0.0',
     isNativeModule: false,
   },
   {
     libName: 'expo-module-template',
+    sdkVersions: '>=29.0.0',
     isNativeModule: false,
   },
 ];
@@ -94,10 +122,11 @@ function defaults(defaultConfig, ...customConfigs) {
 }
 
 const expoSdkUniversalModulesConfigs = expoSdkUniversalModules.map(
-  ({ config, podName, libName, isNativeModule, ...params }) => {
+  ({ config, podName, libName, sdkVersions, isNativeModule, ...params }) => {
     return {
       podName,
       libName,
+      sdkVersions,
       isNativeModule: isNativeModule == null ? true : isNativeModule,
       config: {
         ios: defaults(defaultUniversalModuleConfig.ios, params, config && config.ios),


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/universe/issues/3059 . The current latest version of `xdl` generates bad Podfiles on new detached projects because it includes unimodules that are not dependencies of `expo@29.0.0`.

# How

Added a new `sdkVersions` field to module configs that is a semver range; when generating a Podfile, filter out the modules for which the `sdkVersion` of the project does not satisfy this range.

I filled out the `sdkVersions` of the current modules based on my knowledge, but @tsapeta or someone else should definitely double check them 😅 

# Test Plan

Generated a new SDK 29 project, detached it, and successfully ran `pod install` 🎉  