### PR TITLE
[xdl][expo-cli] update @expo/spawn-async to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     ]
   },
   "devDependencies": {
-    "@expo/spawn-async": "^1.4.0",
+    "@expo/spawn-async": "^1.4.2",
     "eslint": "^5.15.3",
     "eslint-config-universe": "^2.0.0-alpha.0",
     "husky": "^1.1.3",

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -60,7 +60,7 @@
     "@expo/dev-tools": "^0.5.3",
     "@expo/json-file": "^8.1.2",
     "@expo/simple-spinner": "1.0.2",
-    "@expo/spawn-async": "1.3.0",
+    "@expo/spawn-async": "1.4.2",
     "axios": "0.18.0",
     "babel-runtime": "6.26.0",
     "base32.js": "0.1.0",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -35,7 +35,7 @@
     "@expo/ngrok": "2.4.3",
     "@expo/osascript": "^1.9.2",
     "@expo/schemer": "^1.2.4",
-    "@expo/spawn-async": "1.3.0",
+    "@expo/spawn-async": "1.4.2",
     "@expo/webpack-config": "^0.5.1",
     "analytics-node": "^2.1.0",
     "axios": "v0.19.0-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,14 +357,14 @@
   resolved "https://registry.yarnpkg.com/@expo/simple-spinner/-/simple-spinner-1.0.2.tgz#b31447de60e5102837a4edf702839fcc8f7f31f3"
   integrity sha1-sxRH3mDlECg3pO33AoOfzI9/MfM=
 
-"@expo/spawn-async@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.3.0.tgz#01b8a4f6bba10b792663f9272df66c7e90166dad"
-  integrity sha1-Abik9ruhC3kmY/knLfZsfpAWba0=
+"@expo/spawn-async@1.4.2", "@expo/spawn-async@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.4.2.tgz#334b28215e3850071cede3a23d898f977904e01a"
+  integrity sha512-afevfRz0S/R63MfAVQstrowC/M5cwWdIKkim4wqFSYmnvOejq8B8RAeWZ0lKimPmP2QfuvA/FG2L0SzonrHTKQ==
   dependencies:
-    cross-spawn "^5.1.0"
+    cross-spawn "^6.0.5"
 
-"@expo/spawn-async@^1.2.8", "@expo/spawn-async@^1.4.0":
+"@expo/spawn-async@^1.2.8":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.4.0.tgz#39f7777bdee22e1f48d03898c9ed2f150a7f4cbd"
   integrity sha512-jE9zSZ14eOfKxXs+WJZofweKtsAeuQiOpntsb+zp8Ti9/wk+9ZjKkffdld7UfANr8asmzuJYnEoVyL+hMy3SWw==


### PR DESCRIPTION
# Why

I released a new version of `@expo/spawn-async` which preserves async error stack traces. It will help with debuging users issues.

# How

I updated `@expo/spawn-async` package to 1.4.2 in `expo-cli` and `xdl`.

# Test plan

I tested new xdl version with turtle running locally and finally, an error stack trace contained information about the origin of the error.
<img width="1118" alt="Screenshot 2019-04-19 at 10 45 14" src="https://user-images.githubusercontent.com/5256730/56416594-94ef4700-6291-11e9-8092-dacc4ad2774e.png">