### PR TITLE
Make `expo install` work for both managed and bare projects

### DIFF
--- a/packages/expo-cli/src/commands/install.js
+++ b/packages/expo-cli/src/commands/install.js
@@ -3,32 +3,42 @@ import * as ConfigUtils from '@expo/config';
 import fs from 'fs';
 import { inflect } from 'inflection';
 import JsonFile from '@expo/json-file';
-import keyBy from 'lodash/keyBy';
 import npmPackageArg from 'npm-package-arg';
-import partition from 'lodash/partition';
 import path from 'path';
-import { Modules } from 'xdl';
+import { Versions } from 'xdl';
 
 import CommandError from '../CommandError';
 import * as PackageManager from '../PackageManager';
 import log from '../log';
 
 async function installAsync(packages, options) {
-  const projectRoot = findProjectRoot(process.cwd());
-  const { exp } = await ConfigUtils.readConfigJsonAsync(projectRoot);
+  const { projectRoot, workflow } = await findProjectRootAsync(process.cwd());
   const packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,
     yarn: options.yarn,
   });
+
+  if (workflow === 'bare') {
+    return await packageManager.addAsync(...packages);
+  }
+
+  const { exp } = await ConfigUtils.readConfigJsonAsync(projectRoot);
+  if (!Versions.gteSdkVersion(exp, '33.0.0')) {
+    throw new CommandError(
+      'UNSUPPORTED_SDK_VERSION',
+      `expo install is only available for managed apps using Expo SDK version 33 or higher. Current version: ${
+        exp.sdkVersion
+      }.`
+    );
+  }
 
   if (!fs.existsSync(path.join(exp.nodeModulesPath || projectRoot, 'node_modules'))) {
     log.warn(`node_modules not found, running ${packageManager.name} install command.`);
     await packageManager.installAsync();
   }
 
-  const { compatible, incompatible, dependencies } = await listBundledNativeModulesAsync(
-    projectRoot,
-    exp
+  const bundledNativeModules = await JsonFile.readAsync(
+    ConfigUtils.resolveModule('expo/bundledNativeModules.json', projectRoot, exp)
   );
 
   const nativeModules = [];
@@ -36,25 +46,12 @@ async function installAsync(packages, options) {
   const versionedPackages = packages.map(arg => {
     const spec = npmPackageArg(arg);
     const { name } = spec;
-    if (
-      ['tag', 'version', 'range'].includes(spec.type) &&
-      name &&
-      (compatible[name] || incompatible[name])
-    ) {
-      if (compatible[name]) {
-        // Unimodule packages from npm registry are modified to use the bundled version.
-        const version = dependencies[name];
-        const modifiedSpec = `${name}@${version}`;
-        nativeModules.push(modifiedSpec);
-        return modifiedSpec;
-      } else {
-        throw new CommandError(
-          'INCOMPATIBLE_NATIVE_MODULE',
-          `'${name}' is incompatible with Expo SDK ${exp.sdkVersion}.\nSupported SDK versions: ${
-            incompatible[name].sdkVersions
-          }`
-        );
-      }
+    if (['tag', 'version', 'range'].includes(spec.type) && name && bundledNativeModules[name]) {
+      // Unimodule packages from npm registry are modified to use the bundled version.
+      const version = bundledNativeModules[name];
+      const modifiedSpec = `${name}@${version}`;
+      nativeModules.push(modifiedSpec);
+      return modifiedSpec;
     } else {
       // Other packages are passed through unmodified.
       others.push(spec.raw);
@@ -77,42 +74,24 @@ async function installAsync(packages, options) {
   await packageManager.addAsync(...versionedPackages);
 }
 
-function findProjectRoot(base) {
+async function findProjectRootAsync(base) {
   let previous = null;
   let dir = base;
 
   do {
-    if (fs.existsSync(path.join(dir, 'app.json'))) {
-      return dir;
+    if (await JsonFile.getAsync(path.join(dir, 'app.json'), 'expo', null)) {
+      return { projectRoot: dir, workflow: 'managed' };
+    } else if (fs.existsSync(path.join(dir, 'package.json'))) {
+      return { projectRoot: dir, workflow: 'bare' };
     }
     previous = dir;
     dir = path.dirname(dir);
   } while (dir !== previous);
 
-  return base;
-}
-
-async function listBundledNativeModulesAsync(projectRoot, exp) {
-  const packageJsonPath = ConfigUtils.resolveModule('expo/package.json', projectRoot, exp);
-  if (!packageJsonPath) {
-    throw new CommandError(
-      'NO_EXPO',
-      "Package 'expo' not found in node_modules. Please make sure this is a managed Expo project."
-    );
-  }
-  const packageJson = await JsonFile.readAsync(packageJsonPath);
-  const nativeModules = Modules.getAllNativeModules();
-  const [compatibleModules, incompatibleModules] = partition(
-    nativeModules,
-    moduleConfig =>
-      Modules.doesVersionSatisfy(exp.sdkVersion, moduleConfig.sdkVersions) &&
-      packageJson.dependencies[moduleConfig.libName]
+  throw new CommandError(
+    'NO_PROJECT',
+    'No managed or bare projects found. Please make sure you are inside a project folder.'
   );
-  return {
-    compatible: keyBy(compatibleModules, moduleConfig => moduleConfig.libName),
-    incompatible: keyBy(incompatibleModules, moduleConfig => moduleConfig.libName),
-    dependencies: packageJson.dependencies,
-  };
 }
 
 export default program => {


### PR DESCRIPTION
Detect which type of project we're in.
- For `bare`, simply delegate to `yarn add` / `npm install`.
- For `managed`, read the correct package versions from `bundledNativeModules.json` and install them with `yarn add` / `npm install`.