### PR TITLE
[expo-cli] use validator.isURL instead of url.URL

### DIFF
--- a/packages/expo-cli/src/commands/webhooks.js
+++ b/packages/expo-cli/src/commands/webhooks.js
@@ -1,8 +1,8 @@
-import { URL } from 'url';
 import { Webhooks, Exp } from 'xdl';
 import chalk from 'chalk';
 import _ from 'lodash';
 import inquirer from 'inquirer';
+import validator from 'validator';
 
 import log from '../log';
 
@@ -95,17 +95,14 @@ function _sanitizeOptions(options) {
   if (!url) {
     throw new Error('You must provide --url parameter');
   } else {
-    try {
-      // eslint-disable-next-line no-new
-      new URL(url);
-    } catch (err) {
-      if (err instanceof TypeError) {
-        throw new Error(
-          'The provided webhook URL is invalid and must be an absolute URL, including a scheme.'
-        );
-      } else {
-        throw err;
-      }
+    const isValidUrl = validator.isURL(url, {
+      protocols: ['http', 'https'],
+      require_protocol: true,
+    });
+    if (!isValidUrl) {
+      throw new Error(
+        'The provided webhook URL is invalid and must be an absolute URL, including a scheme.'
+      );
     }
 
     if (secret) {


### PR DESCRIPTION
`url.URL` doesn't exist in `node@6.9.1` and we have 
```
"engines": {
    "node": ">=6.9.1"
  },
```
in `package.json`.

@sjchmiela I tested it locally :P