### PR TITLE
[xdl] Add support for packagesToInstallWhenEjecting dictionary in API

### DIFF
--- a/packages/xdl/CHANGELOG.md
+++ b/packages/xdl/CHANGELOG.md
@@ -8,6 +8,7 @@ For guidelines on how to update this file, visit http://keepachangelog.com/en/0.
 
 * `expo-av` and `expo-mail-composer` universal modules configuration.
 * required `sdkVersion` argument to `Modules.` methods.
+* added support for `packagesToInstallWhenEjecting` dictionary used to get a list of packages to install when ejecting
 
 ### Changed
 

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -271,6 +271,13 @@ async function _detachAsync(projectRoot, options) {
     packagesToInstall.push(sdkVersionConfig.expokitNpmPackage);
   }
 
+  const { packagesToInstallWhenEjecting } = sdkVersionConfig;
+  if (packagesToInstallWhenEjecting && typeof packagesToInstallWhenEjecting === 'object') {
+    Object.keys(packagesToInstallWhenEjecting).forEach(packageName => {
+      packagesToInstall.push(`${packageName}@${packagesToInstallWhenEjecting[packageName]}`);
+    });
+  }
+
   if (packagesToInstall.length) {
     await installPackagesAsync(projectRoot, packagesToInstall, {
       packageManager: options.packageManager,

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -17,6 +17,7 @@ import uuid from 'uuid';
 import inquirer from 'inquirer';
 import spawnAsync from '@expo/spawn-async';
 import * as ConfigUtils from '@expo/config';
+import isPlainObject from 'lodash/isPlainObject';
 
 import { isDirectory, regexFileAsync, rimrafDontThrow } from './ExponentTools';
 
@@ -272,7 +273,7 @@ async function _detachAsync(projectRoot, options) {
   }
 
   const { packagesToInstallWhenEjecting } = sdkVersionConfig;
-  if (packagesToInstallWhenEjecting && typeof packagesToInstallWhenEjecting === 'object') {
+  if (isPlainObject(packagesToInstallWhenEjecting)) {
     Object.keys(packagesToInstallWhenEjecting).forEach(packageName => {
       packagesToInstall.push(`${packageName}@${packagesToInstallWhenEjecting[packageName]}`);
     });


### PR DESCRIPTION
Instead of adding another field for `react-native-unimodules` (we need to install this package in some specific version when ejecting), let's extend the API this way!