### PR TITLE
Fix problems with building/running an ejected Expo app

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.js
+++ b/packages/expo-cli/src/commands/eject/Eject.js
@@ -231,7 +231,9 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
     const versions = await Versions.versionsAsync();
     const reactNativeVersion = versions['sdkVersions'][sdkVersion]['facebookReactNativeVersion'];
 
-    pkgJson.dependencies['@babel/runtime'] = 'latest';
+    if (semver.satisfies(sdkVersion, '31 - 32')) {
+      pkgJson.dependencies['@babel/runtime'] = '^7.0.0';
+    }
     pkgJson.dependencies['react-native'] = reactNativeVersion;
 
     if (pkgJson.jest !== undefined) {

--- a/packages/expo-cli/src/commands/eject/Eject.js
+++ b/packages/expo-cli/src/commands/eject/Eject.js
@@ -259,16 +259,14 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
 
     log(chalk.green('Your package.json is up to date!'));
 
-    // Starting from react-native 0.49.x (SDK 22), react-native eject template includes this out of the box.
-    if (!Versions.gteSdkVersion(exp, '22.0.0')) {
-      log(`Adding entry point...`);
-      const lolThatsSomeComplexCode = `import { AppRegistry } from 'react-native';
+    log(`Adding entry point...`);
+    const indexjs = `import { AppRegistry } from 'react-native';
 import App from './App';
+
 AppRegistry.registerComponent('${appJson.name}', () => App);
 `;
-      await fse.writeFile(path.resolve('index.js'), lolThatsSomeComplexCode);
-      log(chalk.green('Added new entry points!'));
-    }
+    await fse.writeFile(path.resolve('index.js'), indexjs);
+    log(chalk.green('Added new entry points!'));
 
     log(`
 Note that using \`${npmOrYarn} start\` will now require you to run Xcode and/or

--- a/packages/expo-cli/src/commands/eject/Eject.js
+++ b/packages/expo-cli/src/commands/eject/Eject.js
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import fse from 'fs-extra';
 import matchRequire from 'match-require';
 import path from 'path';
+import semver from 'semver';
 import spawn from 'cross-spawn';
 import spawnAsync from '@expo/spawn-async';
 import { ProjectUtils, Detach, Versions } from 'xdl';

--- a/packages/expo-cli/src/commands/eject/Eject.js
+++ b/packages/expo-cli/src/commands/eject/Eject.js
@@ -227,6 +227,13 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
     pkgJson.scripts.ios = 'react-native run-ios';
     pkgJson.scripts.android = 'react-native run-android';
 
+    const { sdkVersion } = exp;
+    const versions = await Versions.versionsAsync();
+    const reactNativeVersion = versions['sdkVersions'][sdkVersion]['facebookReactNativeVersion'];
+
+    pkgJson.dependencies['@babel/runtime'] = 'latest';
+    pkgJson.dependencies['react-native'] = reactNativeVersion;
+
     if (pkgJson.jest !== undefined) {
       newDevDependencies.push('jest');
 


### PR DESCRIPTION
This PR addresses several errors related to building and running an ejected Expo app described below:

1. `react-native run-android` and `react-native run-ios` were both throwing the following error:
```
$ react-native run-ios
internal/modules/cjs/loader.js:651
   throw err;
   ^

Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault'
   at Function.Module._resolveFilename (internal/modules/cjs/loader.js:649:15)
   at Function.Module._load (internal/modules/cjs/loader.js:575:25)
   at Module.require (internal/modules/cjs/loader.js:705:19)
   at require (internal/modules/cjs/helpers.js:14:16)
   at Object.<anonymous> (/Users/sergeichestakov/Documents/test-eject/node_modules/react-native/local-cli/cliEntry.js:11:41)
   at Module._compile (internal/modules/cjs/loader.js:799:30)
   at Module._compile (/Users/sergeichestakov/Documents/test-eject/node_modules/pirates/lib/index.js:99:24)
   at Module._extensions..js (internal/modules/cjs/loader.js:810:10)
   at Object.newLoader [as .js] (/Users/sergeichestakov/Documents/test-eject/node_modules/pirates/lib/index.js:104:7)
   at Module.load (internal/modules/cjs/loader.js:666:32)
error Command failed with exit code 1.
```
This is fixed by adding `@babel/runtime` to the dependencies in `package.json` for ejected apps.

2. The following error was being thrown on Android only:
```
Could not find the "expo" package in your project when configuring the packager
JS server already running.
Building and installing the app on the device (cd android && ./gradlew installDebug)...

> Task :app:compileDebugJavaWithJavac FAILED
/Users/sergeichestakov/Documents/test-eject/android/app/src/main/java/com/testeject/MainApplication.java:5: error: cannot find symbol
import com.facebook.react.ReactApplication;
                        ^
 symbol:   class ReactApplication
 location: package com.facebook.react
/Users/sergeichestakov/Documents/test-eject/android/app/src/main/java/com/testeject/MainApplication.java:6: error: cannot find symbol
import com.facebook.react.ReactNativeHost;
                        ^
 symbol:   class ReactNativeHost
 location: package com.facebook.react
/Users/sergeichestakov/Documents/test-eject/android/app/src/main/java/com/testeject/MainApplication.java:14: error: cannot find symbol
public class MainApplication extends Application implements ReactApplication {
                                                           ^
 symbol: class ReactApplication
/Users/sergeichestakov/Documents/test-eject/android/app/src/main/java/com/testeject/MainApplication.java:16: error: cannot find symbol
 private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
               ^
 symbol:   class ReactNativeHost
 location: class MainApplication
/Users/sergeichestakov/Documents/test-eject/android/app/src/main/java/com/testeject/MainApplication.java:36: error: cannot find symbol
 public ReactNativeHost getReactNativeHost() {
        ^
 symbol:   class ReactNativeHost
 location: class MainApplication
/Users/sergeichestakov/Documents/test-eject/android/app/src/main/java/com/testeject/MainApplication.java:16: error: cannot find symbol
 private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
                                                      ^
 symbol:   class ReactNativeHost
 location: class MainApplication
/Users/sergeichestakov/Documents/test-eject/android/app/src/main/java/com/testeject/MainApplication.java:35: error: method does not override or implement a method from a supertype
 @Override
 ^
/Users/sergeichestakov/Documents/test-eject/android/app/src/main/java/com/testeject/MainActivity.java:5: error: MainActivity is not abstract and does not override abstract method getPackages() in ReactActivity
public class MainActivity extends ReactActivity {
      ^
8 errors


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileDebugJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
```
This is fixed by setting an explicit version of React Native in `package.json` (e.g. `0.57.1` rather than  `https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz` as is default).

3. I removed a check for sdk version that was preventing ejected apps >= sdk22.0.0 from generating an `index.js` which meant `App.js` would not register and the app would therefore throw a 404 as non-expo React Native apps require an `index.js` as an entry point.

A comment in the code erroneously stated:
```
// Starting from react-native 0.49.x (SDK 22), react-native eject template includes this out of the box.
```
when in fact that is not the case as described [here](https://github.com/facebook/react-native/releases/tag/v0.49.0). RN 0.49.x is simply the release that switched to having a single, shared point of entry (`index.js`) rather than one for each platform.