### PR TITLE
[expo-cli] fix provisioning profile generation

### DIFF
--- a/packages/expo-cli/src/commands/build/ios/credentials/prompt/index.js
+++ b/packages/expo-cli/src/commands/build/ios/credentials/prompt/index.js
@@ -27,7 +27,7 @@ async function prompt(appleCtx, options, missingCredentials) {
   const names = stillMissingCredentials.map(id => constants.CREDENTIALS[id].name).join(', ');
   log.warn(`We do not have some credentials for you: ${names}`);
 
-  const [answers, metadata] = (await _shouldExpoGenerateCerts())
+  const { credentials: answers, metadata } = (await _shouldExpoGenerateCerts())
     ? await promptForOverrides(appleCtx, stillMissingCredentials)
     : await promptForCredentials(appleCtx, stillMissingCredentials);
 

--- a/packages/expo-cli/src/commands/build/ios/credentials/prompt/promptForCredentials.js
+++ b/packages/expo-cli/src/commands/build/ios/credentials/prompt/promptForCredentials.js
@@ -38,7 +38,7 @@ async function promptForCredentials(appleCtx, types, printWarning = true) {
     Object.assign(metadata, await _calculateMetadata(credentials[type]));
   }
 
-  return [credentials, metadata];
+  return { credentials, metadata };
 }
 
 async function _askQuestionAndProcessAnswer(definition) {

--- a/packages/expo-cli/src/commands/build/ios/credentials/prompt/promptForOverrides.js
+++ b/packages/expo-cli/src/commands/build/ios/credentials/prompt/promptForOverrides.js
@@ -44,8 +44,8 @@ async function promptForOverrides(appleCtx, types) {
     }
   }
   const userProvidedCredentials = await promptForCredentials(appleCtx, toAskUserFor, false);
-  const credentialsToReturn = { ...credentials, ...userProvidedCredentials };
-  return [credentialsToReturn, null];
+  const credentialsToReturn = { ...credentials, ...userProvidedCredentials.credentials };
+  return { credentials: credentialsToReturn, metadata: userProvidedCredentials.metadata };
 }
 
 async function _willUserProvideCredentialsType(name) {

--- a/packages/expo-cli/src/commands/client/selectDistributionCert.js
+++ b/packages/expo-cli/src/commands/client/selectDistributionCert.js
@@ -38,9 +38,11 @@ export default async function selectDistributionCert(context, options = {}) {
   if (promptValue === 'GENERATE') {
     return await generateDistributionCert(context);
   } else if (promptValue === 'UPLOAD') {
-    const userProvidedCredentials = await promptForCredentials(context, ['distributionCert']);
-    const distributionCert = userProvidedCredentials[0].distributionCert;
-    distributionCert.distCertSerialNumber = userProvidedCredentials[1].distCertSerialNumber;
+    const { credentials: userProvidedCredentials, metadata } = await promptForCredentials(context, [
+      'distributionCert',
+    ]);
+    const distributionCert = userProvidedCredentials.distributionCert;
+    distributionCert.distCertSerialNumber = metadata.distCertSerialNumber;
     const isValid = await validateUploadedCertificate(context, distributionCert);
     if (!isValid) {
       return await selectDistributionCert(context, { disableAutoSelectExisting: true });

--- a/packages/expo-cli/src/commands/client/selectPushKey.js
+++ b/packages/expo-cli/src/commands/client/selectPushKey.js
@@ -39,7 +39,7 @@ export default async function selectPushKey(context, options = {}) {
   if (promptValue === 'GENERATE') {
     return await generatePushKey(context);
   } else if (promptValue === 'UPLOAD') {
-    const pushKey = (await promptForCredentials(context, ['pushKey']))[0].pushKey;
+    const pushKey = (await promptForCredentials(context, ['pushKey'])).credentials.pushKey;
     const isValid = await validateUploadedPushKey(context, pushKey);
     if (!isValid) {
       return await selectPushKey(context, { disableAutoSelectExisting: true });


### PR DESCRIPTION
When a user passes his own distribution cert but lets Expo handle provisioning profile generation we generate the provisioning profile for the last dist cert found on Apple Developer Portal. This PR fixes this bug by choosing the right dist cert for provisioning profile.