### PR TITLE
[expo-cli] Remove the experimental workflow prompt from `expo init`

### DIFF
--- a/packages/expo-cli/src/commands/init.js
+++ b/packages/expo-cli/src/commands/init.js
@@ -95,7 +95,7 @@ async function action(projectDir, options) {
       );
     }
   } else {
-    workflow = await promptForWorkflowAsync();
+    workflow = 'managed';
   }
 
   let initialConfig = await promptForInitialConfig(parentDir, dirName, workflow, options);
@@ -193,46 +193,6 @@ async function shouldUseYarnAsync() {
   } catch (e) {
     return false;
   }
-}
-
-async function promptForWorkflowAsync() {
-  let answer = await prompt(
-    {
-      type: 'list',
-      name: 'workflow',
-      message: 'Choose which workflow to use:',
-      choices: [
-        {
-          value: 'managed',
-          name:
-            chalk.bold('managed') +
-            ' (default)' +
-            '\n' +
-            wordwrap(2, process.stdout.columns || 80)(
-              'Build your app with JavaScript with Expo APIs.'
-            ),
-          short: 'managed',
-        },
-
-        {
-          value: 'advanced',
-          name:
-            chalk.bold('advanced') +
-            ' (experimental 🚧)' +
-            '\n' +
-            wordwrap(2, process.stdout.columns || 80)(
-              'Build your app with JavaScript with Expo APIs and custom native modules.'
-            ),
-          short: 'advanced',
-        },
-      ],
-    },
-    {
-      nonInteractiveHelp:
-        '--workflow: argument is required in non-interactive mode. Valid choices are: managed, advanced.',
-    }
-  );
-  return answer.workflow;
 }
 
 async function promptForInitialConfig(parentDir, dirName, workflow, options) {
@@ -375,7 +335,7 @@ export default program => {
     )
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .option('--yarn', 'Use Yarn to install dependencies. (default when Yarn is installed)')
-    .option('--workflow [name]', 'The workflow to use. (managed or advanced)')
+    .option('--workflow [name]', 'The workflow to use. managed (default) or advanced')
     .option('--name [name]', 'The name of your app visible on the home screen.')
     .option('--android-package [name]', 'The package name for your Android app.')
     .option('--ios-bundle-identifier [name]', 'The bundle identifier for your iOS app.')


### PR DESCRIPTION
We previously added a prompt to `expo init` that allowed choosing between the `managed` (a regular Expo project) and `advanced` (an ExpoKit project) workflows.

The `advanced` workflow was marked as experimental, but it seems that people sometimes choose it by mistake, which results in confusing problems: https://forums.expo.io/t/really-stuggling-to-run-in-simultor/18743/2, https://github.com/expo/expo-cli/issues/338. Also once the current work on [universal modules](https://blog.expo.io/expokit-2019-1e5cb02106f8) is done, the upcoming `custom` workflow will likely be a better option for many use cases than the current `advanced` workflow.

This PR removes the experimental `advanced` workflow prompt from `expo init`. However, you can still initialize a project using the advanced workflow, if you pass the `--workflow advanced` flag to the command.