### PR TITLE
[expo-cli][xdl] fix credentials update + fetch bugs

### DIFF
--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -71,12 +71,28 @@ export default program => {
           if (listOfCredentials.length === 0) {
             return;
           }
-          const credentials = listOfCredentials.reduce((acc, credential) => {
-            return { ...acc, ...credential };
-          });
-          await Credentials.updateCredentialsForPlatform(IOS, credentials, [], {
+          const credentials = listOfCredentials.reduce(
+            (acc, credential) => {
+              return { ...acc, ...credential };
+            },
+            { teamId: context.team.id }
+          );
+          const { userCredentialsIds } = await Credentials.updateCredentialsForPlatform(
+            IOS,
+            credentials,
+            [],
+            {
+              username: user.username,
+              experienceName,
+              bundleIdentifier,
+            }
+          );
+
+          // Put an empty entry in AppCredentials model that we can look up by just the bundleIdentifier
+          // This AppCredential entry will be linked with all our UserCredential entries
+          // We need this because push notification credential lookup for Expo clients only uses `bundleIdentifier`
+          await Credentials.updateCredentialsForPlatform(IOS, {}, userCredentialsIds, {
             username: user.username,
-            experienceName,
             bundleIdentifier,
           });
         };

--- a/packages/xdl/src/credentials/Credentials.js
+++ b/packages/xdl/src/credentials/Credentials.js
@@ -59,17 +59,18 @@ export async function updateCredentialsForPlatform(
   newCredentials: Credentials,
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
-): Promise<void> {
-  const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {
+): Promise<Credentials> {
+  const { err, ...rest } = await Api.callMethodAsync('updateCredentials', [], 'post', {
     credentials: newCredentials,
     userCredentialsIds,
     platform,
     ...metadata,
   });
 
-  if (err || !credentials) {
+  if (err || !rest) {
     throw new Error('Error updating credentials.');
   }
+  return rest;
 }
 
 export async function removeCredentialsForPlatform(


### PR DESCRIPTION
# Why

- Push notifications don't work on adhoc builds. 
- This is because push credentials are fetched differently in apps that are identified to be an `Expo Client` vs a normal standalone app. 
- In a regular standalone app, there is a mapping from {bundleIdentifier, experienceName} -> push creds.  In an `Expo Client`, there is a mapping from {bundleIdentifier} -> push creds, and `experienceName` is disregarded

# How

- In adhoc builds, we add an extra entry in the `AppCredentials` table with a bundleIdentifier and null experienceName. This is associated with the `UserCredentials` entry that has the proper push notification credentials.
- We modify the Redis caching to properly generate a cacheKey when experienceName is `null`
- In the `expo-cli`, there is an additional bug that doesn't create new `UserCredential` entries that are fetchable because we were missing the `teamId` field (`teamId` was required in the subsequent fetch lookup). We add `teamId` to the credentials we save.

# Related PRs
https://github.com/expo/expo-cli/pull/741
https://github.com/expo/universe/pull/3586

# Test Plan

- [x] Push notiifications are able to be pushed successfully to adhoc Expo Client

