### PR TITLE
Fix: "cannot assign to read only property `exports` of object: '#<Object>'"

### DIFF
--- a/packages/webpack-config/webpack/loaders/createBabelLoaderAsync.js
+++ b/packages/webpack-config/webpack/loaders/createBabelLoaderAsync.js
@@ -108,7 +108,7 @@ module.exports = async function({
         configFile: true,
         // Only clobber hard coded values.
         ...(customUseOptions || {}),
-
+        sourceType: 'unambiguous',
         root: ensuredProjectRoot,
         // Cache babel files in production
         cacheCompression: isProduction,


### PR DESCRIPTION
Fix blocker for starting expo web.

# Test Plan

- editing the global node_module directly with this change fixes the bug