### PR TITLE
[xdl] add 'native' mode for Android splash screen

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/xdl",
-  "version": "54.2.0-alpha.0",
+  "version": "54.2.0-alpha.1",
   "description": "The Expo Development Library",
   "main": "build/xdl.js",
   "files": [

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/xdl",
-  "version": "54.1.5",
+  "version": "54.2.0-alpha.0",
   "description": "The Expo Development Library",
   "main": "build/xdl.js",
   "files": [

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -211,9 +211,9 @@ function getSplashScreenBackgroundColor(manifest) {
 }
 
 /*
-  if resizeMode is 'contain' (since SDK33) or 'cover' (prior to SDK33) we should show LoadingView:
-  using an ImageView, unlike having a BitmapDrawable
-  provides a fullscreen image without distortions
+  if resizeMode is 'contain' or 'cover' (since SDK33) or 'cover' (prior to SDK33) we should show LoadingView
+  that is presenting splash image in ImageView what allows full control over image sizing unlike
+  ImageDrawable that is provided by Android native splash screen API
 */
 function shouldShowLoadingView(manifest, sdkVersion) {
   const resizeMode =
@@ -222,7 +222,9 @@ function shouldShowLoadingView(manifest, sdkVersion) {
 
   return (
     resizeMode &&
-    (parseSdkMajorVersion(sdkVersion) >= 33 ? resizeMode === 'contain' : resizeMode === 'cover')
+    (parseSdkMajorVersion(sdkVersion) >= 33
+      ? resizeMode === 'contain' || resizeMode === 'cover'
+      : resizeMode === 'cover')
   );
 }
 
@@ -608,7 +610,7 @@ export async function runShellAppModificationsAsync(
     );
   }
 
-  // Handle 'contain' splashScreen mode by showing only background color and then actual splashScreen image inside AppLoadingView
+  // Handle 'contain' and 'cover' splashScreen mode by showing only background color and then actual splashScreen image inside AppLoadingView
   if (shouldShowLoadingView(manifest, sdkVersion)) {
     await regexFileAsync(
       'SHOW_LOADING_VIEW_IN_SHELL_APP = false',

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -144,7 +144,7 @@ function getRemoteOrLocalUrl(manifest, key, isDetached) {
   return _.get(manifest, `${key}Url`);
 }
 
-function backgroundImagesForApp(shellPath, manifest, isDetached, sdkVersion) {
+function backgroundImagesForApp(shellPath, manifest, isDetached) {
   // returns an array like:
   // [
   //   {url: 'urlToDownload', path: 'pathToSaveTo'},
@@ -177,17 +177,10 @@ function backgroundImagesForApp(shellPath, manifest, isDetached, sdkVersion) {
 
   let url = getRemoteOrLocalUrl(manifest, 'splash.image', isDetached);
   if (url) {
-    // since SDK33 background_image placeholder is placed in `mdpi` directory
-    // placeholder is shipped with versioned ExpoView, so we're unable to delete/move it
-    // prior to SDK33 placeholder is in `xxxhdpi` and to be sure that device
-    // is not selecting it as a actual SplashScreen image (according to device's DPI)
-    // we place user-provided image in `xxxhdpi` directory as well
-    const drawableDirectory =
-      parseSdkMajorVersion(sdkVersion) >= 33 ? 'drawable-mdpi' : 'drawable-xxxhdpi';
     return [
       {
         url,
-        path: path.join(basePath, drawableDirectory, 'shell_launch_background_image.png'),
+        path: path.join(basePath, 'drawable-xxxhdpi', 'shell_launch_background_image.png'),
       },
     ];
   }
@@ -422,12 +415,7 @@ export async function runShellAppModificationsAsync(
   let bundleUrl: ?string = manifest.bundleUrl;
   let isFullManifest = !!bundleUrl;
   let version = manifest.version ? manifest.version : '0.0.0';
-  let backgroundImages = backgroundImagesForApp(
-    shellPath,
-    manifest,
-    isRunningInUserContext,
-    sdkVersion
-  );
+  let backgroundImages = backgroundImagesForApp(shellPath, manifest, isRunningInUserContext);
   let splashBackgroundColor = getSplashScreenBackgroundColor(manifest);
   let updatesDisabled = manifest.updates && manifest.updates.enabled === false;
 


### PR DESCRIPTION
# Why
Resolves: https://github.com/expo/expo/issues/4494 and partially https://github.com/expo/expo/issues/3611

# What
- [x] both `contain` and `cover` modes would use `LoadingView` to display image correctly
- [x] newly added `native` option for `android.splash.mode` only would behave behave as `cover` in SDK33 (see schema update here: https://github.com/expo/universe/pull/3574)
- [x] splash image is again copied to `xxxhdpi` directory isted of `mdpi` (that is not really correct, but it preserves Android from upscaling images and for `cover` and `contain` modes would not matter)
- [x] previously mentioned upscaling caused error like this: `Max size of Bitmap that can be set to ImageView is 4096*4096 px` ([link for reference](https://medium.com/@v.danylo/android-16-e56c27173ef4))
- [x] docs: https://github.com/expo/expo/pull/4567

# Tests
Deployed on staging and tested standalone android builds for all three android splash screen modes.
