### PR TITLE
Only start webpack if the user invokes web.

### DIFF
--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -2075,14 +2075,13 @@ export async function startAsync(
     projectRoot,
     developerTool: Config.developerTool,
   });
-  if (!options.webOnly) {
+  if (options.webOnly) {
+    await Webpack.startAsync(projectRoot, options, verbose);
+  } else {
     await startExpoServerAsync(projectRoot);
     await startReactNativeServerAsync(projectRoot, options, verbose);
   }
-  const hasWebSupport = await Doctor.hasWebSupportAsync(projectRoot);
-  if (hasWebSupport) {
-    await Webpack.startAsync(projectRoot, options, verbose);
-  }
+
   if (!Config.offline) {
     try {
       await startTunnelsAsync(projectRoot);


### PR DESCRIPTION
Webpack will only start if:
* platforms only contains web
* `--web-only` flag was passed
* `--web` flag was passed
* User presses `w` in the interactive prompt after running `expo start`
