### PR TITLE
Move root `webpack.config.js` check to XDL

### DIFF
--- a/packages/webpack-config/webpack.config.js
+++ b/packages/webpack-config/webpack.config.js
@@ -1,7 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const developmentConfig = require('./webpack/webpack.dev');
-const productionConfig = require('./webpack/webpack.prod');
 
 function invokePossibleFunction(objectOrMethod, ...args) {
   if (typeof objectOrMethod === 'function') {

--- a/packages/webpack-config/webpack.config.js
+++ b/packages/webpack-config/webpack.config.js
@@ -1,29 +1,10 @@
-const fs = require('fs');
-const path = require('path');
-
-function invokePossibleFunction(objectOrMethod, ...args) {
-  if (typeof objectOrMethod === 'function') {
-    return objectOrMethod(...args);
-  } else {
-    return objectOrMethod;
-  }
-}
-
-function getConfigFromRootIfPossible(filename) {
-  const overridePath = path.resolve(process.cwd(), filename);
-  if (fs.existsSync(overridePath)) {
-    return require(overridePath);
-  } else {
-    return require(path.join(__dirname, 'webpack', filename));
-  }
-}
+const developmentConfig = require('./webpack/webpack.dev');
+const productionConfig = require('./webpack/webpack.prod');
 
 module.exports = function(env = {}, argv) {
   if (env.development) {
-    const config = getConfigFromRootIfPossible('webpack.dev.js');
-    return invokePossibleFunction(config, env, argv);
+    return developmentConfig(env, argv);
   } else {
-    const config = getConfigFromRootIfPossible('webpack.prod.js');
-    return invokePossibleFunction(config, env, argv);
+    return productionConfig(env, argv);
   }
 };

--- a/packages/webpack-config/webpack.config.js
+++ b/packages/webpack-config/webpack.config.js
@@ -1,7 +1,7 @@
-const developmentConfig = require('./webpack/webpack.dev');
-const productionConfig = require('./webpack/webpack.prod');
 const fs = require('fs');
 const path = require('path');
+const developmentConfig = require('./webpack/webpack.dev');
+const productionConfig = require('./webpack/webpack.prod');
 
 function invokePossibleFunction(objectOrMethod, ...args) {
   if (typeof objectOrMethod === 'function') {
@@ -11,23 +11,16 @@ function invokePossibleFunction(objectOrMethod, ...args) {
   }
 }
 
-module.exports = function(env = {}, argv) {
-  // Check if the project has a webpack.config.js in the root.
-  const projectWebpackConfig = path.resolve(process.cwd(), 'webpack.config.js');
-  if (fs.existsSync(projectWebpackConfig)) {
-    const webpackConfig = require(projectWebpackConfig);
-    return invokePossibleFunction(webpackConfig, env, argv);
+function getConfigFromRootIfPossible(filename) {
+  const overridePath = path.resolve(process.cwd(), filename);
+  if (fs.existsSync(overridePath)) {
+    return require(overridePath);
+  } else {
+    return require(path.join(__dirname, 'webpack', filename));
   }
+}
 
-  const getConfigFromRootIfPossible = filename => {
-    const overridePath = path.resolve(process.cwd(), filename);
-    if (fs.existsSync(overridePath)) {
-      return require(overridePath);
-    } else {
-      return require(path.join(__dirname, 'webpack', filename));
-    }
-  };
-
+module.exports = function(env = {}, argv) {
   if (env.development) {
     const config = getConfigFromRootIfPossible('webpack.dev.js');
     return invokePossibleFunction(config, env, argv);

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -32,7 +32,6 @@ import urljoin from 'url-join';
 import uuid from 'uuid';
 import readLastLines from 'read-last-lines';
 import webpack from 'webpack';
-import webpackConfig from '@expo/webpack-config';
 import WebpackDevServer from 'webpack-dev-server';
 
 import * as Analytics from './Analytics';
@@ -1875,7 +1874,7 @@ async function startWebpackServerAsync(projectRoot, options, verbose) {
     return;
   }
   let { dev, https } = await ProjectSettings.readAsync(projectRoot);
-  let config = webpackConfig({ projectRoot, development: dev, production: !dev, https });
+  let config = Web.invokeWebpackConfig({ projectRoot, development: dev, production: !dev, https });
   let webpackServerPort = await _getFreePortAsync(19000);
   ProjectUtils.logInfo(
     projectRoot,
@@ -1920,7 +1919,7 @@ export async function bundleWebpackAsync(projectRoot, packagerOpts) {
   process.env.BABEL_ENV = mode;
   process.env.NODE_ENV = mode;
 
-  let config = webpackConfig({
+  let config = Web.invokeWebpackConfig({
     projectRoot,
     noPolyfill: packagerOpts.noPolyfill,
     development: packagerOpts.dev,

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -1,8 +1,30 @@
+import fs from 'fs';
+import path from 'path';
 import opn from 'opn';
 import chalk from 'chalk';
 import Logger from './Logger';
 import * as UrlUtils from './UrlUtils';
 import { readConfigJsonAsync } from './project/ProjectUtils';
+
+function invokePossibleFunction(objectOrMethod, ...args) {
+  if (typeof objectOrMethod === 'function') {
+    return objectOrMethod(...args);
+  } else {
+    return objectOrMethod;
+  }
+}
+
+export function invokeWebpackConfig(env, argv) {
+  // Check if the project has a webpack.config.js in the root.
+  const projectWebpackConfig = path.resolve(process.cwd(), 'webpack.config.js');
+  if (fs.existsSync(projectWebpackConfig)) {
+    const webpackConfig = require(projectWebpackConfig);
+    return invokePossibleFunction(webpackConfig, env, argv);
+  }
+  // Fallback to the default expo webpack config.
+  const config = require('@expo/webpack-config');
+  return config(env, argv);
+}
 
 function logPreviewNotice() {
   console.log();

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -16,7 +16,7 @@ function invokePossibleFunction(objectOrMethod, ...args) {
 
 export function invokeWebpackConfig(env, argv) {
   // Check if the project has a webpack.config.js in the root.
-  const projectWebpackConfig = path.resolve(process.cwd(), 'webpack.config.js');
+  const projectWebpackConfig = path.resolve(env.projectRoot, 'webpack.config.js');
   if (fs.existsSync(projectWebpackConfig)) {
     const webpackConfig = require(projectWebpackConfig);
     return invokePossibleFunction(webpackConfig, env, argv);


### PR DESCRIPTION
Now you can create a `webpack.config.js` in your root project which reexports `@expo/webpack-config` without creating a stack overflow.