### PR TITLE
[expo-cli] [xdl] check push keys against apple servers when retrievin…

### DIFF
--- a/packages/xdl/src/credentials/IosCredentials.js
+++ b/packages/xdl/src/credentials/IosCredentials.js
@@ -66,6 +66,10 @@ export async function getExistingPushKeys(
   options: { provideFullPushKey?: boolean } = {}
 ): Promise<?CredsList> {
   const pushKeys = await getExistingUserCredentials(username, appleTeamId, 'push-key');
+  return formatPushKeys(pushKeys, options);
+}
+
+export function formatPushKeys(pushKeys, options) {
   return pushKeys.map(({ usedByApps, userCredentialsId, apnsKeyId, apnsKeyP8 }) => {
     let name = `Key ID: ${apnsKeyId}`;
     if (usedByApps) {


### PR DESCRIPTION
…g from postgres or upon upload

This is the push key version of https://github.com/expo/expo-cli/pull/570 and https://github.com/expo/expo-cli/pull/593

# why
- The push keys we have on file may have been revoked so we should check that they are ok to use. Otherwise, we risk sending a revoked push key to turtle and having it fail/error down the line.
- Check the push key that users choose to upload against the Apple Servers. If it is invalid, we go back to the main menu.