### PR TITLE
[expo-cli] update manual testing instructions

### DIFF
--- a/packages/expo-cli/scripts/preversion.js
+++ b/packages/expo-cli/scripts/preversion.js
@@ -29,7 +29,7 @@ ${bold('3) Eject')}: Create an app and eject it immediately. Check that it build
 
     # Test that it builds for Android
     cd ../android
-    ./run.sh`
+    ./gradlew installDevKernelDebug`
 );
 
 inquirer


### PR DESCRIPTION
when i published the newest versions of expo-cli packages and followed the instructions to manually test that the newest changeset is good, the instruction to test an ejected android app seems outdated:

```
    # Test that it builds for Android
    cd ../android
    ./run.sh
```

In the android directory, `run.sh` isnt there:
```
Quinlans-MacBook-Pro:android quin$ ls
android.iml		build.gradle		fastlane		gradle.properties	settings.gradle
app			debug.keystore		gradle			gradlew
```

So i changed it to what's in the expokit docs here: https://docs.expo.io/versions/v32.0.0/expokit/expokit/#4-android-build-and-run

