### PR TITLE
[expo-cli] add logs to let user know they can only register 1 extra d…

### DIFF
--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -103,7 +103,7 @@ export default program => {
 
         const udidPrompt = await prompt({
           name: 'addUdid',
-          message: 'Would you like to register new devices to use the Expo Client with?',
+          message: 'Would you like to register a new device to use the Expo Client with?',
           type: 'confirm',
           default: true,
         });
@@ -129,6 +129,7 @@ export default program => {
         log.newLine();
         log(chalk.green(`${result.registrationUrl}`));
         log.newLine();
+        log('Please note that you can only register one iOS device per request.');
         log(
           "After you register your device, we'll start building your client, and you'll receive an email when it's ready to install."
         );


### PR DESCRIPTION
…evice per request

# why
- some people got confused when they tried to register multiple devices. upon registering the first device, they did not expect the adhoc build to be submitted to turtle.
- this pr adds logs to clarify that you can only register 1 extra device per request

# backstory
- an alternate solution we decided against: we thought of making a udid page that shows all the devices you've registered so far and then making a UI for someone to manually submit the build request once all the devices were registered. we decided not to do this because most people will only be registering one device and we dont want them to get stuck in a state where they forget to press the `submit my build` button or if they lose the links to the registration/status pages .
- current solution: we decided to add logs to expo-cli and if someone tries to register a 2nd device in the same request, we have the udid registration page detect this and show a more useful message