### PR TITLE
[xdl] Fix code assuming node_modules is under the project root

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.js
+++ b/packages/expo-cli/src/commands/eject/Eject.js
@@ -132,7 +132,7 @@ Ejecting is permanent! Please be careful with your selection.
     log(chalk.green('Wrote to app.json, please update it manually in the future.'));
     const ejectCommand = 'node';
     const ejectArgs = [
-      path.resolve('node_modules', 'react-native', 'local-cli', 'cli.js'),
+      ProjectUtils.resolveModule('react-native/local-cli/cli.js', projectRoot, exp);
       'eject',
     ];
 

--- a/packages/xdl/src/UrlUtils.js
+++ b/packages/xdl/src/UrlUtils.js
@@ -136,14 +136,8 @@ export async function constructBundleQueryParamsAsync(projectRoot: string, opts:
 
   let { exp, pkg } = await ProjectUtils.readConfigJsonAsync(projectRoot);
 
-  // Be backwards compatible for users who haven't migrated from `exponent`
-  // to the `expo` sdk package.
-  let sdkPkg = pkg.dependencies['expo'] ? 'expo' : 'exponent';
   // Use an absolute path here so that we can not worry about symlinks/relative requires
-  let nodeModulesPath = exp.nodeModulesPath
-    ? path.join(path.resolve(projectRoot, exp.nodeModulesPath), 'node_modules')
-    : path.join(projectRoot, 'node_modules');
-  let pluginModule = path.join(nodeModulesPath, sdkPkg, 'tools', 'hashAssetFiles');
+  let pluginModule = ProjectUtils.resolveModule('expo/tools/hashAssetFiles', projectRoot, exp);
   queryParams += `&assetPlugin=${encodeURIComponent(pluginModule)}`;
 
   // Only sdk-10.1.0+ supports the assetPlugin parameter. We use only the

--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -187,7 +187,13 @@ async function _renderPodfileFromTemplateAsync(
   );
   if (context.type === 'user') {
     invariant(iosClientVersion, `The iOS client version must be specified`);
-    reactNativeDependencyPath = path.join(context.data.projectPath, 'node_modules', 'react-native');
+    reactNativeDependencyPath = path.dirname(
+      ProjectUtils.resolveModule(
+        'react-native/package.json',
+        context.data.projectPath,
+        context.data.exp
+      )
+    );
     podfileSubstitutions.EXPOKIT_TAG = `ios/${iosClientVersion}`;
     podfileTemplateFilename = 'ExpoKit-Podfile';
     const expoDependenciesPath = path.join(context.data.projectPath, 'node_modules');

--- a/packages/xdl/src/project/Doctor.js
+++ b/packages/xdl/src/project/Doctor.js
@@ -406,10 +406,10 @@ async function _validateNodeModulesAsync(projectRoot): Promise<number> {
 
   // Check to make sure react native is installed
   try {
-    let result = fs.statSync(
-      path.join(nodeModulesPath, 'node_modules', 'react-native', 'local-cli', 'cli.js')
-    );
-    if (!result.isFile()) {
+    ProjectUtils.resolveModule('react-native/local-cli/cli.js', projectRoot, exp);
+    ProjectUtils.clearNotification(projectRoot, 'doctor-react-native-not-installed');
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
       ProjectUtils.logError(
         projectRoot,
         'expo',
@@ -417,17 +417,9 @@ async function _validateNodeModulesAsync(projectRoot): Promise<number> {
         'doctor-react-native-not-installed'
       );
       return FATAL;
+    } else {
+      throw error;
     }
-
-    ProjectUtils.clearNotification(projectRoot, 'doctor-react-native-not-installed');
-  } catch (e) {
-    ProjectUtils.logError(
-      projectRoot,
-      'expo',
-      `Error: React native is not installed. Please run \`npm install\` in your project directory.`,
-      'doctor-react-native-not-installed'
-    );
-    return FATAL;
   }
   return NO_ISSUES;
 }

--- a/packages/xdl/src/project/ProjectUtils.js
+++ b/packages/xdl/src/project/ProjectUtils.js
@@ -159,6 +159,12 @@ export async function fileExistsAsync(file: string): Promise<boolean> {
   }
 }
 
+export function resolveModule(request, projectRoot, exp) {
+  return require.resolve(request, {
+    paths: exp.nodeModulesPath ? [exp.nodeModulesPath] : [projectRoot],
+  });
+}
+
 async function _findConfigPathAsync(projectRoot) {
   const appJson = path.join(projectRoot, 'app.json');
   const expJson = path.join(projectRoot, 'exp.json');
@@ -280,6 +286,10 @@ export async function readConfigJsonAsync(
 
   if (exp && !exp.version) {
     exp.version = pkg.version;
+  }
+
+  if (exp.nodeModulesPath) {
+    exp.nodeModulesPath = path.resolve(projectRoot, exp.nodeModulesPath);
   }
 
   return { exp, pkg, rootConfig };


### PR DESCRIPTION
A few places in the code assumed `node_modules` is directly under the root
folder of the app. This breaks, for example, when the project is using
Yarn workspaces and some modules are hoisted to the `node_modules` folder
in the root of the monorepo.

To fix this, instead of joining paths and assuming a certain folder structure,
we now use `require.resolve` to find packages using the Node package resolution
algorithm that will also look for them in the `node_modules` folders above.