### PR TITLE
[expo-cli] make push keys optional

### DIFF
--- a/packages/expo-cli/src/commands/client/clientBuildApi.js
+++ b/packages/expo-cli/src/commands/client/clientBuildApi.js
@@ -16,8 +16,8 @@ async function createClientBuildRequest({
     bundleIdentifier: context.bundleIdentifier,
     email,
     credentials: {
-      apnsKeyP8: pushKey.apnsKeyP8,
-      apnsKeyId: pushKey.apnsKeyId,
+      ...(pushKey && pushKey.apnsKeyP8 ? { apnsKeyP8: pushKey.apnsKeyP8 } : null),
+      ...(pushKey && pushKey.apnsKeyId ? { apnsKeyId: pushKey.apnsKeyId } : null),
       certP12: distributionCert.certP12,
       certPassword: distributionCert.certPassword,
       teamId: context.team.id,

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -43,7 +43,10 @@ export default program => {
       const pushKey = await selectPushKey(context);
 
       // if user is logged in, then we should update credentials
-      const credentialsList = [distributionCert, pushKey];
+      const credentialsList = [distributionCert, pushKey].filter(
+        // https://stackoverflow.com/questions/18808226/why-is-typeof-null-object
+        cred => typeof cred === 'object' && cred !== null
+      );
       if (user) {
         // store all the credentials that we mark for update
         const updateCredentialsFn = async listOfCredentials => {

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -42,6 +42,12 @@ export default program => {
       const distributionCert = await selectDistributionCert(context);
       const pushKey = await selectPushKey(context);
 
+      if (pushKey === null) {
+        log(
+          `Push notifications will be disabled until you upload your push credentials. See https://docs.expo.io/versions/latest/guides/adhoc-builds/#push-notifications-arent-working for more details.`
+        );
+      }
+
       // if user is logged in, then we should update credentials
       const credentialsList = [distributionCert, pushKey].filter(
         // https://stackoverflow.com/questions/18808226/why-is-typeof-null-object

--- a/packages/expo-cli/src/commands/client/selectPushKey.js
+++ b/packages/expo-cli/src/commands/client/selectPushKey.js
@@ -28,6 +28,7 @@ async function selectPushKey(context, options = {}) {
     choices.push({ name: '[Create a new key]', value: 'GENERATE' });
   }
   choices.push({ name: '[Upload an existing key]', value: 'UPLOAD' });
+  choices.push({ name: '[Skip this for now, you can upload them later]', value: 'SKIP' });
 
   let { pushKey } = await prompt({
     type: 'list',
@@ -47,6 +48,8 @@ async function selectPushKey(context, options = {}) {
 
     // tag for updating to Expo servers
     tagForUpdate(pushKey);
+  } else if (pushKey === 'SKIP') {
+    pushKey = null;
   }
   return pushKey;
 }
@@ -137,6 +140,11 @@ async function generatePushKey(context) {
             name: 'Use an existing key',
             value: 'USE_EXISTING',
           },
+          {
+            key: 's',
+            name: '[Skip this for now, you can upload them later]',
+            value: 'SKIP',
+          },
         ],
       });
       if (answer === 'REVOKE') {
@@ -147,6 +155,8 @@ async function generatePushKey(context) {
           disableCreate: true,
           disableAutoSelectExisting: true,
         });
+      } else if (answer === 'SKIP') {
+        return null;
       }
     }
   }

--- a/packages/expo-cli/src/commands/client/selectPushKey.js
+++ b/packages/expo-cli/src/commands/client/selectPushKey.js
@@ -28,7 +28,7 @@ async function selectPushKey(context, options = {}) {
     choices.push({ name: '[Create a new key]', value: 'GENERATE' });
   }
   choices.push({ name: '[Upload an existing key]', value: 'UPLOAD' });
-  choices.push({ name: '[Skip this for now, you can upload them later]', value: 'SKIP' });
+  choices.push({ name: '[Skip. This will disable push notifications.]', value: 'SKIP' });
 
   let { pushKey } = await prompt({
     type: 'list',
@@ -142,7 +142,7 @@ async function generatePushKey(context) {
           },
           {
             key: 's',
-            name: '[Skip this for now, you can upload them later]',
+            name: '[Skip. This will disable push notifications.]',
             value: 'SKIP',
           },
         ],


### PR DESCRIPTION
# why
- we want to make it as easy as possible for people to make an adhoc build, and push credentials arent required to do this
- users who have already created the maximum apns (2) and don't have their apns to upload from their filesystem should be given the option to continue the build process. Otherwise they will have no choice but to exit the process.

# tests
- [x] ipa gets successfully built through the pipeline without apns getting passed (www and turtle)