### PR TITLE
fix: remove alpha from iOS PWA images when a background color is added

### DIFF
--- a/packages/webpack-pwa-manifest-plugin/src/icons.js
+++ b/packages/webpack-pwa-manifest-plugin/src/icons.js
@@ -122,6 +122,10 @@ async function resize(inputPath, mimeType, width, height, fit = 'contain', backg
       },
       [
         {
+          operation: 'flatten',
+          background,
+        },
+        {
           operation: 'resize',
           width,
           height,


### PR DESCRIPTION
https://twitter.com/Baconbrix/status/1138720833185075200?s=20