### PR TITLE
[expo-cli] fix starting projects with modules installed from github

### DIFF
--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -127,7 +127,10 @@ async function validateDependenciesVersions(projectDir, exp, pkg) {
   for (const moduleName of modulesToCheck) {
     const expectedRange = bundledNativeModules[moduleName];
     const actualRange = pkg.dependencies[moduleName];
-    if (!semver.intersects(expectedRange, actualRange)) {
+    if (
+      (semver.valid(actualRange) || semver.validRange(actualRange)) &&
+      !semver.intersects(expectedRange, actualRange)
+    ) {
       incorrectDeps.push({
         moduleName,
         expectedRange,


### PR DESCRIPTION
If a user installed some module from Github and that module happens to be defined in `expo/bundledNativeModules.json` then we don't handle this case properly (`expo start` fails). I fixed that by verifying whether the version in `package.json` is a valid semver (or range) and if it's not then we skip that module validation.