### PR TITLE
feat: add ExpoInAppPurchases module to xdl config

### DIFF
--- a/packages/xdl/src/modules/config.js
+++ b/packages/xdl/src/modules/config.js
@@ -328,6 +328,19 @@ const expoSdkUniversalModules = [
     sdkVersions: '>=33.0.0',
   },
   {
+    podName: 'EXInAppPurchases',
+    libName: 'expo-in-app-purchases',
+    sdkVersions: '>=33.0.0',
+    config: {
+      ios: {
+        includeInExpoClient: false,
+      },
+      android: {
+        includeInExpoClient: false,
+      },
+    },
+  },
+  {
     libName: 'expo-intent-launcher',
     sdkVersions: '>=33.0.0',
     config: {


### PR DESCRIPTION
As per step one in [this guide](https://github.com/expo/expo/blob/master/guides/Creating%20Universal%20Modules.md#integrate-with-the-native-projects), it seems I have to add the IAP module to the xdl module config in order for it to show up as a dependency in my Podfile and be usable within Expo apps via the Expo client.

Not sure if these instructions are fully up to date (some of the Android ones were a little outdated), but figured this was still a necessary prerequisite. Also, if you guys have any suggestions for how I can get started developing IAP on iOS quickly please let me know. But as of now, it seems this is required for the module to even be exposed when importing the native module as such:
```
import { NativeModulesProxy } from '@unimodules/core';
export default NativeModulesProxy.ExpoInAppPurchases; // this is null on iOS
```