### PR TITLE
feat(webpack-config): add abiliity to disable deep scope

### DIFF
--- a/packages/webpack-config/utils.js
+++ b/packages/webpack-config/utils.js
@@ -1,0 +1,9 @@
+const getPathsAsync = require('./webpack/utils/getPathsAsync');
+const getMode = require('./webpack/utils/getMode');
+const getConfigAsync = require('./webpack/utils/getConfigAsync');
+
+module.exports = {
+  getPathsAsync,
+  getMode,
+  getConfigAsync,
+};

--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -147,6 +147,14 @@ module.exports = async function(env = {}, argv) {
   const isDev = mode === 'development';
   const isProd = mode === 'production';
 
+  // Enables deep scope analysis in production mode.
+  // Remove unused import/exports
+  // override: `env.deepScopeAnalysis`
+  const deepScopeAnalysisEnabled = overrideWithPropertyOrConfig(
+    env.removeUnusedImportExports,
+    isProd
+  );
+
   const locations = await getPathsAsync(env);
   const publicAppManifest = createEnvironmentConstants(config, locations.production.manifest);
 
@@ -158,11 +166,7 @@ module.exports = async function(env = {}, argv) {
   const { noJavaScriptMessage } = config.web.dangerous;
   const noJSComponent = createNoJSComponent(noJavaScriptMessage);
 
-  if (
-    (isProd && config.web.build.deepScopeAnalysis !== false) ||
-    (isDev && config.web.build.deepScopeAnalysis != null)
-  ) {
-    // Remove unused import/exports
+  if (deepScopeAnalysisEnabled) {
     middlewarePlugins.push(new WebpackDeepScopeAnalysisPlugin());
   }
 

--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -158,6 +158,14 @@ module.exports = async function(env = {}, argv) {
   const { noJavaScriptMessage } = config.web.dangerous;
   const noJSComponent = createNoJSComponent(noJavaScriptMessage);
 
+  if (
+    (isProd && config.web.build.deepScopeAnalysis !== false) ||
+    (isDev && config.web.build.deepScopeAnalysis != null)
+  ) {
+    // Remove unused import/exports
+    middlewarePlugins.push(new WebpackDeepScopeAnalysisPlugin());
+  }
+
   const serviceWorker = overrideWithPropertyOrConfig(
     // Prevent service worker in development mode
     config.web.build.serviceWorker,
@@ -393,9 +401,6 @@ module.exports = async function(env = {}, argv) {
         fileName: 'asset-manifest.json',
         publicPath,
       }),
-
-      // Remove unused import/exports
-      isProd && new WebpackDeepScopeAnalysisPlugin(),
 
       ...middlewarePlugins,
 


### PR DESCRIPTION
Some libraries have too many side-effects to enable any kind of tree-shaking (like three.js). In this case we want to completely disable tree-shaking so you can push to prod.

Enable only in production mode:
```js
const createExpoWebpackConfig = require('@expo/webpack-config');
const { getMode } = require('@expo/webpack-config/utils');

module.exports = async function(env, argv) {
  const mode = getMode(env);
  const isProd = mode === 'production';

  const config = await createExpoWebpackConfig(
    {
      ...env,
      removeUnusedImportExports: isProd,
    },
    argv);
  return config;
};
```