### PR TITLE
[xdl] fix offline mode while logged in

### DIFF
--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1646,7 +1646,7 @@ export async function startExpoServerAsync(projectRoot: string) {
       await _resolveGoogleServicesFile(projectRoot, manifest);
       const hostUUID = await UserSettings.anonymousIdentifier();
       let currentSession = await UserManager.getSessionAsync();
-      if (!currentSession) {
+      if (!currentSession || Config.offline) {
         manifest.id = `@${ANONYMOUS_USERNAME}/${manifest.slug}-${hostUUID}`;
       }
       let manifestString = JSON.stringify(manifest);
@@ -1654,7 +1654,7 @@ export async function startExpoServerAsync(projectRoot: string) {
         if (_cachedSignedManifest.manifestString === manifestString) {
           manifestString = _cachedSignedManifest.signedManifest;
         } else {
-          if (!currentSession) {
+          if (!currentSession || Config.offline) {
             const unsignedManifest = {
               manifestString,
               signature: 'UNSIGNED',


### PR DESCRIPTION
This makes `expo start --offline` load a project properly while logged in. Currently it fails by throwing an error from here: https://github.com/expo/expo-cli/blob/1af1912114111072d93043f567671750c806ef55/packages/xdl/src/Exp.js#L261. This PR avoids this function call by treating signing the manifest the same way as if we were logged out.

I additionally had to treat `manifest.id` in the same way as initially the manifest was being generated without an id at all (which caused the clients to crash). This has some side effects, like the project being scoped as a different experience than when properly signed in and online.

I am not sure if this is the right way to fix offline mode -- there may be a better way to do this with fewer side effects, but wanted to open this PR as a first possibility to start the conversation.