### PR TITLE
[expo-cli][traveling-fastlane] enable push notifs from apple portal

### DIFF
--- a/packages/expo-cli/src/commands/build/ios/appleApi/ensureAppExists.js
+++ b/packages/expo-cli/src/commands/build/ios/appleApi/ensureAppExists.js
@@ -2,11 +2,12 @@ import ora from 'ora';
 
 import { runAction, travelingFastlane } from './fastlane';
 
-export default async function ensureAppExists(appleCtx) {
+export default async function ensureAppExists(appleCtx, options = {}) {
   const { appleId, appleIdPassword, team, bundleIdentifier, experienceName } = appleCtx;
   const spinner = ora(`Ensuring App ID exists on Apple Developer Portal...`).start();
   try {
     const { created } = await runAction(travelingFastlane.ensureAppExists, [
+      ...(options.enablePushNotifications ? ['--push-notifications'] : []),
       appleId,
       appleIdPassword,
       team.id,

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -52,7 +52,7 @@ export default program => {
         experienceName,
         username: user ? user.username : null,
       };
-      await appleApi.ensureAppExists(context);
+      await appleApi.ensureAppExists(context, { enablePushNotifications: true });
 
       const distributionCert = await selectDistributionCert(context);
       const pushKey = await selectPushKey(context);

--- a/packages/traveling-fastlane/actions/ensure_app_exists.rb
+++ b/packages/traveling-fastlane/actions/ensure_app_exists.rb
@@ -22,7 +22,7 @@ def ensure_app_exists()
   if app == nil
     {created: true, app: Spaceship::Portal.app.create!(bundle_id: $bundleId, name: $name)}
   else
-    {created: false , app: app}
+    {created: false, app: app}
   end
 end
 

--- a/packages/traveling-fastlane/actions/ensure_app_exists.rb
+++ b/packages/traveling-fastlane/actions/ensure_app_exists.rb
@@ -20,7 +20,7 @@ ENV['FASTLANE_TEAM_ID'] = $teamId
 def ensure_app_exists()
   app = Spaceship::Portal.app.find $bundleId
   if app == nil
-    {created: true , app: Spaceship::Portal.app.create!(bundle_id: $bundleId, name: $name)}
+    {created: true, app: Spaceship::Portal.app.create!(bundle_id: $bundleId, name: $name)}
   else
     {created: false , app: app}
   end

--- a/packages/traveling-fastlane/actions/ensure_app_exists.rb
+++ b/packages/traveling-fastlane/actions/ensure_app_exists.rb
@@ -1,7 +1,18 @@
 require 'spaceship'
 require 'json'
 require 'base64'
+require 'optparse'
 require_relative 'funcs'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: ensure_app_exists.rb [options] appleId password teamId bundleId name"
+
+  opts.on("-p", "--push-notifications", "enable push notifications") do |push_notifications|
+    options[:enablePushNotifications] = push_notifications
+  end
+
+end.parse!
 
 $appleId, $password, $teamId, $bundleId, $name = ARGV
 ENV['FASTLANE_TEAM_ID'] = $teamId
@@ -9,10 +20,16 @@ ENV['FASTLANE_TEAM_ID'] = $teamId
 def ensure_app_exists()
   app = Spaceship::Portal.app.find $bundleId
   if app == nil
-    Spaceship::Portal.app.create!(bundle_id: $bundleId, name: $name)
-    true
+    {created: true , app: Spaceship::Portal.app.create!(bundle_id: $bundleId, name: $name)}
   else
-    false
+    {created: false , app: app}
+  end
+end
+
+def update_service(app, options)
+  if options[:enablePushNotifications]
+    app_service = Spaceship::Portal.app_service.push_notification.on
+    app.update_service(app_service)
   end
 end
 
@@ -22,7 +39,8 @@ with_captured_stderr{
   begin
     Spaceship::Portal.login($appleId, $password)
     Spaceship::Portal.client.team_id = $teamId
-    created = ensure_app_exists()
+    created, app = ensure_app_exists().values_at(:created, :app)
+    update_service(app, options)
     $result = { result: 'success', created: created }
   rescue Spaceship::Client::UnexpectedResponse => e
     $result = {


### PR DESCRIPTION
# why
- in order to make push notifications work for adhoc builds, you need to go into the Apple Development Portal into the `Identifiers` tab, and check the `Push Notifications` box in order to get push notifications working.
- this is very frustrating and not very intuitive at all, and we should enable it for Adhoc builds automatically for users. Maybe we should consider doing it for all standalone builds too (afaik we dont currently do this?)
