### PR TITLE
[expo-cli] Display warning about OTA only if user had ever build that…

### DIFF
--- a/packages/expo-cli/src/commands/publish.js
+++ b/packages/expo-cli/src/commands/publish.js
@@ -58,7 +58,11 @@ export async function action(projectDir: string, options: Options = {}) {
     sdkVersion,
   });
 
-  if (!buildStatus.userHasBuiltAppBefore && !options.duringBuild) {
+  if (
+    buildStatus.userHasBuiltExperienceBefore &&
+    !buildStatus.userHasBuiltAppBefore &&
+    !options.duringBuild
+  ) {
     log.warn(
       'We noticed you did not build a standalone app with this SDK version and release channel before. ' +
         'Remember that OTA updates will not work with the app built with different SDK version and/or release channel. ' +


### PR DESCRIPTION
… app with Expo builders

Uses universe#3345 to validate if showing warning is reasonable.