### PR TITLE
[xdl] resize Android launcher and notification icons during build

### DIFF
--- a/packages/xdl/src/detach/AndroidIcons.js
+++ b/packages/xdl/src/detach/AndroidIcons.js
@@ -1,0 +1,262 @@
+/**
+ *  @flow
+ */
+import fs from 'fs-extra';
+import path from 'path';
+import globby from 'globby';
+
+import {
+  regexFileAsync,
+  saveImageToPathAsync,
+  saveUrlToPathAsync,
+  spawnAsyncThrowError,
+} from './ExponentTools';
+import StandaloneContext from './StandaloneContext';
+import { getImageDimensionsMacOSAsync, resizeImageAsync } from '../tools/ImageUtils';
+
+const iconScales = {
+  mdpi: 1,
+  hdpi: 1.5,
+  xhdpi: 2,
+  xxhdpi: 3,
+  xxxhdpi: 4,
+};
+
+async function _regexFileInResSubfoldersAsync(
+  oldText: string,
+  newText: string,
+  resDirPath: string,
+  folderPrefix: string,
+  folderSuffix: string,
+  fileName: string
+) {
+  return Promise.all(
+    Object.keys(iconScales).map(async key => {
+      return regexFileAsync(
+        oldText,
+        newText,
+        path.join(resDirPath, `${folderPrefix}${key}${folderSuffix}`, fileName)
+      );
+    })
+  );
+}
+
+let _hasShownResizeErrorWindowsLinux = false;
+
+async function _resizeIconsAsync(
+  context: StandaloneContext,
+  resPath: string,
+  prefix: string,
+  mdpiSize: number,
+  filename: string,
+  url: string,
+  isDetached: boolean
+) {
+  let baseImagePath = path.join(resPath, filename);
+
+  try {
+    if (isDetached) {
+      await saveImageToPathAsync(context.data.projectPath, url, baseImagePath);
+    } else {
+      await saveUrlToPathAsync(url, baseImagePath);
+    }
+  } catch (e) {
+    throw new Error(`Failed to save icon file to disk. (${e})`);
+  }
+
+  await Promise.all(
+    Object.entries(iconScales).map(async ([folderSuffix, iconScale]) => {
+      // adaptive icons (mdpiSize 108) must be placed in a -v26 folder
+      let subdirectoryName = `${prefix}${folderSuffix}${mdpiSize === 108 ? '-v26' : ''}`;
+      let destinationPath = path.join(resPath, subdirectoryName);
+      await spawnAsyncThrowError('/bin/cp', [baseImagePath, filename], {
+        stdio: 'inherit',
+        cwd: destinationPath,
+      });
+
+      try {
+        await resizeImageAsync(mdpiSize * iconScale, filename, destinationPath);
+      } catch (e) {
+        // Turtle should be able to resize images, so if it fails we want it to throw.
+        // However, `sips` does not exist on Windows or Linux machines, so we expect
+        // resizing images to error on these OSes and want the detach process to continue anyway.
+        if (isDetached) {
+          if (!_hasShownResizeErrorWindowsLinux) {
+            console.warn(
+              'Failed to resize app icons. Your full size icon will be copied to all android/app/src/main/res directories. For best quality, we recommend providing downscaled versions.'
+            );
+            _hasShownResizeErrorWindowsLinux = true;
+          }
+        } else {
+          throw new Error(`Failed to resize image: ${filename}. ${e}`);
+        }
+      }
+
+      // reject non-square icons
+      const dims = await getImageDimensionsMacOSAsync(destinationPath, filename);
+      if (!dims || dims.length < 2 || dims[0] !== dims[1]) {
+        if (!dims) {
+          // Again, only throw this error on Turtle -- we expect that this will fail
+          // for some detach users but we don't want this to stop the whole process.
+          if (!isDetached) {
+            throw new Error(`Unable to read the dimensions of ${filename}`);
+          }
+        } else {
+          throw new Error(
+            `Android icons must be square, the dimensions of ${filename} are ${dims}`
+          );
+        }
+      }
+    })
+  );
+
+  await spawnAsyncThrowError('/bin/rm', [baseImagePath]);
+}
+
+async function createAndWriteIconsToPathAsync(
+  context: StandaloneContext,
+  resPath: string,
+  isDetached: boolean
+) {
+  let manifest = context.config; // manifest or app.json
+  let iconUrl =
+    manifest.android && manifest.android.iconUrl ? manifest.android.iconUrl : manifest.iconUrl;
+  let notificationIconUrl = manifest.notification ? manifest.notification.iconUrl : null;
+
+  if (isDetached) {
+    // manifest is actually just app.json in this case, so iconUrl fields don't exist
+    iconUrl = manifest.android && manifest.android.icon ? manifest.android.icon : manifest.icon;
+    notificationIconUrl = manifest.notification ? manifest.notification.icon : null;
+  }
+
+  let iconBackgroundUrl;
+  let iconBackgroundColor;
+  let iconForegroundUrl;
+  if (manifest.android && manifest.android.adaptiveIcon) {
+    iconBackgroundColor = manifest.android.adaptiveIcon.backgroundColor;
+    if (isDetached) {
+      iconForegroundUrl = manifest.android.adaptiveIcon.foregroundImage;
+      iconBackgroundUrl = manifest.android.adaptiveIcon.backgroundImage;
+    } else {
+      iconForegroundUrl = manifest.android.adaptiveIcon.foregroundImageUrl;
+      iconBackgroundUrl = manifest.android.adaptiveIcon.backgroundImageUrl;
+    }
+  }
+
+  if (iconUrl || iconForegroundUrl) {
+    // Android 7 and below icon
+    if (iconUrl) {
+      (await globby(['**/ic_launcher.png'], {
+        cwd: resPath,
+        absolute: true,
+      })).forEach(filePath => {
+        fs.removeSync(filePath);
+      });
+
+      await _resizeIconsAsync(
+        context,
+        resPath,
+        'mipmap-',
+        48,
+        'ic_launcher.png',
+        iconUrl,
+        isDetached
+      );
+    }
+
+    // Adaptive icon foreground image
+    if (iconForegroundUrl) {
+      (await globby(['**/ic_foreground.png'], {
+        cwd: resPath,
+        absolute: true,
+      })).forEach(filePath => {
+        fs.removeSync(filePath);
+      });
+
+      await _resizeIconsAsync(
+        context,
+        resPath,
+        'mipmap-',
+        108,
+        'ic_foreground.png',
+        iconForegroundUrl,
+        isDetached
+      );
+    } else {
+      // the OS's default method of coercing normal app icons to adaptive
+      // makes them look quite different from using an actual adaptive icon (with xml)
+      // so we need to support falling back to the old version on Android 8
+      (await globby(['**/mipmap-*-v26/*'], {
+        cwd: resPath,
+        absolute: true,
+        dot: true,
+      })).forEach(filePath => {
+        fs.removeSync(filePath);
+      });
+
+      try {
+        (await globby(['**/mipmap-*-v26'], {
+          cwd: resPath,
+          absolute: true,
+        })).forEach(filePath => {
+          fs.rmdirSync(filePath);
+        });
+      } catch (e) {
+        // we don't want the entire detach script to fail if node
+        // can't remove the directories for whatever reason.
+        // people can remove the directories themselves if they need
+        // so just fail silently here
+      }
+    }
+  }
+
+  // Adaptive icon background image or color
+  if (iconBackgroundUrl) {
+    await _resizeIconsAsync(
+      context,
+      resPath,
+      'mipmap-',
+      108,
+      'ic_background.png',
+      iconBackgroundUrl,
+      isDetached
+    );
+
+    await _regexFileInResSubfoldersAsync(
+      '@color/iconBackground',
+      '@mipmap/ic_background',
+      resPath,
+      'mipmap-',
+      '-v26',
+      'ic_launcher.xml'
+    );
+  } else if (iconBackgroundColor) {
+    await regexFileAsync(
+      '"iconBackground">#FFFFFF',
+      `"iconBackground">${iconBackgroundColor}`,
+      path.join(shellPath, 'app', 'src', 'main', 'res', 'values', 'colors.xml')
+    );
+  }
+
+  // Notification icon
+  if (notificationIconUrl) {
+    (await globby(['**/shell_notification_icon.png'], {
+      cwd: resPath,
+      absolute: true,
+    })).forEach(filePath => {
+      fs.removeSync(filePath);
+    });
+
+    await _resizeIconsAsync(
+      context,
+      resPath,
+      'drawable-',
+      24,
+      'shell_notification_icon.png',
+      notificationIconUrl,
+      isDetached
+    );
+  }
+}
+
+export { createAndWriteIconsToPathAsync };

