### PR TITLE
BREAKING CHANGE: make supported Node.js versions stricter

### DIFF
--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -1,13 +1,37 @@
 #!/usr/bin/env node
+var chalk = require('chalk');
 var getenv = require('getenv');
 var semver = require('semver');
 var version = process.versions.node;
 
-if (semver.satisfies(version, '8.x.x || >=10.0.0')) {
+var supportedVersions = [
+  { range: '>=8.9.0 <9.0.0', name: 'Maintenance LTS' },
+  { range: '>=10.13.0 <11.0.0', name: 'Active LTS' },
+  { range: '>=12.0.0', name: 'Current Release' },
+];
+var isSupported = supportedVersions.some(function(supported) {
+  return semver.satisfies(version, supported.range);
+});
+
+if (isSupported) {
   if (getenv.boolish('EXPO_DEBUG', false)) {
     require('source-map-support').install();
   }
   require('../build/exp.js').run('expo');
 } else {
-  throw new Error('expo-cli supports Node versions 8.x.x, 10.x.x and newer.');
+  var versionInfo = supportedVersions
+    .map(function(supported) {
+      return '* ' + supported.range + ' (' + supported.name + ')';
+    })
+    .join('\n');
+  console.error(
+    chalk.red(
+      'ERROR: Node.js version ' +
+        version +
+        ' is no longer supported.\n\n' +
+        'expo-cli supports following Node.js versions:\n' +
+        versionInfo
+    )
+  );
+  process.exit(1);
 }


### PR DESCRIPTION
We support Node.js maintenance LTS, active LTS and current release versions.
Previously the supported version range was defined as 8.x.x || >=10.0.0,
but this included the 11.x.x versions that reached end-of-life on June 1st 2019.

Update the supported versions to include the exact ranges we support and also
make the error message clearly tell which versions are supported.

Note: the version ranges purposefully use the normal forms such as '>=8.9.0 <9.0.0'
instead of '^8.9.0' to make them easy to understand even without knowledge of the
intricacies of semver.