### PR TITLE
Parallelizing PWA icon generation

### DIFF
--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -443,7 +443,7 @@ function inferWebHomescreenIcons(config: Object = {}, getAbsolutePath: Function,
 }
 
 function inferWebStartupImages(config: Object = {}, getAbsolutePath: Function, options: Object) {
-  const { icon, web = {}, ios = {}, splash = {}, primaryColor } = config;
+  const { icon, web = {}, splash = {}, primaryColor } = config;
   if (Array.isArray(web.startupImages)) {
     return web.startupImages;
   }

--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -303,10 +303,14 @@ function applyWebDefaults(appJSON: Object) {
     webManifest.backgroundColor || splash.backgroundColor || DEFAULT_BACKGROUND_COLOR; // No default background color
 
   /**
+   *
    * https://developer.mozilla.org/en-US/docs/Web/Manifest#prefer_related_applications
    * Specifies a boolean value that hints for the user agent to indicate
    * to the user that the specified native applications (see below) are recommended over the website.
    * This should only be used if the related native apps really do offer something that the website can't... like Expo ;)
+   *
+   * >> The banner won't show up if the app is already installed:
+   * https://github.com/GoogleChrome/samples/issues/384#issuecomment-326387680
    */
 
   const preferRelatedApplications =
@@ -430,7 +434,7 @@ function inferWebHomescreenIcons(config: Object = {}, getAbsolutePath: Function,
     const iOSIconPath = getAbsolutePath(iOSIcon);
     icons.push({
       ios: true,
-      size: 1024,
+      sizes: [72, 114],
       src: iOSIconPath,
       destination,
     });
@@ -439,7 +443,7 @@ function inferWebHomescreenIcons(config: Object = {}, getAbsolutePath: Function,
 }
 
 function inferWebStartupImages(config: Object = {}, getAbsolutePath: Function, options: Object) {
-  const { web = {}, ios = {}, splash = {}, primaryColor } = config;
+  const { icon, web = {}, ios = {}, splash = {}, primaryColor } = config;
   if (Array.isArray(web.startupImages)) {
     return web.startupImages;
   }
@@ -449,7 +453,8 @@ function inferWebStartupImages(config: Object = {}, getAbsolutePath: Function, o
   let startupImages = [];
 
   let splashImageSource;
-  if (webSplash.image || iOSSplash.image || splash.image) {
+  const possibleIconSrc = webSplash.image || iOSSplash.image || splash.image || icon;
+  if (possibleIconSrc) {
     const resizeMode =
       webSplash.resizeMode || iOSSplash.resizeMode || splash.resizeMode || 'contain';
     const backgroundColor =
@@ -458,7 +463,7 @@ function inferWebStartupImages(config: Object = {}, getAbsolutePath: Function, o
       splash.backgroundColor ||
       primaryColor ||
       '#ffffff';
-    splashImageSource = getAbsolutePath(webSplash.image || iOSSplash.image || splash.image);
+    splashImageSource = getAbsolutePath(possibleIconSrc);
     startupImages.push({
       resizeMode,
       color: backgroundColor,

--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -30,7 +30,7 @@ const DEFAULT_DISPLAY = 'fullscreen';
 const DEFAULT_STATUS_BAR = 'default';
 const DEFAULT_LANG_DIR = 'auto';
 const DEFAULT_ORIENTATION = 'any';
-const ICON_SIZES = [96, 128, 192, 256, 384, 512];
+const ICON_SIZES = [192, 512];
 const MAX_SHORT_NAME_LENGTH = 12;
 const DEFAULT_PREFER_RELATED_APPLICATIONS = true;
 
@@ -434,7 +434,7 @@ function inferWebHomescreenIcons(config: Object = {}, getAbsolutePath: Function,
     const iOSIconPath = getAbsolutePath(iOSIcon);
     icons.push({
       ios: true,
-      sizes: [72, 114],
+      sizes: 180,
       src: iOSIconPath,
       destination,
     });

--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -462,7 +462,7 @@ function inferWebStartupImages(config: Object = {}, getAbsolutePath: Function, o
       resizeMode,
       color: backgroundColor,
       src: splashImageSource,
-      supportsTablet: ios.supportsTablet,
+      supportsTablet: webSplash.supportsTablet === undefined ? true : webSplash.supportsTablet,
       orientation: web.orientation,
       destination: `assets/splash`,
     });

--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -423,7 +423,8 @@ function inferWebHomescreenIcons(config: Object = {}, getAbsolutePath: Function,
     // Use template icon
     icon = options.templateIcon;
   }
-  icons.push({ src: icon, size: ICON_SIZES });
+  const destination = `assets/icons`;
+  icons.push({ src: icon, size: ICON_SIZES, destination });
   const iOSIcon = config.icon || ios.icon;
   if (iOSIcon) {
     const iOSIconPath = getAbsolutePath(iOSIcon);
@@ -431,13 +432,14 @@ function inferWebHomescreenIcons(config: Object = {}, getAbsolutePath: Function,
       ios: true,
       size: 1024,
       src: iOSIconPath,
+      destination,
     });
   }
   return icons;
 }
 
 function inferWebStartupImages(config: Object = {}, getAbsolutePath: Function, options: Object) {
-  const { web = {}, ios = {}, splash = {} } = config;
+  const { web = {}, ios = {}, splash = {}, primaryColor } = config;
   if (Array.isArray(web.startupImages)) {
     return web.startupImages;
   }
@@ -448,8 +450,18 @@ function inferWebStartupImages(config: Object = {}, getAbsolutePath: Function, o
 
   let splashImageSource;
   if (webSplash.image || iOSSplash.image || splash.image) {
+    const resizeMode =
+      webSplash.resizeMode || iOSSplash.resizeMode || splash.resizeMode || 'contain';
+    const backgroundColor =
+      webSplash.backgroundColor ||
+      iOSSplash.backgroundColor ||
+      splash.backgroundColor ||
+      primaryColor ||
+      '#ffffff';
     splashImageSource = getAbsolutePath(webSplash.image || iOSSplash.image || splash.image);
     startupImages.push({
+      resizeMode,
+      color: backgroundColor,
       src: splashImageSource,
       supportsTablet: ios.supportsTablet,
       orientation: web.orientation,

--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -448,21 +448,15 @@ function inferWebStartupImages(config: Object = {}, getAbsolutePath: Function, o
     return web.startupImages;
   }
 
-  const { splash: iOSSplash = {} } = ios;
   const { splash: webSplash = {} } = web;
   let startupImages = [];
 
   let splashImageSource;
-  const possibleIconSrc = webSplash.image || iOSSplash.image || splash.image || icon;
+  const possibleIconSrc = webSplash.image || splash.image || icon;
   if (possibleIconSrc) {
-    const resizeMode =
-      webSplash.resizeMode || iOSSplash.resizeMode || splash.resizeMode || 'contain';
+    const resizeMode = webSplash.resizeMode || splash.resizeMode || 'contain';
     const backgroundColor =
-      webSplash.backgroundColor ||
-      iOSSplash.backgroundColor ||
-      splash.backgroundColor ||
-      primaryColor ||
-      '#ffffff';
+      webSplash.backgroundColor || splash.backgroundColor || primaryColor || '#ffffff';
     splashImageSource = getAbsolutePath(possibleIconSrc);
     startupImages.push({
       resizeMode,

--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -10,8 +10,6 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%manifest.json" />
     <!-- iOS icons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%apple-touch-icon.png" />
-    <link rel="apple-touch-startup-image" href="%PUBLIC_URL%apple-touch-icon.png" />
     <link rel="mask-icon" href="" color="" />
 
     <!-- TODO: Bacon: build a reliable system for testing these style changes -->

--- a/packages/webpack-pwa-manifest-plugin/src/icons.js
+++ b/packages/webpack-pwa-manifest-plugin/src/icons.js
@@ -11,8 +11,6 @@ const supportedMimeTypes = [Jimp.MIME_PNG, Jimp.MIME_JPEG, Jimp.MIME_BMP];
 const ASPECT_FILL = 'cover';
 const ASPECT_FIT = 'contain';
 
-const log = (...p) => console.log('Icons:', ...p);
-
 export async function createBaseImageAsync(width, height, color) {
   return new Promise(
     (resolve, reject) =>
@@ -156,7 +154,8 @@ async function resize(img, mimeType, width, height, resizeMode = 'contain', colo
 }
 
 export function retrieveIcons(manifest) {
-  const { startupImages, icon, icons, ...config } = manifest;
+  // Remove these items so they aren't written to disk.
+  const { startupImages, apple, icon, icons, ...config } = manifest;
   const parsedStartupImages = parseArray(startupImages);
 
   let parsedIcons = parseArray(icons);

--- a/packages/webpack-pwa-manifest-plugin/src/icons.js
+++ b/packages/webpack-pwa-manifest-plugin/src/icons.js
@@ -11,6 +11,8 @@ const supportedMimeTypes = [Jimp.MIME_PNG, Jimp.MIME_JPEG, Jimp.MIME_BMP];
 const ASPECT_FILL = 'cover';
 const ASPECT_FIT = 'contain';
 
+const log = (...p) => console.log('Icons:', ...p);
+
 export async function createBaseImageAsync(width, height, color) {
   return new Promise(
     (resolve, reject) =>
@@ -124,12 +126,10 @@ async function processImage(size, icon, fingerprint, publicPath) {
   const _buffer = await getBufferWithMimeAsync(icon, mimeType, { width, height });
   return processIcon(width, height, icon, _buffer, mimeType, publicPath, fingerprint);
 }
-const log = (...p) => console.log('Splashscreen:', ...p);
 
 async function resize(img, mimeType, width, height, resizeMode = 'contain', color) {
   try {
     const initialImage = await Jimp.read(img);
-    log({ resizeMode });
     const center = Jimp.VERTICAL_ALIGN_MIDDLE | Jimp.HORIZONTAL_ALIGN_CENTER;
     if (resizeMode === ASPECT_FILL) {
       return await initialImage
@@ -180,9 +180,7 @@ export async function parseIcons(inputIcons, fingerprint, publicPath) {
   let assets = [];
 
   let promises = [];
-  console.log('processImages');
   for (const icon of inputIcons) {
-    console.log('processImage.icon');
     const { sizes } = icon;
     promises = [
       ...promises,
@@ -193,7 +191,6 @@ export async function parseIcons(inputIcons, fingerprint, publicPath) {
           fingerprint,
           publicPath
         );
-        console.log('processImage.size: ', size);
         icons.push(manifestIcon);
         assets.push(webpackAsset);
       }),

--- a/packages/webpack-pwa-manifest-plugin/src/index.js
+++ b/packages/webpack-pwa-manifest-plugin/src/index.js
@@ -95,7 +95,10 @@ class WebpackPwaManifest {
       }
 
       const publicPath = this.options.publicPath || compilation.options.output.publicPath;
-      await buildResources(this, publicPath);
+
+      // The manifest (this.manifest) should be ready by this point.
+      // It will be written to disk here.
+      const manifestFile = await buildResources(this, publicPath);
 
       if (!this.options.inject) {
         callback(null, htmlPluginData);
@@ -112,14 +115,17 @@ class WebpackPwaManifest {
         });
       }
 
-      const manifestLink = {
-        rel: 'manifest',
-        href: this.manifest.url,
-      };
-      if (this.manifest.crossorigin) {
-        manifestLink.crossorigin = this.manifest.crossorigin;
+      if (manifestFile) {
+        const manifestLink = {
+          rel: 'manifest',
+          href: manifestFile.url,
+        };
+        if (this.manifest.crossorigin) {
+          manifestLink.crossorigin = this.manifest.crossorigin;
+        }
+        tags = applyTag(tags, 'link', manifestLink);
       }
-      tags = applyTag(tags, 'link', manifestLink);
+
       tags = generateMaskIconLink(tags, this.assets);
 
       const tagsHTML = generateHtmlTags(tags);

--- a/packages/webpack-pwa-manifest-plugin/src/injector.js
+++ b/packages/webpack-pwa-manifest-plugin/src/injector.js
@@ -84,8 +84,8 @@ export async function buildResources(self, publicPath = '') {
 
     const { icons = {}, assets = [] } = parsedIconsResult;
     const results = writeManifestToFile(self.manifest, self.options, publicPath, icons);
-    self.manifest = results;
     self.assets = [results, ...assets];
+    return results;
   }
 }
 

--- a/packages/webpack-pwa-manifest-plugin/src/injector.js
+++ b/packages/webpack-pwa-manifest-plugin/src/injector.js
@@ -75,14 +75,11 @@ function writeManifestToFile(manifest, options, publicPath, icons) {
 
 export async function buildResources(self, publicPath = '') {
   if (!self.assets || !self.options.inject) {
-    publicPath = publicPath || '';
     let parsedIconsResult = {};
     if (!self.options.noResources) {
-      parsedIconsResult = await parseIcons(
-        self.options.fingerprints,
-        publicPath,
-        retrieveIcons(self.manifest)
-      );
+      const [results, config] = retrieveIcons(self.manifest);
+      self.manifest = config;
+      parsedIconsResult = await parseIcons(self.options.fingerprints, publicPath, results);
     }
 
     const { icons = {}, assets = [] } = parsedIconsResult;

--- a/packages/webpack-pwa-manifest-plugin/src/injector.js
+++ b/packages/webpack-pwa-manifest-plugin/src/injector.js
@@ -79,7 +79,7 @@ export async function buildResources(self, publicPath = '') {
     if (!self.options.noResources) {
       const [results, config] = retrieveIcons(self.manifest);
       self.manifest = config;
-      parsedIconsResult = await parseIcons(self.options.fingerprints, publicPath, results);
+      parsedIconsResult = await parseIcons(results, self.options.fingerprints, publicPath);
     }
 
     const { icons = {}, assets = [] } = parsedIconsResult;

--- a/packages/webpack-pwa-manifest-plugin/src/validators/Apple.js
+++ b/packages/webpack-pwa-manifest-plugin/src/validators/Apple.js
@@ -56,14 +56,21 @@ function getDevices({ orientation = 'natural', supportsTablet = true }) {
   return devices.map(device => ({ ...device, orientations }));
 }
 
-export function fromStartupImage({ orientation, supportsTablet, src, destination, color }) {
+export function fromStartupImage({
+  orientation,
+  supportsTablet,
+  src,
+  resizeMode,
+  destination,
+  color,
+}) {
   const devices = getDevices({ orientation, supportsTablet });
 
-  let startupImages = [];
+  const startupImages = [];
   for (const device of devices) {
     const { width, height } = device;
     for (const orientation of device.orientations) {
-      let size = orientation === 'portrait' ? [width, height] : [height, width];
+      const size = orientation === 'portrait' ? [width, height] : [height, width];
       startupImages.push({
         ios: 'startup',
         src,
@@ -71,6 +78,7 @@ export function fromStartupImage({ orientation, supportsTablet, src, destination
         scale: device.scale,
         media: assembleOrientationMedia(device.width, device.height, device.scale, orientation),
         destination,
+        resizeMode,
         color,
       });
     }


### PR DESCRIPTION
* Removed iOS splash screen prop from web PWA splash screen since the backgroundColor is used across both iOS and Android
* Changed default `apple-touch-icon` from 1024 to 180
* Removed all icon sizes `96, 128, 192, 256, 384, 512` in favor of browser optimized `192, 512`
* Removed unused template `apple-touch-icon` & `apple-touch-startup-image ` in favor of manifest plugin generated copies
* Fixed splash screen resize mode
* Fixed splash screen contain mode
* Parallelizing all icon generation for faster results
* Fixed splash screens meta tags not being generated