### PR TITLE
[travelling-fastlane] return provisioning profile even if we dont end…

### DIFF
--- a/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
+++ b/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
@@ -77,7 +77,12 @@ with_captured_output{
       device_udids_in_profile = Set.new(existing_profile.devices.map { |d| d.udid })
       all_device_udids = Set.new($udids)
       if device_udids_in_profile == all_device_udids and existing_profile.valid?
-        $result = { result: 'success' }
+        profile = download_provisioning_profile(existing_profile)
+        $result = { 
+          result: 'success',
+          provisioningProfileId: profile[:id],
+          provisioningProfile: profile[:content],
+        }
       else
         # We need to add new devices to the list and create a new provisioning profile.
         existing_profile.devices = devices


### PR DESCRIPTION
… up modifying it

# Why
The provisioning profile is not sent to turtle in the job request, so in the case where we dont end up modifying the provisioning profile, we should just return the profile we requested from Apple so we dont error out. 

# error i saw
![Image from iOS (7)](https://user-images.githubusercontent.com/6380927/56978027-714abd00-6b2b-11e9-9e65-1586a43f3431.png)