--- a/packages/xdl/src/tools/ImageUtils.js
+++ b/packages/xdl/src/tools/ImageUtils.js
@@ -1,0 +1,94 @@
+/**
+ * @flow
+ */
+
+import { spawnAsyncThrowError } from '../detach/ExponentTools';
+import logger from '../detach/Logger';
+
+/**
+ *  @return array [ width, height ] or null if that fails for some reason.
+ */
+async function getImageDimensionsMacOSAsync(
+  dirname: string,
+  basename: string
+): Promise<?Array<number>> {
+  if (process.platform !== 'darwin') {
+    logger.warn('`sips` utility may or may not work outside of macOS');
+  }
+  let dimensions = null;
+  try {
+    dimensions = await _getImageDimensionsAsync(basename, dirname);
+  } catch (_) {}
+  return dimensions;
+}
+
+let _hasWarned = false;
+async function resizeImageAsync(
+  iconSizePx: number,
+  iconFilename: string,
+  destinationIconPath: string
+) {
+  if (
+    process.platform !== 'darwin' &&
+    _resizeImageAsync === _resizeImageWithSipsAsync &&
+    !_hasWarned
+  ) {
+    logger.warn('`sips` utility may or may not work outside of macOS');
+    _hasWarned = true;
+  }
+  return _resizeImageAsync(iconSizePx, iconFilename, destinationIconPath);
+}
+
+async function _resizeImageWithSipsAsync(
+  iconSizePx: number,
+  iconFilename: string,
+  destinationIconPath: string
+) {
+  return spawnAsyncThrowError('sips', ['-Z', iconSizePx, iconFilename], {
+    stdio: ['ignore', 'ignore', 'inherit'], // only stderr
+    cwd: destinationIconPath,
+  });
+}
+
+async function _getImageDimensionsWithSipsAsync(
+  basename: string,
+  dirname: string
+): Promise<Array<number>> {
+  let childProcess = await spawnAsyncThrowError(
+    'sips',
+    ['-g', 'pixelWidth', '-g', 'pixelHeight', basename],
+    {
+      cwd: dirname,
+    }
+  );
+  // stdout looks something like 'pixelWidth: 1200\n pixelHeight: 800'
+  const components = childProcess.stdout.split(/(\s+)/);
+  return components.map(c => parseInt(c, 10)).filter(n => !isNaN(n));
+}
+
+// Allow us to swap out the default implementations of image functions
+let _resizeImageAsync = _resizeImageWithSipsAsync;
+let _getImageDimensionsAsync = _getImageDimensionsWithSipsAsync;
+
+// Allow users to provide an alternate implementation for our image resize function.
+// This is used internally in order to use sharp instead of sips in standalone builder.
+function setResizeImageFunction(
+  fn: (iconSizePx: number, iconFilename: string, destinationIconPath: string) => Promise<any>
+) {
+  _resizeImageAsync = fn;
+}
+
+// Allow users to provide an alternate implementation for our image dimensions function.
+// This is used internally in order to use sharp instead of sips in standalone builder.
+function setGetImageDimensionsFunction(
+  fn: (basename: string, dirname: string) => Promise<?Array<number>>
+) {
+  _getImageDimensionsAsync = fn;
+}
+
+export {
+  getImageDimensionsMacOSAsync,
+  resizeImageAsync,
+  setResizeImageFunction,
+  setGetImageDimensionsFunction,
+};

