### PR TITLE
Implement Auto-Lock on Inactive & Closed Issues

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,37 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 60
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: outdated
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically 🔒locked🔒 since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+only: issues
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,26 +1,26 @@
 # Configuration for Lock Threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 60
+# daysUntilLock: 60
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
-skipCreatedBefore: false
+# skipCreatedBefore: false
 
 # Issues and pull requests with these labels will be ignored. Set to `[]` to disable
-exemptLabels: []
+# exemptLabels: []
 
 # Label to add before locking, such as `outdated`. Set to `false` to disable
-lockLabel: outdated
+# lockLabel: outdated
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: false
+# lockComment: false
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
-setLockReason: true
+# setLockReason: true
 
 # Limit to only `issues` or `pulls`
-only: issues
+# only: issues
 # Optionally, specify configuration settings just for `issues` or `pulls`
 # issues:
 #   exemptLabels:

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -14,10 +14,7 @@ exemptLabels: []
 lockLabel: outdated
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This thread has been automatically 🔒locked🔒 since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related bugs.
+lockComment: false
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true
@@ -34,4 +31,4 @@ only: issues
 #   daysUntilLock: 30
 
 # Repository to extend settings from
-# _extends: repo
+_extends: expo


### PR DESCRIPTION
Once an issue has been closed, and is inactive for a certain period of time (in this case- 60 days, but we can change/update that), it should be locked. This results in less people commenting "I experience this bug, too" after the issue has been closed, and instead they will open up a new issue with more information and a repro

Main things to get feedback on-

- how long before we lock issues? I've chosen 60 days but that's pretty long
- adding the label outdated right now upon locking, any objections? Also see lock comment

Note: I've created a different config file for `expo/expo` repo and `expo/expo-cli` repo, but can always just extend one to the other. I just thought it might be nice to be able to customize each