### PR TITLE
[web] fix `expo customize:web` on Windows

### DIFF
--- a/packages/expo-cli/src/commands/customize.js
+++ b/packages/expo-cli/src/commands/customize.js
@@ -62,7 +62,7 @@ export async function action(projectDir = './', options = {}) {
   let { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
 
   let templateFolder = require.resolve('@expo/webpack-config/web-default/index.html');
-  templateFolder = templateFolder.substring(0, templateFolder.lastIndexOf('/'));
+  templateFolder = path.dirname(templateFolder);
 
   const files = (await fs.readdir(templateFolder)).filter(item => item !== 'icon.png');
   // { expo: { web: { staticPath: ... } } }


### PR DESCRIPTION
Before, `expo customize:web` failed on Windows with the following error:

```
ENOENT: no such file or directory, scandir ''
```

This was due to some pathing logic using `/` as a path delimiter, whereas Windows uses `\` .

This swaps out the `substring` for `path.dirname` which works properly on all platforms.

Tested on Windows and Linux (Ubuntu WSL).

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/4138357/61477520-18820800-a955-11e9-9311-50fce30ac9b3.png)|![image](https://user-images.githubusercontent.com/4138357/61477561-2afc4180-a955-11e9-8139-c01c0db5e715.png)|