### PR TITLE
Add modules for background tasks

### DIFF
--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -178,7 +178,7 @@ async function _renderPodfileFromTemplateAsync(
   let reactNativeDependencyPath;
   const detachableUniversalModules = Modules.getDetachableModulesForPlatformAndSdkVersion(
     'ios',
-    sdkVersion
+    context.data.shellAppSdkVersion || sdkVersion
   );
   if (context.type === 'user') {
     invariant(iosClientVersion, `The iOS client version must be specified`);

--- a/packages/xdl/src/modules/Modules.js
+++ b/packages/xdl/src/modules/Modules.js
@@ -47,7 +47,7 @@ export function getDetachableModulesForPlatformAndSdkVersion(
     return (
       moduleConfig.isNativeModule &&
       moduleConfig.detachable &&
-      semver.satisfies(sdkVersion, moduleConfig.sdkVersions)
+      (sdkVersion === 'UNVERSIONED' || semver.satisfies(sdkVersion, moduleConfig.sdkVersions))
     );
   });
 }

--- a/packages/xdl/src/modules/config.js
+++ b/packages/xdl/src/modules/config.js
@@ -54,6 +54,16 @@ const expoSdkUniversalModules = [
     sdkVersions: '>=32.0.0',
   },
   {
+    podName: 'EXAppLoaderProvider',
+    libName: 'expo-app-loader-provider',
+    sdkVersions: '>=32.0.0',
+  },
+  {
+    podName: 'EXBackgroundFetch',
+    libName: 'expo-background-fetch',
+    sdkVersions: '>=32.0.0',
+  },
+  {
     podName: 'EXBarCodeScanner',
     libName: 'expo-barcode-scanner',
     sdkVersions: '>=30.0.0',
@@ -315,6 +325,16 @@ const expoSdkUniversalModules = [
     podName: 'EXSMS',
     libName: 'expo-sms',
     sdkVersions: '>=29.0.0',
+  },
+  {
+    podName: 'EXTaskManager',
+    libName: 'expo-task-manager',
+    sdkVersions: '>=32.0.0',
+  },
+  {
+    podName: 'EXTaskManagerInterface',
+    libName: 'expo-task-manager-interface',
+    sdkVersions: '>=32.0.0',
   },
 
   // JS-only modules


### PR DESCRIPTION
Related PR: https://github.com/expo/expo/pull/2338

It also fixes some problems on expo/expo CI with the shell app, as it was not including modules that were not released yet (like these one that has `sdkVersion: '>=32.0.0'`), however we need to include them to properly test new modules with unversioned shell apps.