### PR TITLE
[expo-cli] autoselect creds if they exist for adhoc builds

### DIFF
--- a/packages/expo-cli/src/commands/client/clientBuildApi.js
+++ b/packages/expo-cli/src/commands/client/clientBuildApi.js
@@ -1,6 +1,6 @@
 import { ApiV2 } from 'xdl';
 
-export default async function createClientBuildRequest({
+async function createClientBuildRequest({
   user = null,
   context,
   distributionCert,
@@ -27,3 +27,15 @@ export default async function createClientBuildRequest({
     },
   });
 }
+
+async function getExperienceName({ user = null, appleTeamId }) {
+  const { experienceName } = await ApiV2.clientForUser(user).postAsync(
+    'client-build/experience-name',
+    {
+      appleTeamId,
+    }
+  );
+  return experienceName;
+}
+
+export { createClientBuildRequest, getExperienceName };

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -8,7 +8,7 @@ import { runAction, travelingFastlane } from '../build/ios/appleApi/fastlane';
 import selectDistributionCert from './selectDistributionCert';
 import selectPushKey from './selectPushKey';
 import generateBundleIdentifier from './generateBundleIdentifier';
-import createClientBuildRequest from './createClientBuildRequest';
+import { createClientBuildRequest, getExperienceName } from './clientBuildApi';
 import log from '../../log';
 import prompt from '../../prompt';
 
@@ -26,10 +26,11 @@ export default program => {
       const authData = await appleApi.authenticate(options);
       const user = await User.getCurrentUserAsync();
       const bundleIdentifier = generateBundleIdentifier(authData.team.id);
+      const experienceName = await getExperienceName({ user, appleTeamId: authData.team.id });
       const context = {
         ...authData,
         bundleIdentifier,
-        experienceName: 'Expo',
+        experienceName,
         username: user ? user.username : null,
       };
       await appleApi.ensureAppExists(context);

--- a/packages/expo-cli/src/commands/client/selectDistributionCert.js
+++ b/packages/expo-cli/src/commands/client/selectDistributionCert.js
@@ -7,6 +7,8 @@ import promptForCredentials from '../build/ios/credentials/prompt/promptForCrede
 import log from '../../log';
 import prompt from '../../prompt';
 
+import { choosePreferredCreds } from './selectUtils';
+
 // XXX: workaround for https://github.com/babel/babel/issues/6262
 export default selectDistributionCert;
 
@@ -16,7 +18,7 @@ async function selectDistributionCert(context, options = {}) {
 
   // autoselect creds if we find valid ones
   if (certificates.length > 0 && !options.disableAutoSelectExisting) {
-    const autoselectedCertificate = certificates[0];
+    const autoselectedCertificate = choosePreferredCreds(context, certificates);
     log(`Using Distribution Certificate: ${autoselectedCertificate.name}`);
     return autoselectedCertificate;
   }
@@ -40,7 +42,7 @@ async function selectDistributionCert(context, options = {}) {
       .distributionCert;
     const isValid = await validateUploadedCertificate(context, distributionCert);
     if (!isValid) {
-      return await selectDistributionCert(context);
+      return await selectDistributionCert(context, { disableAutoSelectExisting: true });
     }
   }
   return distributionCert;

--- a/packages/expo-cli/src/commands/client/selectDistributionCert.js
+++ b/packages/expo-cli/src/commands/client/selectDistributionCert.js
@@ -14,18 +14,11 @@ async function selectDistributionCert(context, options = {}) {
   const certificates = context.username ? await chooseUnrevokedDistributionCert(context) : [];
   const choices = [...certificates];
 
+  // autoselect creds if we find valid ones
   if (certificates.length > 0 && !options.disableAutoSelectExisting) {
     const autoselectedCertificate = certificates[0];
-    const { useAutoselected } = await prompt({
-      name: 'useAutoselected',
-      message: `Let Expo automatically select a distribution certificate?`,
-      type: 'confirm',
-      default: true,
-    });
-    if (useAutoselected) {
-      log(`Using Distribution Certificate: ${autoselectedCertificate.name}`);
-      return autoselectedCertificate;
-    }
+    log(`Using Distribution Certificate: ${autoselectedCertificate.name}`);
+    return autoselectedCertificate;
   }
 
   if (!options.disableCreate) {

--- a/packages/expo-cli/src/commands/client/selectPushKey.js
+++ b/packages/expo-cli/src/commands/client/selectPushKey.js
@@ -14,6 +14,21 @@ async function selectPushKey(context, options = {}) {
     ? await Credentials.Ios.getExistingPushKeys(context.username, context.team.id)
     : [];
   const choices = [...pushKeys];
+
+  if (pushKeys.length > 0 && !options.disableAutoSelectExisting) {
+    const autoselectedPushkey = pushKeys[0];
+    const { useAutoselected } = await prompt({
+      name: 'useAutoselected',
+      message: `Let Expo automatically select your push credentials?`,
+      type: 'confirm',
+      default: true,
+    });
+    if (useAutoselected) {
+      log(`Using Push Key: ${autoselectedPushkey.name}`);
+      return autoselectedPushkey;
+    }
+  }
+
   if (!options.disableCreate) {
     choices.push({ name: '[Create a new key]', value: 'GENERATE' });
   }
@@ -63,7 +78,10 @@ async function generatePushKey(context) {
         await credentials.revoke(context, ['pushKey']);
         return await generatePushKey(context);
       } else if (answer === 'USE_EXISTING') {
-        return await selectPushKey(context, { disableCreate: true });
+        return await selectPushKey(context, {
+          disableCreate: true,
+          disableAutoSelectExisting: true,
+        });
       }
     }
   }

--- a/packages/expo-cli/src/commands/client/selectPushKey.js
+++ b/packages/expo-cli/src/commands/client/selectPushKey.js
@@ -6,6 +6,8 @@ import promptForCredentials from '../build/ios/credentials/prompt/promptForCrede
 import log from '../../log';
 import prompt from '../../prompt';
 
+import { choosePreferredCreds } from './selectUtils';
+
 // XXX: workaround for https://github.com/babel/babel/issues/6262
 export default selectPushKey;
 
@@ -17,7 +19,7 @@ async function selectPushKey(context, options = {}) {
 
   // autoselect creds if we find valid ones
   if (pushKeys.length > 0 && !options.disableAutoSelectExisting) {
-    const autoselectedPushkey = pushKeys[0];
+    const autoselectedPushkey = choosePreferredCreds(context, pushKeys);
     log(`Using Push Key: ${autoselectedPushkey.name}`);
     return autoselectedPushkey;
   }

--- a/packages/expo-cli/src/commands/client/selectPushKey.js
+++ b/packages/expo-cli/src/commands/client/selectPushKey.js
@@ -15,18 +15,11 @@ async function selectPushKey(context, options = {}) {
     : [];
   const choices = [...pushKeys];
 
+  // autoselect creds if we find valid ones
   if (pushKeys.length > 0 && !options.disableAutoSelectExisting) {
     const autoselectedPushkey = pushKeys[0];
-    const { useAutoselected } = await prompt({
-      name: 'useAutoselected',
-      message: `Let Expo automatically select your push credentials?`,
-      type: 'confirm',
-      default: true,
-    });
-    if (useAutoselected) {
-      log(`Using Push Key: ${autoselectedPushkey.name}`);
-      return autoselectedPushkey;
-    }
+    log(`Using Push Key: ${autoselectedPushkey.name}`);
+    return autoselectedPushkey;
   }
 
   if (!options.disableCreate) {

--- a/packages/expo-cli/src/commands/client/selectUtils.js
+++ b/packages/expo-cli/src/commands/client/selectUtils.js
@@ -1,0 +1,13 @@
+function choosePreferredCreds(context, credentials) {
+  const { experienceName } = context;
+  // prefer the one that matches our experienceName
+  for (const credential of credentials) {
+    if (credential.name.includes(experienceName)) {
+      return credential;
+    }
+  }
+  // else choose an arbitrary one
+  return credentials[0];
+}
+
+export { choosePreferredCreds };


### PR DESCRIPTION
Most users probably don't want to be bothered with manually selecting credentials unless absolutely neccessary. If we find valid credentials, we should autoselect it and just expose a confirmation (Y/n).