### PR TITLE
Accept an array of objects as the data for Android intent filters

### DIFF
--- a/packages/xdl/caches/schema-29.0.0.json
+++ b/packages/xdl/caches/schema-29.0.0.json
@@ -733,7 +733,7 @@
               "properties": {
                 "action": { "type": "string" },
                 "data": {
-                  "type": "object",
+                  "type": ["array", "object"],
                   "properties": {
                     "scheme": { "type": "string" },
                     "host": { "type": "string" },


### PR DESCRIPTION
Follow-up to fix a small mistake in https://github.com/expo/xdl/pull/30

The intent filters is intended to accept an array as "data" or an object however the array type wasn't included in the accepted types.

The underlying logic already works with arrays (a test covers that use case already).

Thanks!