### PR TITLE
Skip initial prompt on Build iOS app with bi --managed me | bi --managed expo

### DIFF
--- a/packages/expo-cli/src/commands/build.js
+++ b/packages/expo-cli/src/commands/build.js
@@ -14,6 +14,7 @@ export default (program: any) => {
   program
     .command('build:ios [project-dir]')
     .alias('bi')
+    .option('-m --managed <whoManges>', 'How would you like to upload your credentials: [expo|me].', /^(expo|me)$/i)
     .option('-c, --clear-credentials', 'Clear credentials stored on expo servers')
     .option(
       '--clear-app-credentials',

--- a/packages/expo-cli/src/commands/build/IOSBuilder.js
+++ b/packages/expo-cli/src/commands/build/IOSBuilder.js
@@ -639,7 +639,8 @@ See https://docs.expo.io/versions/latest/guides/building-standalone-apps.html`
         `Encrypted ${Object.keys(OBLIGATORY_CREDS_KEYS).join(', ')} and saved to expo servers`
       );
     } else if (clientHasAllNeededCreds === false) {
-      const strategy = await prompt(runAsExpertQuestion);
+      const { whoManges } = this.options;
+      const strategy = whoManges?{isExpoManaged:whoManges=="expo"}:await prompt(runAsExpertQuestion);
       const isEnterprise = this.options.appleEnterpriseAccount !== undefined;
       credsStarter.enterpriseAccount = isEnterprise ? 'true' : 'false';
       const { appleCredentials, team } = await this._validateCredsEnsureAppExists(


### PR DESCRIPTION
if run
expo bi --managed me
or
expo bi -m expo

then the initial prompt will be skipped when building ios app