### PR TITLE
[xdl] remove generating dynamic macros for every build

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -218,18 +218,6 @@ export async function copyInitialShellAppFilesAsync(
   shellPath,
   isDetached: boolean = false
 ) {
-  if (androidSrcPath) {
-    await spawnAsync(`../../tools-public/generate-dynamic-macros-android.sh`, [], {
-      pipeToLogger: true,
-      loggerFields: { buildPhase: 'generating dynamic macros' },
-      cwd: path.join(androidSrcPath, 'app'),
-      env: {
-        ...process.env,
-        JSON_LOGS: '0',
-      },
-    }); // populate android template files now since we take out the prebuild step later on
-  }
-
   const initialCopyLogger = logger.withFields({ buildPhase: 'copying initial shell app files' });
 
   const copyToShellApp = async fileName => {

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -218,6 +218,18 @@ export async function copyInitialShellAppFilesAsync(
   shellPath,
   isDetached: boolean = false
 ) {
+  if (androidSrcPath) {
+    // check if the android template files exist
+    // since we take out the prebuild step later on
+    // and we should have generated those files earlier
+    await spawnAsyncThrowError('../../tools-public/check-dynamic-macros-android.sh', [], {
+      pipeToLogger: true,
+      loggerFields: { buildPhase: 'confirming that dynamic macros exist' },
+      cwd: path.join(androidSrcPath, 'app'),
+      env: process.env,
+    });
+  }
+
   const initialCopyLogger = logger.withFields({ buildPhase: 'copying initial shell app files' });
 
   const copyToShellApp = async fileName => {

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -219,7 +219,7 @@ export async function copyInitialShellAppFilesAsync(
   isDetached: boolean = false
 ) {
   if (androidSrcPath) {
-    // check if the android template files exist
+    // check if Android template files exist
     // since we take out the prebuild step later on
     // and we should have generated those files earlier
     await spawnAsyncThrowError('../../tools-public/check-dynamic-macros-android.sh', [], {


### PR DESCRIPTION
So far, we were running `generate-dynamic-macros-android.sh` twice. The first time when creating a Docker image for Android builders and the second time when building a user's standalone app. I verified that when we don't run it the second time, the standalone app works just fine.