### PR TITLE
fix: problem loading the requested app

### DIFF
--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -1792,7 +1792,7 @@ export async function startExpoServerAsync(projectRoot: string) {
         developerTool: Config.developerTool,
       });
     } catch (e) {
-      ProjectUtils.logDebug(projectRoot, 'expo', `Error in manifestHandler: ${e} ${e.stack}`);
+      ProjectUtils.logError(projectRoot, 'expo', e.stack);
       // 5xx = Server Error HTTP code
       res.status(520).send({
         error: e.toString(),

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -178,6 +178,7 @@ export async function constructUrlAsync(
       dev: joi.boolean(),
       strict: joi.boolean(),
       minify: joi.boolean(),
+      https: joi.boolean(),
       urlRandomness: joi
         .string()
         .optional()

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -178,7 +178,7 @@ export async function constructUrlAsync(
       dev: joi.boolean(),
       strict: joi.boolean(),
       minify: joi.boolean(),
-      https: joi.boolean(),
+      https: joi.boolean().optional(),
       urlRandomness: joi
         .string()
         .optional()


### PR DESCRIPTION
Fix "ValidationError: "https" is not allowed" thrown when trying to load the manifest and change the manifest handler so that it logs all errors to make it possible to catch this kind of problems in the future.

![Simulator Screen Shot - iPhone Xʀ - 2019-07-30 at 19 32 03](https://user-images.githubusercontent.com/497214/62147697-ba640600-b300-11e9-8362-84cd14cd8e1f.png)
<img width="566" alt="Screenshot 2019-07-30 at 19 32 32" src="https://user-images.githubusercontent.com/497214/62147724-cb147c00-b300-11e9-9aed-6806494efc64.png">
