### PR TITLE
[xdl] switch to versions/latest and use ApiV2 client

### DIFF
--- a/packages/xdl/src/Api.js
+++ b/packages/xdl/src/Api.js
@@ -223,18 +223,6 @@ export default class ApiClient {
   static host: string = Config.api.host;
   static port: number = Config.api.port || 80;
 
-  static _versionCache = new Cacher(
-    () =>
-      ApiClient.callPathAsync('/--/api/v2/versions', null, null, {
-        headers: {
-          'Expo-Session': '',
-        },
-      }),
-    'versions.json',
-    0,
-    path.join(__dirname, '../caches/versions.json')
-  );
-
   static _schemaCaches = {};
 
   static async callMethodAsync(
@@ -264,10 +252,6 @@ export default class ApiClient {
     return _callMethodAsync(url, method, requestBody, requestOptions);
   }
 
-  static async versionsAsync() {
-    return await ApiClient._versionCache.getAsync();
-  }
-
   static async xdlSchemaAsync(sdkVersion) {
     if (!ApiClient._schemaCaches.hasOwnProperty(sdkVersion)) {
       ApiClient._schemaCaches[sdkVersion] = new Cacher(
@@ -281,16 +265,6 @@ export default class ApiClient {
     }
 
     return await ApiClient._schemaCaches[sdkVersion].getAsync();
-  }
-
-  static async sdkVersionsAsync() {
-    const { sdkVersions } = await ApiClient.versionsAsync();
-    return sdkVersions;
-  }
-
-  static async turtleSdkVersionsAsync() {
-    const { turtleSdkVersions } = await ApiClient.versionsAsync();
-    return turtleSdkVersions;
   }
 
   static async downloadAsync(url, outputPath, options = {}, progressFunction, retryFunction) {

--- a/packages/xdl/src/project/Doctor.js
+++ b/packages/xdl/src/project/Doctor.js
@@ -13,7 +13,6 @@ import Schemer, { SchemerError } from '@expo/schemer';
 
 import * as ExpSchema from './ExpSchema';
 import * as ProjectUtils from './ProjectUtils';
-import Api from '../Api';
 import * as Binaries from '../Binaries';
 import Config from '../Config';
 import * as Versions from '../Versions';
@@ -252,7 +251,7 @@ async function _validateExpJsonAsync(exp, pkg, projectRoot, allowNetwork): Promi
   }
   ProjectUtils.clearNotification(projectRoot, 'doctor-unversioned');
 
-  let sdkVersions = await Api.sdkVersionsAsync();
+  let sdkVersions = await Versions.sdkVersionsAsync();
   if (!sdkVersions) {
     ProjectUtils.logError(
       projectRoot,


### PR DESCRIPTION
blocked by https://github.com/expo/universe/pull/3431

Move to new `versions/latest` endpoint that correctly conforms to the APIv2 protocol (response body should be wrapped in a root level object under a `data` key if there are no errors), and use APIv2 to fetch versions. The current endpoint does not conform to the protocol and cannot be used with the APIv2 client even though it has `api/v2` in the url.