### PR TITLE
[xdl] fix unversioned shell apps

### DIFF
--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -144,17 +144,11 @@ async function _configureVersionsPlistAsync(
   isServiceContext: boolean
 ) {
   await IosPlist.modifyAsync(configFilePath, 'EXSDKVersions', versionConfig => {
-    if (isServiceContext) {
-      delete versionConfig.detachedNativeVersions;
-      // leave versionConfig.sdkVersions unchanged
-      // because the ExpoKit template already contains the list of supported versions.
-    } else {
-      versionConfig.sdkVersions = [standaloneSdkVersion];
-      versionConfig.detachedNativeVersions = {
-        shell: standaloneSdkVersion,
-        kernel: standaloneSdkVersion,
-      };
-    }
+    versionConfig.sdkVersions = [standaloneSdkVersion];
+    versionConfig.detachedNativeVersions = {
+      shell: standaloneSdkVersion,
+      kernel: standaloneSdkVersion,
+    };
     return versionConfig;
   });
 }


### PR DESCRIPTION
In order to fix apps hanging on the splash screen, we have to set `sdkVersions` and `detachedNativeVersions` properly in the `EXSDKVersions` file.
@sjchmiela knows more details and he says it shouldn't break anything.
I've published a canary version of `xdl` with these changes, built a shell app with `tools-public` having that canary release of`xdl` installed, deployed Turtle with the new shell app for SDK31 and built test app and verified it doesn't hang on the splash screen :tada: