### PR TITLE
Reuse browser tabs

### DIFF
--- a/packages/dev-tools/server/dev-server.js
+++ b/packages/dev-tools/server/dev-server.js
@@ -3,7 +3,7 @@ import { Project } from 'xdl';
 import express from 'express';
 import http from 'http';
 import next from 'next';
-import opn from 'opn';
+import openBrowser from 'react-dev-utils/openBrowser';
 
 import { startGraphQLServer } from './DevToolsServer';
 
@@ -34,7 +34,7 @@ async function run() {
     await Project.startAsync(projectDir);
     let url = `http://localhost:${PORT}`;
     console.log(`Development server running at ${url}`);
-    opn(url);
+    openBrowser(url);
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -5,7 +5,7 @@
 import { DevToolsServer } from '@expo/dev-tools';
 import { ProjectUtils, Web, Project, UserSettings, UrlUtils } from 'xdl';
 import chalk from 'chalk';
-import opn from 'opn';
+import openBrowser from 'react-dev-utils/openBrowser';
 import path from 'path';
 
 import log from '../log';
@@ -58,7 +58,7 @@ async function action(projectDir, options) {
   if (!nonInteractive && !exp.isDetached) {
     if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
       log(`Opening DevTools in the browser... (press ${chalk.bold`shift-d`} to disable)`);
-      opn(devToolsUrl, { wait: false });
+      openBrowser(devToolsUrl);
     } else {
       log(
         `Press ${chalk.bold`d`} to open DevTools now, or ${chalk.bold`shift-d`} to always open it automatically.`

--- a/packages/expo-cli/src/commands/start/TerminalUI.js
+++ b/packages/expo-cli/src/commands/start/TerminalUI.js
@@ -14,7 +14,7 @@ import {
 } from 'xdl';
 
 import chalk from 'chalk';
-import opn from 'opn';
+import openBrowser from 'react-dev-utils/openBrowser';
 import readline from 'readline';
 import trimStart from 'lodash/trimStart';
 import wordwrap from 'wordwrap';
@@ -155,7 +155,7 @@ export const startAsync = async (projectDir, options) => {
       case 'd': {
         const { devToolsPort } = await ProjectSettings.readPackagerInfoAsync(projectDir);
         log('Opening DevTools in the browser...');
-        opn(`http://localhost:${devToolsPort}`, { wait: false });
+        openBrowser(`http://localhost:${devToolsPort}`);
         printHelp();
         break;
       }

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import opn from 'opn';
+import openBrowser from 'react-dev-utils/openBrowser';
 import path from 'path';
 
 import Logger from './Logger';
@@ -32,7 +32,7 @@ export async function openProjectAsync(projectRoot) {
 
   try {
     let url = await UrlUtils.constructWebAppUrlAsync(projectRoot);
-    opn(url, { wait: false });
+    openBrowser(url);
     return { success: true, url };
   } catch (e) {
     Logger.global.error(`Couldn't start project on web: ${e.message}`);


### PR DESCRIPTION
Currently, when using web and devtools you get a new tab each time. This exacerbates the annoying feeling of needing to restart the bundler. Using `react-dev-utils/openBrowser` wrapper for the `opn` module we can attempt to reuse tabs when possible.