### PR TITLE
[expo-cli] fix icon validation

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -84,6 +84,7 @@
     "opn": "5.4.0",
     "ora": "1.4.0",
     "pacote": "9.3.0",
+    "pngjs": "^3.4.0",
     "progress": "2.0.0",
     "qrcode-terminal": "0.11.0",
     "semver": "5.5.0",

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -84,7 +84,7 @@
     "opn": "5.4.0",
     "ora": "1.4.0",
     "pacote": "9.3.0",
-    "pngjs": "^3.4.0",
+    "pngjs": "3.4.0",
     "progress": "2.0.0",
     "qrcode-terminal": "0.11.0",
     "semver": "5.5.0",

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.js
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.js
@@ -2,7 +2,6 @@ import isEmpty from 'lodash/isEmpty';
 import pickBy from 'lodash/pickBy';
 import get from 'lodash/get';
 import { XDLError, ErrorCode } from 'xdl';
-import fs from 'fs-extra';
 
 import BaseBuilder from '../BaseBuilder';
 import { PLATFORMS } from '../constants';

--- a/packages/expo-cli/src/commands/build/ios/utils/image.js
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.js
@@ -19,7 +19,7 @@ export async function ensurePNGIsNotTransparent(imagePath) {
         }
         for (let y = 0; y < this.height; y++) {
           for (let x = 0; x < this.width; x++) {
-            let idx = (this.width * y + x) << 2;
+            let idx = (this.width * y + x) * 4;
 
             if (this.data[idx + 3] !== 255) {
               const err = new XDLError(

--- a/packages/expo-cli/src/commands/build/ios/utils/image.js
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.js
@@ -10,7 +10,7 @@ async function ensurePNGIsNotTransparent(imagePath) {
     stream
       .pipe(new PNG({ filterType: 4 }))
       .on('metadata', ({ colorType }) => {
-        if (colorType !== 6) {
+        if (![4, 6].includes(colorType)) {
           hasAlreadyResolved = true;
           stream.close();
           res();
@@ -22,10 +22,10 @@ async function ensurePNGIsNotTransparent(imagePath) {
         }
         try {
           valideAlphaChannelIsEmpty(this.data, pick(this, ['width', 'height']));
+          res();
         } catch (err) {
-          return rej(err);
+          rej(err);
         }
-        res();
       })
       .on('error', err => rej(err));
   });

--- a/packages/expo-cli/src/commands/build/ios/utils/image.js
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.js
@@ -1,15 +1,18 @@
 import fs from 'fs-extra';
 import { PNG } from 'pngjs';
+import pick from 'lodash/pick';
 import { XDLError, ErrorCode } from 'xdl';
 
-export async function ensurePNGIsNotTransparent(imagePath) {
+async function ensurePNGIsNotTransparent(imagePath) {
   let hasAlreadyResolved = false;
   return new Promise((res, rej) => {
-    fs.createReadStream(imagePath)
+    const stream = fs.createReadStream(imagePath);
+    stream
       .pipe(new PNG({ filterType: 4 }))
       .on('metadata', ({ colorType }) => {
         if (colorType !== 6) {
           hasAlreadyResolved = true;
+          stream.close();
           res();
         }
       })
@@ -17,21 +20,29 @@ export async function ensurePNGIsNotTransparent(imagePath) {
         if (hasAlreadyResolved) {
           return;
         }
-        for (let y = 0; y < this.height; y++) {
-          for (let x = 0; x < this.width; x++) {
-            let idx = (this.width * y + x) * 4;
-
-            if (this.data[idx + 3] !== 255) {
-              const err = new XDLError(
-                ErrorCode.INVALID_ASSETS,
-                `Your application icon (${imagePath}) can't have transparency if you wish to upload your app to Apple Store.`
-              );
-              return rej(err);
-            }
-          }
+        try {
+          valideAlphaChannelIsEmpty(this.data, pick(this, ['width', 'height']));
+        } catch (err) {
+          return rej(err);
         }
         res();
       })
       .on('error', err => rej(err));
   });
 }
+
+function valideAlphaChannelIsEmpty(data, { width, height }) {
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let idx = (width * y + x) * 4;
+      if (data[idx + 3] !== 255) {
+        throw new XDLError(
+          ErrorCode.INVALID_ASSETS,
+          `Your application icon can't have transparency if you wish to upload your app to Apple Store.`
+        );
+      }
+    }
+  }
+}
+
+export { ensurePNGIsNotTransparent };

--- a/packages/expo-cli/src/commands/build/ios/utils/image.js
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.js
@@ -9,8 +9,8 @@ async function ensurePNGIsNotTransparent(imagePath) {
     const stream = fs.createReadStream(imagePath);
     stream
       .pipe(new PNG({ filterType: 4 }))
-      .on('metadata', ({ colorType }) => {
-        if (![4, 6].includes(colorType)) {
+      .on('metadata', ({ alpha }) => {
+        if (!alpha) {
           hasAlreadyResolved = true;
           stream.close();
           res();

--- a/packages/expo-cli/src/commands/build/ios/utils/image.js
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.js
@@ -1,0 +1,37 @@
+import fs from 'fs-extra';
+import { PNG } from 'pngjs';
+import { XDLError, ErrorCode } from 'xdl';
+
+export async function ensurePNGIsNotTransparent(imagePath) {
+  let hasAlreadyResolved = false;
+  return new Promise((res, rej) => {
+    fs.createReadStream(imagePath)
+      .pipe(new PNG({ filterType: 4 }))
+      .on('metadata', ({ colorType }) => {
+        if (colorType !== 6) {
+          hasAlreadyResolved = true;
+          res();
+        }
+      })
+      .on('parsed', function() {
+        if (hasAlreadyResolved) {
+          return;
+        }
+        for (let y = 0; y < this.height; y++) {
+          for (let x = 0; x < this.width; x++) {
+            let idx = (this.width * y + x) << 2;
+
+            if (this.data[idx + 3] !== 255) {
+              const err = new XDLError(
+                ErrorCode.INVALID_ASSETS,
+                `Your application icon (${imagePath}) can't have transparency if you wish to upload your app to Apple Store.`
+              );
+              return rej(err);
+            }
+          }
+        }
+        res();
+      })
+      .on('error', err => rej(err));
+  });
+}

--- a/packages/expo-cli/src/commands/build/ios/utils/image.js
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.js
@@ -21,7 +21,7 @@ async function ensurePNGIsNotTransparent(imagePath) {
           return;
         }
         try {
-          valideAlphaChannelIsEmpty(this.data, pick(this, ['width', 'height']));
+          validateAlphaChannelIsEmpty(this.data, pick(this, ['width', 'height']));
           res();
         } catch (err) {
           rej(err);
@@ -31,7 +31,7 @@ async function ensurePNGIsNotTransparent(imagePath) {
   });
 }
 
-function valideAlphaChannelIsEmpty(data, { width, height }) {
+function validateAlphaChannelIsEmpty(data, { width, height }) {
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       let idx = (width * y + x) * 4;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12099,6 +12099,11 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+pngjs@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
+  integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+
 pnp-webpack-plugin@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.4.1.tgz#e8f8c683b496a71c0d200e664c4bb399a9c9585e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12099,7 +12099,7 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-pngjs@^3.4.0:
+pngjs@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==


### PR DESCRIPTION
Closes #414 

In order to verify whether a png doesn't have any transparency, we not only need to check whether the png doesn't have an alpha channel, but we also have to check every pixel and see if the value for the alpha channel is equal to 255.