### PR TITLE
[xdl] Add .expo.* extension for projects running in Expo client

### DIFF
--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1492,6 +1492,7 @@ export async function startReactNativeServerAsync(
     port: packagerPort,
     customLogReporterPath: ConfigUtils.resolveModule('expo/tools/LogReporter', projectRoot, exp),
     assetExts: ['ttf'],
+    sourceExts: ['expo.js', 'expo.ts', 'expo.tsx', 'expo.json', 'js', 'json', 'ts', 'tsx'],
     nonPersistent: !!options.nonPersistent,
   };
 


### PR DESCRIPTION
This allows developers to provide fallback behavior for Expo client when they are running it against a bare app. Eg: you have `Map.js` that imports `react-native-mapbox-gl`, and `Map.expo.js` that imports `react-native-maps`. When you do a native build you'll want the react-native-mapbox-gl one, and when you run in the Expo client, in order for it not to crash due to a missing native module, you will want the react-native-maps one.

Note: this is not implemented for web in this PR. We may follow up with support for web, discussing internally.