### PR TITLE
fix: slow CLI startup time performance regression

### DIFF
--- a/packages/babel-preset-cli/index.js
+++ b/packages/babel-preset-cli/index.js
@@ -6,9 +6,13 @@ module.exports = () => ({
         targets: {
           node: '8.9.0',
         },
+        modules: false,
       },
     ],
     '@babel/preset-typescript',
   ],
-  plugins: ['@babel/plugin-proposal-class-properties'],
+  plugins: [
+    '@babel/plugin-proposal-class-properties',
+    ['@babel/plugin-transform-modules-commonjs', { lazy: source => true }],
+  ],
 });

--- a/packages/babel-preset-cli/package.json
+++ b/packages/babel-preset-cli/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@babel/core": "^7.4.5",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/plugin-transform-modules-commonjs": "^7.5.0",
     "@babel/preset-env": "^7.4.4",
     "@babel/preset-typescript": "^7.3.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,6 +599,16 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-simple-access" "^7.1.0"
 
+"@babel/plugin-transform-modules-commonjs@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz#425127e6045231360858eeaa47a71d75eded7a74"
+  integrity sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
 "@babel/plugin-transform-modules-systemjs@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz#dc83c5665b07d6c2a7b224c00ac63659ea36a405"
@@ -3835,6 +3845,13 @@ babel-plugin-check-es2015-constants@^6.22.0:
   integrity sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-dynamic-import-node@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"
+  integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
+  dependencies:
+    object.assign "^4.1.0"
 
 babel-plugin-emotion@^8.0.12, babel-plugin-emotion@^8.0.4:
   version "8.0.12"
@@ -13792,7 +13809,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.1, object.assign@^4.0.4:
+object.assign@^4.0.1, object.assign@^4.0.4, object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==


### PR DESCRIPTION
When changing the build configurations to add support for TypeScript, the lazy loading of modules that was previously done using the `babel-transform-inline-imports-commonjs` package was removed from `@expo/xdl` and `expo-cli`:
- https://github.com/expo/expo-cli/commit/b45e9dbf724bc077b7fbaf5041961028c4ddf470#diff-77b4343b244f7776c55c7c643d13efe6
- https://github.com/expo/expo-cli/commit/e3c7af725987e17bac74d0e806c67b0691ca626b#diff-b80134f5b17e5b157842c17b91ec70f4

This affected startup time of the CLI negatively, causing every command to take 3-5 seconds to start.

This commit restores lazy loading of modules, now using the `lazy` option of `@babel/plugin-transform-modules-commonjs`.

Thanks to @ninjaachibi for his investigation and profiling that revealed the source of the slowdown was `require`! 🙌 