### PR TITLE
Remove prompting from optimize workflow

### DIFF
--- a/packages/expo-cli/src/commands/optimize.js
+++ b/packages/expo-cli/src/commands/optimize.js
@@ -1,5 +1,4 @@
 import { Project, ProjectUtils, AssetUtils } from '@expo/xdl';
-import prompt from '../prompt';
 import log from '../log';
 
 export async function action(projectDir = './', options = {}) {
@@ -10,18 +9,8 @@ export async function action(projectDir = './', options = {}) {
   }
 
   const hasUnoptimizedAssets = await AssetUtils.hasUnoptimizedAssetsAsync(projectDir, options);
-  const nonInteractive = options.parent && options.parent.nonInteractive;
-  const shouldPromptUser = !options.save && !nonInteractive && hasUnoptimizedAssets;
-  if (shouldPromptUser) {
-    log.warn('Running this command will overwrite the original assets.');
-    const { saveOriginals } = await prompt({
-      type: 'confirm',
-      name: 'saveOriginals',
-      message: 'Do you want to save a backup of each file?',
-    });
-    if (saveOriginals) {
-      options.save = true;
-    }
+  if (!options.save && hasUnoptimizedAssets) {
+    log.warn('This will overwrite the original assets.');
   }
   await Project.optimizeAsync(projectDir, options);
 }

--- a/packages/expo-cli/src/commands/optimize.js
+++ b/packages/expo-cli/src/commands/optimize.js
@@ -12,6 +12,18 @@ export async function action(projectDir = './', options = {}) {
   if (!options.save && hasUnoptimizedAssets) {
     log.warn('This will overwrite the original assets.');
   }
+
+  // Validate custom quality
+  const defaultQuality = 60;
+  const { quality: strQuality } = options;
+
+  const quality = Number(strQuality);
+  const validQuality = Number.isInteger(quality) && quality > 0 && quality <= 100;
+  if (strQuality !== undefined && !validQuality) {
+    throw new Error('Invalid value for --quality flag. Must be an integer between 1 and 100.');
+  }
+  const outputQuality = validQuality ? quality : defaultQuality;
+  options.quality = outputQuality;
   await Project.optimizeAsync(projectDir, options);
 }
 

--- a/packages/expo-cli/src/commands/publish.js
+++ b/packages/expo-cli/src/commands/publish.js
@@ -10,9 +10,7 @@ import simpleSpinner from '@expo/simple-spinner';
 import { Exp, Project, ProjectUtils } from '@expo/xdl';
 
 import log from '../log';
-import prompt from '../prompt';
 import sendTo from '../sendTo';
-import { action as optimize } from './optimize';
 import { installExitHooks } from '../exit';
 
 type Options = {
@@ -35,14 +33,7 @@ export async function action(projectDir: string, options: Options = {}) {
   const nonInteractive = options.parent && options.parent.nonInteractive;
   if (!hasOptimized && !nonInteractive) {
     log.warn('It seems your assets have not been optimized yet.');
-    const { allowOptimization } = await prompt({
-      type: 'confirm',
-      name: 'allowOptimization',
-      message: 'Do you want to optimize assets now?',
-    });
-    if (allowOptimization) {
-      await optimize(projectDir);
-    }
+    log.warn('To compress the images in your project run `expo optimize`');
   }
   const status = await Project.currentStatus(projectDir);
 

--- a/packages/xdl/src/AssetUtils.js
+++ b/packages/xdl/src/AssetUtils.js
@@ -91,14 +91,15 @@ export const getAssetFilesAsync = async (projectDir, options) => {
     allFiles.push(...glob.sync(pattern, globOptions));
   });
   // If --include is passed in, only return files matching that pattern
-  const included = options.include ? [...glob.sync(options.include, globOptions)] : allFiles;
+  const included =
+    options && options.include ? [...glob.sync(options.include, globOptions)] : allFiles;
   const toExclude = new Set();
-  if (options.exclude) {
+  if (options && options.exclude) {
     glob.sync(options.exclude, globOptions).forEach(file => toExclude.add(file));
   }
   // If --exclude is passed in, filter out files matching that pattern
   const excluded = included.filter(file => !toExclude.has(file));
-  const filtered = options.exclude ? excluded : included;
+  const filtered = options && options.exclude ? excluded : included;
   return {
     allFiles: filterImages(allFiles, projectDir),
     selectedFiles: filterImages(filtered, projectDir),

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -2093,15 +2093,7 @@ export async function optimizeAsync(projectRoot: string = './', options: Object 
     delete assetInfo[outdatedHash];
   });
 
-  // Check for custom quality value
-  const defaultQuality = 60;
-  const { quality: strQuality, include, exclude, save } = options;
-  const quality = Number(strQuality);
-  const validQuality = Number.isInteger(quality) && quality > 0 && quality <= 100;
-  if (strQuality !== undefined && !validQuality) {
-    logger.global.warn(`Invalid quality entered. Using default of ${defaultQuality}.`);
-  }
-  const outputQuality = validQuality ? quality : defaultQuality;
+  const { quality, include, exclude, save } = options;
 
   const images = include || exclude ? selectedFiles : allFiles;
   for (const image of images) {
@@ -2112,7 +2104,7 @@ export async function optimizeAsync(projectRoot: string = './', options: Object 
     const { size: prevSize } = fs.statSync(image);
 
     const newName = createNewFilename(image);
-    await optimizeImageAsync(image, newName, outputQuality);
+    await optimizeImageAsync(image, newName, quality);
 
     const { size: newSize } = fs.statSync(image);
     const amountSaved = prevSize - newSize;

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -2094,13 +2094,14 @@ export async function optimizeAsync(projectRoot: string = './', options: Object 
   });
 
   // Check for custom quality value
+  const defaultQuality = 60;
   const { quality: strQuality, include, exclude, save } = options;
   const quality = Number(strQuality);
   const validQuality = Number.isInteger(quality) && quality > 0 && quality <= 100;
   if (strQuality !== undefined && !validQuality) {
-    logger.global.warn('Invalid quality entered. Using default of 60.');
+    logger.global.warn(`Invalid quality entered. Using default of ${defaultQuality}.`);
   }
-  const outputQuality = validQuality ? quality : 60;
+  const outputQuality = validQuality ? quality : defaultQuality;
 
   const images = include || exclude ? selectedFiles : allFiles;
   for (const image of images) {

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -2148,8 +2148,12 @@ export async function optimizeAsync(projectRoot: string = './', options: Object 
       // Delete the renamed original asset
       fs.unlinkSync(newName);
     }
-    totalSaved += amountSaved;
-    logger.global.info(`Saved ${toReadableValue(amountSaved)}`);
+    if (amountSaved) {
+      totalSaved += amountSaved;
+      logger.global.info(`Saved ${toReadableValue(amountSaved)}`);
+    } else {
+      logger.global.info(chalk.gray(`Nothing to compress.`));
+    }
   }
   if (totalSaved === 0) {
     logger.global.info('No assets optimized. Everything is fully compressed!');

--- a/packages/xdl/src/project/Doctor.js
+++ b/packages/xdl/src/project/Doctor.js
@@ -16,6 +16,7 @@ import Schemer, { SchemerError } from '@expo/schemer';
 
 import * as ExpSchema from './ExpSchema';
 import * as ProjectUtils from './ProjectUtils';
+import * as AssetUtils from '../AssetUtils';
 import * as Binaries from '../Binaries';
 import Config from '../Config';
 import * as Versions from '../Versions';
@@ -428,6 +429,20 @@ async function _validateNodeModulesAsync(projectRoot): Promise<number> {
   return NO_ISSUES;
 }
 
+async function _validateOptimizedAssetsAsync(projectRoot: string): void {
+  const hasUnoptimized = await AssetUtils.hasUnoptimizedAssetsAsync(projectRoot);
+  if (hasUnoptimized) {
+    ProjectUtils.logWarning(
+      projectRoot,
+      'expo',
+      `Warning: This project contains unoptimized assets. Please run \`expo optimize\` in your project directory.`,
+      'doctor-unoptimized-assets'
+    );
+  } else {
+    ProjectUtils.clearNotification(projectRoot, 'doctor-unoptimized-assets');
+  }
+}
+
 export async function validateLowLatencyAsync(projectRoot: string): Promise<number> {
   return validateAsync(projectRoot, false);
 }
@@ -532,6 +547,8 @@ async function validateAsync(projectRoot: string, allowNetwork: boolean): Promis
       return nodeModulesStatus;
     }
   }
+
+  await _validateOptimizedAssetsAsync(projectRoot, {});
 
   return status;
 }


### PR DESCRIPTION
After some user feedback, I think it might be best to remove the prompts from the `expo optimize` workflow (including via `expo publish`) in favor of warnings.

The prompt in `expo optimize` was to let the user know that their assets were going to be overwritten and ask if they want to save.a backup. However, given that the images will most likely look the same this shouldn't be a problem. In the off chance that they don't and the quality is noticeably worse, they can always restore them using git since Expo projects are almost always git projects (unless the user deleted the .git folder which is unlikely). I think we should also discourage saving backups as that clutters the file system and is most likely unnecessary.

The prompt during `expo publish` was to let the user know about how to optimize and give them the chance to do so right then and there. However, a warning will accomplish the same thing as far as discoverability and be less annoying since it prevents publishing until the user responds (also works better in non-interactive settings like CI). If they do want to optimize, they can run the command after, double check the images look good, and then republish.

I also made some minor changes including checking to make sure the amount saved is not undefined before logging it (I was getting `saved NaN undefined` if I deleted the `.expo-shared` folder and tried to re-optimize).