### PR TITLE
[expo-cli] order options from most desirable to least

### DIFF
--- a/packages/expo-cli/src/commands/client/selectDistributionCert.js
+++ b/packages/expo-cli/src/commands/client/selectDistributionCert.js
@@ -12,10 +12,12 @@ export default selectDistributionCert;
 
 async function selectDistributionCert(context, options = {}) {
   const certificates = context.username ? await chooseUnrevokedDistributionCert(context) : [];
-  const choices = [{ name: '[Upload an existing certificate]', value: 'UPLOAD' }, ...certificates];
+  const choices = [...certificates];
   if (!options.disableCreate) {
-    choices.unshift({ name: '[Create a new certificate]', value: 'GENERATE' });
+    choices.push({ name: '[Create a new certificate]', value: 'GENERATE' });
   }
+  choices.push({ name: '[Upload an existing certificate]', value: 'UPLOAD' });
+
   let { distributionCert } = await prompt({
     type: 'list',
     name: 'distributionCert',

--- a/packages/expo-cli/src/commands/client/selectPushKey.js
+++ b/packages/expo-cli/src/commands/client/selectPushKey.js
@@ -13,10 +13,12 @@ async function selectPushKey(context, options = {}) {
   const pushKeys = context.username
     ? await Credentials.Ios.getExistingPushKeys(context.username, context.team.id)
     : [];
-  const choices = [{ name: '[Upload an existing key]', value: 'UPLOAD' }, ...pushKeys];
+  const choices = [...pushKeys];
   if (!options.disableCreate) {
-    choices.unshift({ name: '[Create a new key]', value: 'GENERATE' });
+    choices.push({ name: '[Create a new key]', value: 'GENERATE' });
   }
+  choices.push({ name: '[Upload an existing key]', value: 'UPLOAD' });
+
   let { pushKey } = await prompt({
     type: 'list',
     name: 'pushKey',


### PR DESCRIPTION
For the Adhoc build workflow, the most desirable options (in my opinion) is
1/ use existing certificate we have on our servers (least effort)
2/ create new one
3/ upload cert from user's filesystem (most effort)

in the terminal workflow, we should display the options from most desirable to least.