### PR TITLE
[xdl] fix versions endpoint scripts

### DIFF
--- a/packages/xdl/src/Api.js
+++ b/packages/xdl/src/Api.js
@@ -224,7 +224,12 @@ export default class ApiClient {
   static port: number = Config.api.port || 80;
 
   static _versionCache = new Cacher(
-    () => ApiClient.callPathAsync('/--/api/v2/versions'),
+    () =>
+      ApiClient.callPathAsync('/--/api/v2/versions', null, null, {
+        headers: {
+          'Expo-Session': '',
+        },
+      }),
     'versions.json',
     0,
     path.join(__dirname, '../caches/versions.json')


### PR DESCRIPTION
Currently, all XDL and powertools scripts that modify the versions endpoint are broken. Since all of these scripts (but one) read and modify the staging endpoint, but `Api` includes the prod session id with the request, the endpoint returns a 401.

Worse, because the `_versionCache` does not differentiate between staging and prod versions, this error is swallowed and a cached copy of versions is returned (likely from prod). This causes any previous changes on the staging endpoint to be overwritten. We ran into this multiple times while doing the SDK 30 release and had to resort to manually overwriting the entire endpoint whenever we wanted to make any change 😱

This PR explicitly sets the `Expo-Session` header to empty on Versions requests to avoid this problem. No auth is needed to read the endpoint, and a separate secret is used to write to it, so this header is unnecessary. It also removes the `_versionCache` for the reasons above; AFAIK there is no need for it since the versions endpoint always has `max-age=0`.

Tested by running `pt-dev update-turtle-sdk-version` and `pt-dev promote-versions-to-prod` with linked XDL; both worked as expected after this change.