### PR TITLE
[xdl] adjust configureAndCopyArchiveAsync to Expo Client builds

### DIFF
--- a/packages/traveling-fastlane/Rakefile
+++ b/packages/traveling-fastlane/Rakefile
@@ -14,6 +14,7 @@ SCRIPTS = [
   'app_produce',
   'authenticate',
   'ensure_app_exists',
+  'manage_ad_hoc_provisioning_profile',
   'manage_dist_certs',
   'manage_provisioning_profiles',
   'manage_push_keys',

--- a/packages/traveling-fastlane/actions/funcs.rb
+++ b/packages/traveling-fastlane/actions/funcs.rb
@@ -7,6 +7,14 @@ ensure
   $stderr = old_stderr
 end
 
+def with_captured_output
+  old_stdout, old_stderr = $stdout, $stderr
+  $stdout, $stderr = StringIO.new, StringIO.new
+  yield
+ensure
+  $stdout, $stderr = old_stdout, old_stderr
+end
+
 def dump_error(e)
   { type: e.class.to_s, message: e.message, backtrace: e.backtrace }
 end

--- a/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
+++ b/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
@@ -1,0 +1,140 @@
+require 'spaceship'
+require 'json'
+require 'base64'
+require 'set'
+require_relative 'funcs'
+
+ENV['SPACESHIP_AVOID_XCODE_API'] = '1'
+
+$teamId, $udidsString, $bundleId, $certSerialNumber = ARGV
+$udids = $udidsString.split(',')
+
+$result = nil
+
+def find_dist_cert(serialNumber, isEnterprise)
+  certs = if isEnterprise == 'true'
+    Spaceship::Portal.certificate.in_house.all
+  else
+    Spaceship::Portal.certificate.production.all
+  end
+
+  if $certSerialNumber == '__last__'
+    certs.last
+  else
+    certs.find do |c|
+      c.raw_data['serialNum'] == $certSerialNumber
+    end
+  end
+end
+
+def register_missing_devices(udids)
+  all_iphones = Spaceship.device.all_iphones
+  already_added = all_iphones.select { |d| d.enabled? and udids.include?(d.udid) }
+  already_added_udids = already_added.map { |i| i.udid }
+
+  devices = [*already_added]
+
+  udids_to_add = udids - already_added_udids
+  udids_to_add.each { |udid|
+    devices.push Spaceship.device.create!(name: "iPhone (added by Expo)", udid: udid)
+  }
+
+  devices
+end
+
+def find_profile_by_bundle_id(bundle_id)
+  Spaceship::Portal.provisioning_profile.ad_hoc.find_by_bundle_id(bundle_id: bundle_id).first
+end
+
+def download_provisioning_profile(profile)
+  profile_content = profile.download
+  {
+    id: profile.id,
+    content: Base64.encode64(profile_content),
+  }
+end
+
+def in_house?(team_id)
+  team = Spaceship::Portal.client.teams.find { |t| t['teamId'] == team_id }
+  team['type'] === 'In-House'
+end
+
+with_captured_output{
+  begin
+    # Spaceship::Portal doesn't seem to have a method for initializing portal client
+    # without supplying Apple ID username/password (or i didn't find one). Fortunately,
+    # we can pass here whatever we like, as long as we set FASTLANE_SESSION env variable.
+    Spaceship::Portal.login('fake-login', 'fake-password')
+    Spaceship::Portal.client.team_id = $teamId
+
+    # Then we register all missing devices on the Apple Developer Portal. They are identified by UDIDs.
+    devices = register_missing_devices($udids)
+
+    # Then we try to find an already existing provisioning profile for the App ID.
+    existing_profile = find_profile_by_bundle_id($bundleId)
+    if existing_profile
+      # We need to verify whether the existing profile includes all user's devices.
+      device_udids_in_profile = Set.new(existing_profile.devices.map { |d| d.udid })
+      all_device_udids = Set.new($udids)
+      if device_udids_in_profile == all_device_udids and existing_profile.valid?
+        $result = { result: 'success' }
+      else
+        # We need to add new devices to the list and create a new provisioning profile.
+        existing_profile.devices = devices
+        existing_profile.update!
+
+        updated_profile = find_profile_by_bundle_id($bundleId)
+        profile = download_provisioning_profile(updated_profile)
+        $result = {
+          result: 'success',
+          provisioningProfileId: profile[:id],
+          provisioningProfile: Base64.encode64(profile[:content]),
+        }
+      end
+    else
+      # We need to find user's distribution certificate to make a provisioning profile for it.
+      dist_cert = find_dist_cert($certSerialNumber, in_house?($teamId))
+
+      if dist_cert == nil
+        # If the distribution certificate doesn't exist, the user must have deleted it, we can't do anything here :(
+        $result = {
+          result: 'failure',
+          reason: 'No distribution certificate available to make provisioning profile against',
+        }
+      else
+        # If the provisioning profile for the App ID doesn't exist, we just need to create a new one!
+        new_profile = Spaceship::Portal.provisioning_profile.ad_hoc.create!(
+          bundle_id: $bundleId,
+          certificate: dist_cert,
+          devices: devices
+        )
+        profile = download_provisioning_profile(new_profile)
+        $result = {
+          result: 'success',
+          provisioningProfileId: profile[:id],
+          provisioningProfile: Base64.encode64(profile[:content]),
+        }
+      end
+    end
+  rescue Spaceship::Client::UnexpectedResponse => e
+    $result = {
+      result: 'failure',
+      reason: 'Unexpected response',
+      rawDump: e.error_info || dump_error(e)
+    }
+  rescue Spaceship::Client::InvalidUserCredentialsError => e
+    $result = {
+      result: 'failure',
+      type: 'session-expired',
+      reason: 'Apple Session expired',
+    }
+  rescue Exception => e
+    $result = {
+      result: 'failure',
+      reason: 'Unknown reason',
+      rawDump: dump_error(e)
+    }
+  end
+}
+
+$stderr.puts JSON.generate($result)

--- a/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
+++ b/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
@@ -88,7 +88,7 @@ with_captured_output{
         $result = {
           result: 'success',
           provisioningProfileId: profile[:id],
-          provisioningProfile: Base64.encode64(profile[:content]),
+          provisioningProfile: profile[:content],
         }
       end
     else
@@ -112,7 +112,7 @@ with_captured_output{
         $result = {
           result: 'success',
           provisioningProfileId: profile[:id],
-          provisioningProfile: Base64.encode64(profile[:content]),
+          provisioningProfile: profile[:content],
         }
       end
     end

--- a/packages/traveling-fastlane/publishing/darwin/index.js
+++ b/packages/traveling-fastlane/publishing/darwin/index.js
@@ -10,6 +10,7 @@ module.exports = () => {
   return {
     authenticate: p('authenticate'),
     ensureAppExists: p('ensure_app_exists'),
+    manageAdHocProvisioningProfile: p('manage_ad_hoc_provisioning_profile'),
     manageDistCerts: p('manage_dist_certs'),
     managePushKeys: p('manage_push_keys'),
     manageProvisioningProfiles: p('manage_provisioning_profiles'),

--- a/packages/traveling-fastlane/publishing/linux/index.js
+++ b/packages/traveling-fastlane/publishing/linux/index.js
@@ -10,6 +10,7 @@ module.exports = () => {
   return {
     authenticate: p('authenticate'),
     ensureAppExists: p('ensure_app_exists'),
+    manageAdHocProvisioningProfile: p('manage_ad_hoc_provisioning_profile'),
     manageDistCerts: p('manage_dist_certs'),
     managePushKeys: p('manage_push_keys'),
     manageProvisioningProfiles: p('manage_provisioning_profiles'),

--- a/packages/traveling-fastlane/wrappers/manage_ad_hoc_provisioning_profile_wrapper.sh
+++ b/packages/traveling-fastlane/wrappers/manage_ad_hoc_provisioning_profile_wrapper.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+# Figure out where this script is located.
+SELFDIR="`dirname \"$0\"`"
+SELFDIR="`cd \"$SELFDIR\" && pwd`"
+
+export BUNDLE_GEMFILE="$SELFDIR/lib/vendor/Gemfile"
+unset BUNDLE_IGNORE_CONFIG
+
+export FASTLANE_DISABLE_COLORS=1
+export FASTLANE_SKIP_UPDATE_CHECK=1
+export FASTLANE_DISABLE_ANIMATION=1
+
+script="$SELFDIR/lib/app/manage_ad_hoc_provisioning_profile.rb"
+
+lib_loc="$SELFDIR/lib/app"
+
+exec "$SELFDIR/lib/ruby/bin/ruby" -W0 -I"$lib_loc" -rpreload "$script" "$@"

--- a/packages/xdl/src/detach/IosIPABuilder.js
+++ b/packages/xdl/src/detach/IosIPABuilder.js
@@ -11,14 +11,7 @@ import * as IosCodeSigning from './IosCodeSigning';
 const logger = _logger.withFields({ buildPhase: 'building and signing IPA' });
 
 export default function createIPABuilder(buildParams) {
-  const { appUUID, keychainPath, bundleIdentifier, teamID, workingDir, manifest } = buildParams;
-  const workspace = path.join(
-    workingDir,
-    'shellAppWorkspaces',
-    'ios',
-    'default',
-    'ExpoKitApp.xcworkspace'
-  );
+  const { appUUID, keychainPath, bundleIdentifier, teamID, manifest, workspacePath } = buildParams;
   const appDir = path.join('/private/tmp/turtle', appUUID);
   const buildDir = path.join(appDir, 'build');
   const provisionDir = path.join(appDir, 'provisioning');
@@ -63,7 +56,7 @@ export default function createIPABuilder(buildParams) {
       const unsignedIpaPath = path.join(buildDir, `${appUUID}-unsigned.ipa`);
       const ipaBuilderArgs = {
         ipaPath: unsignedIpaPath,
-        workspace,
+        workspacePath,
         archivePath: outputPath,
         codeSignIdentity,
         exportOptionsPlistPath,

--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import invariant from 'invariant';
 import path from 'path';
 import rimraf from 'rimraf';
+import get from 'lodash/get';
 
 import Api from '../Api';
 import {
@@ -342,7 +343,10 @@ function getPaths(context: StandaloneContext) {
   let projectName;
   let supportingDirectory;
   let intermediatesDirectory;
-  if (context.isAnonymous()) {
+
+  if (context.build.isExpoClientBuild()) {
+    projectName = 'Exponent';
+  } else if (context.isAnonymous()) {
     projectName = 'ExpoKitApp';
   } else if (context.config && context.config.name) {
     let projectNameLabel = context.config.name;
@@ -366,7 +370,10 @@ function getPaths(context: StandaloneContext) {
   }
   // sandbox intermediates directory by workspace so that concurrently operating
   // contexts do not interfere with one another.
-  intermediatesDirectory = path.join(iosProjectDirectory, 'ExpoKitIntermediates');
+  intermediatesDirectory = path.join(
+    iosProjectDirectory,
+    context.build.isExpoClientBuild() ? 'ExponentIntermediates' : 'ExpoKitIntermediates'
+  );
   return {
     intermediatesDirectory,
     iosProjectDirectory,

--- a/packages/xdl/src/detach/StandaloneBuildFlags.js
+++ b/packages/xdl/src/detach/StandaloneBuildFlags.js
@@ -1,3 +1,5 @@
+import get from 'lodash/get';
+
 /**
  *  @flow
  *
@@ -26,6 +28,7 @@ class StandaloneBuildFlags {
   static createEmpty = () => {
     let flags = new StandaloneBuildFlags();
     flags.configuration = 'Debug';
+    flags.isExpoClientBuild = () => false;
     return flags;
   };
 
@@ -36,6 +39,7 @@ class StandaloneBuildFlags {
     let flags = new StandaloneBuildFlags();
     flags.configuration = configuration;
     flags.ios = ios;
+    flags.isExpoClientBuild = () => get(ios, 'buildType') === 'client';
     return flags;
   };
 
@@ -46,6 +50,7 @@ class StandaloneBuildFlags {
     let flags = new StandaloneBuildFlags();
     flags.configuration = configuration;
     flags.android = android;
+    flags.isExpoClientBuild = () => false;
     return flags;
   };
 }


### PR DESCRIPTION
Adds support for configuring Expo Client shell app and signing it with an ad-hoc provisioning profile.