### PR TITLE
Added `expo customize:web`

### DIFF
--- a/packages/expo-cli/src/PackageManager.js
+++ b/packages/expo-cli/src/PackageManager.js
@@ -43,6 +43,9 @@ export class NpmPackageManager {
   async addAsync(...names) {
     await this._runAsync(['install', '--save', ...names]);
   }
+  async addDevAsync(...names) {
+    await this._runAsync(['install', '--save-dev', ...names]);
+  }
 
   // Private
   async _runAsync(args) {
@@ -72,6 +75,9 @@ export class YarnPackageManager {
   async addAsync(...names) {
     await this._runAsync(['add', ...names]);
   }
+  async addDevAsync(...names) {
+    await this._runAsync(['add', '--dev', ...names]);
+  }
 
   // Private
   async _runAsync(args) {
@@ -82,7 +88,7 @@ export class YarnPackageManager {
   }
 }
 
-export function createForProject(projectRoot, options) {
+export function createForProject(projectRoot, options = {}) {
   let PackageManager;
   if (options.npm) {
     PackageManager = NpmPackageManager;

--- a/packages/expo-cli/src/commands/customize.js
+++ b/packages/expo-cli/src/commands/customize.js
@@ -60,7 +60,7 @@ export async function action(projectDir = './', options = {}) {
   let templateFolder = require.resolve('@expo/webpack-config/web-default/index.html');
   templateFolder = templateFolder.substring(0, templateFolder.lastIndexOf('/'));
 
-  const files = await fse.readdir(templateFolder);
+  const files = (await fse.readdir(templateFolder)).filter(item => item !== 'icon.png');
   // { expo: { web: { staticPath: ... } } }
   const { web: { staticPath = 'web' } = {} } = exp;
 

--- a/packages/expo-cli/src/commands/customize.js
+++ b/packages/expo-cli/src/commands/customize.js
@@ -1,0 +1,115 @@
+import spawnAsync from '@expo/spawn-async';
+import { ProjectUtils, Web } from '@expo/xdl';
+import chalk from 'chalk';
+import { MultiSelect } from 'enquirer';
+import fs from 'fs';
+import fse from 'fs-extra';
+import path from 'path';
+
+async function maybeWarnToCommitAsync() {
+  let workingTreeStatus = 'unknown';
+  try {
+    let result = await spawnAsync('git', ['status', '--porcelain']);
+    workingTreeStatus = result.stdout === '' ? 'clean' : 'dirty';
+  } catch (e) {
+    // Maybe git is not installed?
+    // Maybe this project is not using git?
+  }
+
+  if (workingTreeStatus === 'dirty') {
+    console.log(
+      chalk.yellow(
+        'You should commit your changes before generating code into the root of your project.'
+      )
+    );
+  }
+}
+
+async function generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder }) {
+  let promises = [];
+
+  for (const file of answer) {
+    if (file.includes('webpack.config.js')) {
+      const projectWebpackConfig = path.resolve(projectDir, file);
+      // copy the file from template
+      promises.push(
+        fse.copy(
+          require.resolve('@expo/webpack-config/template/webpack.config.js'),
+          projectWebpackConfig,
+          { overwrite: true, recursive: true }
+        )
+      );
+      promises.push(Web.ensureDevPackagesInstalledAsync(projectDir, '@expo/webpack-config'));
+    } else {
+      const fileName = path.basename(file);
+      const src = path.resolve(templateFolder, fileName);
+      const dest = path.resolve(projectDir, staticPath, fileName);
+      if (await fse.exists(src)) {
+        promises.push(fse.copy(src, dest, { overwrite: true, recursive: true }));
+      } else {
+        throw new Error(`Expected template file for ${fileName} doesn't exist at path: ${src}`);
+      }
+    }
+  }
+  await Promise.all(promises);
+}
+
+export async function action(projectDir = './', options = {}) {
+  let { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
+
+  let templateFolder = require.resolve('@expo/webpack-config/web-default/index.html');
+  templateFolder = templateFolder.substring(0, templateFolder.lastIndexOf('/'));
+
+  const files = await fse.readdir(templateFolder);
+  // { expo: { web: { staticPath: ... } } }
+  const { web: { staticPath = 'web' } = {} } = exp;
+
+  const allFiles = ['webpack.config.js', ...files.map(file => path.join(staticPath, file))];
+  let values = [];
+
+  for (const file of allFiles) {
+    const localProjectFile = path.resolve(projectDir, file);
+    const exists = fs.existsSync(localProjectFile);
+
+    values.push({
+      name: file,
+      disabled: !options.force && exists ? '✔︎' : false,
+      message: options.force && exists ? chalk.red(file) : file,
+    });
+  }
+
+  if (!values.filter(({ disabled }) => !disabled).length) {
+    console.log(
+      chalk.yellow('\nAll of the custom web files already exist.') +
+        '\nTo regenerate the files run:' +
+        chalk.bold(' expo customize:web --force\n')
+    );
+    return;
+  }
+
+  await maybeWarnToCommitAsync();
+
+  const prompt = new MultiSelect({
+    hint: '(Use <space> to select, <return> to submit)',
+    message: `Which files would you like to generate?`,
+    limit: values.length,
+    choices: values,
+  });
+
+  let answer;
+  try {
+    answer = await prompt.run();
+  } catch (error) {
+    return;
+  }
+  await generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder });
+}
+
+export default program => {
+  program
+    .command('customize:web [project-dir]')
+    .description('Generate static web files into your project.')
+    .option('-f, --force', 'Allows replacing existing files')
+    .allowOffline()
+    .asyncAction(action);
+};

--- a/packages/expo-cli/src/commands/customize.js
+++ b/packages/expo-cli/src/commands/customize.js
@@ -4,12 +4,14 @@ import chalk from 'chalk';
 import { MultiSelect } from 'enquirer';
 import fs from 'fs-extra';
 import path from 'path';
+
+import log from '../log';
 import * as PackageManager from '../PackageManager';
 
-async function maybeWarnToCommitAsync() {
+async function maybeWarnToCommitAsync(projectRoot) {
   let workingTreeStatus = 'unknown';
   try {
-    let result = await spawnAsync('git', ['status', '--porcelain']);
+    const result = await spawnAsync('git', ['status', '--porcelain']);
     workingTreeStatus = result.stdout === '' ? 'clean' : 'dirty';
   } catch (e) {
     // Maybe git is not installed?
@@ -17,7 +19,7 @@ async function maybeWarnToCommitAsync() {
   }
 
   if (workingTreeStatus === 'dirty') {
-    console.log(
+    log(
       chalk.yellow(
         'You should commit your changes before generating code into the root of your project.'
       )
@@ -81,7 +83,7 @@ export async function action(projectDir = './', options = {}) {
   }
 
   if (!values.filter(({ disabled }) => !disabled).length) {
-    console.log(
+    log(
       chalk.yellow('\nAll of the custom web files already exist.') +
         '\nTo regenerate the files run:' +
         chalk.bold(' expo customize:web --force\n')
@@ -89,7 +91,7 @@ export async function action(projectDir = './', options = {}) {
     return;
   }
 
-  await maybeWarnToCommitAsync();
+  await maybeWarnToCommitAsync(projectDir);
 
   const prompt = new MultiSelect({
     hint: '(Use <space> to select, <return> to submit)',

--- a/packages/webpack-config/template/webpack.config.js
+++ b/packages/webpack-config/template/webpack.config.js
@@ -1,0 +1,7 @@
+const createExpoWebpackConfig = require('@expo/webpack-config');
+
+module.exports = function(env, argv) {
+  const config = createExpoWebpackConfig(env, argv);
+  // Customize the config before returning it.
+  return config;
+};

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -1,5 +1,3 @@
-import * as ConfigUtils from '@expo/config';
-import spawn from 'cross-spawn';
 import fs from 'fs-extra';
 import path from 'path';
 import openBrowser from 'react-dev-utils/openBrowser';
@@ -14,38 +12,6 @@ function invokePossibleFunction(objectOrMethod, ...args) {
     return objectOrMethod(...args);
   } else {
     return objectOrMethod;
-  }
-}
-
-export async function ensureDevPackagesInstalledAsync(projectRoot, ...newDevDependencies) {
-  const { exp } = await readConfigJsonAsync(projectRoot);
-
-  // Filter out packages that are already installed.
-  let modulesToInstall = [];
-  for (const module of newDevDependencies) {
-    if (!(await ConfigUtils.resolveModule(module, projectRoot, exp))) {
-      modulesToInstall.push(module);
-    }
-  }
-
-  const useYarn = await fs.exists(path.resolve('yarn.lock'));
-  if (useYarn) {
-    console.log('Installing packages with yarn...');
-    const args = modulesToInstall.length > 0 ? ['add', '--dev', ...modulesToInstall] : [];
-    spawn.sync('yarnpkg', args, { stdio: 'inherit' });
-  } else {
-    // npm prints the whole package tree to stdout unless we ignore it.
-    const stdio = [process.stdin, 'ignore', process.stderr];
-
-    console.log('Installing existing packages with npm...');
-    spawn.sync('npm', ['install'], { stdio });
-
-    if (modulesToInstall.length > 0) {
-      console.log('Installing new packages with npm...');
-      spawn.sync('npm', ['install', '--save-dev', ...modulesToInstall], {
-        stdio,
-      });
-    }
   }
 }
 

--- a/packages/xdl/src/Web.js
+++ b/packages/xdl/src/Web.js
@@ -1,6 +1,8 @@
-import fs from 'fs';
-import openBrowser from 'react-dev-utils/openBrowser';
+import * as ConfigUtils from '@expo/config';
+import spawn from 'cross-spawn';
+import fs from 'fs-extra';
 import path from 'path';
+import openBrowser from 'react-dev-utils/openBrowser';
 
 import Logger from './Logger';
 import * as Doctor from './project/Doctor';
@@ -12,6 +14,38 @@ function invokePossibleFunction(objectOrMethod, ...args) {
     return objectOrMethod(...args);
   } else {
     return objectOrMethod;
+  }
+}
+
+export async function ensureDevPackagesInstalledAsync(projectRoot, ...newDevDependencies) {
+  const { exp } = await readConfigJsonAsync(projectRoot);
+
+  // Filter out packages that are already installed.
+  let modulesToInstall = [];
+  for (const module of newDevDependencies) {
+    if (!(await ConfigUtils.resolveModule(module, projectRoot, exp))) {
+      modulesToInstall.push(module);
+    }
+  }
+
+  const useYarn = await fs.exists(path.resolve('yarn.lock'));
+  if (useYarn) {
+    console.log('Installing packages with yarn...');
+    const args = modulesToInstall.length > 0 ? ['add', '--dev', ...modulesToInstall] : [];
+    spawn.sync('yarnpkg', args, { stdio: 'inherit' });
+  } else {
+    // npm prints the whole package tree to stdout unless we ignore it.
+    const stdio = [process.stdin, 'ignore', process.stderr];
+
+    console.log('Installing existing packages with npm...');
+    spawn.sync('npm', ['install'], { stdio });
+
+    if (modulesToInstall.length > 0) {
+      console.log('Installing new packages with npm...');
+      spawn.sync('npm', ['install', '--save-dev', ...modulesToInstall], {
+        stdio,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
# Why

Make it easier to customize your expo web project. Easily extend the index.html, webpack.config.js, serve.json, and favicon. fixes #671 

# How

Added a command `expo customize:web` with optional `--force` which enables you to overwrite existing files.
This command will prompt the user with files that will be copied over from expo/webpack-config. 

# Test Plan

Run expo `customize:web` in any expo project.

