### PR TITLE
improvement: apple-mobile-web-app-capable meta tag

### DIFF
--- a/packages/webpack-pwa-manifest-plugin/src/createMetatagsFromConfig.js
+++ b/packages/webpack-pwa-manifest-plugin/src/createMetatagsFromConfig.js
@@ -41,7 +41,7 @@ export default function createMetatagsFromConfig(config) {
     // Disable automatic phone number detection.
     'format-detection': apple.formatDetection,
     'apple-touch-fullscreen': apple.touchFullscreen,
-    'mobile-web-app-capable': apple.mobileWebAppCapable,
+    'apple-mobile-web-app-capable': apple.mobileWebAppCapable,
     'apple-mobile-web-app-status-bar-style': apple.barStyle,
     'apple-mobile-web-app-title': web.shortName,
   };

--- a/packages/webpack-pwa-manifest-plugin/src/createMetatagsFromConfig.js
+++ b/packages/webpack-pwa-manifest-plugin/src/createMetatagsFromConfig.js
@@ -28,6 +28,7 @@ export default function createMetatagsFromConfig(config) {
     viewport,
     googleSiteVerification,
     apple = {},
+    android = {},
     twitter = {},
     openGraph = {},
     microsoft = {},
@@ -46,6 +47,11 @@ export default function createMetatagsFromConfig(config) {
     'apple-mobile-web-app-title': web.shortName,
   };
 
+  const androidMetatags = {
+    // [Android Chrome] To enable multi-resolution icons of size [196x196]
+    'mobile-web-app-capable': android.mobileWebAppCapable || apple.mobileWebAppCapable,
+  };
+
   const metaTags = {
     viewport,
     description: config.description,
@@ -53,6 +59,7 @@ export default function createMetatagsFromConfig(config) {
     ...microsoftMetatags,
     ...twitterMetatags,
     ...appleMetatags,
+    ...androidMetatags,
   };
 
   if (googleSiteVerification !== undefined) {


### PR DESCRIPTION
The meta tag should be `apple-mobile-web-app-capable` and not `mobile-web-app-capable` 