### PR TITLE
[xdl] iOS shell app builds propagate xcodebuild errors

### DIFF
--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -88,10 +88,11 @@ async function _buildAsync(
   relativeBuildDestination,
   verbose
 ) {
-  let buildCmd, pathToArtifact;
+  let buildCmd = `set -o pipefail && xcodebuild -workspace ${projectName}.xcworkspace -scheme ${projectName} -configuration ${configuration} archive -derivedDataPath ${buildDest}`,
+    pathToArtifact;
   const buildDest = `${relativeBuildDestination}-${type}`;
   if (type === 'simulator') {
-    buildCmd = `xcodebuild -workspace ${projectName}.xcworkspace -scheme ${projectName} -sdk iphonesimulator -configuration ${configuration} -derivedDataPath ${buildDest} CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=NO | xcpretty`;
+    buildCmd += `-sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=NO | xcpretty`;
     pathToArtifact = path.join(
       buildDest,
       'Build',
@@ -100,7 +101,7 @@ async function _buildAsync(
       `${projectName}.app`
     );
   } else if (type === 'archive') {
-    buildCmd = `xcodebuild -workspace ${projectName}.xcworkspace -scheme ${projectName} -sdk iphoneos -destination generic/platform=iOS -configuration ${configuration} archive -derivedDataPath ${buildDest} -archivePath ${buildDest}/${projectName}.xcarchive CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty`;
+    buildCmd += `-sdk iphoneos -destination generic/platform=iOS -archivePath ${buildDest}/${projectName}.xcarchive CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty`;
     pathToArtifact = path.join(buildDest, `${projectName}.xcarchive`);
   } else {
     throw new Error(`Unsupported build type: ${type}`);


### PR DESCRIPTION
As documented in [xcpretty's usage instructions](https://github.com/supermarin/xcpretty/tree/456604313faf4a1de6a4e687c2412eaf6097c4b0#usage), it doesn't exit with the same status code as the xcodebuild command.

This unblocks expo/expo#2425.