### PR TITLE
Add --quality flag to specify amount of compression

### DIFF
--- a/packages/expo-cli/src/commands/optimize.js
+++ b/packages/expo-cli/src/commands/optimize.js
@@ -29,7 +29,7 @@ export default program => {
     .command('optimize [project-dir]')
     .alias('o')
     .description('Compress the assets in your Expo project')
-    .option('-s, --save', 'Save the original assets with a .expo extension')
+    .option('-s, --save', 'Save the original assets with a .orig extension')
     .option(
       '--quality [number]',
       'Specify the quality the compressed image is reduced to. Default is 60'

--- a/packages/expo-cli/src/commands/optimize.js
+++ b/packages/expo-cli/src/commands/optimize.js
@@ -31,6 +31,10 @@ export default program => {
     .description('Compress the assets in your Expo project')
     .option('-s, --save', 'Save the original assets with a .expo extension')
     .option(
+      '--quality [number]',
+      'Specify the quality the compressed image is reduced to. Default is 60'
+    )
+    .option(
       '--include [pattern]',
       'Include only assets that match this glob pattern relative to the project root'
     )

--- a/packages/xdl/src/AssetUtils.js
+++ b/packages/xdl/src/AssetUtils.js
@@ -33,7 +33,7 @@ export const calculateHash = file => {
 /*
  * Compress an inputted jpg or png and save original copy with .expo extension
  */
-export const optimizeImageAsync = async (image, newName) => {
+export const optimizeImageAsync = async (image, newName, quality) => {
   logger.global.info(`Optimizing ${image}`);
   // Rename the file with .expo extension
   fs.copyFileSync(image, newName);
@@ -43,12 +43,12 @@ export const optimizeImageAsync = async (image, newName) => {
   const { format } = await sharp(buffer).metadata();
   if (format === 'jpeg') {
     await sharp(newName)
-      .jpeg({ quality: 60 })
+      .jpeg({ quality })
       .toFile(image)
       .catch(err => logger.global.error(err));
   } else {
     await sharp(newName)
-      .png({ quality: 60 })
+      .png({ quality })
       .toFile(image)
       .catch(err => logger.global.error(err));
   }

--- a/packages/xdl/src/AssetUtils.js
+++ b/packages/xdl/src/AssetUtils.js
@@ -31,7 +31,7 @@ export const calculateHash = file => {
 };
 
 /*
- * Compress an inputted jpg or png and save original copy with .expo extension
+ * Compress an inputted jpg or png
  */
 export const optimizeImageAsync = async (image, newName, quality) => {
   logger.global.info(`Optimizing ${image}`);

--- a/packages/xdl/src/project/Convert.js
+++ b/packages/xdl/src/project/Convert.js
@@ -64,8 +64,6 @@ export default (async function convertProjectAsync(
   console.log('Updated package.json');
 
   // TODO: Add import Expo from 'expo'; at the top of main file
-  // TODO: Add .expo/* to gitignore
-
   // Copy babelrc
   await JsonFile.writeAsync(babelRcTargetPath, babelRcTemplate);
   console.log('Updated .babelrc');


### PR DESCRIPTION
Allow a user to compress assets to a custom quality via `expo optimize --quality=[number]` where `number` is an integer from 1-100 inclusive.