### PR TITLE
feat(expo-cli): validate project's dependencies when running expo start

### DIFF
--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -111,19 +111,18 @@ async function validateDependenciesVersions(projectDir, exp, pkg) {
   const projectDependencies = Object.keys(pkg.dependencies);
 
   const modulesToCheck = intersection(bundleNativeModulesNames, projectDependencies);
-  const incorrectDeps = modulesToCheck.reduce((acc, moduleName) => {
+  const incorrectDeps = [];
+  for (const moduleName of modulesToCheck) {
     const expectedRange = bundledNativeModules[moduleName];
     const actualRange = pkg.dependencies[moduleName];
     if (!semver.intersects(expectedRange, actualRange)) {
-      acc.push({
+      incorrectDeps.push({
         moduleName,
         expectedRange,
         actualRange,
       });
     }
-    return acc;
-  }, []);
-
+  }
   if (incorrectDeps.length > 0) {
     log.warn(
       "Some of your project's dependencies are not compatible with currently installed expo package version:"
@@ -136,7 +135,10 @@ async function validateDependenciesVersions(projectDir, exp, pkg) {
       );
     });
     log.warn(
-      'Your project may not work correctly until you install the correct versions of the packages.'
+      'Your project may not work correctly until you install the correct versions of the packages.\n' +
+        `To install the correct versions of these packages, please run: ${chalk.inverse(
+          'expo install [package-name ...]'
+        )}`
     );
   }
 }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo-cli/issues/599

# How

I added checking the project's dependencies' versions when a user runs `expo start`.

# Test plan

I installed an incompatible version of `expo-camera` and ran `expo start`. I got this warning:
```
Some of your project's dependencies are not compatible with currently installed expo package version: 
 - expo-camera - expected version range: ~5.0.1 - actual version installed: 4.0.0
Your project may not work correctly until you install the correct versions of the packages.
```