### PR TITLE
[podfile] Add RCT_ENABLE_INSPECTOR=0 to the generated Podfile

### DIFF
--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -324,11 +324,13 @@ function _renderUnversionedPostinstall() {
         config.build_settings['HEADER_SEARCH_PATHS'] ||= ['$(inherited)']
       end
     end
-    # Build React Native with RCT_DEV enabled and ENABLE_PACKAGER_CONNECTION disabled
+    # Build React Native with RCT_DEV enabled and RCT_ENABLE_INSPECTOR and
+    # RCT_ENABLE_PACKAGER_CONNECTION disabled
     next unless target.pod_name == 'React'
     target.native_target.build_configurations.each do |config|
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'RCT_DEV=1'
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'RCT_ENABLE_INSPECTOR=0'
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'ENABLE_PACKAGER_CONNECTION=0'
     end
 `;


### PR DESCRIPTION
The "inspector" refers to the Nuclide inspector that RN tries to connect to on port 8082. This doesn't work with Expo CLI and causes errors when we load a published copy of dev Home from CloudFront and RN tries to connect to `<cloudfront>:8082/<inspector URL>`. This makes the Podfile configure the build so the inspector is disabled and we don't make network requests to unsupported endpoints that will fail.