### PR TITLE
fix: use case-sensitive names for imports

### DIFF
--- a/packages/webpack-pwa-manifest-plugin/src/index.js
+++ b/packages/webpack-pwa-manifest-plugin/src/index.js
@@ -7,8 +7,8 @@ import {
   generateMaskIconLink,
   injectResources,
 } from './injector';
-import validateColors from './validators/Colors';
-import validatePresets from './validators/Presets';
+import validateColors from './validators/colors';
+import validatePresets from './validators/presets';
 
 const TAP_CMD = 'webpack-pwa-manifest-plugin';
 const TAP = 'WebpackPWAManifestPlugin';


### PR DESCRIPTION
> It's always safe to use case-sensitive names

Fixes #545