### PR TITLE
fix: error messages getting printed twice

### DIFF
--- a/packages/xdl/src/createWebpackCompiler.js
+++ b/packages/xdl/src/createWebpackCompiler.js
@@ -63,11 +63,6 @@ export default function createWebpackCompiler({
   webpack,
   onFinished,
 }) {
-  const devSocket = {
-    warnings: warnings => logWarning(projectRoot, warnings),
-    errors: errors => logError(projectRoot, errors),
-  };
-
   // "Compiler" is a low-level interface to Webpack.
   // It lets us listen to some events and provide our own custom messages.
   let compiler;
@@ -110,12 +105,6 @@ export default function createWebpackCompiler({
     });
 
     const messages = formatWebpackMessages(statsData);
-
-    if (messages.errors.length > 0) {
-      devSocket.errors(messages.errors);
-    } else if (messages.warnings.length > 0) {
-      devSocket.warnings(messages.warnings);
-    }
 
     const isSuccessful = !messages.errors.length && !messages.warnings.length;
     if (isSuccessful) {


### PR DESCRIPTION
Previously all error messages were printed twice on the screen.
<img width="1155" alt="Screenshot 2019-05-29 at 18 25 10" src="https://user-images.githubusercontent.com/497214/58569729-58731b80-823f-11e9-8dd1-c9d50e9415cf.png">

This PR fixes that, so error messages only get printed once, after the "failed to compile" message.