### PR TITLE
Fix XDL shell.apk paths, sign the APK properly on SDKs < 32

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1072,12 +1072,33 @@ async function buildShellAppAsync(context: StandaloneContext, sdkVersion: string
           'build',
           'outputs',
           'apk',
-          'devMinSdk',
-          'prodKernel',
+          'prodMinSdkProdKernel',
           'release',
-          'app-devMinSdk-prodKernel-release-unsigned.apk'
+          'app-prodMinSdk-prodKernel-release-unsigned.apk'
         ),
         `shell-unaligned.apk`
+      );
+      await spawnAsync(
+        `jarsigner`,
+        [
+          '-verbose',
+          '-sigalg',
+          'SHA1withRSA',
+          '-digestalg',
+          'SHA1',
+          '-storepass',
+          androidBuildConfiguration.keystorePassword,
+          '-keypass',
+          androidBuildConfiguration.keyPassword,
+          '-keystore',
+          androidBuildConfiguration.keystore,
+          'shell-unaligned.apk',
+          androidBuildConfiguration.keyAlias,
+        ],
+        {
+          pipeToLogger: true,
+          loggerFields: { buildPhase: 'signing created apk' },
+        }
       );
       await spawnAsync(`zipalign`, ['-v', '4', 'shell-unaligned.apk', 'shell.apk'], {
         pipeToLogger: true,


### PR DESCRIPTION
- fix path for APK copying according to https://github.com/expo/expo-cli/blob/eefd08b1b7269ba2608c7bca3ca41e7f2997fb7a/packages/xdl/src/detach/AndroidShellApp.js#L1019-L1021 for SDKs < 32
- add missing `jarsigner` step for SDKs < 32 https://github.com/expo/expo-cli/blob/eefd08b1b7269ba2608c7bca3ca41e7f2997fb7a/packages/xdl/src/detach/AndroidShellApp.js#L1025-L1046