### PR TITLE
[expo-cli] update credentials client side instead of server side

### DIFF
--- a/packages/expo-cli/src/commands/client/selectDistributionCert.js
+++ b/packages/expo-cli/src/commands/client/selectDistributionCert.js
@@ -6,6 +6,7 @@ import * as credentials from '../build/ios/credentials';
 import promptForCredentials from '../build/ios/credentials/prompt/promptForCredentials';
 import log from '../../log';
 import prompt from '../../prompt';
+import { tagForUpdate } from './tagger';
 
 import { choosePreferredCreds } from './selectUtils';
 
@@ -44,6 +45,9 @@ async function selectDistributionCert(context, options = {}) {
     if (!isValid) {
       return await selectDistributionCert(context, { disableAutoSelectExisting: true });
     }
+
+    // tag for updating to Expo servers
+    tagForUpdate(distributionCert);
   }
   return distributionCert;
 }
@@ -119,7 +123,12 @@ async function filterRevokedDistributionCerts(context, distributionCerts) {
 async function generateDistributionCert(context) {
   const manager = appleApi.createManagers(context).distributionCert;
   try {
-    return await manager.create({});
+    const distributionCert = await manager.create({});
+
+    // tag for updating to Expo servers
+    tagForUpdate(distributionCert);
+
+    return distributionCert;
   } catch (e) {
     if (e.code === 'APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR') {
       const certificates = await manager.list();

--- a/packages/expo-cli/src/commands/client/selectPushKey.js
+++ b/packages/expo-cli/src/commands/client/selectPushKey.js
@@ -6,6 +6,7 @@ import * as credentials from '../build/ios/credentials';
 import promptForCredentials from '../build/ios/credentials/prompt/promptForCredentials';
 import log from '../../log';
 import prompt from '../../prompt';
+import { tagForUpdate } from './tagger';
 
 import { choosePreferredCreds } from './selectUtils';
 
@@ -43,6 +44,9 @@ async function selectPushKey(context, options = {}) {
     if (!isValid) {
       return await selectPushKey(context, { disableAutoSelectExisting: true });
     }
+
+    // tag for updating to Expo servers
+    tagForUpdate(pushKey);
   }
   return pushKey;
 }
@@ -108,7 +112,12 @@ async function filterRevokedPushKeys(context, pushKeys) {
 async function generatePushKey(context) {
   const manager = appleApi.createManagers(context).pushKey;
   try {
-    return await manager.create({});
+    const pushKey = await manager.create({});
+
+    // tag for updating to Expo servers
+    tagForUpdate(pushKey);
+
+    return pushKey;
   } catch (e) {
     if (e.code === 'APPLE_KEYS_TOO_MANY_GENERATED_ERROR') {
       const keys = await manager.list();

--- a/packages/expo-cli/src/commands/client/tagger.js
+++ b/packages/expo-cli/src/commands/client/tagger.js
@@ -1,0 +1,26 @@
+/**
+ * @flow
+ */
+
+class Updater {
+  constructor(updateAllFn) {
+    this.updateAllFn = updateAllFn;
+  }
+
+  async updateAllAsync(objs: Array<Object>) {
+    const taggedObjs = objs.filter(obj => obj._shouldUpdate);
+    clearTags(objs);
+    return await this.updateAllFn(taggedObjs);
+  }
+}
+
+function tagForUpdate(obj: Object) {
+  obj._shouldUpdate = true;
+  return obj;
+}
+
+function clearTags(objs: Array<Object>) {
+  objs.forEach(obj => delete obj._shouldUpdate);
+}
+
+export { Updater, tagForUpdate, clearTags };

--- a/packages/expo-cli/src/commands/client/tagger.js
+++ b/packages/expo-cli/src/commands/client/tagger.js
@@ -2,25 +2,26 @@
  * @flow
  */
 
+const updateSymbol = Symbol(); // a unique key to mark an object on whether we should perform an update
 class Updater {
   constructor(updateAllFn) {
     this.updateAllFn = updateAllFn;
   }
 
   async updateAllAsync(objs: Array<Object>) {
-    const taggedObjs = objs.filter(obj => obj._shouldUpdate);
+    const taggedObjs = objs.filter(obj => obj[updateSymbol]);
     clearTags(objs);
     return await this.updateAllFn(taggedObjs);
   }
 }
 
 function tagForUpdate(obj: Object) {
-  obj._shouldUpdate = true;
+  obj[updateSymbol] = true;
   return obj;
 }
 
 function clearTags(objs: Array<Object>) {
-  objs.forEach(obj => delete obj._shouldUpdate);
+  objs.forEach(obj => delete obj[updateSymbol]);
 }
 
 export { Updater, tagForUpdate, clearTags };


### PR DESCRIPTION
Update credentials from `expo-cli`, instead of on the server side when we are processing the adhoc build request.

# why
- the server side updates credentials every single request. on the client side, we can properly detect which cases require updating.
- `expo build:ios` has a similar model of saving credentials: first the credentials are obtained on the client side, updated if needed, then a request is made to the build api
- we want to update credentials as early as possible in the workflow. during user testing, when ppl created dist certs and bailed before the request to the adhoc build api was made, they expected the certs to have been saved.