### PR TITLE
Update Simulator.js

### DIFF
--- a/packages/xdl/src/Simulator.js
+++ b/packages/xdl/src/Simulator.js
@@ -71,7 +71,7 @@ export async function _isSimulatorInstalledAsync() {
     Logger.global.error(XCODE_NOT_INSTALLED_ERROR);
     return false;
   }
-  if (result !== 'com.apple.iphonesimulator') {
+  if (result !== 'com.apple.iphonesimulator' && result !== 'com.apple.CoreSimulator.SimulatorTrampoline') {
     console.warn(
       "Simulator is installed but is identified as '" + result + "'; don't know what that is."
     );


### PR DESCRIPTION
Fixes #469 
For some reason, since Xcode 10.2 update, the app id of the Simulator changes whether it is running or not. 

- When Simulator is NOT running id = `com.apple.CoreSimulator.SimulatorTrampoline`
- When Simulator is running id = `com.apple.iphonesimulator`

In order to test this, you can run the following code in node (ensure Xcode is v10.2) with Simulator not running and with it running, and see the logged output

```
const { execFile } = require('child_process');

let cmd = 'osascript';
let opts = {};
let args = ["-e", 'id of app "Simulator"'];
Object.assign({ stdio: 'inherit' }, opts)

const mypromise = new Promise(function (fulfill, reject) {
  execFile(cmd,args, opts, function (err, result) {
    if (err) {
      reject(err);
    } else {
      fulfill(result);
      }
    });
});

mypromise.then((result) => console.log(result));
```

My proposed change just adds the additional ID so that the CLI will continue running without a problem.