### PR TITLE
Link the CLI executable to `local-expo` for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ Keeping the `master` releasable means that changes merged to it need to be:
 
 You can then run `yarn start` in the root folder to start watching and automatically re-building packages when there are new changes.
 
+To use the local development version Expo CLI, you can run `local-expo`.
+
 ## Submitting a pull request
 
 To submit a pull request:

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "private": true,
+  "name": "expo-cli-workspace",
   "workspaces": [
     "packages/*"
   ],
+  "bin": {
+    "local-expo": "./packages/expo-cli/bin/expo.js"
+  },
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "postbootstrap": "lerna run prepare --stream",
-    "prebootstrap": "yarn",
+    "prebootstrap": "yarn && yarn link",
     "publish": "echo \"This script is deprecated. Run \\\"node ./scripts/publish.js\\\" instead.\"; exit 1",
     "start": "yarn run bootstrap && lerna run watch --parallel --ignore @expo/dev-tools"
   },


### PR DESCRIPTION
To make it easier to test Expo CLI during development (without having to define aliases or use the full path of the executable), let's automatically link it to `local-expo`.

After running `yarn start` in the repository root, you can now use `local-expo` instead of `expo` in your terminal and it uses the local development version of Expo CLI.