### PR TITLE
[xdl] fix bug where credentialsExist always returns true

### DIFF
--- a/packages/xdl/src/Credentials.js
+++ b/packages/xdl/src/Credentials.js
@@ -51,7 +51,8 @@ export type CertsList = Array<CertObject>;
 export async function credentialsExistForPlatformAsync(
   metadata: CredentialMetadata
 ): Promise<?Credentials> {
-  return !!fetchCredentials(metadata, false);
+  const creds = await fetchCredentials(metadata, false);
+  return !!creds; // !! performed on awaited creds
 }
 
 export async function getEncryptedCredentialsForPlatformAsync(


### PR DESCRIPTION
credentialsExistForPlatformAsync always used to return true because `!!` was performed on the Promise itself