### PR TITLE
[xdl] set API_SERVER_ENDPOINT in EXBuildConstants properly

### DIFF
--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -428,6 +428,7 @@ async function _configureConstantsPlistAsync(context: StandaloneContext) {
       process.env.ENVIRONMENT === 'staging'
         ? 'https://staging.exp.host/--/api/v2/'
         : 'https://exp.host/--/api/v2/';
+    return constantsConfig;
   });
 }
 

--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -422,6 +422,7 @@ async function _configureConstantsPlistAsync(context: StandaloneContext) {
     return;
   }
 
+  const { supportingDirectory } = IosWorkspace.getPaths(context);
   await IosPlist.modifyAsync(supportingDirectory, 'EXBuildConstants', constantsConfig => {
     constantsConfig.API_SERVER_ENDPOINT =
       process.env.ENVIRONMENT === 'staging'

--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -417,6 +417,19 @@ async function _configureShellPlistAsync(context: StandaloneContext) {
   });
 }
 
+async function _configureConstantsPlistAsync(context: StandaloneContext) {
+  if (context.type === 'user') {
+    return;
+  }
+
+  await IosPlist.modifyAsync(supportingDirectory, 'EXBuildConstants', constantsConfig => {
+    constantsConfig.API_SERVER_ENDPOINT =
+      process.env.ENVIRONMENT === 'staging'
+        ? 'https://staging.exp.host/--/api/v2/'
+        : 'https://exp.host/--/api/v2/';
+  });
+}
+
 async function configureAsync(context: StandaloneContext) {
   const buildPhaseLogger = logger.withFields({ buildPhase: 'configuring NSBundle' });
 
@@ -440,6 +453,7 @@ async function configureAsync(context: StandaloneContext) {
     await _configureInfoPlistAsync(context);
     await _configureShellPlistAsync(context);
     await _configureEntitlementsAsync(context);
+    await _configureConstantsPlistAsync(context);
     await IosLaunchScreen.configureLaunchAssetsAsync(context, intermediatesDirectory);
     await IosLocalization.writeLocalizationResourcesAsync({
       supportingDirectory,


### PR DESCRIPTION
Turtle apps from staging don't have `API_SERVER_ENDPOINT` set properly. I'm not 100% sure that something else isn't broken, but these changes should fix the problem.