--- a/packages/xdl/src/xdl.js
+++ b/packages/xdl/src/xdl.js
@@ -69,6 +69,9 @@ module.exports = {
   get FsCache() {
     return require('./tools/FsCache');
   },
+  get ImageUtils() {
+    return require('./tools/ImageUtils');
+  },
   get Intercom() {
     return require('./Intercom');
   },


### PR DESCRIPTION
re-opening of https://github.com/expo/universe/pull/2868. This was not merged previously because it relies on `sips` when detached and therefore would fail when used on Windows or Linux. A solution was proposed to use `sharp` instead and install binary packages as optional dependencies of `xdl` (similar to ngrok), but I did not have time to get that working last cycle.

I think this is worth merging as it is now for turtle. (Turtle always uses `sharp` instead of `sips` anyway.) It's less important to resize icons for detached projects, as developers can easily modify the icons themselves before they make their build. However, there is no way for people to provide properly downsized icons for turtle builds, which means app icons can look ugly and pixelated in production.

This code is almost exactly the same as the xdl code in the previous PR -- the only difference is that we now warn instead of throwing if resizing fails on detached projects.

I tested this both in detach and in the `gulp android-shell-app` script and it works correctly in both cases.

Companion universe PR is https://github.com/expo/universe/pull/3134 .