### PR TITLE
improvement(traveling-fastlane) modify adhoc device registration

### DIFF
--- a/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
+++ b/packages/traveling-fastlane/actions/manage_ad_hoc_provisioning_profile.rb
@@ -28,15 +28,15 @@ def find_dist_cert(serialNumber, isEnterprise)
 end
 
 def register_missing_devices(udids)
-  all_iphones = Spaceship.device.all_iphones
-  already_added = all_iphones.select { |d| d.enabled? and udids.include?(d.udid) }
+  all_ios_profile_devices = Spaceship.device.all_ios_profile_devices
+  already_added = all_ios_profile_devices.select { |d| udids.include?(d.udid) }
   already_added_udids = already_added.map { |i| i.udid }
 
   devices = [*already_added]
 
   udids_to_add = udids - already_added_udids
   udids_to_add.each { |udid|
-    devices.push Spaceship.device.create!(name: "iPhone (added by Expo)", udid: udid)
+    devices.push Spaceship.device.create!(name: "iOS Device (added by Expo)", udid: udid)
   }
 
   devices


### PR DESCRIPTION
Made a couple changes to the way adhoc device registration is done. '

# why
- when the `manage_adhoc_proviisoning_profile.rb` script is run, we pass in an array of udids.  We first determine which of these UDIDs to register with Apple. 
- The udids we add should be determined with `udids_to_add = udids_we_pass_in - all_ios_profile_devices`
- `all_iphones` was changed to `all_ios_profile_devices` because we want to use the same fastlane device call we use in https://github.com/expo/expo-cli/pull/705 . Also we want to account for the usecase for installing the Expo client on other devices like iPads.
- originally, if a device is already registered but *disabled*, we will attempt to register it with Apple anyways (`all_iphones.select { |d| d.enabled? and udids.include?(d.udid) }`). This could be undesirable if a user intentionally disables an already registered device and we try to re-register it again with Apple. 
- because people can register devices other than iphones, we change the name to `iOS device` instead of `iPhone`. `iOS device` isnt the most descriptive name, so maybe i can open up another pr to grab the device type from https://github.com/expo/universe/blob/master/server/apple-profile/src/www/WebUDIDAPI.ts#L10 and send it to turtle?