### PR TITLE
[xdl] fix expo eject

### DIFF
--- a/packages/xdl/src/detach/installPackagesAsync.js
+++ b/packages/xdl/src/detach/installPackagesAsync.js
@@ -25,8 +25,12 @@ export default async function installPackagesAsync(
     const packageLockJsonExists: boolean = await fs.pathExists(
       path.join(projectDir, 'package-lock.json')
     );
-    const yarnExists = await commandExists('yarnpkg');
-    packageManager = yarnExists && !packageLockJsonExists ? 'yarn' : 'npm';
+    try {
+      await commandExists('yarnpkg');
+      packageManager = !packageLockJsonExists ? 'yarn' : 'npm';
+    } catch (err) {
+      // yarnpkg doesn't exist, we're going to use npm
+    }
   }
 
   if (packageManager == 'yarn') {


### PR DESCRIPTION
Fixes #336
This fixes `expo eject` if a user doesn't have `yarn` installed.
`command-exists` is a stupid library which throws `null` when the command doesn't exist.