### PR TITLE
BREAKING CHANGE(xdl): use new endpoint to fetch SDK versions supported by Turtle

### DIFF
--- a/packages/expo-cli/src/commands/build/utils.js
+++ b/packages/expo-cli/src/commands/build/utils.js
@@ -12,7 +12,7 @@ async function checkIfSdkIsSupported(sdkVersion, platform) {
         `Unsupported SDK version: our app builders don't have support for ${sdkVersion} version yet. Submitting the app to the ${storeName} may result in an unexpected behaviour`
       )
     );
-    throw new Error('Unsupported sdk version');
+    throw new Error('Unsupported SDK version');
   }
 }
 

--- a/packages/xdl/src/tools/UpdateVersions.js
+++ b/packages/xdl/src/tools/UpdateVersions.js
@@ -80,10 +80,3 @@ export async function updateAndroidApk(s3Client: any, pathToApp: string, appVers
   versions['androidUrl'] = `https://d1ahtucjixef4r.cloudfront.net/Exponent-${appVersion}.apk`;
   await Versions.setVersionsAsync(versions);
 }
-
-export async function updateTurtleVersionAsync(sdkVersion: string, platform: string) {
-  const platforms = platform === 'both' ? ['android', 'ios'] : [platform];
-  const versions = await Versions.versionsAsync();
-  platforms.forEach(p => _.set(versions, ['turtleSdkVersions', p], sdkVersion));
-  await Versions.setVersionsAsync(versions);
-}


### PR DESCRIPTION


# Why

https://github.com/expo/universe/issues/3564

# How

I changed `canTurtleBuildSdkVersion` function so it uses the new endpoint introduced here - https://github.com/expo/universe/pull/3593