### PR TITLE
[web] fix: allow custom default port

### DIFF
--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -32,9 +32,9 @@ export function getServer(projectRoot: string) {
   return webpackDevServerInstance;
 }
 
-async function choosePortAsync(): Promise<number | null> {
+async function choosePortAsync(port:number): Promise<number | null> {
   try {
-    return await choosePort(HOST, DEFAULT_PORT);
+    return await choosePort(HOST, port);
   } catch (error) {
     throw new XDLError('NO_PORT_FOUND', 'No available port found: ' + error.message);
   }
@@ -72,7 +72,7 @@ export async function startAsync(
     info: Web.isInfoEnabled(),
   });
 
-  webpackServerPort = config.devServer.port || await choosePortAsync();
+  webpackServerPort = await choosePortAsync(config.devServer.port || DEFAULT_PORT);
   ProjectUtils.logInfo(
     projectRoot,
     WEBPACK_LOG_TAG,

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -14,11 +14,12 @@ import * as ProjectSettings from './ProjectSettings';
 import * as Web from './Web';
 import * as Doctor from './project/Doctor';
 import XDLError from './XDLError';
-import ip from './ip';
+import ip from './ip'
 
 import type { User as ExpUser } from './User'; //eslint-disable-line
 
-const HOST = process.env.IP || '0.0.0.0';
+const HOST = process.env.IP;
+const PUBLIC_HOST = process.env.HOST;
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 19006;
 const WEBPACK_LOG_TAG = 'expo';
 
@@ -94,9 +95,12 @@ export async function startAsync(
       useYarn,
       onFinished: resolve,
     });
-    webpackDevServerInstance = new WebpackDevServer(compiler, config.devServer);
+    webpackDevServerInstance = new WebpackDevServer(compiler, {
+      ...config.devServer,
+      publicHost: PUBLIC_HOST,
+    });
     // Launch WebpackDevServer.
-    webpackDevServerInstance.listen(webpackServerPort, HOST, error => {
+    webpackDevServerInstance.listen(webpackServerPort, HOST || '0.0.0.0', error => {
       if (error) {
         ProjectUtils.logError(projectRoot, WEBPACK_LOG_TAG, error);
       }
@@ -119,9 +123,9 @@ export async function getUrlAsync(projectRoot: string): Promise<string> {
   if (!devServer) {
     return null;
   }
-  const host = ip.address();
+  const host = PUBLIC_HOST || `${HOST || ip.address()}:${webpackServerPort}`;
   const urlType = await getProtocolAsync(projectRoot);
-  return `${urlType}://${host}:${webpackServerPort}`;
+  return `${urlType}://${host}`;
 }
 
 export async function getProtocolAsync(projectRoot: string): Promise<'http' | 'https'> {

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -32,7 +32,7 @@ export function getServer(projectRoot: string) {
   return webpackDevServerInstance;
 }
 
-async function choosePortAsync(customDefaultPort?:number | undefined): Promise<number | null> {
+async function choosePortAsync(customDefaultPort?: number | undefined): Promise<number | null> {
   try {
     return await choosePort(HOST, customDefaultPort || DEFAULT_PORT);
   } catch (error) {

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -18,7 +18,7 @@ import ip from './ip';
 
 import type { User as ExpUser } from './User'; //eslint-disable-line
 
-const HOST = '0.0.0.0';
+const HOST = process.env.IP || '0.0.0.0';
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 19006;
 const WEBPACK_LOG_TAG = 'expo';
 

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -19,7 +19,7 @@ import ip from './ip';
 import type { User as ExpUser } from './User'; //eslint-disable-line
 
 const HOST = '0.0.0.0';
-const DEFAULT_PORT = 19006;
+const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 19006;
 const WEBPACK_LOG_TAG = 'expo';
 
 let webpackDevServerInstance: WebpackDevServer | null = null;
@@ -32,9 +32,9 @@ export function getServer(projectRoot: string) {
   return webpackDevServerInstance;
 }
 
-async function choosePortAsync(customDefaultPort?: number | undefined): Promise<number | null> {
+async function choosePortAsync(): Promise<number | null> {
   try {
-    return await choosePort(HOST, customDefaultPort || DEFAULT_PORT);
+    return await choosePort(HOST, DEFAULT_PORT);
   } catch (error) {
     throw new XDLError('NO_PORT_FOUND', 'No available port found: ' + error.message);
   }
@@ -72,7 +72,7 @@ export async function startAsync(
     info: Web.isInfoEnabled(),
   });
 
-  webpackServerPort = await choosePortAsync(config.devServer.port);
+  webpackServerPort = config.devServer.port || await choosePortAsync();
   ProjectUtils.logInfo(
     projectRoot,
     WEBPACK_LOG_TAG,

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -32,9 +32,9 @@ export function getServer(projectRoot: string) {
   return webpackDevServerInstance;
 }
 
-async function choosePortAsync(): Promise<number | null> {
+async function choosePortAsync(customDefaultPort?:number | undefined): Promise<number | null> {
   try {
-    return await choosePort(HOST, DEFAULT_PORT);
+    return await choosePort(HOST, customDefaultPort || DEFAULT_PORT);
   } catch (error) {
     throw new XDLError('NO_PORT_FOUND', 'No available port found: ' + error.message);
   }
@@ -72,7 +72,7 @@ export async function startAsync(
     info: Web.isInfoEnabled(),
   });
 
-  webpackServerPort = await choosePortAsync();
+  webpackServerPort = await choosePortAsync(config.devServer.port);
   ProjectUtils.logInfo(
     projectRoot,
     WEBPACK_LOG_TAG,


### PR DESCRIPTION
This fix will allow you to use a custom port for the webpack dev server which is especially handy if you need a specific port in development (e.g. because of CORS).