### PR TITLE
[xdl] change app display name for adhoc builds

### DIFF
--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -257,7 +257,17 @@ async function _configureInfoPlistAsync(context: StandaloneContext) {
 
     // app name
     infoPlist.CFBundleName = config.name;
-    infoPlist.CFBundleDisplayName = config.name;
+
+    if (
+      context.build &&
+      context.build.isExpoClientBuild &&
+      context.build.isExpoClientBuild() === 'client'
+    ) {
+      // public facing app display name for adhoc builds
+      infoPlist.CFBundleDisplayName = 'Expo';
+    } else {
+      infoPlist.CFBundleDisplayName = config.name;
+    }
 
     // determine app linking schemes
     let linkingSchemes = config.scheme ? [config.scheme] : [];

--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -257,17 +257,7 @@ async function _configureInfoPlistAsync(context: StandaloneContext) {
 
     // app name
     infoPlist.CFBundleName = config.name;
-
-    if (
-      context.build &&
-      context.build.isExpoClientBuild &&
-      context.build.isExpoClientBuild() === 'client'
-    ) {
-      // public facing app display name for adhoc builds
-      infoPlist.CFBundleDisplayName = 'Expo';
-    } else {
-      infoPlist.CFBundleDisplayName = config.name;
-    }
+    infoPlist.CFBundleDisplayName = context.build.isExpoClientBuild() ? 'Expo' : config.name;
 
     // determine app linking schemes
     let linkingSchemes = config.scheme ? [config.scheme] : [];


### PR DESCRIPTION
When adhoc builds are run, instead of having the text below the app icon show as `expo-home`, display `Expo` instead.

TODO(quin) test these changes