### PR TITLE
Fix typo templaceSpec->templateSpec

### DIFF
--- a/packages/expo-cli/src/commands/init.js
+++ b/packages/expo-cli/src/commands/init.js
@@ -78,7 +78,7 @@ async function action(projectDir, options) {
       (templateSpec.name === 'blank' ||
         templateSpec.name === 'tabs' ||
         templateSpec.name === 'bare-minimum' ||
-        templaceSpec.name === 'bare-foundation') &&
+        templateSpec.name === 'bare-foundation') &&
       templateSpec.registry
     ) {
       templateSpec.name = templateSpec.escapedName = `expo-template-${templateSpec.name}`;


### PR DESCRIPTION
Was unable to using custom template:
`expo init App --template expo-template-reason`
due to the typo.
detail:
```
ikewat λ EXPO_DEBUG=true expo init App --template expo-template-reason
templaceSpec is not defined
ReferenceError: templaceSpec is not defined
    at _callee$ (/expo-cli@2.11.6/src/commands/init.js:81:9)
...
...
...
```

After the fix, this script works fine.