### PR TITLE
[xdl] add HAVE_GOOGLE_MAPS_UTILS=1 preprocessor definition

### DIFF
--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -272,6 +272,7 @@ function _renderDetachedPostinstall(sdkVersion, isServiceContext) {
           ${maybeDetachedServiceDef}
           # Enable Google Maps support
           config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'HAVE_GOOGLE_MAPS=1'
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'HAVE_GOOGLE_MAPS_UTILS=1'
           ${maybeFrameworkSearchPathDef}
         end
       end


### PR DESCRIPTION
Followup #601. It turned out there is also `HAVE_GOOGLE_MAPS_UTILS` flag that we should pass to the pods project.