### PR TITLE
[expo-cli] [xdl] [traveling-fastlane] check dist certs against apple servers

### DIFF
--- a/packages/traveling-fastlane/actions/manage_dist_certs.rb
+++ b/packages/traveling-fastlane/actions/manage_dist_certs.rb
@@ -24,6 +24,7 @@ def list()
       ownerType: cert.owner_type,
       ownerName: cert.owner_name,
       ownerId: cert.owner_id,
+      serialNumber: cert.raw_data['serialNum'],
     }
   }
 end

--- a/packages/xdl/src/credentials/IosCredentials.js
+++ b/packages/xdl/src/credentials/IosCredentials.js
@@ -31,7 +31,8 @@ export type CredsList = Array<CredObject>;
 
 export async function getExistingDistCerts(
   username: string,
-  appleTeamId: string
+  appleTeamId: string,
+  options: { provideFullCertificate?: boolean } = {}
 ): Promise<?CredsList> {
   const distCerts = await getExistingUserCredentials(username, appleTeamId, 'dist-cert');
   return distCerts.map(({ usedByApps, userCredentialsId, certId, certP12, certPassword }) => {
@@ -46,7 +47,9 @@ export async function getExistingDistCerts(
     return {
       value: {
         distCertSerialNumber: serialNumber,
-        userCredentialsId: String(userCredentialsId),
+        ...(options.provideFullCertificate
+          ? { certP12, certId, certPassword }
+          : { userCredentialsId: String(userCredentialsId) }),
       },
       name,
     };


### PR DESCRIPTION
The dist certs we have on file may have been revoked so we should check that they are ok to use before displaying it as an option to the user. Otherwise, we risk sending a revoked dist cert to turtle and having it fail/error down the line. 