### PR TITLE
Update default quality in help message for optimize command

### DIFF
--- a/packages/expo-cli/src/commands/optimize.js
+++ b/packages/expo-cli/src/commands/optimize.js
@@ -35,7 +35,7 @@ export default program => {
     .option('-s, --save', 'Save the original assets with a .orig extension')
     .option(
       '--quality [number]',
-      'Specify the quality the compressed image is reduced to. Default is 60'
+      `Specify the quality the compressed image is reduced to. Default is 80`
     )
     .option(
       '--include [pattern]',

--- a/packages/expo-cli/src/commands/optimize.js
+++ b/packages/expo-cli/src/commands/optimize.js
@@ -35,7 +35,7 @@ export default program => {
     .option('-s, --save', 'Save the original assets with a .orig extension')
     .option(
       '--quality [number]',
-      `Specify the quality the compressed image is reduced to. Default is 80`
+      'Specify the quality the compressed image is reduced to. Default is 80'
     )
     .option(
       '--include [pattern]',


### PR DESCRIPTION
Increased default quality for `expo optimize` in https://github.com/expo/expo-cli/pull/721, forgot to update help message (i.e. when you run `expo optimize --help`)