### PR TITLE
fix(traveling-fastlane) add flag for iOS device subsets

### DIFF
--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -100,6 +100,7 @@ export default program => {
       }
 
       const { devices } = await runAction(travelingFastlane.listDevices, [
+        '--all-ios-profile-devices',
         context.appleId,
         context.appleIdPassword,
         context.team.id,

--- a/packages/traveling-fastlane/actions/list_devices.rb
+++ b/packages/traveling-fastlane/actions/list_devices.rb
@@ -18,19 +18,11 @@ $appleId, $password, $teamId = ARGV
 ENV['FASTLANE_TEAM_ID'] = $teamId
 
 def get_devices(options)
-  # if no options were specified, return all devices by default
-  if options.empty?
-    return Spaceship::Portal.device.all.map { |device| device.raw_data }
-  end
-
-  # merge devices from all options
-  devices = Set.new()
   if options[:iosProfileDevices]
-    ios_profile_devices = Spaceship::Portal.device.all_ios_profile_devices.map { |device| device.raw_data }
-    devices.merge(ios_profile_devices)
+    Spaceship::Portal.device.all_ios_profile_devices.map { |device| device.raw_data }
+  else
+    Spaceship::Portal.device.all.map { |device| device.raw_data }
   end
-
-  return devices.to_a
 end
 
 def list_devices(options)

--- a/packages/traveling-fastlane/actions/list_devices.rb
+++ b/packages/traveling-fastlane/actions/list_devices.rb
@@ -1,17 +1,44 @@
 require 'spaceship'
 require 'json'
 require 'base64'
+require 'optparse'
 require_relative 'funcs'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: example.rb [options]"
+
+  opts.on("-p", "--all-ios-profile-devices", "all devices that can be used for iOS profiles") do |ios_profile_devices|
+    options[:iosProfileDevices] = ios_profile_devices
+  end
+
+end.parse!
 
 $appleId, $password, $teamId = ARGV
 ENV['FASTLANE_TEAM_ID'] = $teamId
 
-def list_devices()
+def get_devices(options)
+  # if no options were specified, return all devices by default
+  if options.empty?
+    return Spaceship::Portal.device.all.map { |device| device.raw_data }
+  end
+
+  # merge devices from all options
+  devices = Set.new()
+  if options[:iosProfileDevices]
+    ios_profile_devices = Spaceship::Portal.device.all_ios_profile_devices.map { |device| device.raw_data }
+    devices.merge(ios_profile_devices)
+  end
+
+  return devices.to_a
+end
+
+def list_devices(options)
   with_captured_stderr {
     begin
       Spaceship::Portal.login($appleId, $password)
       Spaceship::Portal.client.team_id = $teamId
-      return { result: 'success', devices: Spaceship::Portal.device.all.map { |device| device.raw_data } }
+      return { result: 'success', devices: get_devices(options) }
     rescue Spaceship::Client::UnexpectedResponse => e
       return {
         result: 'failure',
@@ -35,4 +62,4 @@ def list_devices()
 end
 
 
-$stderr.puts JSON.generate(list_devices)
+$stderr.puts JSON.generate(list_devices(options))


### PR DESCRIPTION
this fixes the appletv bug that llamaluvr found

# why
- You can't associate the UDID of an AppleTV to an ios provisioning profile 
- Currently, we compute the list of all UDID's on the client side (cli), and then send it off to turtle to register with apple
- This is bad because the list of UDID's could contain an AppleTV
- Instead of returning all UDIDs, we create support in the `list_devices.rb` script where you can pass in a flag to return only the devices that can be used for iOS profiles