### PR TITLE
feat: allow webpack alias to be specified in app.json

### DIFF
--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -421,7 +421,7 @@ module.exports = function(env = {}, argv) {
       ],
     },
     resolve: {
-      alias: DEFAULT_ALIAS,
+      alias: { ...DEFAULT_ALIAS, ...config.web.build.alias },
       extensions: [
         '.web.ts',
         '.web.tsx',


### PR DESCRIPTION
This allows us to customize the webpack module resolution using `alias` from within our app.json.

Example app.json:
```json
{
  "expo": {
    "name": "Test Expo Web",
    "slug": "testme-web",
    "privacy": "public",
    "sdkVersion": "32.0.0",
    "platforms": ["ios", "android", "web"],
    "version": "1.0.0",
....
    "web": {
      "build": {
        "alias": {
          "react-thing$": "@me/custom-react-thing"
        }
      }
    }
  }
}
```

Side note: I assume I need to update JSON Schema somewhere to reflect this new property, but I am not sure where. Can you point me in the right direction?