### PR TITLE
add check for websupport

### DIFF
--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1841,10 +1841,6 @@ async function startWebpackServerAsync(projectRoot, options, verbose) {
     ProjectUtils.logError(projectRoot, 'expo', 'Webpack is already running.');
     return;
   }
-  const hasWebSupport = await Web.hasWebSupportAsync(projectRoot);
-  if (!hasWebSupport) {
-    return;
-  }
   let { dev, https } = await ProjectSettings.readAsync(projectRoot);
   let config = Web.invokeWebpackConfig({ projectRoot, development: dev, production: !dev, https });
   let webpackServerPort = await _getFreePortAsync(19000);
@@ -2158,7 +2154,10 @@ export async function startAsync(
     await startExpoServerAsync(projectRoot);
     await startReactNativeServerAsync(projectRoot, options, verbose);
   }
-  await startWebpackServerAsync(projectRoot, options, verbose);
+  const hasWebSupport = await Web.hasWebSupportAsync(projectRoot);
+  if (hasWebSupport) {
+    await startWebpackServerAsync(projectRoot, options, verbose);
+  }
   if (!Config.offline) {
     try {
       await startTunnelsAsync(projectRoot);
@@ -2174,7 +2173,10 @@ async function _stopInternalAsync(projectRoot: string): Promise<void> {
   DevSession.stopSession();
   await stopExpoServerAsync(projectRoot);
   await stopReactNativeServerAsync(projectRoot);
-  await stopWebpackServerAsync(projectRoot);
+  const hasWebSupport = await Web.hasWebSupportAsync(projectRoot);
+  if (hasWebSupport) {
+    await stopWebpackServerAsync(projectRoot);
+  }
   if (!Config.offline) {
     try {
       await stopTunnelsAsync(projectRoot);


### PR DESCRIPTION
This closes #460.

Problem is that `stopWebpackServerAsync` gets called (whether or not the webpack server is running) when `stopinternalasync` is called, and results in the logged message shown in the issue (through calling `getWebpackInstance`). I thought the simplest fix would be to check for web support before that call.
This way-> `getWebpackInstance` [here](https://github.com/expo/expo-cli/blob/229fc54e20a812aaa0b0422b035dc49ec56695bf/packages/xdl/src/Project.js#L1832 ) still works as originally intended if it is used somewhere else.
This all ties up with checking for websupport before the `startWebpackServerAsync` call because it results in more consistency and clarity (i.e: why should startwebpack function run and NOT start the webpack?)

Let me know if there's something more for me to add/do here. I know the docs ask for a test plan but I'm not 100% clear on how exactly to do that.

