### PR TITLE
fix(xdl): saveUrlToPathAsync() handles request errors

### DIFF
--- a/packages/xdl/src/detach/ExponentTools.js
+++ b/packages/xdl/src/detach/ExponentTools.js
@@ -49,7 +49,7 @@ function saveUrlToPathAsync(url, path) {
       resolve();
     });
     stream.on('error', reject);
-    pipeRequest({ url, timeout: 20000 }).pipe(stream);
+    pipeRequest({ url, timeout: 20000 }).on('error', reject).pipe(stream);
   });
 }
 


### PR DESCRIPTION
I'm hoping this is what's causing crashes in our android builders.

The error message:
```
internal/streams/legacy.js:59

      throw er; // Unhandled stream error in pipe.
      ^

Error: ETIMEDOUT
    at Timeout._onTimeout (/app/turtle/node_modules/request/request.js:849:19)
    at ontimeout (timers.js:498:11)
    at tryOnTimeout (timers.js:323:5)
    at Timer.listOnTimeout (timers.js:290:5)
```

I could not find usages of request in turtle that does not handle the error event, but
of course it does use xdl.

Either way I think this line is worth changing.