### PR TITLE
Logging improvements

### DIFF
--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1419,10 +1419,23 @@ function _isIgnorableBugReportingExtraData(body) {
   return body.length === 2 && body[0] === 'BugReporting extraData:';
 }
 
+function _isAppRegistryStartupMessage(body) {
+  return body.length === 1 && /^Running application "main" with appParams:/.test(body[0]);
+}
+
 function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: string, logs: any) {
   for (let i = 0; i < logs.length; i++) {
     let log = logs[i];
     let body = typeof log.body === 'string' ? [log.body] : log.body;
+    let level = log.level;
+
+    if (_isIgnorableBugReportingExtraData(body)) {
+      level = logger.DEBUG;
+    }
+    if (_isAppRegistryStartupMessage(body)) {
+      body = [`Running application on ${deviceName}.`];
+    }
+
     let string = body
       .map(obj => {
         if (typeof obj === 'undefined') {
@@ -1441,13 +1454,7 @@ function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: st
         }
       })
       .join(' ');
-    let level = log.level;
-    if (_isIgnorableBugReportingExtraData(body)) {
-      level = logger.DEBUG;
-    }
-    let groupDepth = log.groupDepth;
-    let shouldHide = log.shouldHide;
-    let includesStack = log.includesStack;
+
     ProjectUtils.logWithLevel(
       projectRoot,
       level,
@@ -1455,9 +1462,9 @@ function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: st
         tag: 'device',
         deviceId,
         deviceName,
-        groupDepth,
-        shouldHide,
-        includesStack,
+        groupDepth: log.groupDepth,
+        shouldHide: log.shouldHide,
+        includesStack: log.includesStack,
       },
       string
     );

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1427,7 +1427,7 @@ function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: st
   for (let i = 0; i < logs.length; i++) {
     let log = logs[i];
     let body = typeof log.body === 'string' ? [log.body] : log.body;
-    let level = log.level;
+    let { level } = log;
 
     if (_isIgnorableBugReportingExtraData(body)) {
       level = logger.DEBUG;

--- a/packages/xdl/src/logs/PackagerLogsStream.js
+++ b/packages/xdl/src/logs/PackagerLogsStream.js
@@ -186,7 +186,6 @@ export default class PackagerLogsStream {
           }
 
           chunk = this._maybeParseMsgJSON(chunk);
-          chunk = this._formatMsg(chunk);
           chunk = this._cleanUpNodeErrors(chunk);
           if (chunk.tag === 'metro') {
             this._handleMetroEvent(chunk);
@@ -522,26 +521,6 @@ export default class PackagerLogsStream {
 
     return chunk;
   };
-
-  // This message is just noise
-  // Fall back to the same formatting we did on SDK <= 15 before we had a custom
-  // reporter class.
-  _formatMsg(chunk) {
-    if (typeof chunk.msg === 'object') {
-      return chunk;
-    }
-
-    if (chunk.msg.match(/Looking for JS files in/)) {
-      chunk.msg = '';
-    } else if (chunk.msg.startsWith('\u001b')) {
-      chunk.msg = '';
-    }
-
-    chunk.msg = chunk.msg.replace(/\[\w{2}m/g, '');
-    chunk.msg = chunk.msg.replace(/\[2K/g, '');
-    chunk.msg = trim(chunk.msg);
-    return chunk;
-  }
 }
 
 const NODE_STDLIB_MODULES = [


### PR DESCRIPTION
- **Remove legacy filtering of React Native packager logs**

  React Native packager doesn't exist anymore (it's Metro now) and we pass a custom logger to Metro, which makes all this faffing unnecessary.

  Partially removing ANSI codes from the logs also messed up with Webpack logging because this code was processing all logs, Metro or not.

- **Remove the “Running application "main" with appParams” noise**
  Instead of:
  `Running application "main" with appParams”: { <lots of params> }`
  every time you refresh the app, just show a short:
  `Running application on Ville's iPhone.`
