### PR TITLE
Allow using EXPO_CLI_PASSWORD env var for expo password

### DIFF
--- a/packages/expo-cli/src/accounts.js
+++ b/packages/expo-cli/src/accounts.js
@@ -90,10 +90,12 @@ export async function login(options: CommandOptions) {
     return _usernamePasswordAuth(options.username, options.password);
   } else if (options.username && options.password) {
     return _usernamePasswordAuth(options.username, options.password);
+  } else if (options.username && process.env.EXPO_CLI_PASSWORD) {
+    return _usernamePasswordAuth(options.username, process.env.EXPO_CLI_PASSWORD);
   } else {
     throw new CommandError(
       'NON_INTERACTIVE',
-      'Username and password not provided in non-interactive mode.'
+      "Username and password not provided in non-interactive mode. Set the EXPO_CLI_PASSWORD environment variable if you don't want to pass in passwords through the command line."
     );
   }
 }

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1653,6 +1653,7 @@ let blacklistedEnvironmentVariables = new Set([
   'EXPO_ANDROID_KEYSTORE_PASSWORD',
   'EXPO_IOS_DIST_P12_PASSWORD',
   'EXPO_IOS_PUSH_P12_PASSWORD',
+  'EXPO_CLI_PASSWORD',
 ]);
 
 function shouldExposeEnvironmentVariableInManifest(key) {


### PR DESCRIPTION
Fixes #126.

Usage:
Set environment variable `EXPO_CLI_PASSWORD` to expo password.
```bash
expo login --non-interactive -u username
```