### PR TITLE
Fix 'Opening iOS Sim' indefinite hang

### DIFF
--- a/packages/xdl/src/Simulator.js
+++ b/packages/xdl/src/Simulator.js
@@ -180,7 +180,7 @@ async function _getDefaultSimulatorDeviceUDIDAsync() {
     const { stdout: defaultDeviceUDID } = await spawnAsync('defaults', ['read', 'com.apple.iphonesimulator', 'CurrentDeviceUDID']);
     return defaultDeviceUDID.trim();
   } catch (e) {
-    return false;
+    return null;
   }
 }
 

--- a/packages/xdl/src/Simulator.js
+++ b/packages/xdl/src/Simulator.js
@@ -153,6 +153,17 @@ export async function _isSimulatorRunningAsync() {
   }
 
   let bootedDevice = await _bootedSimulatorDeviceAsync();
+  
+  if (!bootedDevice) {
+    Logger.global.info(`Booting device in iOS simulator...`);
+    try {
+      return await _xcrunAsync(['simctl', 'boot', '5E560ABA-4019-4A8E-A1BB-F01C15533F0F']);
+    } catch (e) {
+      Logger.global.error(`There was a problem booting a device in iOS Simulator. Quit Simulator, and try again.`);
+      throw e;
+    }
+  }
+  
   return !!bootedDevice;
 }
 

--- a/packages/xdl/src/Simulator.js
+++ b/packages/xdl/src/Simulator.js
@@ -178,7 +178,7 @@ async function _bootDefaultSimulatorDeviceAsync() {
 async function _getDefaultSimulatorDeviceUDIDAsync() {
   try {
     const { stdout: defaultDeviceUDID } = await spawnAsync('defaults', ['read', 'com.apple.iphonesimulator', 'CurrentDeviceUDID']);
-    return defaultDeviceUDID.replace(/\n$/, '');
+    return defaultDeviceUDID.trim();
   } catch (e) {
     return false;
   }

--- a/packages/xdl/src/Simulator.js
+++ b/packages/xdl/src/Simulator.js
@@ -155,16 +155,33 @@ export async function _isSimulatorRunningAsync() {
   let bootedDevice = await _bootedSimulatorDeviceAsync();
   
   if (!bootedDevice) {
-    Logger.global.info(`Booting device in iOS simulator...`);
-    try {
-      return await _xcrunAsync(['simctl', 'boot', '5E560ABA-4019-4A8E-A1BB-F01C15533F0F']);
-    } catch (e) {
-      Logger.global.error(`There was a problem booting a device in iOS Simulator. Quit Simulator, and try again.`);
-      throw e;
-    }
+    return await _bootDefaultSimulatorDeviceAsync();
   }
   
   return !!bootedDevice;
+}
+
+async function _bootDefaultSimulatorDeviceAsync() {
+  Logger.global.info(`Booting device in iOS simulator...`);
+  try {
+    let defaultDeviceUDID = await _getDefaultSimulatorDeviceUDIDAsync();
+    if (!defaultDeviceUDID) {
+      defaultDeviceUDID = (await _getFirstAvailableDeviceAsync()).udid;
+    }
+    return await _xcrunAsync(['simctl', 'boot', defaultDeviceUDID]);
+  } catch (e) {
+    Logger.global.error(`There was a problem booting a device in iOS Simulator. Quit Simulator, and try again.`);
+    throw e;
+  }
+}
+
+async function _getDefaultSimulatorDeviceUDIDAsync() {
+  try {
+    const { stdout: defaultDeviceUDID } = await spawnAsync('defaults', ['read', 'com.apple.iphonesimulator', 'CurrentDeviceUDID']);
+    return defaultDeviceUDID.replace(/\n$/, '');
+  } catch (e) {
+    return false;
+  }
 }
 
 async function _waitForSimulatorRunningAsync() {
@@ -174,6 +191,21 @@ async function _waitForSimulatorRunningAsync() {
     await delayAsync(100);
     return await _waitForSimulatorRunningAsync();
   }
+}
+
+async function _getFirstAvailableDeviceAsync() {
+  let simulatorDeviceInfo = await _listSimulatorDevicesAsync();
+  for (let runtime in simulatorDeviceInfo.devices) {
+    let devices = simulatorDeviceInfo.devices[runtime];
+    for (let i = 0; i < devices.length; i++) {
+      let device = devices[i];
+      if (device.isAvailable && device.name.includes('iPhone')) {
+        return device;
+      }
+    }
+  }
+  console.warn('No iPhone devices available in Simulator.')
+  return null;
 }
 
 async function _listSimulatorDevicesAsync() {

--- a/packages/xdl/src/Simulator.js
+++ b/packages/xdl/src/Simulator.js
@@ -204,7 +204,7 @@ async function _getFirstAvailableDeviceAsync() {
       }
     }
   }
-  console.warn('No iPhone devices available in Simulator.')
+  Logger.global.warn('No iPhone devices available in Simulator.')
   return null;
 }
 


### PR DESCRIPTION
Problem booting simulator device if simulator is open but no devices booted.
To repro, have the simulator open, then close the simulator window (⌘W). The simulator doesn't quit, but has no windows. Then try to open an app on iOS simulator with Expo CLI: it hangs indefinitely, waiting for simulator to start.

Device ID is for iPhoneX, wasn't sure if that's an issue. There didn't seem to be any `simctl` args for default sim. If that poses a problem, might be easier to just call `_quitSimulatorAsync` and return false.