### PR TITLE
feat: output SHA-256 hash for universal links

### DIFF
--- a/packages/expo-cli/src/commands/fetch.js
+++ b/packages/expo-cli/src/commands/fetch.js
@@ -143,13 +143,19 @@ Push p12 password:         ${chalk.bold(pushPassword)}
           .update(data)
           .digest('hex')
           .toUpperCase();
+        const googleHash256 = crypto
+          .createHash('sha256')
+          .update(data)
+          .digest('hex')
+          .toUpperCase();
         const fbHash = crypto
           .createHash('sha1')
           .update(data)
           .digest('base64');
-        log(`Google Certificate Fingerprint:  ${googleHash.replace(/(.{2}(?!$))/g, '$1:')}`);
-        log(`Google Certificate Hash:         ${googleHash}`);
-        log(`Facebook Key Hash:               ${fbHash}`);
+        log(`Google Certificate Fingerprint:     ${googleHash.replace(/(.{2}(?!$))/g, '$1:')}`);
+        log(`Google Certificate Hash (SHA-1):    ${googleHash}`);
+        log(`Google Certificate Hash (SHA-256):  ${googleHash256}`);
+        log(`Facebook Key Hash:                  ${fbHash}`);
       } catch (err) {
         if (err.code === 'ENOENT') {
           log.warn('Are you sure you have keytool installed?');


### PR DESCRIPTION
In order to use universal links on Android the SHA-256 hash is needed (see https://docs.branch.io/pages/deep-linking/android-app-links/).