### PR TITLE
[cli] add expo-template-blank-typescript as an option in init command

### DIFF
--- a/packages/expo-cli/CHANGELOG.md
+++ b/packages/expo-cli/CHANGELOG.md
@@ -6,6 +6,8 @@ For guidelines on how to update this file, visit http://keepachangelog.com/en/0.
 
 ### Added
 
+* Added new blank template with TypeScript configuration.
+
 ### Changed
 
 ### Removed

--- a/packages/expo-cli/src/commands/init.js
+++ b/packages/expo-cli/src/commands/init.js
@@ -22,7 +22,12 @@ const FEATURED_TEMPLATES = [
   {
     shortName: 'blank',
     name: 'expo-template-blank',
-    description: 'minimal dependencies to run and an empty root component ',
+    description: 'minimal dependencies to run and an empty root component',
+  },
+  {
+    shortName: 'blank (TypeScript)',
+    name: 'expo-template-blank-typescript',
+    description: 'same as blank but with TypeScript configuration',
   },
   {
     shortName: 'tabs',


### PR DESCRIPTION
Adding `expo-template-blank-typescript` to the list of templates.