### PR TITLE
[expo-cli] Remove timestamp from logs except in non-interactive mode

### DIFF
--- a/packages/expo-cli/src/log.js
+++ b/packages/expo-cli/src/log.js
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import program from 'commander';
 
 let _bundleProgressBar;
 let _oraSpinner;
@@ -69,11 +70,19 @@ function getPrefix(chalkColor) {
 }
 
 function withPrefixAndTextColor(args, chalkColor = chalk.gray) {
-  return [getPrefix(chalkColor), ...args.map(arg => chalkColor(arg))];
+  if (program.nonInteractive) {
+    return [getPrefix(chalkColor), ...args.map(arg => chalkColor(arg))];
+  } else {
+    return args.map(arg => chalkColor(arg));
+  }
 }
 
 function withPrefix(args, chalkColor = chalk.gray) {
-  return [getPrefix(chalkColor), ...args];
+  if (program.nonInteractive) {
+    return [getPrefix(chalkColor), ...args];
+  } else {
+    return args;
+  }
 }
 
 function log(...args) {


### PR DESCRIPTION
The timestamp is useful for CI, build scripts and such, but I don't see much point for it when using Expo CLI interactively in the console. It also takes a lot of precious screen real estate. Some output already doesn't show it, by using the `log.nested()` to log without a timestamp.

This PR removes the timestamp from Expo CLI output except when it's used with the `--non-interactive` flag or in a non-interactive terminal.