### PR TITLE
Don't use a simple spinner when waiting for the build

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.js
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.js
@@ -6,6 +6,7 @@ import { Project, ProjectUtils, Exp, User } from 'xdl';
 import chalk from 'chalk';
 import fp from 'lodash/fp';
 import get from 'lodash/get';
+import ora from 'ora';
 import simpleSpinner from '@expo/simple-spinner';
 
 import * as UrlUtils from '../utils/url';
@@ -349,10 +350,10 @@ ${job.id}
     }
 
     if (this.options.wait) {
-      simpleSpinner.start();
+      let spinner = ora(`Waiting for build to finish...`).start();
       const waitOpts = publicUrl ? { publicUrl } : {};
       const completedJob = await this.wait(buildId, waitOpts);
-      simpleSpinner.stop();
+      spinner.stop();
       const artifactUrl = completedJob.artifactId
         ? UrlUtils.constructArtifactUrl(completedJob.artifactId)
         : completedJob.artifacts.url;

--- a/packages/expo-cli/src/commands/build/BaseBuilder.js
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.js
@@ -7,7 +7,6 @@ import chalk from 'chalk';
 import fp from 'lodash/fp';
 import get from 'lodash/get';
 import ora from 'ora';
-import simpleSpinner from '@expo/simple-spinner';
 
 import * as UrlUtils from '../utils/url';
 import log from '../../log';


### PR DESCRIPTION
The simple spinner can cause issues in basic terminals (e.g. CI terminals), in which it will create a new line per spinning tick. By using a more advanced spinner, we keep the spinner but avoid issues with these terminals.

Another approach could be to detect CI terminals and to disable the loader, but I think the ora spinner is cool, so why not use it here as well?