### PR TITLE
[xdl] Add support for `ios.requireFullScreen` option in `app.json`

### DIFF
--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -372,6 +372,8 @@ async function _configureInfoPlistAsync(context: StandaloneContext) {
       // NOTES: This is defaulted to `true` for now to match the behavior prior to SDK 34, but will change to `false` in a future SDK version.
       infoPlist.UIRequiresFullScreen = true;
     }
+    // Cast to make sure that it is a boolean.
+    infoPlist.UIRequiresFullScreen = Boolean(infoPlist.UIRequiresFullScreen);
 
     // context-specific plist changes
     if (context.type === 'user') {

--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -366,6 +366,13 @@ async function _configureInfoPlistAsync(context: StandaloneContext) {
       infoPlist.UIDeviceFamily = [2];
     }
 
+    // Whether requires full screen on iPad
+    infoPlist.UIRequiresFullScreen = config.ios && config.ios.requireFullScreen;
+    if (infoPlist.UIRequiresFullScreen === null || infoPlist.UIRequiresFullScreen === undefined) {
+      // NOTES: This is defaulted to `true` for now to match the behavior prior to SDK 34, but will change to `false` in a future SDK version.
+      infoPlist.UIRequiresFullScreen = true;
+    }
+
     // context-specific plist changes
     if (context.type === 'user') {
       infoPlist = _configureInfoPlistForLocalDevelopment(infoPlist, context.data.exp);

--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -368,7 +368,7 @@ async function _configureInfoPlistAsync(context: StandaloneContext) {
 
     // Whether requires full screen on iPad
     infoPlist.UIRequiresFullScreen = config.ios && config.ios.requireFullScreen;
-    if (infoPlist.UIRequiresFullScreen === null || infoPlist.UIRequiresFullScreen === undefined) {
+    if (infoPlist.UIRequiresFullScreen == null) {
       // NOTES: This is defaulted to `true` for now to match the behavior prior to SDK 34, but will change to `false` in a future SDK version.
       infoPlist.UIRequiresFullScreen = true;
     }


### PR DESCRIPTION
# Why

Currently, all standalone apps built by Expo do not support iPad's multitasking feature (Slide Over and Split View). We should add an option to allow developers to enable this feature.

https://expo.canny.io/feature-requests/p/ipad-multitasking-for-standalone-apps

# How

Added an `ios.requireFullScreen` option is added in `app.json`.

This is defaulted to `true` for now to match the current behavior (i.e., the behavior prior to SDK 34), but will change to `false` in a future SDK version.

> From @ide:
> 
> We could release this change in two phases:
> 1. Add `ios.requireFullscreen` and make the default value `true`. If you explicitly specify a value, we’ll use that value. but if you don’t specify any value, then the app is full-screen. this preserves today’s current behavior.
> 2. In a future SDK version, we switch the default value to `false`. As long as we communicate this plan clearly to people, and perhaps even print a notice when they run `expo build:ios` in order to educate them, there shouldn’t be a lot of issues for people.

Track step 2 in https://github.com/expo/expo-cli/pull/908.

See also https://github.com/expo/expo/pull/5155 and https://github.com/expo/universe/pull/3633.

# Test Plan

`expo eject` or `expo build` a current app will not result in behavior change.

`expo eject` or `expo build` a app with `ios.requireFullscreen` being `false` in `app.json` will make the app support iPad's multitasking feature.