### PR TITLE
Fix Logging of Expo Web server

### DIFF
--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -65,7 +65,11 @@ async function action(projectDir, options) {
   const startOpts = await parseStartOptionsAsync(projectDir, options);
 
   await Project.startAsync(rootPath, startOpts);
-  await Web.logURL(projectDir);
+  
+  const hasWebSupport = await Web.hasWebSupportAsync(projectDir);
+  if (hasWebSupport) {
+    await Web.logURL(projectDir);
+  }
 
   const url = await UrlUtils.constructManifestUrlAsync(projectDir);
 


### PR DESCRIPTION
Right now, `logURL()` for web is called when web isn't supported, so the message 
>Expo Web is running at null

is displayed in logs.

Change was to check for web support before calling `logURL()`

Tested these changes locally

