### PR TITLE
[xdl] Do not blindly overwrite settings.gradle for SDK>=33

### DIFF
--- a/packages/xdl/CHANGELOG.md
+++ b/packages/xdl/CHANGELOG.md
@@ -9,6 +9,7 @@ For guidelines on how to update this file, visit http://keepachangelog.com/en/0.
 * `expo-av` and `expo-mail-composer` universal modules configuration.
 * required `sdkVersion` argument to `Modules.` methods.
 * added support for `packagesToInstallWhenEjecting` dictionary used to get a list of packages to install when ejecting
+* instead of overwriting `settings.gradle` with static content, XDL will now modify it according to comment rules
 
 ### Changed
 

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -454,9 +454,18 @@ export async function runShellAppModificationsAsync(
       appBuildGradle
     );
 
-    // Don't need to compile expoview or ReactAndroid
-    // react-native link looks for a \n so we need that. See https://github.com/facebook/react-native/blob/master/local-cli/link/android/patches/makeSettingsPatch.js
-    await fs.writeFile(path.join(shellPath, 'settings.gradle'), `include ':app'\n`);
+    if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 33) {
+      let settingsGradle = path.join(shellPath, 'settings.gradle');
+      await deleteLinesInFileAsync(
+        'WHEN_DISTRIBUTING_REMOVE_FROM_HERE',
+        'WHEN_DISTRIBUTING_REMOVE_TO_HERE',
+        settingsGradle
+      );
+    } else {
+      // Don't need to compile expoview or ReactAndroid
+      // react-native link looks for a \n so we need that. See https://github.com/facebook/react-native/blob/master/local-cli/link/android/patches/makeSettingsPatch.js
+      await fs.writeFile(path.join(shellPath, 'settings.gradle'), `include ':app'\n`);
+    }
 
     await regexFileAsync(
       'TEMPLATE_INITIAL_URL',


### PR DESCRIPTION
Related change — https://github.com/expo/expo/commit/efbded1b67917a3f5af5372355320621c225cb4f#diff-74aeda4cd5fc88b4be36cd1a3acefec6