### PR TITLE
[web][push] Add supports for push notification in Expo for Web

### DIFF
--- a/packages/expo-cli/src/commands/push-creds.js
+++ b/packages/expo-cli/src/commands/push-creds.js
@@ -102,7 +102,7 @@ export default (program: any) => {
       let user = await UserManager.getCurrentUserAsync();
       let apiClient = ApiV2.clientForUser(user);
 
-      log("Setting VAPID key on Expo's servers...");
+      log("Setting VAPID keys on Expo's servers...");
 
       await apiClient.putAsync(`credentials/push/web/${remotePackageName}`, {
         vapidPublicKey: options.vapidPubkey,

--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -58,6 +58,9 @@
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
           navigator.serviceWorker.register('/service-worker.js');
+          navigator.serviceWorker.addEventListener('message', event => {
+            console.log(event);
+          });
         });
       }
     </script>

--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -58,9 +58,6 @@
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
           navigator.serviceWorker.register('/service-worker.js');
-          navigator.serviceWorker.addEventListener('message', event => {
-            console.log(event);
-          });
         });
       }
     </script>

--- a/packages/webpack-config/webpack/serviceWorker.js
+++ b/packages/webpack-config/webpack/serviceWorker.js
@@ -22,4 +22,40 @@ self.addEventListener('push', event => {
   event.waitUntil(self.registration.showNotification(title, options));
 });
 
+// https://developer.mozilla.org/en-US/docs/Web/API/Clients
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+
+  event.waitUntil(
+    (async function() {
+      const allClients = await self.clients.matchAll({
+        includeUncontrolled: true,
+      });
+
+      let appClient;
+
+      // Let's see if we already have a window open:
+      for (const client of allClients) {
+        const url = new URL(client.url);
+
+        if (url.pathname === '/') {
+          // Excellent, let's use it!
+          client.focus();
+          appClient = client;
+          break;
+        }
+      }
+
+      // If we didn't find an existing window,
+      // open a new one:
+      if (!appClient) {
+        appClient = await self.clients.openWindow('/');
+      }
+
+      // Message the client:
+      appClient.postMessage('New chat messages!');
+    })()
+  );
+});
+
 workbox.precaching.precacheAndRoute(self.__precacheManifest);

--- a/packages/webpack-config/webpack/serviceWorker.js
+++ b/packages/webpack-config/webpack/serviceWorker.js
@@ -18,6 +18,7 @@ self.addEventListener('push', event => {
   const title = payload.title;
   const options = {
     body: payload.body,
+    data: payload.data || {},
   };
   event.waitUntil(self.registration.showNotification(title, options));
 });
@@ -53,7 +54,7 @@ self.addEventListener('notificationclick', event => {
       }
 
       // Message the client:
-      appClient.postMessage('New chat messages!');
+      appClient.postMessage(event.notification.data);
     })()
   );
 });

--- a/packages/webpack-config/webpack/serviceWorker.js
+++ b/packages/webpack-config/webpack/serviceWorker.js
@@ -6,9 +6,18 @@ workbox.clientsClaim();
  * Add support for push notification.
  */
 self.addEventListener('push', event => {
-  const title = 'Get Started With Workbox';
+  let payload = {};
+  try {
+    payload = JSON.parse(event.data.text());
+  } catch (e) {
+    // If `event.data.text()` is not a JSON object, we just treat it
+    // as a plain string and display it as the body.
+    payload = { title: '', body: event.data.text() };
+  }
+
+  const title = payload.title;
   const options = {
-    body: event.data.text(),
+    body: payload.body,
   };
   event.waitUntil(self.registration.showNotification(title, options));
 });

