### PR TITLE
[travelling-fastlane] change the way we choose provisioning profiles

### DIFF
--- a/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
+++ b/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
@@ -61,7 +61,7 @@ def find_profile_by_bundle_id(bundle_id)
     # append the certificate and update the profile 
     dist_cert = find_dist_cert($certSerialNumber, in_house?($teamId))
     profile = expo_profiles.sort_by{|profile| profile.expires}.last
-    profile.certificates.push(dist_cert)
+    profile.certificates = [dist_cert]
     profile.update!
   else
      # there is no valid provisioning profile available
@@ -133,7 +133,7 @@ with_captured_output{
       else
         # If the provisioning profile for the App ID doesn't exist, we just need to create a new one!
         new_profile = Spaceship::Portal.provisioning_profile.ad_hoc.create!(
-          name: "*[expo] #{$bundleId} AdHoc", # apple drops [ if its the first char (!!)
+          name: "*[expo] #{$bundleId} AdHoc #{DateTime.now.to_s()}", # apple drops [ if its the first char (!!)
           bundle_id: $bundleId,
           certificate: dist_cert,
           devices: devices

--- a/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
+++ b/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
@@ -43,7 +43,31 @@ def register_missing_devices(udids)
 end
 
 def find_profile_by_bundle_id(bundle_id)
-  Spaceship::Portal.provisioning_profile.ad_hoc.find_by_bundle_id(bundle_id: bundle_id).first
+  expo_profiles = Spaceship::Portal.provisioning_profile.ad_hoc.find_by_bundle_id(bundle_id: bundle_id)
+  expo_profiles = expo_profiles.select{ |profile|
+    profile.name.start_with?('*[expo]') and profile.expires.to_datetime > DateTime.now
+  }
+  # find profiles associated with our development cert
+  expo_profiles_with_cert = expo_profiles.select{ |profile|
+    profile.certificates.any?{|cert| cert.raw_data['serialNumber'] == $certSerialNumber} # this api only returns field 'serialNumber', but not 'serialNum'
+  }
+
+  if !expo_profiles_with_cert.empty?
+    # there is an expo managed profile with our desired certificate
+    # return the profile that will be valid for the longest duration
+    expo_profiles_with_cert.sort_by{|profile| profile.expires}.last  
+  elsif !expo_profiles.empty? 
+    # there is an expo managed profile, but it doesnt have our desired certificate
+    # append the certificate and update the profile 
+    dist_cert = find_dist_cert($certSerialNumber, in_house?($teamId))
+    profile = expo_profiles.sort_by{|profile| profile.expires}.last
+    profile.certificates.push(dist_cert)
+    profile.update!
+  else
+     # there is no valid provisioning profile available
+    nil 
+  end
+
 end
 
 def download_provisioning_profile(profile)
@@ -109,6 +133,7 @@ with_captured_output{
       else
         # If the provisioning profile for the App ID doesn't exist, we just need to create a new one!
         new_profile = Spaceship::Portal.provisioning_profile.ad_hoc.create!(
+          name: "*[expo] #{$bundleId} AdHoc", # apple drops [ if its the first char (!!)
           bundle_id: $bundleId,
           certificate: dist_cert,
           devices: devices


### PR DESCRIPTION
# Why
right now, we choose provisioning profiles by selecting the first available profile associated with the app bundle id. this should change because:
- We potentially modify the profile (add udid). The user may have non-expo managed profile they dont want modified (especially as we support adhoc builds for apps other than expo-home). 
- The provisioning profile may not be associated with the correct development certificate that was uploaded to turtle

# what this pr does
- prepend provisioning profile name with "*[expo]", and only modify profiles with this string
- choose the provisioning profile with the development certs we want. If none exist, we add the cert to the profile and update it on the apple servers

# error i saw 
![Image from iOS (6)](https://user-images.githubusercontent.com/6380927/56978460-647a9900-6b2c-11e9-801e-6a55609ee857.png)

# testing
- [x] user has no provisionig profile, expect new one to be made
- [x] user has provisionig profile with invalid cert, expect valid cert to be attached
- [x] user has provisioning profile with valid cert, expect this cert to be returned instead
- [x] user has non-expo managed profile, expect this never to be used