### PR TITLE
Fixed iOS PWA splash screens

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -389,7 +389,7 @@ function inferWebHomescreenIcons(
     // Use template icon
     icon = options.templateIcon;
   }
-  const destination = `assets/icons`;
+  const destination = `apple/icons`;
   icons.push({ src: icon, size: ICON_SIZES, destination });
   const iOSIcon = config.icon || ios.icon;
   if (iOSIcon) {
@@ -430,7 +430,7 @@ function inferWebStartupImages(
       src: splashImageSource,
       supportsTablet: webSplash.supportsTablet === undefined ? true : webSplash.supportsTablet,
       orientation: web.orientation,
-      destination: `assets/splash`,
+      destination: `apple/splash`,
     });
   }
   return startupImages;

--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -160,7 +160,7 @@ module.exports = function(env = {}, argv) {
 
   const serviceWorker = overrideWithPropertyOrConfig(
     // Prevent service worker in development mode
-    env.production ? config.web.build.serviceWorker : false,
+    config.web.build.serviceWorker,
     DEFAULT_SERVICE_WORKER
   );
   if (serviceWorker) {
@@ -168,8 +168,15 @@ module.exports = function(env = {}, argv) {
     // the HTML & assets that are part of the Webpack build.
     middlewarePlugins.push(
       new WorkboxPlugin.GenerateSW({
-        exclude: [/\.LICENSE$/, /\.map$/, /asset-manifest\.json$/],
-        navigateFallback: `${publicPath}index.html`,
+        exclude: [
+          /\.LICENSE$/,
+          /\.map$/,
+          /asset-manifest\.json$/,
+          // Exclude all apple touch images as they are cached locally after the PWA is added.
+          /^\bapple.*\.png$/,
+        ],
+        /// SINGLE PAGE:
+        // navigateFallback: `${publicPath}index.html`,
         clientsClaim: true,
         importWorkboxFrom: 'cdn',
         navigateFallbackBlacklist: [

--- a/packages/webpack-pwa-manifest-plugin/src/createMetatagsFromConfig.js
+++ b/packages/webpack-pwa-manifest-plugin/src/createMetatagsFromConfig.js
@@ -42,6 +42,7 @@ export default function createMetatagsFromConfig(config) {
     'format-detection': apple.formatDetection,
     'apple-touch-fullscreen': apple.touchFullscreen,
     'mobile-web-app-capable': apple.mobileWebAppCapable,
+    'apple-mobile-web-app-capable': apple.mobileWebAppCapable,
     'apple-mobile-web-app-status-bar-style': apple.barStyle,
     'apple-mobile-web-app-title': web.shortName,
   };


### PR DESCRIPTION
Added `apple-mobile-web-app-capable` back. Exclude apple images from the service worker as they are only accessed when the device caches them during PWA generation.