### PR TITLE
fix: detect git even if Xcode is not installed

### DIFF
--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -161,11 +161,6 @@ export async function extractTemplateAppAsync(
 }
 
 async function initGitRepoAsync(root: string) {
-  if (process.platform === 'darwin' && !Binaries.isXcodeInstalled()) {
-    Logger.global.warn(`Unable to initialize git repo. \`git\` not installed.`);
-    return;
-  }
-
   // let's see if we're in a git tree
   let insideGit = true;
   try {
@@ -174,6 +169,9 @@ async function initGitRepoAsync(root: string) {
     });
     Logger.global.debug('New project is already inside of a git repo, skipping git init.');
   } catch (e) {
+    if (e.errno == 'ENOENT') {
+      Logger.global.warn('Unable to initialize git repo. `git` not in PATH.');
+    }
     insideGit = false;
   }
 


### PR DESCRIPTION
Don't guess whether git is installed by checking if Xcode is installed. Just try to use git and warn if it fails.

### Test plan

I've tested with `git` in the path, with `git` not in the path and with a non-executable `git` in the path.
If git is in the path and executable then it is used as expected.
If git is not in the path, the expected warning is printed.

Closes issue #905