### PR TITLE
[expo-cli] adhoc builds: grab available app.json, improve disable services info text

### DIFF
--- a/packages/expo-cli/src/commands/client/clientBuildApi.js
+++ b/packages/expo-cli/src/commands/client/clientBuildApi.js
@@ -8,6 +8,7 @@ async function createClientBuildRequest({
   udids,
   addUdid,
   email,
+  customProjectManifest = {},
 }) {
   return await ApiV2.clientForUser(user).postAsync('client-build/create-ios-request', {
     appleTeamId: context.team.id,
@@ -15,6 +16,7 @@ async function createClientBuildRequest({
     addUdid,
     bundleIdentifier: context.bundleIdentifier,
     email,
+    customProjectManifest,
     credentials: {
       ...(pushKey && pushKey.apnsKeyP8 ? { apnsKeyP8: pushKey.apnsKeyP8 } : null),
       ...(pushKey && pushKey.apnsKeyId ? { apnsKeyId: pushKey.apnsKeyId } : null),

--- a/packages/expo-cli/src/commands/client/clientBuildApi.js
+++ b/packages/expo-cli/src/commands/client/clientBuildApi.js
@@ -8,7 +8,7 @@ async function createClientBuildRequest({
   udids,
   addUdid,
   email,
-  customProjectManifest = {},
+  customAppConfig = {},
 }) {
   return await ApiV2.clientForUser(user).postAsync('client-build/create-ios-request', {
     appleTeamId: context.team.id,
@@ -16,7 +16,7 @@ async function createClientBuildRequest({
     addUdid,
     bundleIdentifier: context.bundleIdentifier,
     email,
-    customProjectManifest,
+    customAppConfig,
     credentials: {
       ...(pushKey && pushKey.apnsKeyP8 ? { apnsKeyP8: pushKey.apnsKeyP8 } : null),
       ...(pushKey && pushKey.apnsKeyId ? { apnsKeyId: pushKey.apnsKeyId } : null),

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -41,7 +41,7 @@ export default program => {
       };
 
       // get custom project manifest if it exists
-      // Note: this is some random user's project, NOT the expo client manifest
+      // Note: this is the current developer's project, NOT the Expo client's manifest
       const spinner = ora(`Finding custom configuration for the Expo client...`).start();
       const appJsonPath = options.config || path.join(projectDir, 'app.json');
       const appJsonExists = await ConfigUtils.fileExistsAsync(appJsonPath);

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -52,7 +52,7 @@ export default program => {
       } else {
         spinner.warn(`Unable to find custom configuration for the Expo client`);
       }
-      if (!_.has(exp, 'ios.config.googleMapsApiKey') && !_.has(exp, 'ios.config.googleApiKey')) {
+      if (!_.has(exp, 'ios.config.googleMapsApiKey')) {
         const disabledReason = exp
           ? `ios.config.googleMapsApiKey does not exist in configuration file found in ${appJsonPath}`
           : 'No custom configuration file could be found. You will need to provide a json file with a valid ios.config.googleMapsApiKey field.';


### PR DESCRIPTION
# Why

- Google maps doesnt work on adhoc build clients
- Normally when a user makes a standalone build, they declare `ios.config.googleMapsApiKey` in their `app.json`. Regular Expo clients have the Expo googleMapsApiKey, but we are not going to use this since we are going to constrain it to the expo client bundleIdentifier soon.

# How
- when a user runs `expo client:ios`, we try to find a valid `app.json` in their cwd or from a passed in `--config` flag. 
- we thread this through to turtle so it knows to use the custom ios configuration 

# Related PRs
https://github.com/expo/expo-cli/pull/747
https://github.com/expo/expo/pull/4674
https://github.com/expo/universe/pull/3589

# Test Plan

- custom adhoc build now works with Google Maps

# Deploy

- [ ] Run postgres migrations in prod 
