### PR TITLE
fix: issues related to @expo/image-utils

### DIFF
--- a/packages/image-utils/index.ts
+++ b/packages/image-utils/index.ts
@@ -1,1 +1,0 @@
-export { sharpAsync, SharpGlobalOptions, SharpCommandOptions } from './src/sharp'; 

--- a/packages/image-utils/src/index.ts
+++ b/packages/image-utils/src/index.ts
@@ -1,0 +1,1 @@
+export { sharpAsync, SharpGlobalOptions, SharpCommandOptions } from './sharp'; 

--- a/packages/image-utils/src/sharp.ts
+++ b/packages/image-utils/src/sharp.ts
@@ -128,10 +128,12 @@ async function findSharpBinAsync(): Promise<string> {
   }
   try {
     const sharpCliPackage = require('sharp-cli/package.json');
+    const libVipsVersion = require('sharp').versions.vips;
     if (
       sharpCliPackage &&
       semver.satisfies(sharpCliPackage.version, requiredCliVersion) &&
-      typeof sharpCliPackage.bin.sharp === 'string'
+      typeof sharpCliPackage.bin.sharp === 'string' &&
+      typeof libVipsVersion === 'string'
     ) {
       _sharpBin = require.resolve(`sharp-cli/${sharpCliPackage.bin.sharp}`);
       return _sharpBin;

--- a/packages/image-utils/src/sharp.ts
+++ b/packages/image-utils/src/sharp.ts
@@ -78,7 +78,7 @@ export async function sharpAsync(
   } catch (error) {
     if (error.stderr) {
       throw new Error(
-        +'\nProcessing images using sharp-cli failed: ' +
+        '\nProcessing images using sharp-cli failed: ' +
           error.message +
           '\nOutput: ' +
           error.stderr.replace(SHARP_HELP_PATTERN, '')


### PR DESCRIPTION
* fix `Cannot find module 'sharp'` (https://github.com/expo/expo-cli/issues/760)
* fix `NaN` inside the error message caused by a stray unary `+` (also from https://github.com/expo/expo-cli/issues/760)
* fix publishing `@expo/image-utils` with `npm` (https://github.com/expo/expo-cli/issues/767)
