### PR TITLE
Fix non-interactive init command

### DIFF
--- a/packages/expo-cli/src/commands/init.js
+++ b/packages/expo-cli/src/commands/init.js
@@ -346,18 +346,20 @@ function validateAndroidPackage(value) {
   if (!isString(value) || value === '') {
     return 'Android package identifier must not be empty.';
   }
-  return /^[a-zA-Z][a-zA-Z0-9\_]*(\.[a-zA-Z][a-zA-Z0-9\_]*)+$/.test(value)
-    ? true
-    : "Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter.";
+  return (
+    /^[a-zA-Z][a-zA-Z0-9\_]*(\.[a-zA-Z][a-zA-Z0-9\_]*)+$/.test(value) ||
+    "Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter."
+  );
 }
 
 function validateIosBundleIdentifier(value) {
   if (!isString(value) || value === '') {
     return 'iOS bundle identifier must not be empty.';
   }
-  return /^[a-zA-Z][a-zA-Z0-9\-\.]+$/.test(value)
-    ? true
-    : "Must start with a letter and only alphanumeric characters, '.' and '-' are allowed.";
+  return (
+    /^[a-zA-Z][a-zA-Z0-9\-\.]+$/.test(value) ||
+    "Must start with a letter and only alphanumeric characters, '.' and '-' are allowed."
+  );
 }
 
 export default program => {

--- a/packages/expo-cli/src/exp.js
+++ b/packages/expo-cli/src/exp.js
@@ -34,7 +34,6 @@ import { loginOrRegisterIfLoggedOut } from './accounts';
 import log from './log';
 import update from './update';
 import urlOpts from './urlOpts';
-import addCommonOptions from './commonOptions';
 import packageJSON from '../package.json';
 
 // The following prototyped functions are not used here, but within in each file found in `./commands`
@@ -52,7 +51,6 @@ Command.prototype.allowOffline = function() {
 // asyncAction is a wrapper for all commands/actions to be executed after commander is done
 // parsing the command input
 Command.prototype.asyncAction = function(asyncFn, skipUpdateCheck) {
-  addCommonOptions(this);
   return this.action(async (...args) => {
     if (!skipUpdateCheck) {
       try {
@@ -107,6 +105,7 @@ Command.prototype.asyncAction = function(asyncFn, skipUpdateCheck) {
 // - Checks if the project directory is valid or not
 // - Runs AsyncAction with the projectDir as an argument
 Command.prototype.asyncActionProjectDir = function(asyncFn, skipProjectValidation, skipAuthCheck) {
+  this.option('--config [file]', 'Specify a path to app.json');
   return this.asyncAction(async (projectDir, ...args) => {
     const opts = args[0];
 

--- a/packages/expo-cli/src/prompt.js
+++ b/packages/expo-cli/src/prompt.js
@@ -5,7 +5,7 @@ import CommandError from './CommandError';
 
 export default function prompt(questions, { nonInteractiveHelp } = {}) {
   if (program.nonInteractive && questions.length !== 0) {
-    let message = `Input is required, but ${program.name} is in non-interactive mode.\n`;
+    let message = `Input is required, but Expo CLI is in non-interactive mode.\n`;
     if (nonInteractiveHelp) {
       message += nonInteractiveHelp;
     } else {


### PR DESCRIPTION
Allow all options to `init` to be passed as command line flags to enable using `init` in non-interactive mode. Fixes #332 and #342.

**Test plan**

Verified that mandatory arguments are checked in non-interactive mode:
<img width="1546" alt="screenshot 2019-02-06 at 21 37 30" src="https://user-images.githubusercontent.com/497214/52369388-46cff300-2a59-11e9-8ff3-0ea7be35f556.png">

Verified that `--ios-bundle-identifier` is validated:
<img width="1546" alt="screenshot 2019-02-06 at 21 52 32" src="https://user-images.githubusercontent.com/497214/52369544-a0382200-2a59-11e9-8a6a-02e1f2b2f1c9.png">

Verified that `--android-package` is validated:
<img width="1546" alt="screenshot 2019-02-06 at 21 53 28" src="https://user-images.githubusercontent.com/497214/52369557-a7f7c680-2a59-11e9-9f75-517934051edc.png">
