### PR TITLE
Implement more options when running in web-only mode

### DIFF
--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -244,7 +244,7 @@ export default (program: any) => {
       async (projectDir, options) => {
         return startWebAction(
           projectDir,
-          await normalizeOptionsAsync(projectDir, { ...options, web: true, webOnly: true })
+          await normalizeOptionsAsync(projectDir, { ...options, webOnly: true })
         );
       },
       /* skipProjectValidation: */ true,

--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -48,6 +48,8 @@ async function startWebAction(projectDir, options) {
   const startOpts = parseStartOptions(projectDir, options);
   await Project.startAsync(rootPath, startOpts);
 
+  await urlOpts.handleMobileOptsAsync(projectDir, options);
+
   if (!options.nonInteractive && !exp.isDetached) {
     await TerminalUI.startAsync(projectDir, startOpts);
   }

--- a/packages/expo-cli/src/commands/start/TerminalUI.js
+++ b/packages/expo-cli/src/commands/start/TerminalUI.js
@@ -118,9 +118,7 @@ export const startAsync = async (projectDir, options) => {
 
   startWaitingForCommand();
 
-  if (!options.webOnly) {
-    await printServerInfo(projectDir, options);
-  }
+  await printServerInfo(projectDir, options);
 
   async function handleKeypress(key) {
     if (options.webOnly) {
@@ -237,7 +235,7 @@ export const startAsync = async (projectDir, options) => {
         clearConsole();
         log('Attempting to open the project in a web browser...');
         await Webpack.openAsync(projectDir);
-        printHelp();
+        await printServerInfo(projectDir, options);
         break;
       }
       case 'c': {

--- a/packages/expo-cli/src/commands/start/TerminalUI.js
+++ b/packages/expo-cli/src/commands/start/TerminalUI.js
@@ -43,11 +43,8 @@ const printUsage = async (projectDir, options = {}) => {
   const openDevToolsAtStartup = await UserSettings.getAsync('openDevToolsAtStartup', true);
   const username = await UserManager.getCurrentUsernameAsync();
   const devMode = dev ? 'development' : 'production';
-  const androidInfo = options.webOnly ? '' : `${b`a`} to run on ${u`A`}ndroid device/emulator`;
-  const iosInfo =
-    !options.webOnly && process.platform === 'darwin'
-      ? `${b`i`} to run on ${u`i`}OS simulator`
-      : '';
+  const androidInfo = `${b`a`} to run on ${u`A`}ndroid device/emulator`;
+  const iosInfo = process.platform === 'darwin' ? `${b`i`} to run on ${u`i`}OS simulator` : '';
   const webInfo = exp.platforms.includes('web') ? `${b`w`} to run on ${u`w`}eb` : '';
   const platformInfo = [androidInfo, iosInfo, webInfo].filter(Boolean).join(', or ');
   log.nested(`
@@ -129,10 +126,17 @@ export const startAsync = async (projectDir, options) => {
     if (options.webOnly) {
       switch (key) {
         case 'a':
-          log(chalk.red` \u203A Opening the Android simulator is not supported in web-only mode`);
+          clearConsole();
+          log('Trying to open the web project in Chrome on Android...');
+          await Android.openProjectAsync(projectDir);
+          printHelp();
           break;
         case 'i':
-          log(chalk.red` \u203A Opening the iOS simulator is not supported in web-only mode`);
+          clearConsole();
+          log('Trying to open the web project in Safari on the iOS simulator...');
+          await Simulator.openWebProjectAsync(projectDir);
+          printHelp();
+          // log(chalk.red` \u203A Opening the iOS simulator is not supported in web-only mode`);
           break;
         case 'e':
           log(chalk.red` \u203A Sending a URL is not supported in web-only mode`);

--- a/packages/expo-cli/src/commands/start/TerminalUI.js
+++ b/packages/expo-cli/src/commands/start/TerminalUI.js
@@ -128,7 +128,7 @@ export const startAsync = async (projectDir, options) => {
         case 'a':
           clearConsole();
           log('Trying to open the web project in Chrome on Android...');
-          await Android.openProjectAsync(projectDir);
+          await Android.openWebProjectAsync(projectDir);
           printHelp();
           break;
         case 'i':

--- a/packages/expo-cli/src/exit.js
+++ b/packages/expo-cli/src/exit.js
@@ -3,7 +3,10 @@
 import chalk from 'chalk';
 import { Project } from '@expo/xdl';
 
-export function installExitHooks(projectDir: string) {
+export function installExitHooks(
+  projectDir: string,
+  onStop: (projectDir: string) => Promise<void> = Project.stopAsync
+) {
   // install ctrl+c handler that writes non-running state to directory
   if (process.platform === 'win32') {
     require('readline')
@@ -16,11 +19,13 @@ export function installExitHooks(projectDir: string) {
       });
   }
 
-  process.on('SIGINT', () => {
-    console.log(chalk.blue('\nStopping packager...'));
-    Project.stopAsync(projectDir).then(() => {
-      console.log(chalk.green('Packager stopped.'));
-      process.exit();
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      console.log(chalk.blue('\nStopping packager...'));
+      onStop(projectDir).then(() => {
+        console.log(chalk.green('Packager stopped.'));
+        process.exit();
+      });
     });
-  });
+  }
 }

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -85,11 +85,19 @@ function printQRCode(url: string) {
 
 async function handleMobileOptsAsync(projectDir: string, options: any) {
   if (options.android) {
-    await Android.openProjectAsync(projectDir);
+    if (options.webOnly) {
+      await Android.openWebProjectAsync(projectDir);
+    } else {
+      await Android.openProjectAsync(projectDir);
+    }
   }
 
   if (options.ios) {
-    await Simulator.openProjectAsync(projectDir);
+    if (options.webOnly) {
+      await Simulator.openWebProjectAsync(projectDir);
+    } else {
+      await Simulator.openProjectAsync(projectDir);
+    }
   }
 
   if (options.web) {

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -41,6 +41,7 @@
     "@expo/webpack-config": "^0.7.0",
     "analytics-node": "3.3.0",
     "axios": "0.19.0",
+    "boxen": "^4.1.0",
     "chalk": "2.4.1",
     "concat-stream": "1.6.2",
     "decache": "4.4.0",

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -17,7 +17,8 @@ import UserSettings from './UserSettings';
 import * as UrlUtils from './UrlUtils';
 import * as Versions from './Versions';
 import { getImageDimensionsAsync } from './tools/ImageUtils';
-
+// @ts-ignore
+import { getUrlAsync as getWebpackUrlAsync } from './Webpack';
 let _lastUrl: string | null = null;
 const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
 const CANT_START_ACTIVITY_ERROR = 'Activity not started, unable to resolve Intent';
@@ -256,6 +257,21 @@ export async function openProjectAsync(
     return { success: true, url: projectUrl };
   } catch (e) {
     Logger.global.error(`Couldn't start project on Android: ${e.message}`);
+    return { success: false, error: e };
+  }
+}
+
+export async function openWebProjectAsync(
+  projectRoot: string
+): Promise<{ success: true; url: string } | { success: false; error: string }> {
+  try {
+    await startAdbReverseAsync(projectRoot);
+
+    const projectUrl = await getWebpackUrlAsync(projectRoot);  
+    await openUrlAsync(projectUrl, true);
+    return { success: true, url: projectUrl };
+  } catch (e) {
+    Logger.global.error(`Couldn't open the web project on Android: ${e.message}`);
     return { success: false, error: e };
   }
 }

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -2186,12 +2186,9 @@ export async function startAsync(
 
 async function _stopInternalAsync(projectRoot: string): Promise<void> {
   DevSession.stopSession();
+  Webpack.stopAsync(projectRoot);
   await stopExpoServerAsync(projectRoot);
   await stopReactNativeServerAsync(projectRoot);
-  const hasWebSupport = await Doctor.hasWebSupportAsync(projectRoot);
-  if (hasWebSupport) {
-    await Webpack.stopAsync(projectRoot);
-  }
   if (!Config.offline) {
     try {
       await stopTunnelsAsync(projectRoot);
@@ -2199,6 +2196,11 @@ async function _stopInternalAsync(projectRoot: string): Promise<void> {
       ProjectUtils.logDebug(projectRoot, 'expo', `Error stopping ngrok ${e.message}`);
     }
   }
+}
+
+export async function stopWebOnlyAsync(projectDir: string): Promise<void> {
+  Webpack.stopAsync(projectDir);
+  await DevSession.stopSession();
 }
 
 export async function stopAsync(projectDir: string): Promise<void> {

--- a/packages/xdl/src/Project.js
+++ b/packages/xdl/src/Project.js
@@ -189,9 +189,9 @@ async function _resolveGoogleServicesFile(projectRoot, manifest) {
 async function _resolveManifestAssets(projectRoot, manifest, resolver, strict = false) {
   try {
     // Asset fields that the user has set
-    const assetSchemas = (await ExpSchema.getAssetSchemasAsync(manifest.sdkVersion)).filter(
-      ({ fieldPath }) => get(manifest, fieldPath)
-    );
+    const assetSchemas = (await ExpSchema.getAssetSchemasAsync(
+      manifest.sdkVersion
+    )).filter(({ fieldPath }) => get(manifest, fieldPath));
 
     // Get the URLs
     const urls = await Promise.all(
@@ -224,9 +224,7 @@ async function _resolveManifestAssets(projectRoot, manifest, resolver, strict = 
       logMethod(
         projectRoot,
         'expo',
-        `Unable to resolve asset "${e.localAssetPath}" from "${
-          e.manifestField
-        }" in your app/exp.json.`
+        `Unable to resolve asset "${e.localAssetPath}" from "${e.manifestField}" in your app/exp.json.`
       );
     } else {
       logMethod(
@@ -367,9 +365,7 @@ export async function mergeAppDistributions(
     return indexes.sort((index1, index2) => {
       if (semver.eq(index1.sdkVersion, index2.sdkVersion)) {
         logger.global.error(
-          `Encountered multiple index.json with the same SDK version ${
-            index1.sdkVersion
-          }. This could result in undefined behavior.`
+          `Encountered multiple index.json with the same SDK version ${index1.sdkVersion}. This could result in undefined behavior.`
         );
       }
       return semver.gte(index1.sdkVersion, index2.sdkVersion) ? -1 : 1;
@@ -802,9 +798,7 @@ export async function publishAsync(
         // ADD EMBEDDED RESPONSES HERE
         // START EMBEDDED RESPONSES
         embeddedResponses.add(new Constants.EmbeddedResponse("${fullManifestUrl}", "assets://shell-app-manifest.json", "application/json"));
-        embeddedResponses.add(new Constants.EmbeddedResponse("${
-          androidManifest.bundleUrl
-        }", "assets://shell-app.bundle", "application/javascript"));
+        embeddedResponses.add(new Constants.EmbeddedResponse("${androidManifest.bundleUrl}", "assets://shell-app.bundle", "application/javascript"));
         // END EMBEDDED RESPONSES`,
         constantsPath
       );
@@ -2166,8 +2160,9 @@ export async function startAsync(
 
   let { exp } = await ProjectUtils.readConfigJsonAsync(projectRoot);
   if (options.webOnly) {
-    await Webpack.startAsync(projectRoot, options);
+    await Webpack.restartAsync(projectRoot, options);
     DevSession.startSession(projectRoot, exp, 'web');
+    return exp;
   } else {
     await startExpoServerAsync(projectRoot);
     await startReactNativeServerAsync(projectRoot, options, verbose);
@@ -2187,7 +2182,9 @@ export async function startAsync(
 async function _stopInternalAsync(projectRoot: string): Promise<void> {
   DevSession.stopSession();
   Webpack.stopAsync(projectRoot);
+  ProjectUtils.logInfo(projectRoot, 'expo', '\u203A Closing Expo server');
   await stopExpoServerAsync(projectRoot);
+  ProjectUtils.logInfo(projectRoot, 'expo', '\u203A Stopping Metro bundler');
   await stopReactNativeServerAsync(projectRoot);
   if (!Config.offline) {
     try {

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -17,6 +17,8 @@ import UserSettings from './UserSettings';
 import * as Versions from './Versions';
 import XDLError from './XDLError';
 import * as UrlUtils from './UrlUtils';
+// @ts-ignore
+import { getUrlAsync as getWebpackUrlAsync } from './Webpack';
 
 let _lastUrl: string | null = null;
 
@@ -477,6 +479,18 @@ export async function openProjectAsync(
   let { exp } = await ConfigUtils.readConfigJsonAsync(projectRoot);
 
   let result = await openUrlInSimulatorSafeAsync(projectUrl, !!exp.isDetached);
+  if (result.success) {
+    return { success: true, url: projectUrl };
+  } else {
+    return { success: result.success, error: result.msg };
+  }
+}
+
+export async function openWebProjectAsync(
+  projectRoot: string
+): Promise<{ success: true; url: string } | { success: false; error: string }> {
+  const projectUrl = await getWebpackUrlAsync(projectRoot);  
+  const result = await openUrlInSimulatorSafeAsync(projectUrl, true);
   if (result.success) {
     return { success: true, url: projectUrl };
   } else {

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -114,6 +114,7 @@ export async function startAsync(
 
 export async function stopAsync(projectRoot: string): Promise<void> {
   if (webpackDevServerInstance) {
+    console.log(chalk.bold('[web]'), chalk.blue('Stopping Webpack Dev Server'));
     await new Promise(resolve => webpackDevServerInstance.close(() => resolve()));
     webpackDevServerInstance = null;
     webpackServerPort = null;

--- a/packages/xdl/src/Webpack.js
+++ b/packages/xdl/src/Webpack.js
@@ -134,8 +134,6 @@ export async function startAsync(
     });
   });
 
-  await printConnectionInstructions(projectRoot);
-
   await ProjectSettings.setPackagerInfoAsync(projectRoot, {
     webpackServerPort,
   });

--- a/packages/xdl/src/project/ProjectUtils.ts
+++ b/packages/xdl/src/project/ProjectUtils.ts
@@ -1,6 +1,6 @@
 import * as ConfigUtils from '@expo/config';
 import path from 'path';
-
+import chalk from 'chalk';
 import * as Analytics from '../Analytics';
 import Logger, { LogStream, Log } from '../Logger';
 
@@ -61,6 +61,22 @@ export function logWithLevel(
 
 export function logDebug(projectRoot: string, tag: LogTag, message: string, id?: string) {
   _getLogger(projectRoot).debug({ tag }, message.toString());
+}
+
+export function getPlatformTag(platform: string): string {
+  const input = platform.toLowerCase().trim();
+  switch (input) {
+    case 'ios':
+      return chalk.bgWhite.black(' iOS ');
+    case 'android':
+      return chalk.bgGreen.black(' Android ');
+    case 'node':
+      return chalk.bgCyan.black(' Node ');
+    case 'web':
+      return chalk.bgMagenta.black(' web ');
+    default:
+      return chalk.bgWhite.black(` ${platform} `);
+  }
 }
 
 export function logInfo(projectRoot: string, tag: LogTag, message: string, id?: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4687,7 +4687,7 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-boxen@4.1.0:
+boxen@4.1.0, boxen@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.1.0.tgz#256f6b2eb09ba22ea558e5acc0a5ff637bf8ed03"
   integrity sha512-Iwq1qOkmEsl0EVABa864Bbj3HCL4186DRZgFW/NrFs5y5GMM3ljsxzMLgOHdWISDRvcM8beh8q4tTNzXz+mSKg==


### PR DESCRIPTION
- Added `expo start:web` which has no unused options (deprecates `expo start --web-only`)
- Updated web beta warning to more clear
- Label React and web logs
- Fixed signals for killing the process. Web now stops faster
- Display error messages when you attempt to use native TerminalUI controls like (e) in web-only mode
- Removed unused option to send a link on web
- Added the ability to open the web project in Safari for iOS in the simulator when the user presses `i` in web-only mode
- Added the ability to open the web project in Chrome for Android when the user presses `a` in web-only mode
