### PR TITLE
fix(xdl): Adding a timeout to a ModuleVersion request to the npm registry

### DIFF
--- a/packages/xdl/src/tools/ModuleVersion.ts
+++ b/packages/xdl/src/tools/ModuleVersion.ts
@@ -8,7 +8,7 @@ import { Cacher } from './FsCache';
 function createModuleVersionChecker(name: string, currentVersion: string) {
   const UpdateCacher = new Cacher(
     async () => {
-      const pkgJson = await npmPackageJson(name, { version: currentVersion });
+      const pkgJson = await pTimeout(npmPackageJson(name, { version: currentVersion }), 2000);
       return {
         latestVersion: await pTimeout(latestVersionAsync(name), 2000),
         deprecated: pkgJson.deprecated,


### PR DESCRIPTION
As part of checking for cli version updates, a request is made to the npm registry using the ["package-json" npm package](https://www.npmjs.com/package/package-json). That package doesn't respect proxy settings in any way, which means the request will time out if used behind a corporate proxy (which is my Expo use case). The standard timeout here is ~60 seconds.

Because this check is made every cli command if we don't have the data cached and because my environment fails to load the data, this is adding a minute of hang time before every cli command I make.

There is already a timeout applied to the other registry request in this same function, so I've decided to use the same pattern and timeout value (2 seconds) on this first check as well.

I'll still have an extra 2 seconds of time to wait through but that's so much better than the current case.