### PR TITLE
Add how to get info about a specific command in --help output

### DIFF
--- a/packages/expo-cli/src/exp.js
+++ b/packages/expo-cli/src/exp.js
@@ -50,6 +50,10 @@ Command.prototype.allowOffline = function() {
   return this;
 };
 
+program.on('--help', () => {
+  log(`To learn more about a specific command and its options use 'expo [command] --help'\n`);
+});
+
 // asyncAction is a wrapper for all commands/actions to be executed after commander is done
 // parsing the command input
 Command.prototype.asyncAction = function(asyncFn, skipUpdateCheck) {


### PR DESCRIPTION
Currently it's not very clear how to get information about a specific command and see what the options are. 

This PR fixes that by adding a message about it at the end of the `--help` output.