### PR TITLE
Config upgrades for codesandbox

### DIFF
--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -232,7 +232,7 @@ export async function getConfigForPWA(
   getAbsolutePath: Function,
   options: Object
 ) {
-  const { exp } = await readConfigJsonAsync(projectRoot, { isConfigOptional: true });
+  const { exp } = await readConfigJsonAsync(projectRoot, { isConfigOptional: false });
   return ensurePWAConfig(exp, getAbsolutePath, options);
 }
 export function getNameFromConfig(exp: Object = {}) {

--- a/packages/config/src/Config.js
+++ b/packages/config/src/Config.js
@@ -227,9 +227,13 @@ function sanitizePublicPath(publicPath) {
   return publicPath + '/';
 }
 
-export function getConfigForPWA(projectRoot: string, getAbsolutePath: Function, options: Object) {
-  const config = unsafeReadConfigJsonSync(projectRoot);
-  return ensurePWAConfig(config, getAbsolutePath, options);
+export async function getConfigForPWA(
+  projectRoot: string,
+  getAbsolutePath: Function,
+  options: Object
+) {
+  const { exp } = await readConfigJsonAsync(projectRoot, { isConfigOptional: true });
+  return ensurePWAConfig(exp, getAbsolutePath, options);
 }
 export function getNameFromConfig(exp: Object = {}) {
   // For RN CLI support
@@ -511,31 +515,6 @@ function applyRequiredConfigFields(projectRoot: string, exp: Object, pkg: Object
   }
 
   return outputExp;
-}
-
-export function unsafeReadConfigJsonSync(projectRoot: string) {
-  const { configPath, configNamespace } = findConfigFile(projectRoot);
-
-  let exp;
-  let rootConfig;
-
-  try {
-    exp = require(configPath);
-  } catch (error) {}
-
-  exp = exp || { expo: { platforms: ['android', 'ios', 'web'] } };
-
-  if (configNamespace) {
-    // if we're not using exp.json, then we've stashed everything under an expo key
-    rootConfig = exp;
-    exp = exp[configNamespace];
-  }
-
-  if (!rootConfig) {
-    throw new Error(`${APP_JSON_FILE_NAME} could not be found at: ${configPath}`);
-  }
-
-  return exp;
 }
 
 export async function readConfigJsonAsync(

--- a/packages/webpack-config/webpack.config.js
+++ b/packages/webpack-config/webpack.config.js
@@ -3,10 +3,10 @@ const developmentConfig = require('./webpack/webpack.dev');
 const productionConfig = require('./webpack/webpack.prod');
 const getMode = require('./webpack/utils/getMode');
 
-module.exports = function(env = {}, argv) {
+module.exports = async function(env = {}, argv) {
   // Fill all config values with PWA defaults
   if (!env.config) {
-    env.config = getConfig(env);
+    env.config = await getConfig(env);
   }
 
   const mode = getMode(env);

--- a/packages/webpack-config/webpack.config.js
+++ b/packages/webpack-config/webpack.config.js
@@ -1,4 +1,4 @@
-const getConfig = require('./webpack/utils/getConfig');
+const getConfigAsync = require('./webpack/utils/getConfigAsync');
 const developmentConfig = require('./webpack/webpack.dev');
 const productionConfig = require('./webpack/webpack.prod');
 const getMode = require('./webpack/utils/getMode');
@@ -6,14 +6,14 @@ const getMode = require('./webpack/utils/getMode');
 module.exports = async function(env = {}, argv) {
   // Fill all config values with PWA defaults
   if (!env.config) {
-    env.config = await getConfig(env);
+    env.config = await getConfigAsync(env);
   }
 
   const mode = getMode(env);
 
   if (mode === 'development') {
-    return developmentConfig(env, argv);
+    return await developmentConfig(env, argv);
   } else {
-    return productionConfig(env, argv);
+    return await productionConfig(env, argv);
   }
 };

--- a/packages/webpack-config/webpack/createDevServerConfig.js
+++ b/packages/webpack-config/webpack/createDevServerConfig.js
@@ -1,13 +1,13 @@
 const evalSourceMapMiddleware = require('react-dev-utils/evalSourceMapMiddleware');
 const errorOverlayMiddleware = require('react-dev-utils/errorOverlayMiddleware');
 const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMiddleware');
-const getPaths = require('./utils/getPaths');
+const { getPathsAsync } = require('./utils/PathUtils');
 
 const host = process.env.HOST || '0.0.0.0';
 
-module.exports = function(env = {}, argv, allowedHost, proxy = undefined) {
+module.exports = async function(env = {}, argv, allowedHost, proxy = undefined) {
   const { https = false, config: { web: { build: { publicPath = '/' } = {} } = {} } = {} } = env;
-  const locations = getPaths(env);
+  const locations = await getPathsAsync(env);
   // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpackDevServer.config.js
   const CRA = {
     // Enable gzip compression of generated files.

--- a/packages/webpack-config/webpack/createIndexHTMLFromAppJSON.js
+++ b/packages/webpack-config/webpack/createIndexHTMLFromAppJSON.js
@@ -1,7 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { overrideWithPropertyOrConfig } = require('./utils/config');
-const getPaths = require('./utils/getPaths');
-const getConfig = require('./utils/getConfig');
+const { getPathsAsync } = require('./utils/PathUtils');
+const getConfigAsync = require('./utils/getConfigAsync');
 const getMode = require('./utils/getMode');
 
 const DEFAULT_MINIFY = {
@@ -17,9 +17,9 @@ const DEFAULT_MINIFY = {
   minifyURLs: true,
 };
 
-module.exports = function createIndexHTMLFromAppJSON(env) {
-  const locations = getPaths(env);
-  const config = getConfig(env);
+module.exports = async function createIndexHTMLFromAppJSON(env) {
+  const locations = await getPathsAsync(env);
+  const config = await getConfigAsync(env);
   const isProduction = getMode(env) === 'production';
 
   const { web: { name, build = {} } = {} } = config;

--- a/packages/webpack-config/webpack/loaders/createBabelLoader.js
+++ b/packages/webpack-config/webpack/loaders/createBabelLoader.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const getPaths = require('../utils/getPaths');
+const { ensureProjectRoot } = require('../utils/PathUtils');
 
 const getModule = name => path.join('node_modules', name);
 
@@ -14,12 +14,6 @@ const includeModulesThatContainPaths = [
   getModule('@unimodules'),
 ];
 
-function ensureRoot(possibleProjectRoot) {
-  if (typeof possibleProjectRoot === 'string') {
-    return possibleProjectRoot;
-  }
-  return getPaths().root;
-}
 /**
  * A complex babel loader which uses the project's `babel.config.js`
  * to resolve all of the Unimodules which are shipped as ES modules (early 2019).
@@ -30,11 +24,11 @@ module.exports = function({
    */
   mode,
   babelProjectRoot,
-  pathsToInclude = [],
+  extraModules = [],
   ...options
 } = {}) {
-  const ensuredProjectRoot = ensureRoot(babelProjectRoot);
-  const modules = [...includeModulesThatContainPaths, ...pathsToInclude];
+  const ensuredProjectRoot = ensureProjectRoot(babelProjectRoot);
+  const modules = [...includeModulesThatContainPaths, ...extraModules];
   const customUse = options.use || {};
   const customUseOptions = customUse.options || {};
 

--- a/packages/webpack-config/webpack/utils/PathUtils.js
+++ b/packages/webpack-config/webpack/utils/PathUtils.js
@@ -71,7 +71,7 @@ async function getPathsAsync({ locations, projectRoot }) {
   const { exp: nativeAppManifest, pkg } = await ConfigUtils.readConfigJsonAsync(
     absoluteProjectRoot,
     {
-      isConfigOptional: true,
+      isConfigOptional: false,
     }
   );
 

--- a/packages/webpack-config/webpack/utils/getConfigAsync.js
+++ b/packages/webpack-config/webpack/utils/getConfigAsync.js
@@ -1,13 +1,15 @@
 const { getConfigForPWA } = require('@expo/config');
-const getPaths = require('./getPaths');
+const { getPathsAsync } = require('./PathUtils');
 
-module.exports = function(env) {
+async function getConfigAsync(env) {
   if (env.config) {
     return env.config;
   }
-  const locations = getPaths(env);
+  const locations = await getPathsAsync(env);
   // Fill all config values with PWA defaults
   return getConfigForPWA(env.projectRoot, locations.absolute, {
     templateIcon: locations.template.get('icon.png'),
   });
-};
+}
+
+module.exports = getConfigAsync;

--- a/packages/webpack-config/webpack/utils/getDevtool.js
+++ b/packages/webpack-config/webpack/utils/getDevtool.js
@@ -1,0 +1,16 @@
+function getDevtool(env, { devtool }) {
+  if (env.production) {
+    // string or false
+    if (devtool !== undefined) {
+      // When big assets are involved sources maps can become expensive and cause your process to run out of memory.
+      return devtool;
+    }
+    return 'source-map';
+  }
+  if (env.development) {
+    return 'cheap-module-source-map';
+  }
+  return false;
+}
+
+module.exports = getDevtool;

--- a/packages/webpack-config/webpack/utils/getPaths.js
+++ b/packages/webpack-config/webpack/utils/getPaths.js
@@ -73,7 +73,7 @@ module.exports = function getPaths({ locations, projectRoot }) {
     appMain = main;
   }
 
-  const nativeAppManifest = require(appJsonPath);
+  const nativeAppManifest = ConfigUtils.unsafeReadConfigJsonSync(absoluteProjectRoot);
   const config = ConfigUtils.ensurePWAConfig(nativeAppManifest);
 
   const productionPath = absolute(config.web.build.output);

--- a/packages/webpack-config/webpack/webpack.dev.js
+++ b/packages/webpack-config/webpack/webpack.dev.js
@@ -4,22 +4,21 @@ const webpack = require('webpack');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 const common = require('./webpack.common.js');
-const getPaths = require('./utils/getPaths');
-const getConfig = require('./utils/getConfig');
+const { getPathsAsync } = require('./utils/PathUtils');
+const getConfigAsync = require('./utils/getConfigAsync');
 
 const createDevServerConfig = require('./createDevServerConfig');
 
-module.exports = function(env = {}, argv) {
+module.exports = async function(env = {}, argv) {
   if (!env.config) {
     // Fill all config values with PWA defaults
-    env.config = getConfig(env);
+    env.config = await getConfigAsync(env);
   }
 
-  const locations = getPaths(env);
+  const locations = await getPathsAsync(env);
 
-  const devServer = createDevServerConfig(env, argv);
-  return merge(common(env, argv), {
-    mode: 'development',
+  const devServer = await createDevServerConfig(env, argv);
+  return merge(await common(env, argv), {
     entry: [
       // https://github.com/facebook/create-react-app/blob/e59e0920f3bef0c2ac47bbf6b4ff3092c8ff08fb/packages/react-scripts/config/webpack.config.js#L144
       // Include an alternative client for WebpackDevServer. A client's job is to

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -42,7 +42,7 @@ export async function openProjectAsync(projectRoot) {
 
 // If platforms only contains the "web" field
 export async function onlySupportsWebAsync(projectRoot) {
-  const { exp } = await readConfigJsonAsync(projectRoot);
+  const { exp } = await readConfigJsonAsync(projectRoot, { isConfigOptional: true });
   if (Array.isArray(exp.platforms) && exp.platforms.length === 1) {
     return exp.platforms[0] === 'web';
   }

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -20,7 +20,7 @@ export async function invokeWebpackConfigAsync(env, argv) {
   const projectWebpackConfig = path.resolve(env.projectRoot, 'webpack.config.js');
   if (fs.existsSync(projectWebpackConfig)) {
     const webpackConfig = require(projectWebpackConfig);
-    return invokePossibleFunction(webpackConfig, env, argv);
+    return await invokePossibleFunction(webpackConfig, env, argv);
   }
   // Fallback to the default expo webpack config.
   const config = require('@expo/webpack-config');

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -15,7 +15,7 @@ function invokePossibleFunction(objectOrMethod, ...args) {
   }
 }
 
-export function invokeWebpackConfig(env, argv) {
+export async function invokeWebpackConfigAsync(env, argv) {
   // Check if the project has a webpack.config.js in the root.
   const projectWebpackConfig = path.resolve(env.projectRoot, 'webpack.config.js');
   if (fs.existsSync(projectWebpackConfig)) {
@@ -24,7 +24,7 @@ export function invokeWebpackConfig(env, argv) {
   }
   // Fallback to the default expo webpack config.
   const config = require('@expo/webpack-config');
-  return config(env, argv);
+  return await config(env, argv);
 }
 
 export async function openProjectAsync(projectRoot) {

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -42,7 +42,7 @@ export async function openProjectAsync(projectRoot) {
 
 // If platforms only contains the "web" field
 export async function onlySupportsWebAsync(projectRoot) {
-  const { exp } = await readConfigJsonAsync(projectRoot, { isConfigOptional: true });
+  const { exp } = await readConfigJsonAsync(projectRoot, { isConfigOptional: false });
   if (Array.isArray(exp.platforms) && exp.platforms.length === 1) {
     return exp.platforms[0] === 'web';
   }

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -57,7 +57,7 @@ export async function startAsync(
   const { webName } = ConfigUtils.getNameFromConfig(exp);
 
   let { dev, https } = await ProjectSettings.readAsync(projectRoot);
-  const config = Web.invokeWebpackConfig({
+  const config = await Web.invokeWebpackConfigAsync({
     projectRoot,
     pwa: true,
     development: dev,
@@ -145,7 +145,7 @@ export async function bundleAsync(projectRoot: string, packagerOpts: Object): Pr
   process.env.BABEL_ENV = mode;
   process.env.NODE_ENV = mode;
 
-  let config = Web.invokeWebpackConfig({
+  let config = await Web.invokeWebpackConfigAsync({
     projectRoot,
     pwa: packagerOpts.pwa,
     polyfill: packagerOpts.polyfill,

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -53,7 +53,7 @@ export async function startAsync(
 
   const useYarn = ConfigUtils.isUsingYarn(projectRoot);
 
-  const { exp } = await ProjectUtils.readConfigJsonAsync(projectRoot);
+  const { exp } = await ProjectUtils.readConfigJsonAsync(projectRoot, { isConfigOptional: true });
   const { webName } = ConfigUtils.getNameFromConfig(exp);
 
   let { dev, https } = await ProjectSettings.readAsync(projectRoot);

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -53,7 +53,7 @@ export async function startAsync(
 
   const useYarn = ConfigUtils.isUsingYarn(projectRoot);
 
-  const { exp } = await ProjectUtils.readConfigJsonAsync(projectRoot, { isConfigOptional: true });
+  const { exp } = await ProjectUtils.readConfigJsonAsync(projectRoot, { isConfigOptional: false });
   const { webName } = ConfigUtils.getNameFromConfig(exp);
 
   let { dev, https } = await ProjectSettings.readAsync(projectRoot);

--- a/packages/xdl/src/project/Doctor.js
+++ b/packages/xdl/src/project/Doctor.js
@@ -439,7 +439,8 @@ export async function validateWithNetworkAsync(projectRoot: string): Promise<num
 export async function hasWebSupportAsync(projectRoot, exp) {
   let inputExp = exp;
   if (!exp) {
-    inputExp = (await ProjectUtils.readConfigJsonAsync(projectRoot)).exp;
+    inputExp = (await ProjectUtils.readConfigJsonAsync(projectRoot, { isConfigOptional: true }))
+      .exp;
   }
   const { platforms } = inputExp;
   if (!Array.isArray(platforms)) {

--- a/packages/xdl/src/project/Doctor.js
+++ b/packages/xdl/src/project/Doctor.js
@@ -439,7 +439,7 @@ export async function validateWithNetworkAsync(projectRoot: string): Promise<num
 export async function hasWebSupportAsync(projectRoot, exp) {
   let inputExp = exp;
   if (!exp) {
-    inputExp = (await ProjectUtils.readConfigJsonAsync(projectRoot, { isConfigOptional: true }))
+    inputExp = (await ProjectUtils.readConfigJsonAsync(projectRoot, { isConfigOptional: false }))
       .exp;
   }
   const { platforms } = inputExp;

--- a/packages/xdl/src/project/ProjectUtils.js
+++ b/packages/xdl/src/project/ProjectUtils.js
@@ -130,10 +130,11 @@ export async function readExpRcAsync(projectRoot: string): Promise<any> {
 }
 
 export async function readConfigJsonAsync(
-  projectRoot: string
+  projectRoot: string,
+  options: Object
 ): Promise<{ exp?: Object, pkg?: Object, rootConfig?: Object }> {
   try {
-    return await ConfigUtils.readConfigJsonAsync(projectRoot);
+    return await ConfigUtils.readConfigJsonAsync(projectRoot, options);
   } catch (error) {
     logError(projectRoot, 'expo', error.message);
     return { exp: null, pkg: null };


### PR DESCRIPTION
* Possible to generate a temp expo config in the `.expo` folder when one isn't present. This will also log out: "Config not found. Using virtual app.json, it's recommended that you create an app.json in the root of your project."
* Async webpack.config for reading a newly generated expo config.

# Test Plan

In a project without an `app.json` use `node start.js`

```js
// /start.js
const fs = require("fs");
const { Webpack } = require("xdl");

Webpack.startAsync(
  fs.realpathSync(process.cwd()),
  { nonInteractive: process.stdout.isTTY },
  true
);
```

which should generate `.expo/app.json`, and start the web project.

Once published, the following sandbox should work: https://codesandbox.io/s/rr8kl1lkpn