### PR TITLE
Configuring the production compression

### DIFF
--- a/packages/webpack-config/webpack/createIndexHTMLFromAppJSON.js
+++ b/packages/webpack-config/webpack/createIndexHTMLFromAppJSON.js
@@ -1,5 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const createMetatagsFromConfig = require('./createMetatagsFromConfig');
+const { overrideWithPropertyOrConfig } = require('./utils/config');
 
 const DEFAULT_MINIFY = {
   removeComments: true,
@@ -14,28 +15,17 @@ const DEFAULT_MINIFY = {
   minifyURLs: true,
 };
 
-function isObject(val) {
-  if (val === null) {
-    return false;
-  }
-  return typeof val === 'function' || typeof val === 'object';
-}
-
 function createIndexHTMLFromAppJSON(appManifest, locations) {
   // Is the app.json from expo-cli or react-native-cli
   const { web = {} } = appManifest;
-  const { minifyHTML } = web;
 
   const meta = createMetatagsFromConfig(appManifest);
 
-  let minify = DEFAULT_MINIFY;
   /**
    * The user can disable minify with
    * `web.minifyHTML = false || {}`
    */
-  if (minifyHTML === false || isObject(minifyHTML)) {
-    minify = minifyHTML;
-  }
+  const minify = overrideWithPropertyOrConfig(web.minifyHTML, DEFAULT_MINIFY);
 
   // Generates an `index.html` file with the <script> injected.
   return new HtmlWebpackPlugin({

--- a/packages/webpack-config/webpack/utils/config.js
+++ b/packages/webpack-config/webpack/utils/config.js
@@ -1,0 +1,38 @@
+function isObject(val) {
+  if (val === null) {
+    return false;
+  }
+  return typeof val === 'function' || typeof val === 'object';
+}
+
+/**
+ * Given a config option that could evalutate to true, config, or null; return a config.
+ * e.g.
+ * `polyfill: true` returns the `config`
+ * `polyfill: {}` returns `{}`
+ */
+
+function enableWithPropertyOrConfig(prop, config) {
+  // Value is truthy but not a replacement config.
+  if (prop && !isObject(prop)) {
+    // Return the default config
+    return config;
+  }
+  // Return falsey or replacement config.
+  return prop;
+}
+
+/**
+ * Used for features that are enabled by default unless specified otherwise.
+ */
+function overrideWithPropertyOrConfig(prop, config) {
+  if (prop === undefined) {
+    return config;
+  }
+  return enableWithPropertyOrConfig(prop, config);
+}
+
+module.exports = {
+  enableWithPropertyOrConfig,
+  overrideWithPropertyOrConfig,
+};

--- a/packages/webpack-config/webpack/webpack.prod.js
+++ b/packages/webpack-config/webpack/webpack.prod.js
@@ -7,14 +7,70 @@ const BrotliPlugin = require('brotli-webpack-plugin');
 
 const common = require('./webpack.common.js');
 const getLocations = require('./webpackLocations');
+const { enableWithPropertyOrConfig, overrideWithPropertyOrConfig } = require('./utils/config');
+
+const DEFAULT_GZIP = {
+  test: /\.(js|css)$/,
+  filename: '[path].gz[query]',
+  algorithm: 'gzip',
+  threshold: 1024,
+  minRatio: 0.8,
+};
+
+const DEFAULT_BROTLI = {
+  asset: '[path].br[query]',
+  test: /\.(js|css)$/,
+  threshold: 1024,
+  minRatio: 0.8,
+};
 
 module.exports = function(env = {}) {
   const locations = getLocations(env.projectRoot);
+
+  const appJSON = require(locations.appJson);
+  if (!appJSON) {
+    throw new Error('app.json could not be found at: ' + locations.appJson);
+  }
+  // For RN CLI support
+  const appManifest = appJSON.expo || appJSON;
+  const { web = {} } = appManifest;
+  const { build: buildConfig = {} } = web;
 
   const appEntry = [locations.appMain];
 
   if (env.polyfill) {
     appEntry.unshift('@babel/polyfill');
+  }
+
+  const plugins = [
+    // Delete the build folder
+    new CleanWebpackPlugin([locations.production.folder], {
+      root: locations.root,
+      dry: false,
+    }),
+    // Copy the template files over
+    new CopyWebpackPlugin([
+      {
+        from: locations.template.folder,
+        to: locations.production.folder,
+        ignore: 'index.html',
+      },
+    ]),
+
+    new MiniCssExtractPlugin({
+      filename: 'static/css/[contenthash].css',
+      chunkFilename: 'static/css/[contenthash].chunk.css',
+    }),
+  ];
+
+  const gzipConfig = overrideWithPropertyOrConfig(buildConfig.gzip, DEFAULT_GZIP);
+  if (gzipConfig) {
+    plugins.push(new CompressionPlugin(gzipConfig));
+  }
+
+  const brotliConfig = enableWithPropertyOrConfig(buildConfig.brotli, DEFAULT_BROTLI);
+  if (brotliConfig) {
+    plugins.push(new BrotliPlugin(brotliConfig));
   }
 
   return merge(common(env), {
@@ -23,41 +79,6 @@ module.exports = function(env = {}) {
       app: appEntry,
     },
     devtool: 'cheap-module-source-map',
-    plugins: [
-      // Delete the build folder
-      new CleanWebpackPlugin([locations.production.folder], {
-        root: locations.root,
-        dry: false,
-      }),
-
-      new CopyWebpackPlugin([
-        {
-          from: locations.template.folder,
-          to: locations.production.folder,
-          ignore: 'index.html',
-        },
-      ]),
-
-      new MiniCssExtractPlugin({
-        filename: 'static/css/[contenthash].css',
-        chunkFilename: 'static/css/[contenthash].chunk.css',
-      }),
-
-      // GZIP files
-      new CompressionPlugin({
-        test: /\.(js|css)$/,
-        filename: '[path].gz[query]',
-        algorithm: 'gzip',
-        threshold: 1024,
-        minRatio: 0.8,
-      }),
-      // Secondary compression for systems that serve .br
-      new BrotliPlugin({
-        asset: '[path].br[query]',
-        test: /\.(js|css)$/,
-        threshold: 1024,
-        minRatio: 0.8,
-      }),
-    ],
+    plugins,
   });
 };


### PR DESCRIPTION
Added options to the `app.json` for configuring the production compression in web projects.
* fixes #461
* `brotli` is disabled by default
* gzip can be configured from the app.json
* moved common tools to a central utils file in webpack