### PR TITLE
fix(xdl): Inject `process.env` with Next.js's `env` instead of setting it directly

### DIFF
--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -520,10 +520,11 @@ function _createNextJsConfig({
   }
   const includeFunc = expoBabelLoader.include as ((path: string) => boolean);
 
-  // Inject `process.env` with Next.js's `env` instead of `process.env` in
-  // Webpack's `DefinePlugin`.
+  // Inject `process.env` with Next.js's `env` instead of setting `process.env`
+  // directly with Webpack's `DefinePlugin`.
   const definePlugin = _findDefinePlugin(expoWebpackConfig.plugins!) as any;
   const definitions = (definePlugin || {}).definitions;
+  // Next.js does not accept `NODE_ENV` in `env`, so we exclude it.
   const { 'process.env': { NODE_ENV, ...processEnv } } = definitions;
   delete definitions['process.env'];
 

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -458,6 +458,7 @@ async function startNextJsAsync({
     conf: _createNextJsConfig({
       projectRoot,
       expoWebpackConfig,
+      userConfigOnly: !dev,
     }),
   });
   const handle = app.getRequestHandler();
@@ -501,14 +502,19 @@ async function bundleNextJsAsync({
 function _createNextJsConfig({
   projectRoot,
   expoWebpackConfig,
+  userConfigOnly = false,
 }: {
   projectRoot: string;
   expoWebpackConfig: Web.WebpackConfiguration;
+  userConfigOnly?: boolean;
 }): { [key: string]: any } {
   let userNextJsConfig: any = {};
   const userNextConfigJsPath = path.join(projectRoot, 'next.config.js');
   if (fs.existsSync(userNextConfigJsPath)) {
     userNextJsConfig = require(userNextConfigJsPath);
+  }
+  if (userConfigOnly) {
+    return userNextJsConfig;
   }
 
   // `include` function is from https://github.com/expo/expo-cli/blob/3933f3d6ba65bffec2738ece71b62f2c284bd6e4/packages/webpack-config/webpack/loaders/createBabelLoaderAsync.js#L76-L96


### PR DESCRIPTION
If we use our `new DefinePlugin(environmentVariables)` directly

https://github.com/expo/expo-cli/blob/0d8ac7c1969b594d55f04793f81fdc101152ee44/packages/webpack-config/webpack/webpack.config.unimodules.js#L117-L121

There will be this error during `target: "serverless"` build:
```
~/Documents/Github/stanford-daily$ yarn expo build:web
yarn run v1.17.3
$ /Users/hesyifei/Documents/Github/stanford-daily/node_modules/.bin/expo build:web
Creating an optimized production build ...

> Using external babel configuration
> Location: "/Users/hesyifei/Documents/Github/stanford-daily/babel.config.js"
TypeError: result.setExpression is not a function
    at Parser.evaluateExpression (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:2147:14)
    at hooks.evaluate.for.tap.expr (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:181:17)
    at SyncBailHook.eval (eval at create (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:16)
    at Parser.evaluateExpression (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:2144:25)
    at Parser.getRenameIdentifier (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:819:23)
    at Parser.walkVariableDeclaration (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:1452:31)
    at Parser.walkStatement (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:997:10)
    at Parser.walkStatements (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:868:9)
    at Parser.parse (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:2284:9)
    at doBuild.err (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/NormalModule.js:474:32)
TypeError: result.setExpression is not a function
    at Parser.evaluateExpression (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:2147:14)
    at parser.hooks.expressionLogicalOperator.tap.expression (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/ConstPlugin.js:231:30)
    at SyncBailHook.eval (eval at create (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:16)
    at Parser.walkLogicalExpression (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:1757:55)
    at Parser.walkExpression (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:1607:10)
    at Parser.walkVariableDeclaration (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:1469:32)
    at Parser.walkStatement (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:997:10)
    at Parser.walkStatements (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:868:9)
    at Parser.parse (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/Parser.js:2284:9)
    at doBuild.err (/Users/hesyifei/Documents/Github/stanford-daily/node_modules/next/node_modules/webpack/lib/NormalModule.js:474:32)
```

This is somehow related to how we nested the `process.env`:

https://github.com/expo/expo-cli/blob/0d8ac7c1969b594d55f04793f81fdc101152ee44/packages/webpack-config/webpack/createClientEnvironment.js#L39-L42

So instead of using our `new DefinePlugin(environmentVariables),` to set `'process.env'`, we use Next.js's [`env`](https://nextjs.org/docs#build-time-configuration) option to set it.

(It eventually get tranfered to
```
      {
         "definitions":{
            "process.env.PUBLIC_URL":"\"\\\"/\\\"\"",
            "process.env.APP_MANIFEST":"\"{\\\"name\\\":\\\"Stanford Daily\\\",\\\"slug\\\":\\\"stanford-daily\\\",\\\"owner\\\":\\\"stanforddaily\\\",\\\"privacy\\\":\\\"public\\\",\\\"sdkVersion\\\":\\\"34.0.0\\\",\\\"platforms\\\":[\\\"ios\\\",\\\"android\\\",\\\"web\\\"],\\\"version\\\":\\\"1.0.0\\\",\\\"orientation\\\":\\\"portrait\\\",\\\"icon\\\":\\\"./assets/icon.png\\\",\\\"splash\\\":{\\\"image\\\":\\\"./assets/splash.png\\\",\\\"resizeMode\\\":\\\"contain\\\",\\\"backgroundColor\\\":\\\"#ffffff\\\"},\\\"updates\\\":{\\\"fallbackToCacheTimeout\\\":0},\\\"assetBundlePatterns\\\":[\\\"**/*\\\"],\\\"web\\\":{},\\\"description\\\":\\\"A Neat Expo App\\\",\\\"primaryColor\\\":\\\"#4630EB\\\"}\"",
            "process.env.NODE_ENV":"\"production\"",
            "process.browser":"false",
            "process.env.__NEXT_EXPORT_TRAILING_SLASH":"false",
            "process.env.__NEXT_MODERN_BUILD":false,
            "typeof window":"\"undefined\"",
            "global.GENTLY":"false"
         }
      },
```
)