--- a/packages/webpack-config/webpack/serviceWorker.js
+++ b/packages/webpack-config/webpack/serviceWorker.js
@@ -8,7 +8,7 @@ workbox.clientsClaim();
 self.addEventListener('push', event => {
   let payload = {};
   try {
-    payload = JSON.parse(event.data.text());
+    payload = event.data.json();
   } catch (e) {
     // If `event.data.text()` is not a JSON object, we just treat it
     // as a plain string and display it as the body.

--- a/packages/webpack-config/webpack/serviceWorker.js
+++ b/packages/webpack-config/webpack/serviceWorker.js
@@ -3,16 +3,6 @@
 workbox.clientsClaim();
 
 /**
- * The workboxSW.precacheAndRoute() method efficiently caches and responds to
- * requests for URLs in the manifest.
- * See https://goo.gl/S9QRab
- * (Copied from automatically genereated `service-worker.js`.)
- */
-self.__precacheManifest = [].concat(self.__precacheManifest || []);
-workbox.precaching.suppressWarnings();
-workbox.precaching.precacheAndRoute(self.__precacheManifest, {});
-
-/**
  * Add support for push notification.
  */
 self.addEventListener('push', event => {
@@ -22,3 +12,5 @@ self.addEventListener('push', event => {
   };
   event.waitUntil(self.registration.showNotification(title, options));
 });
+
+workbox.precaching.precacheAndRoute(self.__precacheManifest);

--- a/packages/webpack-config/webpack/serviceWorker.js
+++ b/packages/webpack-config/webpack/serviceWorker.js
@@ -1,0 +1,24 @@
+/* global workbox, self */
+
+workbox.clientsClaim();
+
+/**
+ * The workboxSW.precacheAndRoute() method efficiently caches and responds to
+ * requests for URLs in the manifest.
+ * See https://goo.gl/S9QRab
+ * (Copied from automatically genereated `service-worker.js`.)
+ */
+self.__precacheManifest = [].concat(self.__precacheManifest || []);
+workbox.precaching.suppressWarnings();
+workbox.precaching.precacheAndRoute(self.__precacheManifest, {});
+
+/**
+ * Add support for push notification.
+ */
+self.addEventListener('push', event => {
+  const title = 'Get Started With Workbox';
+  const options = {
+    body: event.data.text(),
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});

--- a/packages/webpack-config/webpack/serviceWorker.js
+++ b/packages/webpack-config/webpack/serviceWorker.js
@@ -35,11 +35,13 @@ self.addEventListener('notificationclick', event => {
 
       let appClient;
 
+      let path = event.notification.data._webPath || '/';
+
       // Let's see if we already have a window open:
       for (const client of allClients) {
         const url = new URL(client.url);
 
-        if (url.pathname === '/') {
+        if (url.pathname === path) {
           // Excellent, let's use it!
           client.focus();
           appClient = client;
@@ -50,7 +52,7 @@ self.addEventListener('notificationclick', event => {
       // If we didn't find an existing window,
       // open a new one:
       if (!appClient) {
-        appClient = await self.clients.openWindow('/');
+        appClient = await self.clients.openWindow(path);
       }
 
       // Message the client:

--- a/packages/webpack-config/webpack/webpack.common.js
+++ b/packages/webpack-config/webpack/webpack.common.js
@@ -180,7 +180,9 @@ module.exports = async function(env = {}, argv) {
     // Generate a service worker script that will precache, and keep up to date,
     // the HTML & assets that are part of the Webpack build.
     middlewarePlugins.push(
-      new WorkboxPlugin.GenerateSW({
+      new WorkboxPlugin.InjectManifest({
+        swSrc: require.resolve('./serviceWorker.js'),
+        swDest: 'service-worker.js',
         exclude: [
           /\.LICENSE$/,
           /\.map$/,
@@ -188,17 +190,18 @@ module.exports = async function(env = {}, argv) {
           // Exclude all apple touch images as they are cached locally after the PWA is added.
           /^\bapple.*\.png$/,
         ],
+        importWorkboxFrom: 'cdn',
+        // TODO: Support these two:
+        /*
         /// SINGLE PAGE:
         // navigateFallback: `${publicPath}index.html`,
-        clientsClaim: true,
-        importWorkboxFrom: 'cdn',
         navigateFallbackBlacklist: [
           // Exclude URLs starting with /_, as they're likely an API call
           new RegExp('^/_'),
           // Exclude URLs containing a dot, as they're likely a resource in
           // public/ and not a SPA route
           new RegExp('/[^/]+\\.[^/]+$'),
-        ],
+        ],*/
         ...(isDev
           ? {
               include: [], // Don't cache any assets in dev mode.


### PR DESCRIPTION
- In CLI, added supports for uploading (`push:web:upload`), generating (`push:web:generate`), showing (`push:web:show`), and clearing (`push:web:clear`) VAPID key pair and VAPID subject.
- In service worker, added supports for displaying push notifications as well as sending push notifications payload to the client (the webpage) after clicking the notification.

TODO:
- Some options in `GenerateSW` are not transformed into `serviceWorker.js`.