### PR TITLE
BREAKING CHANGE: convert AssetUtils to TypeScript, drop AssetUtils.toReadableValue

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -3,7 +3,12 @@
   "version": "55.0.14",
   "description": "The Expo Development Library",
   "main": "build/xdl.js",
-  "files": ["build", "binaries", "caches", "scripts"],
+  "files": [
+    "build",
+    "binaries",
+    "caches",
+    "scripts"
+  ],
   "scripts": {
     "start": "yarn build && yarn run watch",
     "build": "tsc --emitDeclarationOnly && gulp build",
@@ -69,6 +74,7 @@
     "package-json": "6.4.0",
     "pacote": "9.3.0",
     "plist": "2.1.0",
+    "pretty-bytes": "^5.2.0",
     "probe-image-size": "4.0.0",
     "querystring": "0.2.0",
     "raven": "2.6.3",

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -28,6 +28,7 @@ import semver from 'semver';
 import split from 'split';
 import treekill from 'tree-kill';
 import md5hex from 'md5hex';
+import prettyBytes from 'pretty-bytes';
 import urljoin from 'url-join';
 import uuid from 'uuid';
 import readLastLines from 'read-last-lines';
@@ -43,7 +44,6 @@ import {
   optimizeImageAsync,
   calculateHash,
   createNewFilename,
-  toReadableValue,
 } from './AssetUtils';
 import Config from './Config';
 import * as Doctor from './project/Doctor';
@@ -2137,7 +2137,7 @@ export async function optimizeAsync(projectRoot: string = './', options: Object 
     }
     if (amountSaved) {
       totalSaved += amountSaved;
-      logger.global.info(`Saved ${toReadableValue(amountSaved)}`);
+      logger.global.info(`Saved ${prettyBytes(amountSaved)}`);
     } else {
       logger.global.info(chalk.gray(`Nothing to compress.`));
     }
@@ -2146,7 +2146,7 @@ export async function optimizeAsync(projectRoot: string = './', options: Object 
     logger.global.info('No assets optimized. Everything is fully compressed!');
   } else {
     logger.global.info(
-      `Finished compressing assets. ${chalk.green(toReadableValue(totalSaved))} saved.`
+      `Finished compressing assets. ${chalk.green(prettyBytes(totalSaved))} saved.`
     );
   }
   assetJson.writeAsync(assetInfo);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14874,6 +14874,11 @@ pretty-bytes@^4.0.2:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
   integrity sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=
 
+pretty-bytes@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.2.0.tgz#96c92c6e95a0b35059253fb33c03e260d40f5a1f"
+  integrity sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w==
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"


### PR DESCRIPTION
Convert XDL AssetUtils module to TypeScript.

This is marked as a "breaking change" because removing `AssetUtils.toReadableValue` in favor of the `pretty-bytes` package causes a semver major version bump.