### PR TITLE
[expo-cli][traveling-fastlane] ask for 2fa code only once

### DIFF
--- a/packages/traveling-fastlane/Gemfile
+++ b/packages/traveling-fastlane/Gemfile
@@ -8,7 +8,7 @@ source 'https://rubygems.org'
 gem 'unf_ext', '0.0.6'
 gem 'json', '1.8.2'
 # Plain, non-native dependencies
-gem 'fastlane', '2.108.0'
+gem 'fastlane', '2.109.1'
 
 group :development do
   gem 'rake'

--- a/packages/traveling-fastlane/Gemfile.lock
+++ b/packages/traveling-fastlane/Gemfile.lock
@@ -18,15 +18,15 @@ GEM
     dotenv (2.5.0)
     emoji_regex (0.1.1)
     excon (0.62.0)
-    faraday (0.15.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)
       http-cookie (~> 1.0.0)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.4)
-    fastlane (2.108.0)
+    fastimage (2.1.5)
+    fastlane (2.109.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -120,8 +120,8 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     tty-cursor (0.6.0)
     tty-screen (0.6.5)
-    tty-spinner (0.8.0)
-      tty-cursor (>= 0.5.0)
+    tty-spinner (0.9.0)
+      tty-cursor (~> 0.6.0)
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
@@ -143,7 +143,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.108.0)
+  fastlane (= 2.109.1)
   json (= 1.8.2)
   rake
   unf_ext (= 0.0.6)


### PR DESCRIPTION
Fixes https://forums.expo.io/t/cant-build-ios/16684
TLDR: when a user has 2FA enabled, we should use the session produced by fastlane to make further requests to Apple servers.