### PR TITLE
[xdl] Fix Yarn existence check throwing null

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -38,7 +38,6 @@
     "analytics-node": "^2.1.0",
     "axios": "v0.19.0-beta.1",
     "chalk": "2.4.1",
-    "command-exists": "1.2.7",
     "concat-stream": "1.6.2",
     "decache": "4.4.0",
     "delay-async": "1.1.0",

--- a/packages/xdl/src/detach/installPackagesAsync.js
+++ b/packages/xdl/src/detach/installPackagesAsync.js
@@ -1,9 +1,9 @@
 // @flow
 
 import spawnAsync from '@expo/spawn-async';
-import commandExists from 'command-exists';
 import fs from 'fs-extra';
 import path from 'path';
+import semver from 'semver';
 
 import logger from './Logger';
 
@@ -25,7 +25,7 @@ export default async function installPackagesAsync(
     const packageLockJsonExists: boolean = await fs.pathExists(
       path.join(projectDir, 'package-lock.json')
     );
-    const yarnExists = await commandExists('yarnpkg');
+    const yarnExists = await yarnExistsAsync();
     packageManager = yarnExists && !packageLockJsonExists ? 'yarn' : 'npm';
   }
 
@@ -47,5 +47,14 @@ export default async function installPackagesAsync(
       cwd: projectDir,
       stdio: 'inherit',
     });
+  }
+}
+
+async function yarnExistsAsync() {
+  try {
+    let version = (await spawnAsync('yarnpkg', ['--version'])).stdout.trim();
+    return !!semver.valid(version);
+  } catch (e) {
+    return false;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,11 +3631,6 @@ combined-stream@1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-command-exists@1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.7.tgz#16828f0c3ff2b0c58805861ef211b64fc15692a8"
-  integrity sha512-doWDvhXCcW5LK0cIUWrOQ8oMFXJv3lEQCkJpGVjM8v9SV0uhqYXB943538tEA2CiaWqSyuYUGAm5ezDwEx9xlw==
-
 commander@2.17.1, commander@^2.11.0, commander@^2.9.0:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"


### PR DESCRIPTION
Fixes `expo eject` crashing if Yarn is not installed.

Fixes #336. Closes #340.