### PR TITLE
[expo-cli] Add a few manual pre-release checks

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -13,6 +13,7 @@
     "build": "gulp clean && gulp build",
     "watch": "gulp watch",
     "prepare": "yarn build",
+    "preversion": "node ./scripts/preversion.js",
     "pkg": "pkg ."
   },
   "bin": {
@@ -47,6 +48,7 @@
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
+    "boxen": "^2.0.0",
     "eslint": "^4.12.0",
     "eslint-config-universe": "^1.0.6",
     "gulp": "^4.0.0",

--- a/packages/expo-cli/scripts/preversion.js
+++ b/packages/expo-cli/scripts/preversion.js
@@ -9,16 +9,16 @@ console.log(
     `
 ${bold('1) Offline development')}:
   Check that you're logged in (\`expo whoami\`) and then make sure
-  \`expo start\` works without internet connection.
+  \`<repo-dir>/packages/expo-cli/bin/expo.js start --offline\` works without internet connection.
   (Use Network Link Conditioner with the the "100% Loss" profile, or turn off your wi-fi.)
 ${bold('2) Offline development, logged out')}:
-  Same as (1), but first run \`expo logout\`
+  Run \`expo logout\` and then \`<repo-dir>/packages/expo-cli/bin/expo.js start\`.
 ${bold('3) Eject')}: Create an app and eject it immediately. Check that it builds.
 
-    expo init testapp --template blank
+    <repo-dir>/packages/expo-cli/bin/expo.js init testapp --template blank
     cd testapp
-    expo eject --eject-method expoKit
-    expo start
+    <repo-dir>/packages/expo-cli/bin/expo.js eject --eject-method expoKit
+    <repo-dir>/packages/expo-cli/bin/expo.js start
 
     # In another terminal:
     # Test that it builds for iOS
@@ -29,7 +29,7 @@ ${bold('3) Eject')}: Create an app and eject it immediately. Check that it build
 
     # Test that it builds for Android
     cd ../android
-    ./gradlew installDevMinSdkDevKernelDebug`
+    ./run.sh`
 );
 
 let CHECKLIST = ['I have completed all the checks'];

--- a/packages/expo-cli/scripts/preversion.js
+++ b/packages/expo-cli/scripts/preversion.js
@@ -1,0 +1,49 @@
+let { bold } = require('chalk');
+let boxen = require('boxen');
+let inquirer = require('inquirer');
+
+console.log(
+  boxen(bold("Please complete these checks before publishing the 'expo-cli' package:"), {
+    padding: 1,
+  }) +
+    `
+${bold('1) Offline development')}:
+  Check that you're logged in (\`expo whoami\`) and then make sure
+  \`expo start\` works without internet connection.
+  (Use Network Link Conditioner with the the "100% Loss" profile, or turn off your wi-fi.)
+${bold('2) Offline development, logged out')}:
+  Same as (1), but first run \`expo logout\`
+${bold('3) Eject')}: Create an app and eject it immediately. Check that it builds.
+
+    expo init testapp --template blank
+    cd testapp
+    expo eject --eject-method expoKit
+    expo start
+
+    # In another terminal:
+    # Test that it builds for iOS
+    cd ios
+    pod install
+    open testapp.xcworkspace
+    # then press "Run" in Xcode
+
+    # Test that it builds for Android
+    cd ../android
+    ./gradlew installDevMinSdkDevKernelDebug`
+);
+
+let CHECKLIST = ['I have completed all the checks'];
+
+inquirer
+  .prompt({
+    type: 'confirm',
+    name: 'completed',
+    message: 'Have you completed all the checks?',
+    default: false,
+  })
+  .then(answer => {
+    if (!answer.completed) {
+      console.error('Please complete all the checks before continuing.');
+      process.exit(1);
+    }
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2839,6 +2839,19 @@ boxen@^1.2.1:
     term-size "^1.2.0"
     widest-line "^2.0.0"
 
+boxen@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-2.0.0.tgz#46ba3953b1a3d99aaf89ad8c7104a32874934a58"
+  integrity sha512-9DK9PQqcOpsvlKOK3f3lVK+vQsqH4JDGMX73FCWcHRxQQtop1U8urn4owrt5rnc2NgZAJ6wWjTDBc7Fhv+vz/w==
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^5.0.0"
+    chalk "^2.4.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.1.1"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3200,6 +3213,11 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+camelcase@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000844:
   version "1.0.30000877"


### PR DESCRIPTION
# Why

The `master` branch should be releasable at any time. It should be as straightforward as possible for Expo CLI maintainers to publish a new release. At the same time, we should make sure that when releasing new versions, we don't break the developer experience of Expo CLI users.

Offline development, logged-out development and ejecting has previously had many regressions, so these manual tests target those features specifically. To make releasing as smooth as possible, most of these manual tests should be automated in the future.

# How

Added a `preversion` script to the `expo-cli` package, which Lerna will run before bumping the package version when we run `lerna publish`. The script shows instructions for manual tests to perform before publishing.

# Test Plan

Run `lerna publish`. Answering "no" to the "Have you completed all the checks?" prompt will interrupt publishing.