### PR TITLE
Added `--no-pwa` flag

### DIFF
--- a/packages/expo-cli/src/commands/build/index.js
+++ b/packages/expo-cli/src/commands/build/index.js
@@ -107,12 +107,11 @@ export default (program: any) => {
   program
     .command('build:web [project-dir]')
     .option('--no-polyfill', 'Prevent webpack from including @babel/polyfill')
-    .option('-d, --dev', 'Bundle your project using webpack in dev mode.')
     .option(
-      '--stats <path>',
-      'Output path for webpack stats. Defaults to "web-build-stats.json"',
-      'web-build-stats.json'
+      '--no-pwa',
+      'Prevent webpack from generating the manifest.json and injecting meta into the index.html head.'
     )
+    .option('-d, --dev', 'Bundle your project using webpack in dev mode.')
     .description('Build a production bundle for your project, compressed and ready for deployment.')
     .asyncActionProjectDir(
       (projectDir, options) => Webpack.bundleAsync(projectDir, options),

--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -140,15 +140,17 @@ module.exports = function(env = {}, argv) {
     );
   }
 
-  // Generate the `manifest.json`
-  middlewarePlugins.push(
-    new WebpackPWAManifestPlugin(config, {
-      ...env,
-      publicPath,
-      noResources: env.development,
-      filename: locations.production.manifest,
-    })
-  );
+  if (env.pwa) {
+    // Generate the `manifest.json`
+    middlewarePlugins.push(
+      new WebpackPWAManifestPlugin(config, {
+        ...env,
+        publicPath,
+        noResources: env.development,
+        filename: locations.production.manifest,
+      })
+    );
+  }
 
   /**
    * report: {

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -59,6 +59,7 @@ export async function startAsync(
   let { dev, https } = await ProjectSettings.readAsync(projectRoot);
   const config = Web.invokeWebpackConfig({
     projectRoot,
+    pwa: true,
     development: dev,
     production: !dev,
     https,
@@ -146,6 +147,7 @@ export async function bundleAsync(projectRoot: string, packagerOpts: Object): Pr
 
   let config = Web.invokeWebpackConfig({
     projectRoot,
+    pwa: packagerOpts.pwa,
     polyfill: packagerOpts.polyfill,
     development: packagerOpts.dev,
     production: !packagerOpts.dev,


### PR DESCRIPTION
with `expo build:web --no-pwa` you can prevent the bundling of PWA features which can save up to a minute of generation time. 