### PR TITLE
Remove kernel.android.bundle in standalone apps in SDK32+

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -216,7 +216,8 @@ function shouldShowLoadingView(manifest) {
 export async function copyInitialShellAppFilesAsync(
   androidSrcPath,
   shellPath,
-  isDetached: boolean = false
+  isDetached: boolean,
+  sdkVersion: ?string
 ) {
   if (androidSrcPath && !isDetached) {
     // check if Android template files exist
@@ -258,6 +259,18 @@ export async function copyInitialShellAppFilesAsync(
   await copyToShellApp('debug.keystore');
   await copyToShellApp('run.sh');
   await copyToShellApp('maven'); // this is a symlink
+
+  // kernel.android.bundle isn't ever used in standalone apps (at least in kernel v32)
+  // but in order to not change behavior in older SDKs, we'll remove the file only in 32+.
+  if (parseSdkMajorVersion(sdkVersion) >= 32) {
+    try {
+      await fs.remove(path.join(shellPath, 'app/src/main/assets/kernel.android.bundle'));
+    } catch (e) {
+      initialCopyLogger.warn(
+        'Warning: Could not remove kernel.android.bundle from shell app directory.'
+      );
+    }
+  }
 }
 
 exports.createAndroidShellAppAsync = async function createAndroidShellAppAsync(args: any) {
@@ -331,7 +344,7 @@ exports.createAndroidShellAppAsync = async function createAndroidShellAppAsync(a
     releaseChannel
   );
 
-  await copyInitialShellAppFilesAsync(androidSrcPath, shellPath);
+  await copyInitialShellAppFilesAsync(androidSrcPath, shellPath, false, sdkVersion);
   await removeObsoleteSdks(shellPath, sdkVersion);
   await runShellAppModificationsAsync(context, false, sdkVersion);
 

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -266,9 +266,7 @@ export async function copyInitialShellAppFilesAsync(
     try {
       await fs.remove(path.join(shellPath, 'app/src/main/assets/kernel.android.bundle'));
     } catch (e) {
-      initialCopyLogger.warn(
-        'Warning: Could not remove kernel.android.bundle from shell app directory.'
-      );
+      // let's hope it's just not present in the shell app template
     }
   }
 }

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -320,7 +320,8 @@ async function detachAndroidAsync(context: StandaloneContext, expoViewUrl: strin
     await AndroidShellApp.copyInitialShellAppFilesAsync(
       path.join(process.env.EXPO_VIEW_DIR, 'android'),
       androidProjectDirectory,
-      true
+      true,
+      context.data.exp.sdkVersion
     );
   } else {
     tmpExpoDirectory = path.join(context.data.projectPath, 'temp-android-directory');
@@ -330,7 +331,8 @@ async function detachAndroidAsync(context: StandaloneContext, expoViewUrl: strin
     await AndroidShellApp.copyInitialShellAppFilesAsync(
       tmpExpoDirectory,
       androidProjectDirectory,
-      true
+      true,
+      context.data.exp.sdkVersion
     );
   }
 


### PR DESCRIPTION
# Why

`kernel.android.bundle` isn't used in standalone apps yet we include it in every ejected or standalone apps. x-ref: https://github.com/expo/expo/pull/2850

# How

Pass `sdkVersion` around and remove the offending file from shell app if `sdkVersion > 32`.

# Test Plan

I'll deploy staging Turtle with this XDL and see if an app built against this XDL works ok.