### PR TITLE
[xdl] Remove expo-payments-stripe from default universal modules

### DIFF
--- a/packages/xdl/src/modules/config.js
+++ b/packages/xdl/src/modules/config.js
@@ -269,6 +269,7 @@ const expoSdkUniversalModules = [
     podName: 'EXPaymentsStripe',
     libName: 'expo-payments-stripe',
     sdkVersions: '>=30.0.0',
+    detachable: false,
     config: {
       ios: {
         includeInExpoClient: false,


### PR DESCRIPTION
Will fix https://forums.expo.io/t/rejected-from-app-store-for-stripe-payments-integration-but-i-dont-use-stripe/16837, https://forums.expo.io/t/apple-app-transfer-rejected-passbook-integration-api/16908.