### PR TITLE
[xdl] Make simulator builds and Android APKs SDK-specific

### DIFF
--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -29,7 +29,7 @@ export function isPlatformSupported(): boolean {
   );
 }
 
-async function _getAdbOutputAsync(args: string[]): Promise<string> {
+export async function _getAdbOutputAsync(args: string[]): Promise<string> {
   await Binaries.addToPathAsync('adb');
 
   try {
@@ -111,7 +111,7 @@ function _apkCacheDirectory() {
   return dir;
 }
 
-async function _downloadApkAsync() {
+export async function _downloadApkAsync(url?: string) {
   let versions = await Versions.versionsAsync();
   let apkPath = path.join(_apkCacheDirectory(), `Exponent-${versions.androidVersion}.apk`);
 
@@ -120,16 +120,16 @@ async function _downloadApkAsync() {
   }
 
   await Api.downloadAsync(
-    versions.androidUrl,
+    url || versions.androidUrl,
     path.join(_apkCacheDirectory(), `Exponent-${versions.androidVersion}.apk`)
   );
   return apkPath;
 }
 
-async function _installExpoAsync() {
+export async function _installExpoAsync(url?: string) {
   Logger.global.info(`Downloading latest version of Expo`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
-  let path = await _downloadApkAsync();
+  let path = await _downloadApkAsync(url);
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
   Logger.global.info(`Installing Expo on device`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
@@ -138,7 +138,7 @@ async function _installExpoAsync() {
   return result;
 }
 
-async function _uninstallExpoAsync() {
+export async function _uninstallExpoAsync() {
   Logger.global.info('Uninstalling Expo from Android device.');
   return await _getAdbOutputAsync(['uninstall', 'host.exp.exponent']);
 }
@@ -171,7 +171,7 @@ export async function upgradeExpoAsync(): Promise<boolean> {
 }
 
 // Open Url
-async function _assertDeviceReadyAsync() {
+export async function _assertDeviceReadyAsync() {
   const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
 
   if (!(await _isDeviceAttachedAsync())) {

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -29,7 +29,7 @@ export function isPlatformSupported(): boolean {
   );
 }
 
-export async function _getAdbOutputAsync(args: string[]): Promise<string> {
+export async function getAdbOutputAsync(args: string[]): Promise<string> {
   await Binaries.addToPathAsync('adb');
 
   try {
@@ -46,14 +46,14 @@ export async function _getAdbOutputAsync(args: string[]): Promise<string> {
 
 // Device attached
 async function _isDeviceAttachedAsync() {
-  let devices = await _getAdbOutputAsync(['devices']);
+  let devices = await getAdbOutputAsync(['devices']);
   let lines = _.trim(devices).split(/\r?\n/);
   // First line is "List of devices".
   return lines.length > 1;
 }
 
 async function _isDeviceAuthorizedAsync() {
-  let devices = await _getAdbOutputAsync(['devices']);
+  let devices = await getAdbOutputAsync(['devices']);
   let lines = _.trim(devices).split(/\r?\n/);
   lines.shift();
   let listOfDevicesWithoutFirstLine = lines.join('\n');
@@ -64,7 +64,7 @@ async function _isDeviceAuthorizedAsync() {
 
 // Expo installed
 async function _isExpoInstalledAsync() {
-  let packages = await _getAdbOutputAsync(['shell', 'pm', 'list', 'packages', '-f']);
+  let packages = await getAdbOutputAsync(['shell', 'pm', 'list', 'packages', '-f']);
   let lines = packages.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
     let line = lines[i];
@@ -81,7 +81,7 @@ async function _isExpoInstalledAsync() {
 }
 
 async function _expoVersionAsync() {
-  let info = await _getAdbOutputAsync(['shell', 'dumpsys', 'package', 'host.exp.exponent']);
+  let info = await getAdbOutputAsync(['shell', 'dumpsys', 'package', 'host.exp.exponent']);
 
   let regex = /versionName=([0-9.]+)/;
   let regexMatch = regex.exec(info);
@@ -111,7 +111,7 @@ function _apkCacheDirectory() {
   return dir;
 }
 
-export async function _downloadApkAsync(url?: string) {
+export async function downloadApkAsync(url?: string) {
   let versions = await Versions.versionsAsync();
   let apkPath = path.join(_apkCacheDirectory(), `Exponent-${versions.androidVersion}.apk`);
 
@@ -126,32 +126,32 @@ export async function _downloadApkAsync(url?: string) {
   return apkPath;
 }
 
-export async function _installExpoAsync(url?: string) {
+export async function installExpoAsync(url?: string) {
   Logger.global.info(`Downloading latest version of Expo`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
-  let path = await _downloadApkAsync(url);
+  let path = await downloadApkAsync(url);
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
   Logger.global.info(`Installing Expo on device`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
-  let result = await _getAdbOutputAsync(['install', path]);
+  let result = await getAdbOutputAsync(['install', path]);
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
   return result;
 }
 
-export async function _uninstallExpoAsync() {
+export async function uninstallExpoAsync() {
   Logger.global.info('Uninstalling Expo from Android device.');
-  return await _getAdbOutputAsync(['uninstall', 'host.exp.exponent']);
+  return await getAdbOutputAsync(['uninstall', 'host.exp.exponent']);
 }
 
 export async function upgradeExpoAsync(): Promise<boolean> {
   try {
-    await _assertDeviceReadyAsync();
+    await assertDeviceReadyAsync();
 
-    await _uninstallExpoAsync();
-    await _installExpoAsync();
+    await uninstallExpoAsync();
+    await installExpoAsync();
     if (_lastUrl) {
       Logger.global.info(`Opening ${_lastUrl} in Expo.`);
-      await _getAdbOutputAsync([
+      await getAdbOutputAsync([
         'shell',
         'am',
         'start',
@@ -171,7 +171,7 @@ export async function upgradeExpoAsync(): Promise<boolean> {
 }
 
 // Open Url
-export async function _assertDeviceReadyAsync() {
+export async function assertDeviceReadyAsync() {
   const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
 
   if (!(await _isDeviceAttachedAsync())) {
@@ -188,7 +188,7 @@ export async function _assertDeviceReadyAsync() {
 }
 
 async function _openUrlAsync(url: string) {
-  let output = await _getAdbOutputAsync([
+  let output = await getAdbOutputAsync([
     'shell',
     'am',
     'start',
@@ -206,11 +206,11 @@ async function _openUrlAsync(url: string) {
 
 async function openUrlAsync(url: string, isDetached: boolean = false): Promise<void> {
   try {
-    await _assertDeviceReadyAsync();
+    await assertDeviceReadyAsync();
 
     let installedExpo = false;
     if (!isDetached && !(await _isExpoInstalledAsync())) {
-      await _installExpoAsync();
+      await installExpoAsync();
       installedExpo = true;
     }
 
@@ -325,7 +325,7 @@ async function adbReverse(port: number) {
   }
 
   try {
-    await _getAdbOutputAsync(['reverse', `tcp:${port}`, `tcp:${port}`]);
+    await getAdbOutputAsync(['reverse', `tcp:${port}`, `tcp:${port}`]);
     return true;
   } catch (e) {
     Logger.global.warn(`Couldn't adb reverse: ${e.message}`);
@@ -339,7 +339,7 @@ async function adbReverseRemove(port: number) {
   }
 
   try {
-    await _getAdbOutputAsync(['reverse', '--remove', `tcp:${port}`]);
+    await getAdbOutputAsync(['reverse', '--remove', `tcp:${port}`]);
     return true;
   } catch (e) {
     // Don't send this to warn because we call this preemptively sometimes

--- a/packages/xdl/src/Versions.ts
+++ b/packages/xdl/src/Versions.ts
@@ -25,6 +25,10 @@ export type SDKVersion = {
   isDeprecated?: boolean;
   packagesToInstallWhenEjecting?: { [name: string]: string };
   releaseNoteUrl?: string;
+  iosClientUrl?: string;
+  iosClientVersion?: string;
+  androidClientUrl?: string;
+  androidClientVersion?: string;
 };
 
 export type SDKVersions = { [version: string]: SDKVersion };

--- a/packages/xdl/src/tools/UpdateVersions.ts
+++ b/packages/xdl/src/tools/UpdateVersions.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import semver from 'semver';
 import spawnAsync from '@expo/spawn-async';
 
 import * as Versions from '../Versions';
@@ -23,7 +24,8 @@ export async function updateSdkVersionsAsync(
 export async function updateIOSSimulatorBuild(
   s3Client: any,
   pathToApp: string,
-  appVersion: string
+  appVersion: string,
+  sdkVersion?: string,
 ) {
   let tempAppPath = path.join(process.cwd(), 'temp-app.tar.gz');
 
@@ -49,13 +51,17 @@ export async function updateIOSSimulatorBuild(
 
   console.log('Adding to server config...');
 
-  let versions = await Versions.versionsAsync();
-  versions['iosVersion'] = appVersion;
-  versions['iosUrl'] = `https://dpq5q02fu5f55.cloudfront.net/Exponent-${appVersion}.tar.gz`;
-  await Versions.setVersionsAsync(versions);
+  const clientUrl = `https://dpq5q02fu5f55.cloudfront.net/Exponent-${appVersion}.tar.gz`;
+  
+  await updateClientUrlAndVersionAsync(sdkVersion, 'ios', clientUrl, appVersion);
 }
 
-export async function updateAndroidApk(s3Client: any, pathToApp: string, appVersion: string) {
+export async function updateAndroidApk(
+  s3Client: any,
+  pathToApp: string,
+  appVersion: string,
+  sdkVersion?: string,
+) {
   let file = fs.createReadStream(pathToApp);
 
   console.log('Uploading...');
@@ -71,8 +77,37 @@ export async function updateAndroidApk(s3Client: any, pathToApp: string, appVers
 
   console.log('Adding to server config...');
 
-  let versions = await Versions.versionsAsync();
-  versions['androidVersion'] = appVersion;
-  versions['androidUrl'] = `https://d1ahtucjixef4r.cloudfront.net/Exponent-${appVersion}.apk`;
+  const clientUrl = `https://d1ahtucjixef4r.cloudfront.net/Exponent-${appVersion}.apk`;
+
+  await updateClientUrlAndVersionAsync(sdkVersion, 'android', clientUrl, appVersion);
+}
+
+async function updateClientUrlAndVersionAsync(
+  sdkVersion: string | undefined,
+  platform: 'ios' | 'android',
+  clientUrl: string,
+  appVersion: string
+) {
+  // Unfortunately it needs to be of `any` type to be able to change dynamic keys in the object.
+  const versions: any = await Versions.versionsAsync();
+
+  // Create new SDK version config if not there yet.
+  if (sdkVersion && !versions.sdkVersions[sdkVersion]) {
+    versions.sdkVersions[sdkVersion] = {};
+  }
+
+  // For compatibility reason we have to maintain that global config, but only when we're updating the most recent SDK.
+  if (!sdkVersion || Object.keys(versions.sdkVersions).sort(semver.rcompare)[0] === sdkVersion) {
+    versions[`${platform}Version`] = appVersion;
+    versions[`${platform}Url`] = clientUrl;
+  }
+
+  // Update SDK version config.
+  if (sdkVersion) {
+    const sdkVersionConfig = versions.sdkVersions[sdkVersion];
+    sdkVersionConfig[`${platform}ClientUrl`] = clientUrl;
+    sdkVersionConfig[`${platform}ClientVersion`] = appVersion;
+  }
+
   await Versions.setVersionsAsync(versions);
 }

--- a/packages/xdl/src/tools/UpdateVersions.ts
+++ b/packages/xdl/src/tools/UpdateVersions.ts
@@ -91,12 +91,12 @@ async function updateClientUrlAndVersionAsync(
   // Unfortunately it needs to be of `any` type to be able to change dynamic keys in the object.
   const versions: any = await Versions.versionsAsync();
 
-  // Create new SDK version config if not there yet.
+  // Create new SDK version config if it's not there yet.
   if (sdkVersion && !versions.sdkVersions[sdkVersion]) {
     versions.sdkVersions[sdkVersion] = {};
   }
 
-  // For compatibility reason we have to maintain that global config, but only when we're updating the most recent SDK.
+  // For compatibility reasons we have to maintain that global config, but only when we're updating the most recent SDK.
   if (!sdkVersion || Object.keys(versions.sdkVersions).sort(semver.rcompare)[0] === sdkVersion) {
     versions[`${platform}Version`] = appVersion;
     versions[`${platform}Url`] = clientUrl;


### PR DESCRIPTION
Instead of saving iOS simulator builds and Android APKs urls to the global config, we would like to store them at SDK-specific configuration - it is required for https://github.com/expo/expo/pull/5331.
I've also exported a few more methods and made it possible internally to install an app from any url and not only the latest one.