### PR TITLE
feat: add a `--changelog` flag to the `expo upload:ios` command

### DIFF
--- a/packages/expo-cli/src/commands/upload.js
+++ b/packages/expo-cli/src/commands/upload.js
@@ -33,6 +33,7 @@ export default program => {
     'sku',
     'language',
     'publicUrl',
+    'changelog'
   ];
   const iosCommand = program.command('upload:ios [projectDir]').alias('ui');
   setCommonOptions(iosCommand, '.ipa');


### PR DESCRIPTION
Add `changelog` option to IOS_OPTIONS so I can add test notes for my QA team when uploading to TestFlight through circleCI