### PR TITLE
fix(expo-cli): use production mode in build:web

### DIFF
--- a/packages/expo-cli/src/commands/build/index.js
+++ b/packages/expo-cli/src/commands/build/index.js
@@ -115,7 +115,13 @@ export default (program: any) => {
     .option('-d, --dev', 'Bundle your project using webpack in dev mode.')
     .description('Build a production bundle for your project, compressed and ready for deployment.')
     .asyncActionProjectDir(
-      (projectDir, options) => Webpack.bundleAsync(projectDir, options),
+      (projectDir, options) => {
+        if (typeof options.dev === 'undefined') {
+          options.dev = false;
+        }
+        
+        Webpack.bundleAsync(projectDir, options)
+      },
       /* skipProjectValidation: */ false,
       /* skipAuthCheck: */ true
     );


### PR DESCRIPTION
Currently, when running `build:web` the option `dev` is `undefined` by default. If for any reason `dev` is `true` in `.expo/settings.json` or the command is executed for the first time the project will subsequently be built in dev mode.