### PR TITLE
Provide default pattern if assetBundlePatterns is unspecified

### DIFF
--- a/packages/xdl/src/AssetUtils.js
+++ b/packages/xdl/src/AssetUtils.js
@@ -87,7 +87,8 @@ export const getAssetFilesAsync = async (projectDir, options) => {
 
   // All files must be returned even if flags are passed in to properly update assets.json
   const allFiles = [];
-  assetBundlePatterns.forEach(pattern => {
+  const patterns = assetBundlePatterns || ['**/*'];
+  patterns.forEach(pattern => {
     allFiles.push(...glob.sync(pattern, globOptions));
   });
   // If --include is passed in, only return files matching that pattern


### PR DESCRIPTION
Currently, if a user does not specify an `assetBundlePatterns` field in their `app.json` running `expo optimize` will cause it to crash. 

This PR fixes that bug by adding a default pattern and resolves #645.