### PR TITLE
[expo-cli] Only verify the app exists if credentials are created in expo build:ios

### DIFF
--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.js
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.js
@@ -26,11 +26,11 @@ class IOSBuilder extends BaseBuilder {
     await this.scheduleBuild(publishedExpIds, projectMetadata.bundleIdentifier);
   }
 
-  async getAppleCtx({ bundleIdentifier, username }) {
+  async getAppleCtx({ bundleIdentifier, username, experienceName }) {
     if (!this.appleCtx) {
       await apple.setup();
       const authData = await apple.authenticate(this.options);
-      this.appleCtx = { ...authData, bundleIdentifier, username };
+      this.appleCtx = { ...authData, bundleIdentifier, username, experienceName };
     }
     return this.appleCtx;
   }
@@ -132,8 +132,6 @@ class IOSBuilder extends BaseBuilder {
         projectMetadata
       );
     }
-
-    await apple.ensureAppExists(appleCtx, projectMetadata.experienceName);
 
     const {
       userCredentialsIds,

--- a/packages/expo-cli/src/commands/build/ios/appleApi/ensureAppExists.js
+++ b/packages/expo-cli/src/commands/build/ios/appleApi/ensureAppExists.js
@@ -2,8 +2,8 @@ import ora from 'ora';
 
 import { runAction, travelingFastlane } from './fastlane';
 
-export default async function ensureAppExists(appleCtx, experienceName) {
-  const { appleId, appleIdPassword, team, bundleIdentifier } = appleCtx;
+export default async function ensureAppExists(appleCtx) {
+  const { appleId, appleIdPassword, team, bundleIdentifier, experienceName } = appleCtx;
   const spinner = ora(`Ensuring App ID exists on Apple Developer Portal...`).start();
   try {
     await runAction(travelingFastlane.ensureAppExists, [

--- a/packages/expo-cli/src/commands/build/ios/credentials/generate.js
+++ b/packages/expo-cli/src/commands/build/ios/credentials/generate.js
@@ -11,6 +11,8 @@ async function generate(appleCtx, credentialsToGenerate, metadata) {
     return {};
   }
 
+  await apple.ensureAppExists(appleCtx);
+
   log(`We're going to generate:`);
   credentialsToGenerate.forEach(type => {
     log(`- ${constants.CREDENTIALS[type].name}`);


### PR DESCRIPTION
If there are no new credentials that need to be created and added , do not check if the app exists in the Apple portal. This makes it possible to build an app with existing credentials or credentials you upload, without the Apple ID that the app is linked to.

*Test plan*

Built a brand new app with `expo build:ios`, choosing " Expo handles all credentials, you can still provide overrides", the App ID was ensured before creating the credentials:
```
✔ Ensured App ID exists on Apple Developer Portal!
[12:22:17] We're going to generate:
[12:22:17] - Apple Distribution Certificate
[12:22:17] - Apple Push Notifications service key
[12:22:17] - Apple Provisioning Profile
✔ Generated Apple Distribution Certificate
✔ Generated Apple Push Notifications service key
✔ Generated Apple Provisioning Profile
```
The app was built successfully.

Built the app again, and made sure this time there was no `Ensured App ID exists on Apple Developer Portal!` printed in the console.