### PR TITLE
feat: added commit message template

### DIFF
--- a/.github/.COMMIT_TEMPLATE
+++ b/.github/.COMMIT_TEMPLATE
@@ -1,0 +1,21 @@
+# 🚨🚨ATTENTION🚨🚨
+# Please follow the commit message format below 📝
+#
+# <type>: <description>
+# [optional body]
+# [optional footer]
+# 
+# types: "fix" = patches a bug in the codebase
+# 	 "feat" = introduces new feature to codebase
+#	 "improvement" = improvement without adding a feature or fixing a bug
+#	 various others: "chore" "docs" "style" "refactor" "perf" "test"
+# 
+# Include "BREAKING CHANGE:" at the beginning of the body or footer if your commit introduces a breaking API change
+
+
+
+
+
+
+# Example commit messages @ https://www.conventionalcommits.org/en/v1.0.0-beta.4/#examples
+# Thank you for cooperating, this allows us to auto-generate fantastic a fantastic changelog :)

--- a/.github/.COMMIT_TEMPLATE
+++ b/.github/.COMMIT_TEMPLATE
@@ -18,4 +18,4 @@
 
 
 # Example commit messages @ https://www.conventionalcommits.org/en/v1.0.0-beta.4/#examples
-# Thank you for cooperating, this allows us to auto-generate fantastic a fantastic changelog :)
+# Thank you for cooperating, this allows us to auto-generate a fantastic changelog :)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Keeping the `master` releasable means that changes merged to it need to be:
 
 1. Clone the repository.
 2. Run `yarn run bootstrap`. (Installs dependencies, links and builds packages.)
-3. Run `git config commit.message .github/.COMMIT_TEMPLATE` (Sets you up with our commit message template)
+3. Run `git config commit.template .github/.COMMIT_TEMPLATE` (Sets you up with our commit message template)
 
 You can then run `yarn start` in the root folder to start watching and automatically re-building packages when there are new changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ Keeping the `master` releasable means that changes merged to it need to be:
 
 1. Clone the repository.
 2. Run `yarn run bootstrap`. (Installs dependencies, links and builds packages.)
+3. Run `git config commit.message .github/.COMMIT_TEMPLATE` (Sets you up with our commit message template)
 
 You can then run `yarn start` in the root folder to start watching and automatically re-building packages when there are new changes.
 


### PR DESCRIPTION
New template follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) format. Also added a step in the `Setting up the repository for development` section of the `Contributing` readme to configure this template for your local repo, but maybe we can make this part of the `bootstrap` script so there aren't 2 separate scripts to run to set up the repo for development?

This is the first step towards an automated changelog. 
Second step- We already use `lerna publish` command in the `publish` script, adding the [--conventional-commits flag](https://github.com/lerna/lerna/tree/master/commands/version#--conventional-commits) should automatically up our versions & generate/update changelog files (NOTE: I'm not familiar with Lerna so feel free to correct me if I'm wrong about that implementation)