### PR TITLE
fix: iOS Simulator booting device when booted

### DIFF
--- a/packages/xdl/src/__integration_tests__/Simulator-test.js
+++ b/packages/xdl/src/__integration_tests__/Simulator-test.js
@@ -19,7 +19,7 @@ describe('simulator', () => {
     await delayAsync(1000); // 3 seconds
 
     // Open the simulator
-    await Simulator._openSimulatorAsync();
+    await Simulator._openAndBootSimulatorAsync();
 
     await delayAsync(9000); // 3 seconds
 


### PR DESCRIPTION
(Redo of [PR 547](https://github.com/expo/expo-cli/pull/547))

Closes [536](https://github.com/expo/expo-cli/issues/536)

---

Follows the logic suggested in the issue. Additionally:

`_waitForSimulatorRunningAsync` was an extraneous function since `_waitForDeviceToBoot` is more specific. this way, we don't try to open the app url before the device is actually booted.

I also edited `_getFirstAvailableDeviceAsync` to only loop over iOS devices (since if there's no default, that's most likely what the user wants to test on), **and** it will start with the devices on the newest iOS software, which is also probably a good practice (faster boot-up time, as well)

@brentvatne I don't know if we should listen for the xcrun error codes and swallow them, because then we'd have to reroute and repeat the check boot step again. If we did do that, we'd still probably want to set a timeout anyways to prevent a user from getting into an infinite loop with that. But let me know if you had a different idea

Tested locally by starting with and without default simulator in the following scenarios: 
- starting from closed simulator app
- starting with simulator app open with no device booted
- starting with simulator open and device booted