### PR TITLE
expo start --web-only

### DIFF
--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -3,7 +3,7 @@
  */
 
 import { DevToolsServer } from '@expo/dev-tools';
-import { ProjectUtils, ProjectSettings, Project, UserSettings, UrlUtils } from 'xdl';
+import { ProjectUtils, ProjectSettings, Web, Project, UserSettings, UrlUtils } from 'xdl';
 import chalk from 'chalk';
 import opn from 'opn';
 import path from 'path';
@@ -30,6 +30,12 @@ async function action(projectDir, options) {
 
   if (options.maxWorkers) {
     startOpts.maxWorkers = options.maxWorkers;
+  }
+
+  if (options.webOnly) {
+    startOpts.webOnly = options.webOnly;
+  } else {
+    startOpts.webOnly = await Web.onlySupportsWebAsync(projectDir);
   }
 
   let devToolsUrl = await DevToolsServer.startAsync(root);
@@ -84,6 +90,7 @@ export default (program: any) => {
     .description('Starts or restarts a local server for your app and gives you a URL to it')
     .option('-s, --send-to [dest]', 'An email address to send a link to')
     .option('-c, --clear', 'Clear the React Native packager cache')
+    .option('--web-only', 'Only start the webpack server')
     // TODO(anp) set a default for this dynamically based on whether we're inside a container?
     .option('--max-workers [num]', 'Maximum number of tasks to allow Metro to spawn.')
     .urlOpts()

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -41,6 +41,15 @@ export async function hasWebSupportAsync(projectRoot) {
   return isWebConfigured;
 }
 
+// If platforms only contains the "web" field
+export async function onlySupportsWebAsync(projectRoot) {
+  const { exp } = await readConfigJsonAsync(projectRoot);
+  if (Array.isArray(exp.platforms) && exp.platforms.length === 1) {
+    return exp.platforms[0] === 'web';
+  }
+  return false;
+}
+
 function getWebSetupLogs() {
   const appJsonRules = chalk.white(
     `


### PR DESCRIPTION
* Added `--web-only` flag to CLI to make usage in `react-native init` projects work better.
* Added a case where `webOnly` is enabled if `expo.platforms` only contains `web`
* Fixed bug when stopping webpack dev server