### PR TITLE
Add assetPlugins arg to React Native server start for SDK33+

### DIFF
--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1491,6 +1491,14 @@ export async function startReactNativeServerAsync(
     nonPersistent: !!options.nonPersistent,
   };
 
+  if (Versions.gteSdkVersion(exp, '33.0.0')) {
+    packagerOpts.assetPlugins = ConfigUtils.resolveModule(
+      'expo/tools/hashAssetFiles',
+      projectRoot,
+      exp
+    );
+  }
+
   if (options.maxWorkers) {
     packagerOpts['max-workers'] = options.maxWorkers;
   }
@@ -1535,6 +1543,7 @@ export async function startReactNativeServerAsync(
     },
     ['start']
   );
+
   if (options.reset) {
     cliOpts.push('--reset-cache');
   } // Get custom CLI path from project package.json, but fall back to node_module path

--- a/packages/xdl/src/Versions.js
+++ b/packages/xdl/src/Versions.js
@@ -61,6 +61,25 @@ export function gteSdkVersion(expJson: any, sdkVersion: string): boolean {
   }
 }
 
+export function lteSdkVersion(expJson: any, sdkVersion: string): boolean {
+  if (!expJson.sdkVersion) {
+    return false;
+  }
+
+  if (expJson.sdkVersion === 'UNVERSIONED') {
+    return false;
+  }
+
+  try {
+    return semver.lte(expJson.sdkVersion, sdkVersion);
+  } catch (e) {
+    throw new XDLError(
+      ErrorCode.INVALID_VERSION,
+      `${expJson.sdkVersion} is not a valid version. Must be in the form of x.y.z`
+    );
+  }
+}
+
 export function parseSdkVersionFromTag(tag: string) {
   if (tag.startsWith('sdk-')) {
     return tag.substring(4);


### PR DESCRIPTION
Start the React Native server with the assetPlugins CLI flag from https://github.com/react-native-community/cli/pull/318 and stop using a query parameter in the URL, as support for this regressed in Metro recentlyish and it's not an ideal way to inject this plugin anyhow.