### PR TITLE
[expo-xli][xdl][Android] Splash screen standalone app fixes

### DIFF
--- a/packages/expo-cli/src/commands/build/AndroidBuilder.js
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.js
@@ -5,7 +5,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import untildify from 'untildify';
-import { Exp, Credentials } from 'xdl';
+import { Android, Credentials, Exp } from 'xdl';
 import chalk from 'chalk';
 
 import log from '../../log';
@@ -21,6 +21,10 @@ export default class AndroidBuilder extends BaseBuilder {
     const buildOptions = options.publicUrl ? { publicUrl: options.publicUrl } : {};
     // Validate project
     const sdkVersion = await this.validateProject(buildOptions);
+
+    // Check SplashScreen images sizes
+    await Android.checkSplashScreenImages(this.projectDir);
+
     // Check the status of any current builds
     await this.checkForBuildInProgress({
       platform: ANDROID,

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -70,6 +70,7 @@
     "p-timeout": "2.0.1",
     "pacote": "9.2.3",
     "plist": "2.1.0",
+    "probe-image-size": "^4.0.0",
     "querystring": "0.2.0",
     "raven": "2.6.3",
     "read-chunk": "2.1.0",

--- a/packages/xdl/src/detach/AndroidIcons.js
+++ b/packages/xdl/src/detach/AndroidIcons.js
@@ -12,7 +12,7 @@ import {
   spawnAsyncThrowError,
 } from './ExponentTools';
 import StandaloneContext from './StandaloneContext';
-import { getImageDimensionsMacOSAsync, resizeImageAsync } from '../tools/ImageUtils';
+import { resizeImageAsync, getImageDimensionsAsync } from '../tools/ImageUtils';
 
 const iconScales = {
   mdpi: 1,
@@ -93,19 +93,15 @@ async function _resizeIconsAsync(
       }
 
       // reject non-square icons
-      const dims = await getImageDimensionsMacOSAsync(destinationPath, filename);
-      if (!dims || dims.length < 2 || dims[0] !== dims[1]) {
-        if (!dims) {
-          // Again, only throw this error on Turtle -- we expect that this will fail
-          // for some detach users but we don't want this to stop the whole process.
-          if (!isDetached) {
-            throw new Error(`Unable to read the dimensions of ${filename}`);
-          }
-        } else {
-          throw new Error(
-            `Android icons must be square, the dimensions of ${filename} are ${dims}`
-          );
+      const dims = await getImageDimensionsAsync(destinationPath, filename);
+      if (!dims) {
+        // Again, only throw this error on Turtle -- we expect that this will fail
+        // for some detach users but we don't want this to stop the whole process.
+        if (!isDetached) {
+          throw new Error(`Unable to read the dimensions of ${filename}`);
         }
+      } else if (dims.width !== dims.height) {
+        throw new Error(`Android icons must be square, the dimensions of ${filename} are ${dims}`);
       }
     })
   );

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -152,8 +152,8 @@ function backgroundImagesForApp(shellPath, manifest, isDetached) {
   // ]
   let basePath = path.join(shellPath, 'app', 'src', 'main', 'res');
   if (_.get(manifest, 'android.splash')) {
-    var splash = _.get(manifest, 'android.splash');
-    return _.reduce(
+    const splash = _.get(manifest, 'android.splash');
+    const results = _.reduce(
       imageKeys,
       function(acc, imageKey) {
         let url = getRemoteOrLocalUrl(splash, imageKey, isDetached);
@@ -168,6 +168,11 @@ function backgroundImagesForApp(shellPath, manifest, isDetached) {
       },
       []
     );
+
+    // No splash screen images declared in 'android.splash' configuration, proceed to general one
+    if (results.length !== 0) {
+      return results;
+    }
   }
 
   let url = getRemoteOrLocalUrl(manifest, 'splash.image', isDetached);
@@ -175,7 +180,7 @@ function backgroundImagesForApp(shellPath, manifest, isDetached) {
     return [
       {
         url,
-        path: path.join(basePath, 'drawable-xxxhdpi', 'shell_launch_background_image.png'),
+        path: path.join(basePath, 'drawable-mdpi', 'shell_launch_background_image.png'),
       },
     ];
   }

--- a/packages/xdl/src/detach/IosIcons.js
+++ b/packages/xdl/src/detach/IosIcons.js
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { saveImageToPathAsync, saveUrlToPathAsync, spawnAsyncThrowError } from './ExponentTools';
 import StandaloneContext from './StandaloneContext';
-import { getImageDimensionsMacOSAsync, resizeImageAsync } from '../tools/ImageUtils';
+import { getImageDimensionsAsync, resizeImageAsync } from '../tools/ImageUtils';
 import logger from './Logger';
 
 function _getAppleIconQualifier(iconSize: number, iconResolution: number): string {
@@ -122,15 +122,13 @@ async function createAndWriteIconsToPathAsync(
           }
 
           // reject non-square icons (because Apple will if we don't)
-          const dims = await getImageDimensionsMacOSAsync(destinationIconPath, iconFilename);
-          if (!dims || dims.length < 2 || dims[0] !== dims[1]) {
-            if (!dims) {
-              throw new Error(`Unable to read the dimensions of ${iconFilename}`);
-            } else {
-              throw new Error(
-                `iOS icons must be square, the dimensions of ${iconFilename} are ${dims}`
-              );
-            }
+          const dims = await getImageDimensionsAsync(destinationIconPath, iconFilename);
+          if (!dims) {
+            throw new Error(`Unable to read the dimensions of ${iconFilename}`);
+          } else if (dims.width !== dims.height) {
+            throw new Error(
+              `iOS icons must be square, the dimensions of ${iconFilename} are ${dims}`
+            );
           }
 
           if (!usesDefault) {

--- a/packages/xdl/src/tools/ImageUtils.js
+++ b/packages/xdl/src/tools/ImageUtils.js
@@ -63,36 +63,6 @@ async function _resizeImageWithSipsAsync(
   });
 }
 
-/**
- * Legacy function using `sip` command available on MacOS
- * We're using `probe-imgae-size` nodeJS package
- */
-async function _getImageDimensionsWithSipsAsync(
-  dirname: string,
-  basename: string
-): Promise<Array<number>> {
-  if (process.platform !== 'darwin') {
-    logger.warn('`sips` utility may or may not work outside of macOS');
-  }
-  let childProcess = await spawnAsyncThrowError(
-    'sips',
-    ['-g', 'pixelWidth', '-g', 'pixelHeight', basename],
-    {
-      cwd: dirname,
-    }
-  );
-  // stdout looks something like 'pixelWidth: 1200\n pixelHeight: 800'
-  const components = childProcess.stdout.split(/(\s+)/);
-  const dimensions = components.map(c => parseInt(c, 10)).filter(n => !isNaN(n));
-  if (dimensions.length !== 2) {
-    return null;
-  }
-  return {
-    width: dimensions[0],
-    height: dimensions[1],
-  };
-}
-
 // Allow us to swap out the default implementations of image functions
 let _resizeImageAsync = _resizeImageWithSipsAsync;
 let _getImageDimensionsAsync = _getImageDimensionsWithImageProbeAsync;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4269,6 +4269,11 @@ deepmerge@^1.3.0:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
   integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
 
+deepmerge@^2.0.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 default-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-compare/-/default-compare-1.0.0.tgz#cb61131844ad84d84788fb68fd01681ca7781a2f"
@@ -10976,6 +10981,18 @@ probe-image-size@^3.1.0:
     next-tick "^1.0.0"
     stream-parser "~0.3.1"
 
+probe-image-size@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-4.0.0.tgz#d35b71759e834bcf580ea9f18ec8b9265c0977eb"
+  integrity sha512-nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==
+  dependencies:
+    any-promise "^1.3.0"
+    deepmerge "^2.0.1"
+    inherits "^2.0.3"
+    next-tick "^1.0.0"
+    request "^2.83.0"
+    stream-parser "~0.3.1"
+
 process-nextick-args@^1.0.7, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -11799,7 +11816,7 @@ request@2.85.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@2.88.0, request@^2.79.0, request@^2.81.0, request@^2.87.0:
+request@2.88.0, request@^2.79.0, request@^2.81.0, request@^2.83.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==


### PR DESCRIPTION
# Why

It fixes messed up `resizeMode` on standalone Android apps.
Moreover when no `mdpi` to `xxxhdpi` image is provided it copies `splash.image` to `mdpi` directory as baseline resolution (was copied to `xxxhdpi` previously).

# Test

- [x] Needs to be tested on turtles staging.