### PR TITLE
Increase default optimize quality to 80

### DIFF
--- a/packages/expo-cli/src/commands/optimize.js
+++ b/packages/expo-cli/src/commands/optimize.js
@@ -14,7 +14,7 @@ export async function action(projectDir = './', options = {}) {
   }
 
   // Validate custom quality
-  const defaultQuality = 60;
+  const defaultQuality = 80;
   const { quality: strQuality } = options;
 
   const quality = Number(strQuality);


### PR DESCRIPTION
Users have been reporting the quality of some of their images is too low after they run `expo optimize`.

This increases the default compression from 60% of the original to 80%.