### PR TITLE
feat(webpack-config): add mjs support

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -28,6 +28,7 @@ const DEFAULT_VIEWPORT =
 // Use root to work better with create-react-app
 const DEFAULT_ROOT_ID = `root`;
 const DEFAULT_BUILD_PATH = `web-build`;
+const DEFAULT_STATIC_PATH = `web`;
 const DEFAULT_LANGUAGE_ISO_CODE = `en`;
 const DEFAULT_NO_JS_MESSAGE = `Oh no! It looks like JavaScript is not enabled in your browser.`;
 const DEFAULT_NAME = 'Expo App';
@@ -234,6 +235,7 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
   const noJavaScriptMessage = webDangerous.noJavaScriptMessage || DEFAULT_NO_JS_MESSAGE;
   const rootId = webBuild.rootId || DEFAULT_ROOT_ID;
   const buildOutputPath = webBuild.output || DEFAULT_BUILD_PATH;
+  const buildStaticPath = webBuild.static || DEFAULT_STATIC_PATH;
   const publicPath = sanitizePublicPath(webManifest.publicPath);
   const primaryColor = appManifest.primaryColor || DEFAULT_THEME_COLOR;
   const description = appManifest.description || DEFAULT_DESCRIPTION;
@@ -302,6 +304,7 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
       build: {
         ...webBuild,
         output: buildOutputPath,
+        static: buildStaticPath,
         rootId,
         publicPath,
       },

--- a/packages/expo-cli/src/commands/customize.js
+++ b/packages/expo-cli/src/commands/customize.js
@@ -66,7 +66,7 @@ export async function action(projectDir = './', options = {}) {
 
   const files = (await fs.readdir(templateFolder)).filter(item => item !== 'icon.png');
   // { expo: { web: { staticPath: ... } } }
-  const { web: { staticPath = 'web' } = {} } = exp;
+  const { web: { build: { static: staticPath = 'web' } = {} } = {} } = exp;
 
   const allFiles = ['webpack.config.js', ...files.map(file => path.join(staticPath, file))];
   let values = [];

--- a/packages/webpack-config/webpack/loaders/createBabelLoader.js
+++ b/packages/webpack-config/webpack/loaders/createBabelLoader.js
@@ -61,7 +61,7 @@ module.exports = function({
 
   const isProduction = mode === 'production';
   return {
-    test: /\.[jt]sx?$/,
+    test: /\.(js|mjs|jsx|ts|tsx)$/,
     // Can only clobber test
     // Prevent clobbering the `include` and `use` values.
     ...options,

--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -115,7 +115,7 @@ const fallbackLoaderConfiguration = {
   // by webpacks internal loaders.
 
   // Excludes: js, jsx, ts, tsx, html, json
-  exclude: [/\.jsx?$/, /\.tsx?$/, /\.html$/, /\.json$/],
+  exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
   options: {
     name: 'static/media/[name].[hash:8].[ext]',
   },
@@ -146,7 +146,7 @@ module.exports = function(env = {}, argv) {
   const mode = getMode(env);
   const isDev = mode === 'development';
   const isProd = mode === 'production';
-
+  const useTypeScript = true;
   const locations = getPaths(env);
   const publicAppManifest = createEnvironmentConstants(config, locations.production.manifest);
 
@@ -429,17 +429,9 @@ module.exports = function(env = {}, argv) {
     },
     resolve: {
       alias: DEFAULT_ALIAS,
-      extensions: [
-        '.web.ts',
-        '.web.tsx',
-        '.ts',
-        '.tsx',
-        '.web.js',
-        '.web.jsx',
-        '.js',
-        '.jsx',
-        '.json',
-      ],
+      extensions: locations.extensions
+        .map(ext => `.${ext}`)
+        .filter(ext => useTypeScript || !ext.includes('ts')),
       plugins: [
         // Adds support for installing with Plug'n'Play, leading to faster installs and adding
         // guards against forgotten dependencies and such.


### PR DESCRIPTION
First step for adding support for `nomodule` will be to add support for `.mjs`.
Also added static path to `app.json` and unified across customize and webpack.