### PR TITLE
Select and send a push key in the adhoc build request

### DIFF
--- a/packages/expo-cli/src/commands/client/createClientBuildRequest.js
+++ b/packages/expo-cli/src/commands/client/createClientBuildRequest.js
@@ -4,6 +4,7 @@ export default async function createClientBuildRequest({
   user = null,
   context,
   distributionCert,
+  pushKey,
   udids,
   addUdid,
   email,
@@ -16,6 +17,8 @@ export default async function createClientBuildRequest({
     bundleIdentifier: context.bundleIdentifier,
     email,
     credentials: {
+      apnsKeyP8: pushKey.apnsKeyP8,
+      apnsKeyId: pushKey.apnsKeyId,
       certP12: distributionCert.certP12,
       certPassword: distributionCert.certPassword,
       teamId: context.team.id,

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -6,6 +6,7 @@ import urlOpts from '../../urlOpts';
 import * as appleApi from '../build/ios/appleApi';
 import { runAction, travelingFastlane } from '../build/ios/appleApi/fastlane';
 import selectDistributionCert from './selectDistributionCert';
+import selectPushKey from './selectPushKey';
 import generateBundleIdentifier from './generateBundleIdentifier';
 import createClientBuildRequest from './createClientBuildRequest';
 import log from '../../log';
@@ -32,7 +33,7 @@ export default program => {
 
       const distributionCert = await selectDistributionCert(context);
       // TODO(fson): Select and save a push key.
-      // const pushKey = await selectPushKey(context);
+      const pushKey = await selectPushKey(context);
 
       let email;
       if (user) {
@@ -68,6 +69,7 @@ export default program => {
         user,
         context,
         distributionCert,
+        pushKey,
         udids,
         addUdid,
         email,

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -32,7 +32,6 @@ export default program => {
       await appleApi.ensureAppExists(context);
 
       const distributionCert = await selectDistributionCert(context);
-      // TODO(fson): Select and save a push key.
       const pushKey = await selectPushKey(context);
 
       let email;


### PR DESCRIPTION
We previously didn't send the push key because it was not handled by the server end point in the beginning.