### PR TITLE
Use latest module template in generate-module

### DIFF
--- a/packages/expo-cli/src/commands/generate-module/fetchTemplate.js
+++ b/packages/expo-cli/src/commands/generate-module/fetchTemplate.js
@@ -4,7 +4,7 @@ import pacote from 'pacote';
 import chalk from 'chalk';
 import { Logger } from 'xdl';
 
-const DEFAULT_TEMPLATE = 'expo-module-template@2.0.1';
+const DEFAULT_TEMPLATE = 'expo-module-template@latest';
 
 /**
  * Fetches directory from npm or given templateDirectory into destinationPath


### PR DESCRIPTION
When I ran `expo generate-module`, several errors were being thrown with the following format:
```
ENOENT: no such file or directory, lstat '/Users/sergeichestakov/Documents/expo-cli/packages/expo-cli/bin/expo-test/android/src/main/java/expo/module/template'
```
It seemed to be relying on the latest version of the template, but was actually downloading `v2.0.1` which didn't have those files/directories, thus throwing an error when calling `fs` functions on them.

This PR fixes these bugs by downloading the latest expo-module-template from npm