### PR TITLE
refactor(xdl): use `plist` npm package instead of `plutil`

### DIFF
--- a/packages/xdl/src/detach/IosPlist.js
+++ b/packages/xdl/src/detach/IosPlist.js
@@ -3,7 +3,6 @@ import path from 'path';
 import plist from 'plist';
 
 import { spawnAsyncThrowError } from './ExponentTools';
-import logger from './Logger';
 
 function _getNormalizedPlistFilename(plistName) {
   let plistFilename;
@@ -15,54 +14,29 @@ function _getNormalizedPlistFilename(plistName) {
   return plistFilename;
 }
 
+function buildPlistFromObject(object) {
+  // We start with an offset of -1, because Xcode maintains a custom indentation of the plist.
+  // Ref: https://github.com/facebook/react-native/issues/11668
+  return plist.build(object, { indent: '\t', offset: -1 }) + '\n';
+}
+
 /**
  *  @param plistName base filename of property list. if no extension, assumes .plist
  */
 async function modifyAsync(plistPath, plistName, transform) {
-  let plistFilename = _getNormalizedPlistFilename(plistName);
-  let configPlistName = path.join(plistPath, plistFilename);
-  let configFilename = path.join(plistPath, `${plistName}.json`);
+  const plistFilename = _getNormalizedPlistFilename(plistName);
+  const configPlistName = path.join(plistPath, plistFilename);
 
   // grab original plist as json object
-  let config;
-  if (process.platform === 'darwin') {
-    await spawnAsyncThrowError('plutil', [
-      '-convert',
-      'json',
-      configPlistName,
-      '-o',
-      configFilename,
-    ]);
-    let configContents = await fs.readFile(configFilename, 'utf8');
-
-    try {
-      config = JSON.parse(configContents);
-    } catch (e) {
-      logger.info(`Error parsing ${configFilename}`, e);
-      logger.info('The erroneous file contents was:', configContents);
-      config = {};
-    }
-  } else {
-    config = plist.parse(fs.readFileSync(configPlistName, 'utf8'));
-  }
+  const config = plist.parse(fs.readFileSync(configPlistName, 'utf8'));
 
   // apply transformation
-  config = transform(config);
+  const transformedConfig = transform(config);
 
-  // back up old plist and swap in modified one
-  await spawnAsyncThrowError('/bin/cp', [configPlistName, `${configPlistName}.bak`]);
-  await fs.writeFile(configFilename, JSON.stringify(config));
-  if (process.platform === 'darwin') {
-    await spawnAsyncThrowError('plutil', [
-      '-convert',
-      'xml1',
-      configFilename,
-      '-o',
-      configPlistName,
-    ]);
-  } else {
-    await fs.writeFile(configPlistName, plist.build(config));
-  }
+  // build plist content from object
+  const newPlistContent = buildPlistFromObject(transformedConfig);
+
+  await fs.writeFile(configPlistName, newPlistContent);
 
   return config;
 }
@@ -74,19 +48,10 @@ async function createBlankAsync(plistPath, plistName) {
   await fs.writeFile(tmpConfigFile, JSON.stringify(emptyConfig));
 
   // convert to plist
-  let plistFilename = _getNormalizedPlistFilename(plistName);
-  let configPlistName = path.join(plistPath, plistFilename);
-  if (process.platform === 'darwin') {
-    await spawnAsyncThrowError('plutil', [
-      '-convert',
-      'xml1',
-      tmpConfigFile,
-      '-o',
-      configPlistName,
-    ]);
-  } else {
-    await fs.writeFile(configPlistName, JSON.stringify(plist.build(emptyConfig)));
-  }
+  const plistFilename = _getNormalizedPlistFilename(plistName);
+  const configPlistName = path.join(plistPath, plistFilename);
+
+  await fs.writeFile(configPlistName, buildPlistFromObject(emptyConfig));
 
   // remove tmp json file
   await spawnAsyncThrowError('/bin/rm', [tmpConfigFile]);


### PR DESCRIPTION
I've jumped into this part of code when working on https://github.com/expo/expo/pull/4591

I'm not fully sure why, but we used both `plutil` command line tool available on macOS and `plist` package from npm when running on Linux or Windows. I can only suspect it was caused by the different plist formatting used by Xcode and `plutil` (with opening `<dict>` being at the same level as `<plist>` and with tabs instead of spaces). However, `plist` package also supports such formatting through its options, so we can use one, cross-platform solution instead.

Question: does anybody know why we are creating these Info.plist backups? One backup in plist format and one in json 🙄 Seems like we don't need any of them.