### PR TITLE
[xdl] plumb publicUrl via build command to turtles

### DIFF
--- a/packages/exp/src/commands/build.js
+++ b/packages/exp/src/commands/build.js
@@ -41,7 +41,10 @@ export default (program: any) => {
     .option('--dist-p12-path <dist.p12>', 'Path to your Distribution Certificate P12.')
     .option('--push-p12-path <push.p12>', 'Path to your Push Notification Certificate P12.')
     .option('--provisioning-profile-path <.mobileprovision>', 'Path to your Provisioning Profile.')
-    .option('--public-url <url>', 'Url for an externally hosted app.')
+    .option(
+      '--public-url <url>',
+      'The URL of an externally hosted manifest (for self-hosted apps).'
+    )
     .description(
       'Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.'
     )
@@ -77,7 +80,7 @@ export default (program: any) => {
     .option('--no-wait', 'Exit immediately after triggering build.')
     .option('--keystore-path <app.jks>', 'Path to your Keystore.')
     .option('--keystore-alias <alias>', 'Keystore Alias')
-    .option('--public-url <url>', 'Url for an externally hosted app.')
+    .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     .description(
       'Build a standalone APK for your project, signed and ready for submission to the Google Play Store.'
     )
@@ -99,7 +102,10 @@ export default (program: any) => {
   program
     .command('build:status [project-dir]')
     .alias('bs')
-    .option('--public-url <url>', 'Url for an externally hosted app.')
+    .option(
+      '--public-url <url>',
+      'The URL of an externally hosted manifest (for self-hosted apps).'
+    )
     .description(`Gets the status of a current (or most recently finished) build for your project.`)
     .asyncActionProjectDir(async (projectDir, options) => {
       if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {

--- a/packages/exp/src/commands/build.js
+++ b/packages/exp/src/commands/build.js
@@ -2,11 +2,13 @@
  * @flow
  */
 
+import { UrlUtils } from 'xdl';
 import BaseBuilder from './build/BaseBuilder';
 import IOSBuilder from './build/IOSBuilder';
 import AndroidBuilder from './build/AndroidBuilder';
 import BuildError from './build/BuildError';
 import log from '../log';
+import CommandError from '../CommandError';
 
 export default (program: any) => {
   program
@@ -39,10 +41,14 @@ export default (program: any) => {
     .option('--dist-p12-path <dist.p12>', 'Path to your Distribution Certificate P12.')
     .option('--push-p12-path <push.p12>', 'Path to your Push Notification Certificate P12.')
     .option('--provisioning-profile-path <.mobileprovision>', 'Path to your Provisioning Profile.')
+    .option('--public-url <url>', 'Url for an externally hosted app.')
     .description(
       'Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.'
     )
     .asyncActionProjectDir((projectDir, options) => {
+      if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
+        throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
+      }
       let channelRe = new RegExp(/^[a-z\d][a-z\d._-]*$/);
       if (!channelRe.test(options.releaseChannel)) {
         log.error(
@@ -59,7 +65,7 @@ export default (program: any) => {
         process.exit(1);
       }
       const iosBuilder = new IOSBuilder(projectDir, options);
-      return iosBuilder.command();
+      return iosBuilder.command(options);
     });
 
   program
@@ -71,10 +77,14 @@ export default (program: any) => {
     .option('--no-wait', 'Exit immediately after triggering build.')
     .option('--keystore-path <app.jks>', 'Path to your Keystore.')
     .option('--keystore-alias <alias>', 'Keystore Alias')
+    .option('--public-url <url>', 'Url for an externally hosted app.')
     .description(
       'Build a standalone APK for your project, signed and ready for submission to the Google Play Store.'
     )
     .asyncActionProjectDir((projectDir, options) => {
+      if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
+        throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
+      }
       let channelRe = new RegExp(/^[a-z\d][a-z\d._-]*$/);
       if (!channelRe.test(options.releaseChannel)) {
         log.error(
@@ -83,17 +93,25 @@ export default (program: any) => {
         process.exit(1);
       }
       const androidBuilder = new AndroidBuilder(projectDir, options);
-      return androidBuilder.command();
+      return androidBuilder.command(options);
     });
 
   program
     .command('build:status [project-dir]')
     .alias('bs')
+    .option('--public-url <url>', 'Url for an externally hosted app.')
     .description(`Gets the status of a current (or most recently finished) build for your project.`)
     .asyncActionProjectDir(async (projectDir, options) => {
+      if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
+        throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
+      }
       const builder = new BaseBuilder(projectDir, options);
       try {
-        return await builder.checkStatus('all', false);
+        return await builder.checkStatus({
+          platform: 'all',
+          current: false,
+          ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
+        });
       } catch (e) {
         if (e instanceof BuildError) {
           return;

--- a/packages/exp/src/commands/build/AndroidBuilder.js
+++ b/packages/exp/src/commands/build/AndroidBuilder.js
@@ -14,9 +14,7 @@ import prompt from '../../prompt';
 
 export default class AndroidBuilder extends BaseBuilder {
   async run(options) {
-    const buildOptions = {
-      ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
-    };
+    const buildOptions = options.publicUrl ? { publicUrl: options.publicUrl } : {};
     // Check the status of any current builds
     await this.checkStatus({ platform: 'android', ...buildOptions });
     // Validate project

--- a/packages/exp/src/commands/build/AndroidBuilder.js
+++ b/packages/exp/src/commands/build/AndroidBuilder.js
@@ -13,23 +13,30 @@ import BaseBuilder from './BaseBuilder';
 import prompt from '../../prompt';
 
 export default class AndroidBuilder extends BaseBuilder {
-  async run() {
+  async run(options) {
+    const buildOptions = {
+      ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
+    };
     // Check the status of any current builds
-    await this.checkStatus('android');
+    await this.checkStatus({ platform: 'android', ...buildOptions });
     // Validate project
-    await this.validateProject();
+    await this.validateProject(buildOptions);
     // Check for existing credentials, collect any missing credentials, and validate them
-    await this.collectAndValidateCredentials();
+    await this.collectAndValidateCredentials(buildOptions);
     // Publish the current experience, if necessary
-    const publishedExpIds = await this.ensureReleaseExists('android');
+    let publishedExpIds = options.publicUrl ? undefined : await this.ensureReleaseExists('android');
+
     // Initiate a build
-    await this.build(publishedExpIds, 'android');
+    await this.build(publishedExpIds, 'android', buildOptions);
   }
 
-  async _clearCredentials() {
+  async _clearCredentials(options = {}) {
+    const publicUrl = options.publicUrl;
     const {
       args: { username, remotePackageName, remoteFullPackageName: experienceName },
-    } = await Exp.getPublishInfoAsync(this.projectDir);
+    } = publicUrl
+      ? await Exp.getThirdPartyInfoAsync(publicUrl)
+      : await Exp.getPublishInfoAsync(this.projectDir);
 
     const credentialMetadata = {
       username,
@@ -78,10 +85,11 @@ export default class AndroidBuilder extends BaseBuilder {
     }
   }
 
-  async collectAndValidateCredentials() {
-    const {
-      args: { username, remoteFullPackageName: experienceName },
-    } = await Exp.getPublishInfoAsync(this.projectDir);
+  async collectAndValidateCredentials(options = {}) {
+    const publicUrl = options.publicUrl;
+    const { args: { username, remoteFullPackageName: experienceName } } = publicUrl
+      ? await Exp.getThirdPartyInfoAsync(publicUrl)
+      : await Exp.getPublishInfoAsync(this.projectDir);
 
     const credentialMetadata = {
       username,
@@ -161,7 +169,7 @@ export default class AndroidBuilder extends BaseBuilder {
 
       if (!answers.uploadKeystore) {
         if (this.options.clearCredentials && credentialsExist) {
-          await this._clearCredentials();
+          await this._clearCredentials(options);
         }
         // just continue
       } else {
@@ -200,8 +208,11 @@ export default class AndroidBuilder extends BaseBuilder {
     await Credentials.updateCredentialsForPlatform('android', credentials, credentialMetadata);
   }
 
-  async validateProject() {
-    const { args: { sdkVersion } } = await Exp.getPublishInfoAsync(this.projectDir);
+  async validateProject(options) {
+    const publicUrl = options.publicUrl;
+    const { args: { sdkVersion } } = publicUrl
+      ? await Exp.getThirdPartyInfoAsync(publicUrl)
+      : await Exp.getPublishInfoAsync(this.projectDir);
     await this.checkIfSdkIsSupported(sdkVersion, 'android');
   }
 }

--- a/packages/exp/src/commands/build/BaseBuilder.js
+++ b/packages/exp/src/commands/build/BaseBuilder.js
@@ -260,9 +260,7 @@ ${buildStatus.id}
 
     if (this.options.wait) {
       simpleSpinner.start();
-      const waitOpts = {
-        ...(extraArgs.publicUrl ? { publicUrl: extraArgs.publicUrl } : {}),
-      };
+      const waitOpts = extraArgs.publicUrl ? { publicUrl: extraArgs.publicUrl } : {};
       const completedJob = await this.wait(buildId, waitOpts);
       simpleSpinner.stop();
       const artifactUrl = completedJob.artifactId

--- a/packages/exp/src/commands/unreleased/export.js
+++ b/packages/exp/src/commands/unreleased/export.js
@@ -3,7 +3,7 @@
  */
 import validator from 'validator';
 import path from 'path';
-import { Project } from 'xdl';
+import { Project, UrlUtils } from 'xdl';
 
 import log from '../log';
 import { installExitHooks } from '../exit';
@@ -14,7 +14,7 @@ export async function action(projectDir: string, options: Options = {}) {
     throw new CommandError('MISSING_PUBLIC_URL', 'Missing required option: --public-url');
   }
   // If we are not in dev mode, ensure that url is https
-  if (!options.dev && !validator.isURL(options.publicUrl, { protocols: ['https'] })) {
+  if (!options.dev && !UrlUtils.isHttps(options.publicUrl)) {
     throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
   } else if (!validator.isURL(options.publicUrl, { protocols: ['http', 'https'] })) {
     console.warn(`Dev Mode: publicUrl ${options.publicUrl} does not conform to HTTP format.`);

--- a/packages/exp/src/commands/url.js
+++ b/packages/exp/src/commands/url.js
@@ -62,13 +62,13 @@ export default program => {
 
   program
     .command('url:ipa [project-dir]')
-    .option('--public-url <url>', 'Url for an externally hosted app.')
+    .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     .description('Displays the standalone iOS binary URL you can use to download your app binary')
     .asyncActionProjectDir(logArtifactUrl('ios'), true);
 
   program
     .command('url:apk [project-dir]')
-    .option('--public-url <url>', 'Url for an externally hosted app.')
+    .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     .description(
       'Displays the standalone Android binary URL you can use to download your app binary'
     )

--- a/packages/exp/src/commands/url.js
+++ b/packages/exp/src/commands/url.js
@@ -9,7 +9,14 @@ import urlOpts from '../urlOpts';
 import printRunInstructionsAsync from '../printRunInstructionsAsync';
 
 const logArtifactUrl = platform => async (projectDir, options) => {
-  const res = await Project.buildAsync(projectDir, { current: false, mode: 'status' });
+  if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
+    throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
+  }
+  const res = await Project.buildAsync(projectDir, {
+    current: false,
+    mode: 'status',
+    ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
+  });
   const url = fp.compose(
     fp.get(['artifacts', 'url']),
     fp.head,
@@ -55,11 +62,13 @@ export default program => {
 
   program
     .command('url:ipa [project-dir]')
+    .option('--public-url <url>', 'Url for an externally hosted app.')
     .description('Displays the standalone iOS binary URL you can use to download your app binary')
     .asyncActionProjectDir(logArtifactUrl('ios'), true);
 
   program
     .command('url:apk [project-dir]')
+    .option('--public-url <url>', 'Url for an externally hosted app.')
     .description(
       'Displays the standalone Android binary URL you can use to download your app binary'
     )

--- a/packages/xdl/src/Exp.js
+++ b/packages/xdl/src/Exp.js
@@ -2,7 +2,6 @@
  * @flow
  */
 
-import axios from 'axios';
 import promisify from 'util.promisify';
 import fs from 'fs-extra';
 import mkdirp from 'mkdirp';

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1,7 +1,6 @@
 /**
  * @flow
  */
-import axios from 'axios';
 import bodyParser from 'body-parser';
 import child_process from 'child_process';
 import crypto from 'crypto';

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1104,7 +1104,7 @@ async function _readFileForUpload(path) {
 }
 
 async function getConfigAsync(
-  projectRoot: string, 
+  projectRoot: string,
   options: {
     current?: boolean,
     mode?: string,
@@ -1115,12 +1115,11 @@ async function getConfigAsync(
     bundleIdentifier?: string,
     publicUrl?: string,
   } = {}
-){
+) {
   if (!options.publicUrl) {
     // get the manifest from the project directory
     const { exp, pkg } = await ProjectUtils.readConfigJsonAsync(projectRoot);
-    configName = await ProjectUtils.configFilenameAsync(projectRoot);
-    configPrefix = configName === 'app.json' ? 'expo.' : '';
+    const configName = await ProjectUtils.configFilenameAsync(projectRoot);
     return {
       exp,
       pkg,
@@ -1130,11 +1129,11 @@ async function getConfigAsync(
   } else {
     // get the externally hosted manifest
     return {
-      exp: await ThirdParty.getManifest(options.publicUrl, options);
-      configName: options.publicUrl;
-      configPrefix: '';
-      pkg: {};
-    }
+      exp: await ThirdParty.getManifest(options.publicUrl, options),
+      configName: options.publicUrl,
+      configPrefix: '',
+      pkg: {},
+    };
   }
 }
 
@@ -1177,7 +1176,7 @@ export async function buildAsync(
     throw new XDLError(ErrorCode.INVALID_OPTIONS, e.toString());
   }
 
-  const {exp, pkg, configName, configPrefix} = await getConfigAsync(projectRoot, options);
+  const { exp, pkg, configName, configPrefix } = await getConfigAsync(projectRoot, options);
 
   if (!exp || !pkg) {
     throw new XDLError(

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1,7 +1,7 @@
 /**
  * @flow
  */
-
+import axios from 'axios';
 import bodyParser from 'body-parser';
 import child_process from 'child_process';
 import crypto from 'crypto';
@@ -44,6 +44,7 @@ import { isNode } from './tools/EnvironmentHelper';
 import * as ProjectSettings from './ProjectSettings';
 import * as ProjectUtils from './project/ProjectUtils';
 import * as Sentry from './Sentry';
+import * as ThirdParty from './ThirdParty';
 import * as UrlUtils from './UrlUtils';
 import UserManager from './User';
 import UserSettings from './UserSettings';
@@ -378,7 +379,7 @@ export async function exportForAppHosting(
   // TODO(quin): follow up and write a doc page that explains these fields that users don't specify in app.json
   exp.publishedTime = new Date().toISOString();
 
-  // generate revisionId the same way www does
+  // generate revisionId and id the same way www does
   const hashIds = new HashIds(uuid.v1(), 10);
   exp.revisionId = hashIds.encode(Date.now());
 
@@ -399,6 +400,7 @@ export async function exportForAppHosting(
 
   // save the android manifest
   exp.bundleUrl = urljoin(publicUrl, 'bundles', androidBundleUrl);
+  exp.platform = 'android';
   await _writeArtifactSafelyAsync(
     projectRoot,
     null,
@@ -408,6 +410,7 @@ export async function exportForAppHosting(
 
   // save the ios manifest
   exp.bundleUrl = urljoin(publicUrl, 'bundles', iosBundleUrl);
+  exp.platform = 'ios';
   await _writeArtifactSafelyAsync(
     projectRoot,
     null,
@@ -1111,6 +1114,7 @@ export async function buildAsync(
     type?: string,
     releaseChannel?: string,
     bundleIdentifier?: string,
+    publicUrl?: string,
   } = {}
 ) {
   await UserManager.ensureLoggedInAsync();
@@ -1130,6 +1134,7 @@ export async function buildAsync(
     type: joi.any().valid('archive', 'simulator', 'client'),
     releaseChannel: joi.string().regex(/[a-z\d][a-z\d._-]*/),
     bundleIdentifier: joi.string().regex(/^[a-zA-Z][a-zA-Z0-9\-\.]+$/),
+    publicUrl: joi.string(),
   });
 
   try {
@@ -1138,9 +1143,19 @@ export async function buildAsync(
     throw new XDLError(ErrorCode.INVALID_OPTIONS, e.toString());
   }
 
-  let { exp, pkg } = await ProjectUtils.readConfigJsonAsync(projectRoot);
-  const configName = await ProjectUtils.configFilenameAsync(projectRoot);
-  const configPrefix = configName === 'app.json' ? 'expo.' : '';
+  let exp, pkg, configName, configPrefix;
+  if (!options.publicUrl) {
+    // get the manifest from the project directory
+    ({ exp, pkg } = await ProjectUtils.readConfigJsonAsync(projectRoot));
+    const configName = await ProjectUtils.configFilenameAsync(projectRoot);
+    configPrefix = configName === 'app.json' ? 'expo.' : '';
+  } else {
+    // get the externally hosted manifest
+    exp = await ThirdParty.getManifest(options.publicUrl, options);
+    configName = options.publicUrl;
+    configPrefix = '';
+    pkg = {};
+  }
 
   if (!exp || !pkg) {
     throw new XDLError(

--- a/packages/xdl/src/ThirdParty.js
+++ b/packages/xdl/src/ThirdParty.js
@@ -38,13 +38,13 @@ async function _extractManifest(expOrArray, publicUrl) {
     return expOrArray;
   }
 
+  const { sdkVersions } = await Versions.versionsAsync();
   for (let i = 0; i < expOrArray.length; i++) {
     const manifestCandidate = expOrArray[i];
     const sdkVersion = manifestCandidate.sdkVersion;
     if (!sdkVersion) {
       continue;
     }
-    const { sdkVersions } = await Versions.versionsAsync();
     const versionObj = sdkVersions[sdkVersion];
     if (!versionObj) {
       continue;
@@ -55,7 +55,7 @@ async function _extractManifest(expOrArray, publicUrl) {
       return manifestCandidate;
     }
   }
-  const supportedVersions = await Versions.versionsAsync();
+  const supportedVersions = Object.keys(sdkVersions);
   throw new XDLError(
     ErrorCode.INVALID_MANIFEST,
     `No compatible manifest found at ${publicUrl}. Please use one of the SDK versions supported: ${JSON.stringify(

--- a/packages/xdl/src/ThirdParty.js
+++ b/packages/xdl/src/ThirdParty.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import ErrorCode from './ErrorCode';
-import Versions from './Versions';
+import * as Versions from './Versions';
 import XDLError from './XDLError';
 
 export async function getManifest(publicUrl, opts = {}) {
@@ -44,8 +44,14 @@ async function _extractManifest(expOrArray, publicUrl) {
     if (!sdkVersion) {
       continue;
     }
-    const turtleCanBuild = Versions.canTurtleBuildSdkVersion(sdkVersion);
-    if (turtleCanBuild) {
+    const { sdkVersions } = await Versions.versionsAsync();
+    const versionObj = sdkVersions[sdkVersion];
+    if (!versionObj) {
+      continue;
+    }
+
+    const isDeprecated = versionObj.isDeprecated || false;
+    if (!isDeprecated) {
       return manifestCandidate;
     }
   }

--- a/packages/xdl/src/ThirdParty.js
+++ b/packages/xdl/src/ThirdParty.js
@@ -20,7 +20,7 @@ export async function getManifest(publicUrl, opts = {}) {
       `Unable to fetch manifest from ${publicUrl}. ` + e.toString()
     );
   }
-  exp = _extractManifest(exp, publicUrl);
+  exp = await _extractManifest(exp, publicUrl);
   if (opts.platform && exp.platform !== opts.platform && opts.platform !== 'all') {
     throw new XDLError(
       ErrorCode.INVALID_MANIFEST,
@@ -32,7 +32,7 @@ export async function getManifest(publicUrl, opts = {}) {
 
 // Third party publicUrls can return an array of manifests
 // We need to choose the first compatible one
-function _extractManifest(expOrArray, publicUrl) {
+async function _extractManifest(expOrArray, publicUrl) {
   // if its not an array, assume it was a single manifest obj
   if (!Array.isArray(expOrArray)) {
     return expOrArray;
@@ -49,8 +49,11 @@ function _extractManifest(expOrArray, publicUrl) {
       return manifestCandidate;
     }
   }
+  const supportedVersions = await Versions.versionsAsync();
   throw new XDLError(
     ErrorCode.INVALID_MANIFEST,
-    `No compatible manifest found at ${publicUrl}. Make sure you have a compatible sdkVersion.`
+    `No compatible manifest found at ${publicUrl}. Please use one of the SDK versions supported: ${JSON.stringify(
+      supportedVersions
+    )}`
   );
 }

--- a/packages/xdl/src/ThirdParty.js
+++ b/packages/xdl/src/ThirdParty.js
@@ -1,0 +1,56 @@
+import axios from 'axios';
+import ErrorCode from './ErrorCode';
+import Versions from './Versions';
+import XDLError from './XDLError';
+
+export async function getManifest(publicUrl, opts = {}) {
+  const req = {
+    url: publicUrl,
+    method: 'get',
+    headers: { Accept: 'application/expo+json,application/json' },
+  };
+
+  let exp;
+  try {
+    const resp = await axios.request(req);
+    exp = resp.data;
+  } catch (e) {
+    throw new XDLError(
+      ErrorCode.INVALID_MANIFEST,
+      `Unable to fetch manifest from ${publicUrl}. ` + e.toString()
+    );
+  }
+  exp = _extractManifest(exp, publicUrl);
+  if (opts.platform && exp.platform !== opts.platform && opts.platform !== 'all') {
+    throw new XDLError(
+      ErrorCode.INVALID_MANIFEST,
+      `Manifest from ${publicUrl} is not compatible with the ${opts.platform} platform`
+    );
+  }
+  return exp;
+}
+
+// Third party publicUrls can return an array of manifests
+// We need to choose the first compatible one
+function _extractManifest(expOrArray, publicUrl) {
+  // if its not an array, assume it was a single manifest obj
+  if (!Array.isArray(expOrArray)) {
+    return expOrArray;
+  }
+
+  for (let i = 0; i < expOrArray.length; i++) {
+    const manifestCandidate = expOrArray[i];
+    const sdkVersion = manifestCandidate.sdkVersion;
+    if (!sdkVersion) {
+      continue;
+    }
+    const turtleCanBuild = Versions.canTurtleBuildSdkVersion(sdkVersion);
+    if (turtleCanBuild) {
+      return manifestCandidate;
+    }
+  }
+  throw new XDLError(
+    ErrorCode.INVALID_MANIFEST,
+    `No compatible manifest found at ${publicUrl}. Make sure you have a compatible sdkVersion.`
+  );
+}

--- a/packages/xdl/src/UrlUtils.js
+++ b/packages/xdl/src/UrlUtils.js
@@ -7,6 +7,7 @@ import os from 'os';
 import path from 'path';
 import url from 'url';
 import promisify from 'util.promisify';
+import validator from 'validator';
 
 import ip from './ip';
 import Config from './Config';
@@ -345,4 +346,8 @@ export function getPlatformSpecificBundleUrl(url: string, platform: string) {
   } else {
     return url;
   }
+}
+
+export async function isHttps(url) {
+  return validator.isURL(url, { protocols: ['https'] });
 }

--- a/packages/xdl/src/xdl.js
+++ b/packages/xdl/src/xdl.js
@@ -123,6 +123,9 @@ module.exports = {
   get Simulator() {
     return require('./Simulator');
   },
+  get ThirdParty() {
+    return require('./ThirdParty');
+  },
   get UpdateVersions() {
     return require('./tools/UpdateVersions');
   },


### PR DESCRIPTION
# Why

We want a user to be able to host their own manifest, bundles, etc on their own servers. We also want them to be able to build a standalone binary with this url embedded in it. Instead of embedding the manifest and OTA updating from expo servers, we give the user the option to use their own server endpoints instead.

If a client submits a build request with a `publicUrl` parameter, we embed the manifest from `publicUrl` and pass in `publicUrl` to the shell app builders.

# Test Plan

- [ ] android builds normally (no creds)
- [ ] android builds normally (uploading creds)
- [ ] android clear creds work
- [ ] ios simulator builds normally (no creds)
- [ ] ios archive builds normally (no creds)
- [ ] ios archive builds normally (uploading creds)
- [ ] ios clear creds work
- [ ] (xdl) multimanifests successfully parsed