### PR TITLE
fix(webpack-config): set body overflow-y to "auto"

### DIFF
--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -40,7 +40,7 @@
       body {
         display: flex;
         /* Allows you to scroll below the viewport; default value is visible */
-        overflow-y: scroll;
+        overflow-y: auto;
         overscroll-behavior-y: none;
         text-rendering: optimizeLegibility;
         -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
When set to `auto` the scrollbar will be hidden unless there is a need for it.

Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow