### PR TITLE
Fix `isDetachexped` -> `isDetached` in command parser

### DIFF
--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -69,7 +69,7 @@ async function action(projectDir, options) {
 
   await urlOpts.handleMobileOptsAsync(projectDir, options);
 
-  if (!nonInteractive && !exp.isDetachexped) {
+  if (!nonInteractive && !exp.isDetached) {
     await TerminalUI.startAsync(projectDir, startOpts);
   } else {
     if (!exp.isDetached) {


### PR DESCRIPTION
`rg isDetachexped` shows that there are no other references to this property, which looks like a typo for `isDetached`.