### PR TITLE
Fix breaking changes with optimize

### DIFF
--- a/packages/expo-cli/src/commands/optimize.js
+++ b/packages/expo-cli/src/commands/optimize.js
@@ -10,7 +10,9 @@ export async function action(projectDir = './', options = {}) {
   }
 
   const hasUnoptimizedAssets = await AssetUtils.hasUnoptimizedAssetsAsync(projectDir, options);
-  if (!options.save && hasUnoptimizedAssets) {
+  const nonInteractive = options.parent && options.parent.nonInteractive;
+  const shouldPromptUser = !options.save && !nonInteractive && hasUnoptimizedAssets;
+  if (shouldPromptUser) {
     log.warn('Running this command will overwrite the original assets.');
     const { saveOriginals } = await prompt({
       type: 'confirm',

--- a/packages/expo-cli/src/commands/publish.js
+++ b/packages/expo-cli/src/commands/publish.js
@@ -32,7 +32,8 @@ export async function action(projectDir: string, options: Options = {}) {
     process.exit(1);
   }
   const hasOptimized = fs.existsSync(path.join(projectDir, '/.expo-shared/assets.json'));
-  if (!hasOptimized) {
+  const nonInteractive = options.parent && options.parent.nonInteractive;
+  if (!hasOptimized && !nonInteractive) {
     log.warn('It seems your assets have not been optimized yet.');
     const { allowOptimization } = await prompt({
       type: 'confirm',

--- a/packages/xdl/src/AssetUtils.js
+++ b/packages/xdl/src/AssetUtils.js
@@ -35,7 +35,6 @@ export const calculateHash = file => {
  */
 export const optimizeImageAsync = async (image, newName) => {
   logger.global.info(`Optimizing ${image}`);
-  // Rename the file with .expo extension
   fs.copyFileSync(image, newName);
 
   // Extract the format and compress
@@ -81,7 +80,10 @@ export const hasUnoptimizedAssetsAsync = async (projectDir, options) => {
 export const getAssetFilesAsync = async (projectDir, options) => {
   const { exp } = await readConfigJsonAsync(projectDir);
   const { assetBundlePatterns } = exp;
-  const globOptions = { cwd: projectDir, ignore: '**/node_modules/**' };
+  const globOptions = {
+    cwd: projectDir,
+    ignore: ['**/node_modules/**', '**/ios/**', '**/android/**'],
+  };
 
   // All files must be returned even if flags are passed in to properly update assets.json
   const allFiles = [];


### PR DESCRIPTION
This PR addresses a couple of issues brought up with the new `expo optimize` command in 2.17.0:
1. Allows for a non-interactive flag in both publish and optimize to stop the program from prompting the user (Resolves #578).
2. Ignores the `ios/` and `android/` directories when searching for assets to optimize as that becomes a problem for apps ejected with ExpoKit (Resolves #581).