### PR TITLE
[xdl] exclude expo-face-detector and expo-payments from being used on ejected apps by default

### DIFF
--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -381,7 +381,7 @@ require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
 use_unimodules!(
   exclude: [
     'expo-face-detector',
-    'expo-payments',
+    'expo-payments-stripe',
   ],
 )`,
       2

--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -378,7 +378,12 @@ function _renderUnversionedUniversalModulesDependencies(universalModules, sdkVer
       `
 # Install unimodules
 require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
-use_unimodules!`,
+use_unimodules!(
+  exclude: [
+    'expo-face-detector',
+    'expo-payments',
+  ],
+)`,
       2
     );
   } else {


### PR DESCRIPTION
In `use_unimodules` method, `expo-face-detector` and `expo-payments` should be excluded by default when ejecting an app.