### PR TITLE
Add missing android intentsFilters.autoVerify

### DIFF
--- a/packages/xdl/caches/schema-30.0.0.json
+++ b/packages/xdl/caches/schema-30.0.0.json
@@ -716,6 +716,7 @@
           "intentFilters": {
             "description": "An array of intent filters.",
             "example": [{
+              "autoVerify": true,
               "action": "VIEW",
               "data": {
                 "scheme": "https",
@@ -731,6 +732,7 @@
             "items": {
               "type": "object",
               "properties": {
+                "autoVerify": { "type": "boolean" },
                 "action": { "type": "string" },
                 "data": {
                   "type": ["array", "object"],


### PR DESCRIPTION
If you try and use android intent filter with `autoVerify` you get the following error:

```
[11:08:04] Error: Problems validating fields in app.json. See https://docs.expo.io/versions/v30.0.0/guides/configuration.html.
[11:08:04]  • Field: android.intentFilters[0] - should NOT have additional property 'autoVerify'.
[11:08:04] Couldn't publish because errors were found. (See logs above.) Please fix the errors and try again.
```

The logic is all there in the code, it's just blocking you with the schema validation.