### PR TITLE
Remove `Web` from Default Platforms

### DIFF
--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -558,7 +558,7 @@ export async function readConfigJsonAsync(
   }
 
   if (exp && !exp.platforms) {
-    exp.platforms = ['android', 'ios', 'web'];
+    exp.platforms = ['android', 'ios'];
   }
 
   if (exp.nodeModulesPath) {


### PR DESCRIPTION
If `platforms` key is missing in `app.json`, default is to provide it with all three (ios, android, & web). This results in the warning message - 

>Error: Problem validating fields in app.json. See https://docs.expo.io/versions/v32.0.0/workflow/configuration/
 • Field: platforms - should NOT have more than 2 items.

And also starts the webpack server. Proposing that by default just include ios and android in `platforms`

cc @brentvatne 