### PR TITLE
[web-projects] Send platform information in updates

### DIFF
--- a/packages/xdl/src/DevSession.js
+++ b/packages/xdl/src/DevSession.js
@@ -7,6 +7,7 @@ import Config from './Config';
 import logger from './Logger';
 import * as UrlUtils from './UrlUtils';
 import UserManager from './User';
+import * as ProjectSettings from './ProjectSettings';
 
 const UPDATE_FREQUENCY_SECS = 20;
 
@@ -16,6 +17,7 @@ let keepUpdating = true;
 export async function startSession(
   projectRoot: string,
   exp: any,
+  platform: 'native' | 'web',
   forceUpdate: boolean = false
 ): Promise<void> {
   if (forceUpdate) {
@@ -33,13 +35,22 @@ export async function startSession(
     }
 
     try {
-      let url = await UrlUtils.constructManifestUrlAsync(projectRoot);
+      let url;
+      if (platform === 'native') {
+        url = await UrlUtils.constructManifestUrlAsync(projectRoot);
+      } else if (platform === 'web') {
+        url = await UrlUtils.constructWebAppUrlAsync(projectRoot);
+      } else {
+        throw new Error(`Unsupported platform: ${platform}`);
+      }
+
       let apiClient = ApiV2Client.clientForUser(authSession);
       await apiClient.postAsync('development-sessions/notify-alive', {
         data: {
           session: {
             description: `${exp.name} on ${os.hostname()}`,
             hostname: os.hostname(),
+            platform,
             config: {
               // TODO: if icons are specified, upload a url for them too so people can distinguish
               description: exp.description,
@@ -56,7 +67,7 @@ export async function startSession(
       logger.global.debug(e, `Error updating dev session: ${e}`);
     }
 
-    setTimeout(() => startSession(projectRoot, exp), UPDATE_FREQUENCY_SECS * 1000);
+    setTimeout(() => startSession(projectRoot, exp, platform), UPDATE_FREQUENCY_SECS * 1000);
   }
 }
 

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -2170,11 +2170,15 @@ export async function startAsync(
     projectRoot,
     developerTool: Config.developerTool,
   });
+
+  let { exp } = await ProjectUtils.readConfigJsonAsync(projectRoot);
   if (options.webOnly) {
     await Webpack.startAsync(projectRoot, options, verbose);
+    DevSession.startSession(projectRoot, exp, 'web');
   } else {
     await startExpoServerAsync(projectRoot);
     await startReactNativeServerAsync(projectRoot, options, verbose);
+    DevSession.startSession(projectRoot, exp, 'native');
   }
 
   if (!Config.offline) {
@@ -2184,8 +2188,6 @@ export async function startAsync(
       ProjectUtils.logDebug(projectRoot, 'expo', `Error starting tunnel ${e.message}`);
     }
   }
-  let { exp } = await ProjectUtils.readConfigJsonAsync(projectRoot);
-  DevSession.startSession(projectRoot, exp);
   return exp;
 }
 


### PR DESCRIPTION
# Why

Building out the expo-cli side of  showing in-development sessions for web projects (for Expo for Web).

# How

In xdl/src/DevSession.js, expo-cli will send individual updates for
'native' and 'web' projects.

In xdl/src/Project.js, expo-cli will spawn a 'web' server as well
as a 'native' server if all platforms are supported in app.json.

# Test Plan

run apps/native-component-list with expo/expo running on branch @jkhales/display_app_platform