### PR TITLE
[xdl] add expo-print-callbacks to module config

### DIFF
--- a/packages/xdl/src/modules/config.js
+++ b/packages/xdl/src/modules/config.js
@@ -168,6 +168,20 @@ const expoSdkUniversalModules = [
     sdkVersions: '>=30.0.0',
   },
   {
+    libName: 'expo-print-callbacks',
+    sdkVersions: '>=30.0.0',
+    config: {
+      ios: {
+        versionable: false,
+        detachable: false,
+        includeInExpoClient: false,
+      },
+      android: {
+        versionable: false,
+      },
+    },
+  },
+  {
     podName: 'EXReactNativeAdapter',
     libName: 'expo-react-native-adapter',
     sdkVersions: '>=29.0.0',


### PR DESCRIPTION
Companion PR to https://github.com/expo/universe/pull/3113 . Adds new module to XDL config.

Tested by running `./generate-files-ios.sh` and ensuring that this new module was not added to the podfile (it's android only).