### PR TITLE
Strip unneeded SDKs code from Android shell app

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdl",
-  "version": "51.4.0",
+  "version": "51.4.1-alpha.9",
   "description": "The Expo Development Library",
   "main": "build/xdl.js",
   "files": [
@@ -133,5 +133,5 @@
     "promise-print": "^2.3.0",
     "rimraf": "^2.5.4"
   },
-  "gitHead": "5e6aab74774ccab6b22c4ece13c285022e04bff2"
+  "gitHead": "58a1704c720ba35613d6cb6048a1f3d9abba550d"
 }

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -402,14 +402,9 @@ export async function runShellAppModificationsAsync(
     let appBuildGradle = path.join(shellPath, 'app', 'build.gradle');
     await regexFileAsync(/\/\* UNCOMMENT WHEN DISTRIBUTING/g, '', appBuildGradle);
     await regexFileAsync(/END UNCOMMENT WHEN DISTRIBUTING \*\//g, '', appBuildGradle);
-    await regexFileAsync(
-      /\/\/ WHEN_DISTRIBUTING_REMOVE_FROM_HERE/g,
-      '/* REMOVED_WHEN_DISTRIBUTING_FROM_HERE',
-      appBuildGradle
-    );
-    await regexFileAsync(
-      /\/\/ WHEN_DISTRIBUTING_REMOVE_TO_HERE/g,
-      'REMOVED_WHEN_DISTRIBUTING_TO_HERE */',
+    await deleteLinesInFileAsync(
+      'WHEN_DISTRIBUTING_REMOVE_FROM_HERE',
+      'WHEN_DISTRIBUTING_REMOVE_TO_HERE',
       appBuildGradle
     );
 

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1192,7 +1192,11 @@ async function removeObsoleteSdks(shellPath: string, requiredSdkVersion: string)
     constants: path.join(shellPath, 'expoview/src/main/java/host/exp/exponent/Constants.java'),
   };
 
-  Promise.all(Object.values(filePaths).map(removeInvalidSdkLinesWhenPreparingShell));
+  Promise.all(
+    Object.values(filePaths).map(filePath =>
+      removeInvalidSdkLinesWhenPreparingShell(majorSdkVersion, filePath)
+    )
+  );
 
   // The single SDK change will happen when transitioning from SDK 30 to 31.
   // Since SDK 31 there will be no versioned ABIs in shell applications, only unversioned one.

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1190,6 +1190,8 @@ async function removeObsoleteSdks(shellPath: string, requiredSdkVersion: string)
     ),
     // Remove invalid ABI versions from Constants
     constants: path.join(shellPath, 'expoview/src/main/java/host/exp/exponent/Constants.java'),
+    // Remove non-existent DevSettingsActivities
+    appAndroidManifest: path.join(shellPath, 'app/src/main/AndroidManifest.xml'),
   };
 
   Promise.all(


### PR DESCRIPTION
Missing block for https://github.com/expo/expo/pull/2330.

Removes obsolete SDK-specific code from `android-shell-app` upon its creation.