### PR TITLE
BREAKING CHANGE(xdl): remove Binaries.sourceBashLoginScriptsAsync()

### DIFF
--- a/packages/xdl/src/Diagnostics.js
+++ b/packages/xdl/src/Diagnostics.js
@@ -100,7 +100,6 @@ function _formatBytes(bytes: number): string {
 export async function getDeviceInfoAsync(options: any = {}): Promise<any> {
   let info = {};
 
-  await Binaries.sourceBashLoginScriptsAsync();
   let whichCommand = process.platform === 'win32' ? 'where' : 'which';
 
   try {

--- a/packages/xdl/src/FileSystem.js
+++ b/packages/xdl/src/FileSystem.js
@@ -49,7 +49,6 @@ export async function openFileInEditorAsync(path: string) {
   if (process.platform === 'darwin') {
     // This will use the ENV var $EXPO_EDITOR if set, or else will try various
     // popular editors, looking for one that is open, or if none are, one that is installed
-    await Binaries.sourceBashLoginScriptsAsync();
     return await osascript.openInEditorAsync(path, process.env.EXPO_EDITOR);
   } else if (process.platform === 'win32') {
     throw new XDLError('PLATFORM_NOT_SUPPORTED', 'openFileInEditorAsync not supported');
@@ -60,7 +59,6 @@ export async function openProjectInEditorAsync(dir: string) {
   if (process.platform === 'darwin') {
     // This will use the ENV var $EXPO_EDITOR if set, or else will try various
     // popular editors, looking for one that is open, or if none are, one that is installed
-    await Binaries.sourceBashLoginScriptsAsync();
     return await osascript.openInEditorAsync(dir, process.env.EXPO_EDITOR);
   } else if (process.platform === 'win32') {
     throw new XDLError('PLATFORM_NOT_SUPPORTED', 'openProjectInEditorAsync not supported');

--- a/packages/xdl/src/project/Doctor.js
+++ b/packages/xdl/src/project/Doctor.js
@@ -40,8 +40,6 @@ function _isNpmVersionWithinRanges(npmVersion, ranges) {
 
 async function _checkNpmVersionAsync(projectRoot) {
   try {
-    await Binaries.sourceBashLoginScriptsAsync();
-
     try {
       let yarnVersionResponse = await spawnAsync('yarnpkg', ['--version']);
       if (yarnVersionResponse.status === 0) {


### PR DESCRIPTION
This function has already been a no-up, unless running inside XDE (a former desktop app). Since XDE is long gone, this code is no longer necessary.