### PR TITLE
[ios] Generate Podfile with ENABLE_PACKAGER_CONNECTION=0 + target iOS 10+

### DIFF
--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -313,22 +313,23 @@ function _renderUnversionedPostinstall() {
   return `
     if ${podsToChangeRB}.include? target.pod_name
       target.native_target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '9.0'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '10.0'
       end
     end
     # Can't specify this in the React podspec because we need
     # to use those podspecs for detached projects which don't reference ExponentCPP.
     if target.pod_name.start_with?('React')
       target.native_target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '9.0'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '10.0'
         config.build_settings['HEADER_SEARCH_PATHS'] ||= ['$(inherited)']
       end
     end
-    # Build React Native with RCT_DEV enabled
+    # Build React Native with RCT_DEV enabled and ENABLE_PACKAGER_CONNECTION disabled
     next unless target.pod_name == 'React'
     target.native_target.build_configurations.each do |config|
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'RCT_DEV=1'
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'ENABLE_PACKAGER_CONNECTION=0'
     end
 `;
 }


### PR DESCRIPTION
This makes two changes to the Podfile generator:

- The ENABLE_PACKAGER_CONNECTION flag on iOS is set to 0. We seem not to use it and to causes lots of log spam. Live reloads work without it.
- Sets the iOS target to 10+ since we are dropping 9.

We'll need a new version of XDL on npm so that the Expo repo can depend on this new code.

Tested by applying these changes to the Podfile directly and building the client.