### PR TITLE
Show a note about eject when running `detach`

### DIFF
--- a/packages/expo-cli/src/exp.js
+++ b/packages/expo-cli/src/exp.js
@@ -377,9 +377,12 @@ function runAsync(programName) {
         }
       });
       if (!commands.includes(subCommand)) {
-        console.log(
+        log.warn(
           `"${subCommand}" is not an ${programName} command. See "${programName} --help" for the full list of commands.`
         );
+        if (subCommand === 'detach') {
+          log('To eject your project to ExpoKit (previously "detach"), use `expo eject`.');
+        }
       }
     } else {
       program.help();


### PR DESCRIPTION
exp (the predecessor of Expo CLI) had a command named `detach` that would eject your project to ExpoKit. In Expo CLI this functionality is a part of the `expo eject` (which lets you choose `ExpoKit` when ejecting).

This PR adds a more helpful error message when running the `detach` command that doesn't exist.

<img width="770" alt="screenshot 2019-02-18 at 12 32 23" src="https://user-images.githubusercontent.com/497214/52945171-ca52e380-3379-11e9-9a1d-e193170fb745.png">
