### PR TITLE
[web] Add webpack support for TypeScript files

### DIFF
--- a/packages/webpack-config/webpack/createBabelConfig.js
+++ b/packages/webpack-config/webpack/createBabelConfig.js
@@ -14,7 +14,7 @@ const includeModulesThatContainPaths = [
 module.exports = function(babelRoot, { pathsToInclude = [], ...options } = {}) {
   const modules = [...includeModulesThatContainPaths, ...pathsToInclude];
   return {
-    test: /\.jsx?$/,
+    test: /\.[jt]sx?$/,
     include(inputPath) {
       for (const option of modules) {
         if (inputPath.includes(option)) {

--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -262,7 +262,7 @@ module.exports = function(env = {}) {
     },
     resolve: {
       symlinks: false,
-      extensions: ['.web.js', '.js', '.jsx', '.json'],
+      extensions: ['.web.ts', '.ts', '.tsx', '.web.js', '.js', '.jsx', '.json'],
       alias: {
         // Alias direct react-native imports to react-native-web
         'react-native$': 'react-native-web',

--- a/packages/webpack-config/webpack/webpackLocations.js
+++ b/packages/webpack-config/webpack/webpackLocations.js
@@ -3,6 +3,14 @@ const findWorkspaceRoot = require('find-yarn-workspace-root');
 const fs = require('fs');
 
 const possibleMainFiles = [
+  'index.web.ts',
+  'index.ts',
+  'index.web.tsx',
+  'index.tsx',
+  'src/index.web.ts',
+  'src/index.ts',
+  'src/index.web.tsx',
+  'src/index.tsx',
   'index.web.js',
   'index.js',
   'index.web.jsx',


### PR DESCRIPTION
This allows webpack to load (and babel to process) *.ts and *.tsx files.

This brings the Expo Web behavior inline with the normal Expo behavior.