### PR TITLE
Add meaningful error messages for incorrect project names during ejection

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.js
+++ b/packages/expo-cli/src/commands/eject/Eject.js
@@ -123,7 +123,7 @@ export async function ejectAsync(projectRoot: string, options) {
             message: "What should your app appear as on a user's home screen?",
             default: name || exp.name,
             validate: s => {
-              return s.length > 0;
+              return s.length > 0 ? true : 'Your app display name cannot be empty.';
             },
           },
           {
@@ -131,7 +131,12 @@ export async function ejectAsync(projectRoot: string, options) {
             message: 'What should your Android Studio and Xcode projects be called?',
             default: pkgJson.name ? stripDashes(pkgJson.name) : undefined,
             validate: s => {
-              return s.length > 0 && s.indexOf('-') === -1 && s.indexOf(' ') === -1;
+              if (s.length === 0) {
+                return 'Your project name cannot be empty.';
+              } else if (s.indexOf('-') !== -1 || s.indexOf(' ') !== -1) {
+                return 'Your project name cannot contain any dash or whitespace.'
+              }
+              return true;
             },
           },
         ],


### PR DESCRIPTION
Hi, and first of all thanks for this project.

While trying to run `eject`, it took me a while to figure out why I was stuck at the "project name" step. It turned out I had a dash in the project name, which is not allowed, but there was no feedback to inform me.

This PR just adds string error messages in inquirer prompts, instead of `false` booleans, so that the user is informed of what's wrong.

![capture d ecran 2019-02-13 a 19 09 23](https://user-images.githubusercontent.com/5681392/52733894-2efdef00-2fc4-11e9-9164-64a675f8038d.png)

