### PR TITLE
Make `manifest.env` available in publish and export commands

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1943,22 +1943,6 @@ export async function stopReactNativeServerAsync(projectRoot: string): Promise<v
   });
 }
 
-let blacklistedEnvironmentVariables = new Set([
-  'EXPO_APPLE_PASSWORD',
-  'EXPO_ANDROID_KEY_PASSWORD',
-  'EXPO_ANDROID_KEYSTORE_PASSWORD',
-  'EXPO_IOS_DIST_P12_PASSWORD',
-  'EXPO_IOS_PUSH_P12_PASSWORD',
-  'EXPO_CLI_PASSWORD',
-]);
-
-function shouldExposeEnvironmentVariableInManifest(key: string) {
-  if (blacklistedEnvironmentVariables.has(key.toUpperCase())) {
-    return false;
-  }
-  return key.startsWith('REACT_NATIVE_') || key.startsWith('EXPO_');
-}
-
 export async function startExpoServerAsync(projectRoot: string): Promise<void> {
   _assertValidProjectRoot(projectRoot);
   await stopExpoServerAsync(projectRoot);
@@ -2002,12 +1986,6 @@ export async function startExpoServerAsync(projectRoot: string): Promise<void> {
         projectRoot,
       };
       manifest.packagerOpts = packagerOpts;
-      manifest.env = {};
-      for (let key of Object.keys(process.env)) {
-        if (shouldExposeEnvironmentVariableInManifest(key)) {
-          manifest.env[key] = process.env[key];
-        }
-      }
       let platform = (req.headers['exponent-platform'] || 'ios').toString();
       let entryPoint = Exp.determineEntryPoint(projectRoot, platform);
       let mainModuleName = UrlUtils.guessMainModulePath(entryPoint);


### PR DESCRIPTION
Make `process.env` variables available in `manifest.env` in `expo publish` and `expo export` commands like in `expo start` allowing a project to have a `app.json` with settings which can be set using environment variables, eg:

In `app.json`:

```json
{
  "expo": {
    "extra": {
      "apiEndpoint": "http://www.example.com/api"
    }
  }
}
```

In `src/App.js`:

```js
import { Constants } from 'expo';

class App extends Component {
  constructor(props) {
    super(props);
    this.apiUrl = process.env.EXPO_API_URL || Constants.manifest.extra.apiUrl;
  }
}
```

```sh
$ # Following already works in `start` command
$ EXPO_API_URL="http://localhost:8080/api" expo start
$ # Usage in `publish` command
$ EXPO_API_URL="http://localhost:8080/api" expo publish
```