### PR TITLE
Fix release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     ]
   },
   "devDependencies": {
+    "@expo/spawn-async": "^1.4.0",
     "eslint": "^5.15.3",
     "eslint-config-universe": "^2.0.0-alpha.0",
     "husky": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,7 +364,7 @@
   dependencies:
     cross-spawn "^5.1.0"
 
-"@expo/spawn-async@^1.2.8":
+"@expo/spawn-async@^1.2.8", "@expo/spawn-async@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.4.0.tgz#39f7777bdee22e1f48d03898c9ed2f150a7f4cbd"
   integrity sha512-jE9zSZ14eOfKxXs+WJZofweKtsAeuQiOpntsb+zp8Ti9/wk+9ZjKkffdld7UfANr8asmzuJYnEoVyL+hMy3SWw==


### PR DESCRIPTION
Because of lacking support for npm 2FA (https://github.com/lerna/lerna/issues/1091), our release script often fails and leaves behind a bad mess with tags to remove, working tree to clean and commits to reverse if you want to attempt again. This is kind of bad, if you need to make a release and you end up fighting the tools that are supposed to help with it, not make it more difficult.

This PR aims to fix some of the issues with the release script. Instead trying to use `lerna publish` for the whole process, we now call `lerna version` to determine which packages to publish, bump versions and tag them in git. Then the script loops over all packages and finds those with a version not found in the npm registry and simply runs `npm publish` to publish them, in topologically sorted order.

`npm publish` handles npm 2FA just fine, and prompts for a one time password, if needed, so 2FA should no longer be an issue.