### PR TITLE
[expo-cli] loop when user has no registered udids and chose to not re…

### DIFF
--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -57,31 +57,30 @@ export default program => {
       ]);
       const udids = devices.map(device => device.deviceNumber);
       log.newLine();
-      log(
-        'Custom builds of the Expo Client can only be installed on devices which have been registered with Apple at build-time.'
-      );
-      log('These devices are currently registered on your Apple Developer account:');
-      const table = new CliTable({ head: ['Name', 'Identifier'], style: { head: ['cyan'] } });
-      table.push(...devices.map(device => [device.name, device.deviceNumber]));
-      log(table.toString());
 
-      const promptToRegisterUdid = async () => {
-        const { addUdid } = await prompt({
+      let addUdid;
+      if (udids.length === 0) {
+        log(
+          'There are no devices registered to your Apple Developer account. Please follow the instructions below to register an iOS device.'
+        );
+        addUdid = true;
+      } else {
+        log(
+          'Custom builds of the Expo Client can only be installed on devices which have been registered with Apple at build-time.'
+        );
+        log('These devices are currently registered on your Apple Developer account:');
+        const table = new CliTable({ head: ['Name', 'Identifier'], style: { head: ['cyan'] } });
+        table.push(...devices.map(device => [device.name, device.deviceNumber]));
+        log(table.toString());
+
+        const udidPrompt = await prompt({
           name: 'addUdid',
           message: 'Would you like to register new devices to use the Expo Client with?',
           type: 'confirm',
           default: true,
         });
-
-        if (udids.length === 0 && !addUdid) {
-          log.error(
-            'There are no devices registered to your Apple Developer account. You must register at least one device.'
-          );
-          return await promptToRegisterUdid();
-        }
-        return { addUdid };
-      };
-      const { addUdid } = await promptToRegisterUdid();
+        addUdid = udidPrompt.addUdid;
+      }
 
       const result = await createClientBuildRequest({
         user,

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -64,12 +64,24 @@ export default program => {
       const table = new CliTable({ head: ['Name', 'Identifier'], style: { head: ['cyan'] } });
       table.push(...devices.map(device => [device.name, device.deviceNumber]));
       log(table.toString());
-      const { addUdid } = await prompt({
-        name: 'addUdid',
-        message: 'Would you like to register new devices to use the Expo Client with?',
-        type: 'confirm',
-        default: true,
-      });
+
+      const promptToRegisterUdid = async () => {
+        const { addUdid } = await prompt({
+          name: 'addUdid',
+          message: 'Would you like to register new devices to use the Expo Client with?',
+          type: 'confirm',
+          default: true,
+        });
+
+        if (udids.length === 0 && !addUdid) {
+          log.error(
+            'There are no devices registered to your Apple Developer account. You must register at least one device.'
+          );
+          return await promptToRegisterUdid();
+        }
+        return { addUdid };
+      };
+      const { addUdid } = await promptToRegisterUdid();
 
       const result = await createClientBuildRequest({
         user,


### PR DESCRIPTION
…gister any device

# why
loop on the `Register your device` prompt if we detect the user has no registered device, and chose not to register any additional device. otherwise, we send empty udids array to turtle which will eventually fail