### PR TITLE
[xdl] default to yarn when installing new packages, if it exists

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -40,6 +40,7 @@
     "axios": "0.16.2",
     "body-parser": "^1.15.2",
     "chalk": "^2.4.1",
+    "command-exists": "^1.2.7",
     "concat-stream": "^1.6.0",
     "decache": "^4.1.0",
     "delay-async": "^1.0.0",

--- a/packages/xdl/src/detach/installPackageAsync.js
+++ b/packages/xdl/src/detach/installPackageAsync.js
@@ -1,6 +1,7 @@
 // @flow
 
 import spawnAsync from '@expo/spawn-async';
+import commandExists from 'command-exists';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -18,7 +19,11 @@ export default async function installPackageAsync(
   packageVersion?: string,
   options?: any = {}
 ): Promise<InstallResult> {
-  const useYarn: boolean = await fs.pathExists(path.join(appPath, 'yarn.lock'));
+  const packageLockJsonExists: boolean = await fs.pathExists(
+    path.join(appPath, 'package-lock.json')
+  );
+  const yarnExists = await commandExists('yarnpkg');
+  const useYarn = yarnExists && !packageLockJsonExists;
 
   let command = '';
   let args = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2518,6 +2518,10 @@ combined-stream@1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-exists@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.7.tgz#16828f0c3ff2b0c58805861ef211b64fc15692a8"
+
 command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"


### PR DESCRIPTION
If you run `expo init` and then eject to ExpoKit immediately, the current script installs the `expokit` npm package using npm by default (since `yarn.lock` doesn't exist). However, `npm` does something funky here and totally erases the `node_modules/react-native` folder (aside from its own `node_modules`). This makes both `expo start` and, in the ios directory, `pod install` fail. While this is fixable by simply reinstalling node_modules, the fix may not be obvious from the error message, and this extra step should not be necessary.

Using `yarn` as the default fixes this at least for people who have `yarn` installed.

I'm not tied to this PR, just wanted to suggest this in case it's worth it!