### PR TITLE
[expo-cli] fix generating certificates for windows users with spaces …

### DIFF
--- a/packages/expo-cli/src/commands/build/auth.js
+++ b/packages/expo-cli/src/commands/build/auth.js
@@ -331,7 +331,7 @@ async function spawnAndCollectJSONOutputAsync(program, args) {
       try {
         if (process.platform === 'win32') {
           prgm = WSL_BASH;
-          cmd = ['-c', `${WSL_ONLY_PATH} /mnt/c${windowsToWSLPath(program)} "${args.join(' ')}"`];
+          cmd = ['-c', `${WSL_ONLY_PATH} "/mnt/c${windowsToWSLPath(program)}" "${args.join(' ')}"`];
           if (DEBUG) {
             log.warn(`Running: bash.exe ${cmd.join(' ')}`);
           }


### PR DESCRIPTION
…in username

Fixes #260