### PR TITLE
[expo-cli] limit builds inflight for adhoc builds

### DIFF
--- a/packages/expo-cli/src/commands/client/clientBuildApi.js
+++ b/packages/expo-cli/src/commands/client/clientBuildApi.js
@@ -37,4 +37,10 @@ async function getExperienceName({ user = null, appleTeamId }) {
   return experienceName;
 }
 
-export { createClientBuildRequest, getExperienceName };
+async function isAllowedToBuild({ user = null, appleTeamId }) {
+  return await ApiV2.clientForUser(user).postAsync('client-build/allowed-to-build', {
+    appleTeamId,
+  });
+}
+
+export { createClientBuildRequest, getExperienceName, isAllowedToBuild };

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import CliTable from 'cli-table';
 import { Android, Simulator, User, Credentials } from '@expo/xdl';
 
+import CommandError from '../../CommandError';
 import urlOpts from '../../urlOpts';
 import * as appleApi from '../build/ios/appleApi';
 import { PLATFORMS } from '../build/constants';
@@ -37,8 +38,10 @@ export default program => {
       });
 
       if (!isAllowed) {
-        log.error(`New Expo client build request disallowed. Reason: ${errorMessage}`);
-        return;
+        throw new CommandError(
+          'CLIENT_BUILD_REQUEST_NOT_ALLOWED',
+          `New Expo client build request disallowed. Reason: ${errorMessage}`
+        );
       }
 
       const bundleIdentifier = generateBundleIdentifier(authData.team.id);

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -40,7 +40,7 @@ export default program => {
       if (!isAllowed) {
         throw new CommandError(
           'CLIENT_BUILD_REQUEST_NOT_ALLOWED',
-          `New Expo client build request disallowed. Reason: ${errorMessage}`
+          `New Expo Client build request disallowed. Reason: ${errorMessage}`
         );
       }
 


### PR DESCRIPTION
# Why

Prevent malicious users from spamming the turtle queues with redundant adhoc build jobs

# How

- If a user is logged in, if there is an adhoc build currently in progress, disallow the user from creating another adhoc build request.
- If a user is not logged in (anonymous), if there are more than 5 anonymous builds with the same apple team id, disallow the user from creating another adhoc build request

# Test Plan
- [x] able to create 5 anonymous builds with same apple team id
- [x] unable to create 6 anonymous builds with same apple team id
- [x] able to create 1 user build
- [x] unable to create 2 user builds

# related prs
https://github.com/expo/universe/pull/3549