### PR TITLE
[Unimodule] `expo-google-sign-in`

### DIFF
--- a/packages/xdl/src/modules/config.js
+++ b/packages/xdl/src/modules/config.js
@@ -211,6 +211,11 @@ const expoSdkUniversalModules = [
     sdkVersions: '>=30.0.0',
   },
   {
+    podName: 'EXGoogleSignIn',
+    libName: 'expo-google-sign-in',
+    sdkVersions: '>=32.0.0',
+  },
+  {
     podName: 'EXGL',
     libName: 'expo-gl',
     sdkVersions: '>=29.0.0',


### PR DESCRIPTION
`Expo.Google` native features are spotty or inconsistent. This native module will replace the native parts of `Expo.Google` for legacy. `Expo.GoogleSignIn` only works in standalone.

[x-post](https://github.com/expo/expo/pull/2543)