### PR TITLE
Ability to override babel project root

### DIFF
--- a/packages/webpack-config/webpack/loaders/createBabelLoaderAsync.js
+++ b/packages/webpack-config/webpack/loaders/createBabelLoaderAsync.js
@@ -36,7 +36,7 @@ function logPackage(packageName) {
 
 async function ensureRootAsync(possibleProjectRoot) {
   if (typeof possibleProjectRoot === 'string') {
-    return possibleProjectRoot;
+    return path.resolve(possibleProjectRoot);
   }
   return (await getPathsAsync()).root;
 }

--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -249,7 +249,7 @@ module.exports = async function(env = {}, argv) {
     imageLoaderConfiguration,
     await createBabelLoaderAsync({
       mode,
-      babelProjectRoot: locations.root,
+      babelProjectRoot: babelAppConfig.root || locations.root,
       verbose: babelAppConfig.verbose,
       include: babelAppConfig.include,
       use: babelAppConfig.use,


### PR DESCRIPTION
In the case of an example project, you may want to set the babel root to be `../` this will enable that functionality with `"expo.web.build.babel.root": "../"` in the `app.json`