### PR TITLE
Change new cli version warning text

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -417,7 +417,7 @@ async function checkCliVersionAsync() {
       boxen(
         chalk.green(`There is a new version of ${packageJSON.name} available (${latest}).
 You are currently using ${packageJSON.name} ${current}
-Run \`npm install -g ${packageJSON.name}\` to get the latest version`),
+Install expo-cli globally using the package manager of your choice; for example: \`npm install -g ${packageJSON.name}\` to get the latest version`),
         { borderColor: 'green', padding: 1 }
       )
     );


### PR DESCRIPTION
Changed the text as to not make it seem as though npm is the only or recommended way of updating expo-cli to avoid confusion for users (such as https://github.com/expo/expo-cli/issues/914).