### PR TITLE
RFC: Support per project account via .expo-env.json

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -369,7 +369,7 @@ function runAsync(programName: string) {
       process.exit(0);
     });
 
-    program.on('command:*', subCommand => {
+    program.on('command:*', (subCommand: string) => {
       log.warn(
         `"${subCommand}" is not an ${programName} command. See "${programName} --help" for the full list of commands.`
       );

--- a/packages/xdl/src/UserSettings.ts
+++ b/packages/xdl/src/UserSettings.ts
@@ -25,9 +25,41 @@ export type UserData = {
 
 const SETTINGS_FILE_NAME = 'state.json';
 
+const ENV_FILE_NAME = '.expo-env.json';
+
+function findExpoEnvFile() {
+  let dir = path.resolve(process.cwd());
+  while (dir != '/') {
+    let env_file = path.join(dir, ENV_FILE_NAME);
+    try {
+      if (fs.statSync(env_file).isFile()) {
+        return env_file;
+      }
+    } catch (e) {
+      // no env file, continue with parent
+    }
+
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+function expoEnv() {
+  let envFile = findExpoEnvFile();
+  if (envFile) {
+    try {
+      let envConfig = JSON.parse(fs.readFileSync(envFile).toString());
+      return envConfig['env'];
+    } catch (e) {
+      return null;
+    }
+  }
+}
+
 function userSettingsFile(): string {
   let dir = dotExpoHomeDirectory();
-  let file = path.join(dir, SETTINGS_FILE_NAME);
+  let env = expoEnv();
+  let file = path.join(dir, env ? `${env}-${SETTINGS_FILE_NAME}` : SETTINGS_FILE_NAME);
   try {
     // move exponent.json to state.json
     let oldFile = path.join(dir, 'exponent.json');


### PR DESCRIPTION
See https://expo.canny.io/feature-requests/p/per-project-expo-account

You can use separate accounts used to publish different projects by placing a `.expo-env.json` file with a "env" value. Projects with different "env" value uses different credentials. With this you can avoid  `expo-cli logout` and `expo-cli login` when working on multiple projects with different expo accounts.

Example .expo-env.json:
```
{
  "env" : "foo
}
```
this results in expo using `~/.expo/foo-state.json` instead of the default `~/.expo/state.json` to store credentials.

This PR is a prototype, no docs, no tests, comments are welcome.