### PR TITLE
[expo-cli] Escape dot in channel name regexp to match only dot character

### DIFF
--- a/packages/expo-cli/src/commands/publish.js
+++ b/packages/expo-cli/src/commands/publish.js
@@ -20,7 +20,7 @@ type Options = {
 };
 
 export async function action(projectDir: string, options: Options = {}) {
-  let channelRe = new RegExp(/^[a-z\d][a-z\d._-]*$/);
+  let channelRe = new RegExp(/^[a-z\d][a-z\d\._-]*$/);
   if (options.releaseChannel && !channelRe.test(options.releaseChannel)) {
     log.error(
       'Release channel name can only contain lowercase letters, numbers and special characters . _ and -'


### PR DESCRIPTION
Just something I noticed accidentally. 🙂 