### PR TITLE
Remove "SMS" from link-sending descriptions

### DIFF
--- a/packages/dev-tools/TESTING.md
+++ b/packages/dev-tools/TESTING.md
@@ -14,8 +14,8 @@
   - ✅ Should show a toast that says simulator is opening.
   - ✅ Should replace the toast with success toast when finished.
   - ✅ Should replace the toast with an error toast, if opening failed.
-* Open on a device by sending email/SMS
-  - ✅ Should validate that the recipient (number/address) is not empty.
+* Open on a device by sending email
+  - ✅ Should validate that the recipient (email address) is not empty.
   - ✅ Should show a toast and disable send button when sending.
   - ✅ Should replace the toast with a success toast when sent.
   - ✅ Should show an error if sending failed (e.g. machine not connected to internet).

--- a/packages/dev-tools/components/ProjectManager.js
+++ b/packages/dev-tools/components/ProjectManager.js
@@ -112,7 +112,7 @@ class ProjectManager extends React.Component {
       toast: {
         id: 'send-email-or-number',
         name: 'error',
-        text: `Please provide a valid email or phone number.`,
+        text: `Please provide a valid email address.`,
       },
     });
 

--- a/packages/dev-tools/components/ProjectManagerSidebarOptions.js
+++ b/packages/dev-tools/components/ProjectManagerSidebarOptions.js
@@ -123,7 +123,7 @@ export default class ProjectManagerSidebarOptions extends React.Component {
 
     const sendHeader = (
       <div className={STYLES_CONTENT_GROUP} onClick={this._handleSendHeaderClick}>
-        <span className={STYLES_CONTENT_GROUP_LEFT}>Send link with email/SMS…</span>
+        <span className={STYLES_CONTENT_GROUP_LEFT}>Send link with email…</span>
       </div>
     );
 
@@ -148,7 +148,7 @@ export default class ProjectManagerSidebarOptions extends React.Component {
 
         <ContentGroup header={sendHeader} isActive={this.state.isSendFormVisible}>
           <InputWithButton
-            placeholder="Enter email or number"
+            placeholder="Enter email address"
             value={this.props.recipient}
             onChange={this.props.onRecipientChange}
             onValidation={this.props.onEmailOrNumberValidation}

--- a/packages/dev-tools/server/graphql/GraphQLSchema.js
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.js
@@ -281,7 +281,7 @@ const typeDefs = graphql`
     openSimulator(platform: Platform!): OpenSimulatorResult
     # Publishes the current project to expo.io
     publishProject(releaseChannel: String): PublishProjectResult
-    # Sends the project URL by email or SMS.
+    # Sends the project URL by email.
     sendProjectUrl(recipient: String!): SendProjectResult
     # Updates specified project settings.
     setProjectSettings(settings: ProjectSettingsInput!): Project

--- a/packages/expo-cli/README.md
+++ b/packages/expo-cli/README.md
@@ -21,9 +21,9 @@ To view this on your phone, do the following:
 
 - Go get the Expo app on your Android or iOS device. It's available [on the Google Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent) and [on the iOS App Store](https://itunes.com/apps/exponent).
 
-- Run `expo send` to send a link via email or text. You can also use the `--send-to` option when running `expo start`.
+- Run `expo send` to send a link via email. You can also use the `--send-to` option when running `expo start`.
 
-- Check your e-mail or texts and tap the link. The Expo app should open and you should be able to view your experience there!
+- Check your e-mail and tap the link. The Expo app should open and you should be able to view your experience there!
 
 ## Publishing a Project
 

--- a/packages/expo-cli/src/askUser.js
+++ b/packages/expo-cli/src/askUser.js
@@ -3,20 +3,18 @@ import { UserSettings } from 'xdl';
 
 async function askForSendToAsync() {
   var sendToFromSettings = await UserSettings.getAsync('sendTo', null);
-  console.log("Enter a mobile number or e-mail and we'll send a link to your phone.");
+  console.log("Enter an email address and we'll send a link to your phone.");
   var answers = await prompt(
     [
       {
         type: 'input',
         name: 'sendTo',
         message:
-          'Your mobile number or e-mail' +
-          (sendToFromSettings ? ' (space to not send anything)' : '') +
-          ':',
+          'Your email address' + (sendToFromSettings ? ' (space to not send anything)' : '') + ':',
         default: sendToFromSettings,
       },
     ],
-    { nonInteractiveHelp: 'Please specify mobile number or email address with --send-to.' }
+    { nonInteractiveHelp: 'Please specify email address with --send-to.' }
   );
   let recipient = answers.sendTo.trim();
   await UserSettings.mergeAsync({ sendTo: recipient });
@@ -29,6 +27,6 @@ export default {
 
 if (require.main === module) {
   askForSendToAsync().then(function(sendTo) {
-    console.log('Your mobile number or email is', sendTo);
+    console.log('Your email address is', sendTo);
   });
 }

--- a/packages/expo-cli/src/commands/publish.js
+++ b/packages/expo-cli/src/commands/publish.js
@@ -110,7 +110,7 @@ export default (program: any) => {
     .alias('p')
     .description('Publishes your project to exp.host')
     .option('-q, --quiet', 'Suppress verbose output from the React Native packager.')
-    .option('-s, --send-to [dest]', 'A phone number or e-mail address to send a link to')
+    .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')
     .option('-c, --clear', 'Clear the React Native packager cache')
     // TODO(anp) set a default for this dynamically based on whether we're inside a container?
     .option('--max-workers [num]', 'Maximum number of tasks to allow Metro to spawn.')

--- a/packages/expo-cli/src/commands/send.js
+++ b/packages/expo-cli/src/commands/send.js
@@ -47,12 +47,9 @@ async function action(projectDir, options) {
 export default program => {
   program
     .command('send [project-dir]')
-    .description('Sends a link to your project to a phone number or e-mail address')
+    .description('Sends a link to your project to an email address')
     //.help('You must have the server running for this command to work')
-    .option(
-      '-s, --send-to  [dest]',
-      'Specifies the mobile number or e-mail address to send this URL to'
-    )
+    .option('-s, --send-to  [dest]', 'Specifies the email address to send this URL to')
     .urlOpts()
     .asyncActionProjectDir(action);
 };

--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -85,7 +85,7 @@ export default (program: any) => {
     .command('start [project-dir]')
     .alias('r')
     .description('Starts or restarts a local server for your app and gives you a URL to it')
-    .option('-s, --send-to [dest]', 'A phone number or e-mail address to send a link to')
+    .option('-s, --send-to [dest]', 'An email address to send a link to')
     .option('-c, --clear', 'Clear the React Native packager cache')
     .option('--https', 'To start webpack with https protocol')
     // TODO(anp) set a default for this dynamically based on whether we're inside a container?

--- a/packages/expo-cli/src/commands/start/TerminalUI.js
+++ b/packages/expo-cli/src/commands/start/TerminalUI.js
@@ -54,7 +54,7 @@ const printUsage = async projectDir => {
  \u203A Press ${b`shift-d`} to ${
     openDevToolsAtStartup ? 'disable' : 'enable'
   } automatically opening ${u`D`}evTools at startup.
- \u203A Press ${b`e`} to send an app link with ${u`e`}mail/SMS.
+ \u203A Press ${b`e`} to send an app link with ${u`e`}mail.
  \u203A Press ${b`p`} to toggle ${u`p`}roduction mode. (current mode: ${i(devMode)})
  \u203A Press ${b`r`} to ${u`r`}estart bundler, or ${b`shift-r`} to restart and clear cache.
  \u203A Press ${b`s`} to ${u`s`}ign ${
@@ -86,7 +86,7 @@ export const printServerInfo = async projectDir => {
   }
   log.nested(item(`Scan the QR code above with the Expo app (Android) or the Camera app (iOS).`));
   log.nested(item(`Press ${b`a`} for Android emulator${iosInfo}.`));
-  log.nested(item(`Press ${b`e`} to send a link to your phone with email/SMS.`));
+  log.nested(item(`Press ${b`e`} to send a link to your phone with email.`));
   if (!username) {
     log.nested(item(`Press ${b`s`} to sign in and enable more options.`));
   }
@@ -199,7 +199,7 @@ export const startAsync = async (projectDir, options) => {
         };
         clearConsole();
         process.stdin.addListener('keypress', handleKeypress);
-        log('Please enter your phone number or email address (press ESC to cancel) ');
+        log('Please enter your email address (press ESC to cancel) ');
         rl.question(defaultRecipient ? `[default: ${defaultRecipient}]> ` : '> ', async sendTo => {
           cleanup();
           if (!sendTo && defaultRecipient) {

--- a/packages/expo-cli/src/printRunInstructionsAsync.js
+++ b/packages/expo-cli/src/printRunInstructionsAsync.js
@@ -12,7 +12,7 @@ export default async function printRunInstructionsAsync() {
     log(`${chalk.underline('Android devices')}: scan the above QR code.`);
     log(
       `${chalk.underline('iOS devices')}: run ${chalk.bold(
-        'exp send -s <your-phone-number-or-email>'
+        'exp send -s <your-email-address>'
       )} in this project directory in another terminal window to send the URL to your device.`
     );
 


### PR DESCRIPTION
This removes SMS from the UI for sending project development links. The server endpoint still behaves the same, but the UI now promotes email over SMS. Email is more reliable, much cheaper, and more customizable. We'll make a similar change on web as well.

## Test plan

Ran the CLI on a test project and verified that both the CLI and web UI showed just "email" without "SMS" for sending links.

Web:
![Screen Shot 2019-03-15 at 12 23 58 PM](https://user-images.githubusercontent.com/379606/54457143-e6019d80-471d-11e9-93f7-d3c4f63adcf2.png)

CLI:
![Screen Shot 2019-03-15 at 12 24 13 PM](https://user-images.githubusercontent.com/379606/54457144-e6019d80-471d-11e9-9467-da0221acc673.png)
