### PR TITLE
refactor: remove Flow types from the detach folder

### DIFF
--- a/packages/xdl/CHANGELOG.md
+++ b/packages/xdl/CHANGELOG.md
@@ -6,23 +6,25 @@ For guidelines on how to update this file, visit http://keepachangelog.com/en/0.
 
 ### Added
 
-* added support for build modes on Android
-* `expo-av` and `expo-mail-composer` universal modules configuration.
-* required `sdkVersion` argument to `Modules.` methods.
-* added support for `packagesToInstallWhenEjecting` dictionary used to get a list of packages to install when ejecting
-* instead of overwriting `settings.gradle` with static content, XDL will now modify it according to comment rules
-* use `react-native-unimodules` autolinking in ejected apps
+- added support for build modes on Android
+- `expo-av` and `expo-mail-composer` universal modules configuration.
+- required `sdkVersion` argument to `Modules.` methods.
+- added support for `packagesToInstallWhenEjecting` dictionary used to get a list of packages to install when ejecting
+- instead of overwriting `settings.gradle` with static content, XDL will now modify it according to comment rules
+- use `react-native-unimodules` autolinking in ejected apps
 
 ### Changed
 
 ### Removed
 
+- Dropped support for SDK 24, `Detach.detachAsync` now requires SDK version 25.0.0 or newer.
+
 ## [51.1.0] - 2018-08-28
 
 ### Changed
 
-* Allow for passsing workingdir for android shell app builder.
-* Allow for generating ios shell app with single sdk.
+- Allow for passsing workingdir for android shell app builder.
+- Allow for generating ios shell app with single sdk.
 
 ## [51.0.0] - 2018-08-24
 
@@ -34,65 +36,65 @@ For guidelines on how to update this file, visit http://keepachangelog.com/en/0.
 
 ### Changed
 
-* Fix shell app builder commands
+- Fix shell app builder commands
 
 ## [50.6.1] - 2018-07-20
 
 ### Changed
 
-* Fix signing iOS entitlements.
+- Fix signing iOS entitlements.
 
 ## [50.6.0] - 2018-07-16
 
 ### Added
 
-* Add function for cleaning up old turtle keychains.
+- Add function for cleaning up old turtle keychains.
 
 ## [50.5.2] - 2018-07-12
 
 ### Added
 
-* Allow for passing app manifest to AndroidShellApp and IosShellApp modules as an argument.
+- Allow for passing app manifest to AndroidShellApp and IosShellApp modules as an argument.
 
 ## [50.5.1] - 2018-07-10
 
 ### Changed
 
-* Fix provisioning profile validation.
-* Fix signing entitlements.
-* Retry fetching manifest up to 5 times.
+- Fix provisioning profile validation.
+- Fix signing entitlements.
+- Retry fetching manifest up to 5 times.
 
 ## [50.5.0] - 2018-06-27
 
 ### Changed
 
-* If Metro has stopped, we now try to restart it when publishing.
-* Log bundling errors with log level as error.
-* Color the message in syntax errors as red.
-* Expo fork of React Native is only required in ExpoKit projects.
+- If Metro has stopped, we now try to restart it when publishing.
+- Log bundling errors with log level as error.
+- Color the message in syntax errors as red.
+- Expo fork of React Native is only required in ExpoKit projects.
 
 ### Removed
 
-* Remove `npm ls` validation from `Doctor`.
+- Remove `npm ls` validation from `Doctor`.
 
 ## [50.4.2] - 2018-06-20
 
 ### Removed
 
-* Remove ImageHelpers module.
-* Remove sharp from peer dependencies.
+- Remove ImageHelpers module.
+- Remove sharp from peer dependencies.
 
 ## [50.4.0] - 2018-06-19
 
 ### Added
 
-* Added support for new turtle agent.
+- Added support for new turtle agent.
 
 ## [50.3.0] - 2018-06-14
 
 ### Changed
 
-* Hide redundant messages from the logs:
+- Hide redundant messages from the logs:
   - Stop printing "Expo is ready"
   - Stop printing "Scanning folders for symlinks in..."
 
@@ -100,515 +102,515 @@ For guidelines on how to update this file, visit http://keepachangelog.com/en/0.
 
 ### Changed
 
-* Fix generating provisioning profile
+- Fix generating provisioning profile
 
 ## [50.2.0] - 2018-06-11
 
 ### Added
 
-* Add support for `android.adaptiveIcon` app.json fields in shell app script
-* Add provisioning profile validation
+- Add support for `android.adaptiveIcon` app.json fields in shell app script
+- Add provisioning profile validation
 
 ### Changed
 
-* Ensure that all versioned react native pods target iOS 9
-* Use released gulp 4.0
-* Upgrade `fs-extra` to remove warning on Node v10.1.0.
+- Ensure that all versioned react native pods target iOS 9
+- Use released gulp 4.0
+- Upgrade `fs-extra` to remove warning on Node v10.1.0.
 
 ## [50.1.0] - 2018-05-31
 
 ### Added
 
-* Add support for backing up Android credentials.
+- Add support for backing up Android credentials.
 
 ### Changed
 
-* Change JSON payload used for sign up.
-* Remove deprecated flag `splash` that allowed old standalone apps to skip the splash API.
-* Fix generating fingerprint from certificate (fixes expo/expo#1771)
+- Change JSON payload used for sign up.
+- Remove deprecated flag `splash` that allowed old standalone apps to skip the splash API.
+- Fix generating fingerprint from certificate (fixes expo/expo#1771)
 
 ## [50.0.0] - 2018-05-14
 
 ### Added
 
-* Add iOS app signing
-* Add creating Android keystores
-* Add `ProjectUtils.writeConfigJsonAsync` for modifying `app.json` configuration
-* Add a unique ID to each log entry
+- Add iOS app signing
+- Add creating Android keystores
+- Add `ProjectUtils.writeConfigJsonAsync` for modifying `app.json` configuration
+- Add a unique ID to each log entry
 
 ### Changed
 
-* Fix handing configuration files using a custom file name (fixes expo/expo#1688)
-* Add more logging to ExpoKit asset bundling
-* Store user session state in a different file when using the staging API
-* Warn about builds for invalid SDK version
-* Fix infinitely waiting for Metro bundler to start if it crashes
-* Ensure error messages from Metro bundler are logged
-* Hide the noisy "BugReporting extraData" logs from react-native
+- Fix handing configuration files using a custom file name (fixes expo/expo#1688)
+- Add more logging to ExpoKit asset bundling
+- Store user session state in a different file when using the staging API
+- Warn about builds for invalid SDK version
+- Fix infinitely waiting for Metro bundler to start if it crashes
+- Ensure error messages from Metro bundler are logged
+- Hide the noisy "BugReporting extraData" logs from react-native
 
 ### Removed
 
-* Remove `clientId` from requests to `userProfileAsync` API.
+- Remove `clientId` from requests to `userProfileAsync` API.
 
 ## [49.2.0] - 2018-04-27
 
 ### Changed
 
-* Fix generating entitlements in standalone iOS builds.
-* `Simulator.openProjectAsync` now returns a result object.
-* Fix Android package name validation.
-* Fix resolving a relative path specified in `android.googleServicesFile`.
+- Fix generating entitlements in standalone iOS builds.
+- `Simulator.openProjectAsync` now returns a result object.
+- Fix Android package name validation.
+- Fix resolving a relative path specified in `android.googleServicesFile`.
 
 ## [49.1.0] - 2018-04-18
 
 ### Changed
 
-* Enabled session authentication.
-* Make iOS build select credentials based on `bundleIdentifier`.
-* Always generate a scheme for detached apps, if a custom one is not defined.
-* Starting from SDK 27, the `detach.scheme` setting is no longer used.
+- Enabled session authentication.
+- Make iOS build select credentials based on `bundleIdentifier`.
+- Always generate a scheme for detached apps, if a custom one is not defined.
+- Starting from SDK 27, the `detach.scheme` setting is no longer used.
 
 ### Removed
 
-* Removed legacy Auth0 authentication.
+- Removed legacy Auth0 authentication.
 
 ## [49.0.2] - 2018-04-13
 
 ### Changed
 
-* Fix handling of unrecognized Metro events.
+- Fix handling of unrecognized Metro events.
 
 ## [49.0.0] - 2018-04-12
 
 ### Changed
 
-* Syntax errors in `app.json` now display more useful error messages.
-* Improve the error message for trying to create a project in a path that collides with a file.
-* Automatically add `LSApplicationQueriesSchemes` when detaching an app that uses the Facebook API (expo/expo#1619).
-* Fix regressions with logging events from Metro Bundler.
-* Support for canceling a template download.
-* Get project templates from a CDN for faster downloads.
+- Syntax errors in `app.json` now display more useful error messages.
+- Improve the error message for trying to create a project in a path that collides with a file.
+- Automatically add `LSApplicationQueriesSchemes` when detaching an app that uses the Facebook API (expo/expo#1619).
+- Fix regressions with logging events from Metro Bundler.
+- Support for canceling a template download.
+- Get project templates from a CDN for faster downloads.
 
 ## [48.3.0] - 2018-03-31
 
 ### Changed
 
-* Made reading authentication state more robust.
+- Made reading authentication state more robust.
 
 ## [48.2.0] - 2018-03-30
 
 ### Added
 
-* Added `push:android` commands and support for `android.googleServicesFile` app.json config.
+- Added `push:android` commands and support for `android.googleServicesFile` app.json config.
 
 ## [48.0.7] - 2018-03-24
 
-* Fix a regression in `Detach`.
+- Fix a regression in `Detach`.
 
 ## [48.0.6] - 2018-03-16
 
-* Fix a regression with starting tunnels on Windows.
+- Fix a regression with starting tunnels on Windows.
 
 ## [48.0.5] - 2018-03-15
 
 ### Added
 
-* `Project.startAsync` now allows `maxWorkers` option to be passed to Metro.
-* Added `developerTool` to XDL Serve Manifest event.
-* Detach command now prompts for iOS `bundleIdentifier` and Android `package` unless found in `app.json`.
+- `Project.startAsync` now allows `maxWorkers` option to be passed to Metro.
+- Added `developerTool` to XDL Serve Manifest event.
+- Detach command now prompts for iOS `bundleIdentifier` and Android `package` unless found in `app.json`.
 
 ### Changed
 
-* Moved authentication to use the sessions API.
-* Upgraded authentication libraries.
-* Upgraded ngrok binaries.
-* Fixed unnecessary requests being made to `localhost:80` before starting the server.
-* XDL now trims the hostname read from `EXPO_PACKAGER_HOSTNAME` environment variables to fix issues on Windows.
+- Moved authentication to use the sessions API.
+- Upgraded authentication libraries.
+- Upgraded ngrok binaries.
+- Fixed unnecessary requests being made to `localhost:80` before starting the server.
+- XDL now trims the hostname read from `EXPO_PACKAGER_HOSTNAME` environment variables to fix issues on Windows.
 
 ## [48.0.4] - 2018-02-02
 
 ### Changed
 
-* Increase `maxBodyLength` for HTTP requests.
+- Increase `maxBodyLength` for HTTP requests.
 
 ## [48.0.3] - 2018-02-01
 
 ### Changed
 
-* Improve logging of publishing errors.
+- Improve logging of publishing errors.
 
 ## [48.0.2] - 2018-01-25
 
 ### Changed
 
-* Fix project validation crashing when `npm ls` doesn't return a package version.
-* Fix unnecessary warning "Problem checking node_modules dependencies" being shown when server is stopped using Ctrl+C.
-* Fix iOS detach attempting to download assets when none are specified.
+- Fix project validation crashing when `npm ls` doesn't return a package version.
+- Fix unnecessary warning "Problem checking node_modules dependencies" being shown when server is stopped using Ctrl+C.
+- Fix iOS detach attempting to download assets when none are specified.
 
 ## [48.0.1] - 2018-01-19
 
 ### Changed
 
-* Fix _inquirer ... is not a function error
+- Fix \_inquirer ... is not a function error
 
 ## [48.0.0] - 2018-01-18
 
 ### Changed
 
-* Detach upgrades for SDK 25.
+- Detach upgrades for SDK 25.
 
 ## [47.2.0] - 2018-01-17
 
 ### Added
 
-* Support for HTTP(S) reverse proxies using `EXPO_PACKAGER_PROXY_URL` and `EXPO_MANIFEST_PROXY_URL` environment variables.
+- Support for HTTP(S) reverse proxies using `EXPO_PACKAGER_PROXY_URL` and `EXPO_MANIFEST_PROXY_URL` environment variables.
 
 ### Changed
 
-* Fix `DocumentPicker` entitlements in detached iOS apps.
-* Other iOS detach improvements.
+- Fix `DocumentPicker` entitlements in detached iOS apps.
+- Other iOS detach improvements.
 
 ## [47.1.2] - 2017-12-18
 
 ### Changed
 
-* Fixed detach bug
+- Fixed detach bug
 
 ## [47.1.1] - 2017-12-13
 
 ### Added
 
-* Add support for SDK 24
+- Add support for SDK 24
 
 ### Changed
 
-* Fix duplicate assets in manifest "bundledAssets"
-* Fix adb reverse not running for all ports
+- Fix duplicate assets in manifest "bundledAssets"
+- Fix adb reverse not running for all ports
 
 ## [47.1.0] - 2017-12-07
 
 ### Added
 
-* Add support for custom `*UsageDescription` strings in iOS standalone builds
+- Add support for custom `*UsageDescription` strings in iOS standalone builds
 
 ### Changed
 
-* Fix failed downloads being stored in template cache
-* Remove invalid peer dependency warnings
+- Fix failed downloads being stored in template cache
+- Remove invalid peer dependency warnings
 
 ### Removed
 
-* Deprecate `urlType` and `strict` project settings
+- Deprecate `urlType` and `strict` project settings
 
 ## [47.0.4] - 2017-11-23
 
 ### Changed
 
-* Increase template download timeout
-* Improve error handling
+- Increase template download timeout
+- Improve error handling
 
 ## [47.0.0] - 2017-11-16
 
 ### Added
 
-* Support for release channels
+- Support for release channels
 
 ### Changed
 
-* HTTP requests use Chromium network stack in Electron
-* Detach and Turtle improvements
-* Replaced deprecated tar.gz package
+- HTTP requests use Chromium network stack in Electron
+- Detach and Turtle improvements
+- Replaced deprecated tar.gz package
 
 ## [46.1.0] - 2017-10-27
 
 ### Changed
 
-* Only detach iOS on macOS or when a --force flag is added
+- Only detach iOS on macOS or when a --force flag is added
 
 ## [46.0.1] - 2017-10-18
 
 ### Added
 
-* Fix weird warnings during detach.
+- Fix weird warnings during detach.
 
 ## [46.0.0] - 2017-10-18
 
 ### Added
 
-* No npm warnings if yarn exists
+- No npm warnings if yarn exists
 
 ### Changed
 
-* Error message improvements
-* Fix schema validation issues
+- Error message improvements
+- Fix schema validation issues
 
 ### Removed
 
-* Remove dependency on macOS to detach
-* Remove sentry event logging temporarily
+- Remove dependency on macOS to detach
+- Remove sentry event logging temporarily
 
 ## [45.0.0] - 2017-09-27
 
 ### Added
 
-* Powertools updates
+- Powertools updates
 
 ### Changed
 
-* Improve sending link via SMS, better message, make sure user is logged in
+- Improve sending link via SMS, better message, make sure user is logged in
 
 ## [44.0.2] - 2017-08-24
 
 ### Changed
 
-* @expo/schemer updated to fix issue running in XDE
-* fixes XDE 20 errors and code being skipped in local testing because of env var
+- @expo/schemer updated to fix issue running in XDE
+- fixes XDE 20 errors and code being skipped in local testing because of env var
 
 ## [44.0.0] - 2017-08-18
 
 ### Added
 
-* Add missing push notification permission
-* New schema validation library
-* Allow boolean packagerOpts
-* Sentry integration for error reporting
-* Test ngrok tunnels and use fallback
+- Add missing push notification permission
+- New schema validation library
+- Allow boolean packagerOpts
+- Sentry integration for error reporting
+- Test ngrok tunnels and use fallback
 
 ### Changed
 
-* iOS Pod tools generate Podfile with c++ bridge and 3rd party dependencies
-* exp install handles errors better
-* Better authentication errors
+- iOS Pod tools generate Podfile with c++ bridge and 3rd party dependencies
+- exp install handles errors better
+- Better authentication errors
 
 ## [43.0.1] - 2017-07-25
 
 ### Added
 
-* Re-enable intercom
+- Re-enable intercom
 
 ## [43.0.0] - 2017-07-21
 
 ### Changed
 
-* Catch errors in state.json parsing
-* Detach updates for SDK 19
-* Don't validate React Native version when not using our fork
+- Catch errors in state.json parsing
+- Detach updates for SDK 19
+- Don't validate React Native version when not using our fork
 
 ## [42.4.0] - 2017-07-10
 
 ### Changed
 
-* Make ngrok a dev dependency of xdl, needs to be provided by xdl consumers that expect to create tunnels. (Yay for drastically smaller CRNA installs!)
-* Remove react peer dependency and associated warnings -- xdl consumers should provide react.
-* Setting offline mode will no longer automatically log a user out.
-* Validate npm against a version range, not just any 5.x.x release.
-* Use a fork of bunyan without DTraceProviderBindings issues.
-* Remove deprecation warnings about @exponent/* packages.
+- Make ngrok a dev dependency of xdl, needs to be provided by xdl consumers that expect to create tunnels. (Yay for drastically smaller CRNA installs!)
+- Remove react peer dependency and associated warnings -- xdl consumers should provide react.
+- Setting offline mode will no longer automatically log a user out.
+- Validate npm against a version range, not just any 5.x.x release.
+- Use a fork of bunyan without DTraceProviderBindings issues.
+- Remove deprecation warnings about @exponent/\* packages.
 
 ### Added
 
-* Display standalone build IDs in error messages so users can get help much faster on failed builds.
+- Display standalone build IDs in error messages so users can get help much faster on failed builds.
 
 ## [42.3.0] - 2017-07-07
 
 ### Changed
 
-* Convert wrong npm version to warning, was error.
-* Log debug log messages to file, skip terminal.
+- Convert wrong npm version to warning, was error.
+- Log debug log messages to file, skip terminal.
 
 ## [42.2.0]
 
 ### Changed
 
-* Suppress some spurious @providesModule warnings that come from RN itself.
+- Suppress some spurious @providesModule warnings that come from RN itself.
 
 ## [42.1.0] - 2017-06-23
 
 ### Changed
 
-* Fixed a couple of issues with checking npm version.
-* Backed out Axios network requests.
+- Fixed a couple of issues with checking npm version.
+- Backed out Axios network requests.
 
 ## [42.0.0] - 2017-06-22
 
 ### Changed
 
-* Move network requests to Axios.
-* Warn if using an unsupported npm version.
-* Provide cached schema for validating SDK 18 projects.
+- Move network requests to Axios.
+- Warn if using an unsupported npm version.
+- Provide cached schema for validating SDK 18 projects.
 
 ## [41.0.0] - 2017-05-12
 
 ### Added
 
-* Post-publish hooks.
-* Better log reporting
-* Fix Android HMR bug by adding `:80` to url.
+- Post-publish hooks.
+- Better log reporting
+- Fix Android HMR bug by adding `:80` to url.
 
 ## [39.0.0] - 2017-04-06
 
 ### Added
 
-* Better log reporting
-* Fix Android HMR bug by adding `:80` to url.
+- Better log reporting
+- Fix Android HMR bug by adding `:80` to url.
 
 ## [37.0.2] - 2017-04-02
 
 ### Added
 
-* When serving manifest over LAN, if request hostname is localhost then
-manifest urls also use localhost. This makes it easier to open a project
-in simulator when on locked-down wifi.
+- When serving manifest over LAN, if request hostname is localhost then
+  manifest urls also use localhost. This makes it easier to open a project
+  in simulator when on locked-down wifi.
 
 ## [37.0.1] - 2017-03-21
 
 ### Changed
 
-* Fixed download bug.
+- Fixed download bug.
 
 ## [37.0.0] - 2017-03-20
 
 ### Added
 
-* Support `EXPO_PACKAGER_HOSTNAME` and `REACT_NATIVE_PACKAGER_HOSTNAME` env variables.
-* All `EXPO_*` and `REACT_NATIVE_*` env variables are sent in the manifest.
+- Support `EXPO_PACKAGER_HOSTNAME` and `REACT_NATIVE_PACKAGER_HOSTNAME` env variables.
+- All `EXPO_*` and `REACT_NATIVE_*` env variables are sent in the manifest.
 
 ### Changed
 
-* New project download progress bar fixes.
+- New project download progress bar fixes.
 
 ## [36.1.0] - 2017-03-17
 
 ### Changed
 
-* Fixed `Android.upgradeExpoAsync`.
-* Change docs url from docs.getexponent.com to docs.expo.io.
+- Fixed `Android.upgradeExpoAsync`.
+- Change docs url from docs.getexponent.com to docs.expo.io.
 
 ## [36.0.0] - 2017-03-16
 
 ### Added
 
-* Converting RN projects to SDK 15 is now supported.
-* Improved template downloads.
+- Converting RN projects to SDK 15 is now supported.
+- Improved template downloads.
 
 ### Changed
 
-* Eliminated a large class of Flow errors for xdl consumers.
-* xdl's ngrok dependency now bundles the binaries with the package. This is a tradeoff -- the download is larger, but there's no need to rely on an external CDN which may or may not respect npm/yarn's network configuration.
+- Eliminated a large class of Flow errors for xdl consumers.
+- xdl's ngrok dependency now bundles the binaries with the package. This is a tradeoff -- the download is larger, but there's no need to rely on an external CDN which may or may not respect npm/yarn's network configuration.
 
 ### Removed
 
-* Removed the `diskusage` and `runas` optional dependencies. They were causing problems for users without native build tools who were also using certain versions of yarn.
+- Removed the `diskusage` and `runas` optional dependencies. They were causing problems for users without native build tools who were also using certain versions of yarn.
 
 ## [35.0.0] - 2017-03-15
 
 ### Changed
 
-* Detach changes for SDK 15.
+- Detach changes for SDK 15.
 
 ## [34.0.0] - 2017-03-07
 
 ### Changed
 
-* Fixed detach for SDK 14.
+- Fixed detach for SDK 14.
 
 ## [33.0.0] - 2017-03-06
 
 ### Changed
 
-* References to Exponent have been renamed to Expo.
+- References to Exponent have been renamed to Expo.
 
 ## [32.0.0] - 2017-02-28
 
 ### Added
 
-* New iOS simulator warnings.
+- New iOS simulator warnings.
 
 ### Changed
 
-* `Android.openProjectAsync` now returns an object with `success` (boolean) and `error` (nullable object) keys to indicate the result of the action.
-* Fixed a bug in persisting project settings.
+- `Android.openProjectAsync` now returns an object with `success` (boolean) and `error` (nullable object) keys to indicate the result of the action.
+- Fixed a bug in persisting project settings.
 
 ### Removed
 
-* Removed export of `Android.openUrlAsync` that is not used by any current consumers.
+- Removed export of `Android.openUrlAsync` that is not used by any current consumers.
 
 ## [31.1.0] - 2017-02-24
 
 ### Changed
 
-* Fix detach on windows.
-* Add Xcode warning if osascript command fails.
-* Show full error if publish gets a 500 response from packager.
+- Fix detach on windows.
+- Add Xcode warning if osascript command fails.
+- Show full error if publish gets a 500 response from packager.
 
 ## [31.0.0] - 2017-02-22
 
 ### Changed
 
-* Updates to iOS detach script.
+- Updates to iOS detach script.
 
 ## [30.0.1] - 2017-02-20
 
 ### Changed
 
-* Make offline mode only use local IP temporarily.
-* Minor watchman stability improvements.
+- Make offline mode only use local IP temporarily.
+- Minor watchman stability improvements.
 
 ## [30.0.0] - 2017-02-14
 
 ### Added
 
-* Add redux store for notifications.
-* Add suggestion to point command line tools to Xcode.
+- Add redux store for notifications.
+- Add suggestion to point command line tools to Xcode.
 
 ### Changed
 
-* Another fix for getting logged out.
-* Make Project.stopAsync more reliable.
+- Another fix for getting logged out.
+- Make Project.stopAsync more reliable.
 
 ## [29.5.0] - 2017-01-27
 
 ### Changed
 
-* Compile bundled watchman without pcre.
-* Better Xcode error handling.
+- Compile bundled watchman without pcre.
+- Better Xcode error handling.
 
 ## [29.4.0] - 2017-01-25
 
 ### Added
 
-* Support for running the RN packager with the `Config.offline` flag, bypassing an Expo account.
-* Workarounds for state corruption problems in watchman.
+- Support for running the RN packager with the `Config.offline` flag, bypassing an Expo account.
+- Workarounds for state corruption problems in watchman.
 
 ### Changed
 
-* Improved error messages for a variety of issues.
+- Improved error messages for a variety of issues.
 
 ## [29.3.0] - 2017-01-23
 
 ### Changed
 
-* Resolved several issues that resulted in premature logout of Expo account sessions.
+- Resolved several issues that resulted in premature logout of Expo account sessions.
 
 ## [29.2.0] - 2017-1-18
 
 ### Changed
 
-* Ensure that the user is logged in on every api call.
-* Fix detach script to remove all comments from .gradle file.
+- Ensure that the user is logged in on every api call.
+- Fix detach script to remove all comments from .gradle file.
 
 ## [29.0.0] - 2017-1-17
 
 ### Changed
 
-* Fix accounts bugs.
-* First release of detach.
+- Fix accounts bugs.
+- First release of detach.
 
 ## [28.0.0] - 2017-1-11
 
 ### Changed
 
-* Better accounts system!
+- Better accounts system!
 
 ## [0.26.6] - 2016-12-07
 

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -109,6 +109,7 @@
     "@types/analytics-node": "^3.1.1",
     "@types/concat-stream": "^1.6.0",
     "@types/getenv": "^0.7.0",
+    "@types/globby": "6.1.0",
     "@types/hashids": "^1.0.30",
     "@types/joi": "^14.3.3",
     "@types/minipass": "^2.2.0",

--- a/packages/xdl/src/detach/AndroidIcons.ts
+++ b/packages/xdl/src/detach/AndroidIcons.ts
@@ -1,6 +1,3 @@
-/**
- *  @flow
- */
 import fs from 'fs-extra';
 import path from 'path';
 import globby from 'globby';
@@ -11,7 +8,7 @@ import {
   saveUrlToPathAsync,
   spawnAsyncThrowError,
 } from './ExponentTools';
-import StandaloneContext from './StandaloneContext';
+import StandaloneContext, { StandaloneContextDataUser } from './StandaloneContext';
 import { resizeImageAsync, getImageDimensionsAsync } from '../tools/ImageUtils';
 
 const iconScales = {
@@ -56,7 +53,8 @@ async function _resizeIconsAsync(
 
   try {
     if (isDetached) {
-      await saveImageToPathAsync(context.data.projectPath, url, baseImagePath);
+      const data = context.data as StandaloneContextDataUser;
+      await saveImageToPathAsync(data.projectPath, url, baseImagePath);
     } else {
       await saveUrlToPathAsync(url, baseImagePath);
     }

--- a/packages/xdl/src/detach/AndroidIntentFilters.ts
+++ b/packages/xdl/src/detach/AndroidIntentFilters.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-export default function renderIntentFilters(intentFilters) {
+export default function renderIntentFilters(intentFilters: any) {
   // returns an array of <intent-filter> tags:
   // [
   //   `<intent-filter>
@@ -14,7 +14,7 @@ export default function renderIntentFilters(intentFilters) {
   //   </intent-filter>`,
   //   ...
   // ]
-  return intentFilters.map(intentFilter => {
+  return intentFilters.map((intentFilter: any) => {
     const autoVerify = intentFilter.autoVerify ? ' android:autoVerify="true"' : '';
 
     return `<intent-filter${autoVerify}>
@@ -25,19 +25,19 @@ export default function renderIntentFilters(intentFilters) {
   });
 }
 
-function renderIntentFilterDatumEntries(datum) {
+function renderIntentFilterDatumEntries(datum: any) {
   return _.toPairs(datum)
     .map(entry => `android:${entry[0]}="${entry[1]}"`)
     .join(' ');
 }
 
-function renderIntentFilterData(data) {
+function renderIntentFilterData(data: any) {
   return (Array.isArray(data) ? data : [data])
     .map(datum => `<data ${renderIntentFilterDatumEntries(datum)}/>`)
     .join('\n');
 }
 
-function renderIntentFilterCategory(category) {
+function renderIntentFilterCategory(category: any) {
   return (Array.isArray(category) ? category : [category])
     .map(cat => `<category android:name="android.intent.category.${cat}"/>`)
     .join('\n');

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1,10 +1,3 @@
-// Copyright 2015-present 650 Industries. All rights reserved.
-/**
- * @flow
- */
-
-'use strict';
-
 import fs from 'fs-extra';
 import path from 'path';
 import replaceString from 'replace-string';
@@ -32,8 +25,6 @@ const {
 
 const imageKeys = ['mdpi', 'hdpi', 'xhdpi', 'xxhdpi', 'xxxhdpi'];
 
-type BuildMode = 'debug' | 'release';
-
 // Do not call this from anything used by detach
 function exponentDirectory(workingDir) {
   if (workingDir) {
@@ -53,7 +44,7 @@ function xmlWeirdAndroidEscape(original) {
   return replaceString(noApos, "'", "\\'");
 }
 
-exports.updateAndroidShellAppAsync = async function updateAndroidShellAppAsync(args: any) {
+exports.updateAndroidShellAppAsync = async function updateAndroidShellAppAsync(args) {
   let { url, sdkVersion, releaseChannel, workingDir } = args;
 
   releaseChannel = releaseChannel ? releaseChannel : 'default';
@@ -226,8 +217,8 @@ function shouldShowLoadingView(manifest, sdkVersion) {
 export async function copyInitialShellAppFilesAsync(
   androidSrcPath,
   shellPath,
-  isDetached: boolean,
-  sdkVersion: ?string
+  isDetached,
+  sdkVersion
 ) {
   if (androidSrcPath && !isDetached) {
     // check if Android template files exist
@@ -283,7 +274,7 @@ export async function copyInitialShellAppFilesAsync(
   }
 }
 
-exports.createAndroidShellAppAsync = async function createAndroidShellAppAsync(args: any) {
+exports.createAndroidShellAppAsync = async function createAndroidShellAppAsync(args) {
   let {
     url,
     sdkVersion,
@@ -367,7 +358,7 @@ exports.createAndroidShellAppAsync = async function createAndroidShellAppAsync(a
   }
 };
 
-function shellPathForContext(context: StandaloneContext) {
+function shellPathForContext(context) {
   if (context.type === 'user') {
     return path.join(context.data.projectPath, 'android');
   } else {
@@ -380,15 +371,11 @@ function shellPathForContext(context: StandaloneContext) {
   }
 }
 
-export async function runShellAppModificationsAsync(
-  context: StandaloneContext,
-  sdkVersion: ?string,
-  buildMode: ?BuildMode
-) {
+export async function runShellAppModificationsAsync(context, sdkVersion, buildMode) {
   const fnLogger = logger.withFields({ buildPhase: 'running shell app modifications' });
 
   let shellPath = shellPathForContext(context);
-  let url: string = context.published.url;
+  let url = context.published.url;
   let manifest = context.config; // manifest or app.json
   let releaseChannel = context.published.releaseChannel;
 
@@ -416,7 +403,7 @@ export async function runShellAppModificationsAsync(
 
   let name = manifest.name;
   let scheme = manifest.scheme || (manifest.detach && manifest.detach.scheme);
-  let bundleUrl: ?string = manifest.bundleUrl;
+  let bundleUrl = manifest.bundleUrl;
   let isFullManifest = !!bundleUrl;
   let version = manifest.version ? manifest.version : '0.0.0';
   let backgroundImages = backgroundImagesForApp(shellPath, manifest, isRunningInUserContext);
@@ -1059,12 +1046,7 @@ export async function runShellAppModificationsAsync(
   );
 }
 
-async function buildShellAppAsync(
-  context: StandaloneContext,
-  sdkVersion: string,
-  buildType: string,
-  buildMode: BuildMode
-) {
+async function buildShellAppAsync(context, sdkVersion, buildType, buildMode) {
   let shellPath = shellPathForContext(context);
   const ext = buildType === 'app-bundle' ? 'aab' : 'apk';
 
@@ -1215,7 +1197,7 @@ async function buildShellAppAsync(
   }
 }
 
-export function addDetachedConfigToExp(exp: Object, context: StandaloneContext): Object {
+export function addDetachedConfigToExp(exp, context) {
   if (context.type !== 'user') {
     console.warn(`Tried to modify exp for a non-user StandaloneContext, ignoring`);
     return exp;
@@ -1293,7 +1275,7 @@ const removeInvalidSdkLinesWhenPreparingShell = async (majorSdkVersion, filePath
   );
 };
 
-async function removeObsoleteSdks(shellPath: string, requiredSdkVersion: string) {
+async function removeObsoleteSdks(shellPath, requiredSdkVersion) {
   const filePathsToTransform = {
     // Remove obsolete `expoview-abiXX_X_X` dependencies
     appBuildGradle: path.join(shellPath, 'app/build.gradle'),
@@ -1334,10 +1316,7 @@ async function removeObsoleteSdks(shellPath: string, requiredSdkVersion: string)
   );
 }
 
-async function prepareEnabledModules(
-  shellPath: string,
-  modules?: Array<{ name: string, version: string, dirname: string }>
-) {
+async function prepareEnabledModules(shellPath, modules) {
   const enabledModulesDir = path.join(shellPath, 'enabled-modules');
   const packagesDir = path.join(shellPath, '..', 'packages');
   await fs.remove(enabledModulesDir);

--- a/packages/xdl/src/detach/AssetBundle.js
+++ b/packages/xdl/src/detach/AssetBundle.js
@@ -1,35 +1,16 @@
-// Copyright 2015-present 650 Industries. All rights reserved.
-/**
- * @flow
- */
-
 import _ from 'lodash';
 import fs from 'fs-extra';
 import path from 'path';
 import url from 'url';
 
 import { saveUrlToPathAsync } from './ExponentTools';
-import StandaloneContext from './StandaloneContext';
 
 const EXPO_DOMAINS = ['expo.io', 'exp.host', 'expo.test', 'localhost'];
 const ASSETS_DIR_DEFAULT_URL = 'https://d1wp6m56sqw74a.cloudfront.net/~assets';
 
-export async function bundleAsync(
-  context: StandaloneContext,
-  assets: ?(Array<string> | Array<Object>),
-  dest: string,
-  oldFormat: boolean = false
-): Promise<void> {
+export async function bundleAsync(context, assets, dest) {
   if (!assets) {
     return;
-  }
-  // Compat with exp 46.x.x, can remove when this version is phasing out.
-  if (typeof assets[0] === 'object') {
-    assets = assets.reduce(
-      (res, cur) =>
-        res.concat(cur.fileHashes.map(h => 'asset_' + h + (cur.type ? '.' + cur.type : ''))),
-      []
-    );
   }
 
   await fs.ensureDir(dest);
@@ -46,11 +27,7 @@ export async function bundleAsync(
           extensionIndex >= 0
             ? asset.substring(prefixLength, extensionIndex)
             : asset.substring(prefixLength);
-        await saveUrlToPathAsync(
-          urlResolver(hash),
-          // For sdk24 the runtime expects only the hash as the filename.
-          path.join(dest, oldFormat ? hash : asset)
-        );
+        await saveUrlToPathAsync(urlResolver(hash), path.join(dest, asset));
       })
     );
   }
@@ -58,9 +35,9 @@ export async function bundleAsync(
 
 function createAssetsUrlResolver(context) {
   let assetsDirUrl = ASSETS_DIR_DEFAULT_URL;
-  if (context) {
+  if (context && context.published) {
     const { assetUrlOverride = './assets' } = context.config;
-    const publishedUrl = context.published.url;
+    const publishedUrl = context.published.urls;
     const { hostname } = url.parse(publishedUrl);
     const maybeExpoDomain = _.takeRight(hostname.split('.'), 2).join('.');
     if (!_.includes(EXPO_DOMAINS, maybeExpoDomain)) {

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -1,10 +1,3 @@
-// Copyright 2015-present 650 Industries. All rights reserved.
-/**
- * @flow
- */
-
-'use strict';
-
 // Set EXPO_VIEW_DIR to universe/exponent to test locally
 
 import fs from 'fs-extra';
@@ -49,7 +42,7 @@ async function yesnoAsync(message) {
   return ok;
 }
 
-export async function detachAsync(projectRoot: string, options: any = {}) {
+export async function detachAsync(projectRoot, options = {}) {
   let originalLogger = logger.loggerObj;
   logger.configure({
     trace: options.verbose ? console.trace.bind(console) : () => {},
@@ -133,9 +126,7 @@ async function _detachAsync(projectRoot, options) {
   ) {
     if (process.env.EXPO_VIEW_DIR) {
       logger.warn(
-        `Detaching is not supported for SDK ${
-          exp.sdkVersion
-        }; ignoring this because you provided EXPO_VIEW_DIR`
+        `Detaching is not supported for SDK ${exp.sdkVersion}; ignoring this because you provided EXPO_VIEW_DIR`
       );
       sdkVersionConfig = {};
     } else {
@@ -248,9 +239,7 @@ async function _detachAsync(projectRoot, options) {
 
   if (sdkVersionConfig && sdkVersionConfig.expoReactNativeTag) {
     packagesToInstall.push(
-      `react-native@https://github.com/expo/react-native/archive/${
-        sdkVersionConfig.expoReactNativeTag
-      }.tar.gz`
+      `react-native@https://github.com/expo/react-native/archive/${sdkVersionConfig.expoReactNativeTag}.tar.gz`
     );
   } else if (process.env.EXPO_VIEW_DIR) {
     // ignore, using test directory
@@ -289,7 +278,7 @@ async function _detachAsync(projectRoot, options) {
 /**
  *  Create a detached Expo iOS app pointing at the given project.
  */
-async function detachIOSAsync(context: StandaloneContext) {
+async function detachIOSAsync(context) {
   await IosWorkspace.createDetachedAsync(context);
 
   logger.info('Configuring iOS project...');
@@ -298,7 +287,7 @@ async function detachIOSAsync(context: StandaloneContext) {
   logger.info(`iOS detach is complete!`);
 }
 
-async function detachAndroidAsync(context: StandaloneContext, expoViewUrl: string) {
+async function detachAndroidAsync(context, expoViewUrl) {
   if (context.type !== 'user') {
     throw new Error(`detachAndroidAsync only supports user standalone contexts`);
   }
@@ -338,7 +327,7 @@ async function detachAndroidAsync(context: StandaloneContext, expoViewUrl: strin
   logger.info('Android detach is complete!\n');
 }
 
-async function ensureBuildConstantsExistsIOSAsync(configFilePath: string) {
+async function ensureBuildConstantsExistsIOSAsync(configFilePath) {
   // EXBuildConstants is included in newer ExpoKit projects.
   // create it if it doesn't exist.
   const doesBuildConstantsExist = fs.existsSync(
@@ -350,7 +339,7 @@ async function ensureBuildConstantsExistsIOSAsync(configFilePath: string) {
   }
 }
 
-async function _getIosExpoKitVersionThrowErrorAsync(iosProjectDirectory: string) {
+async function _getIosExpoKitVersionThrowErrorAsync(iosProjectDirectory) {
   let expoKitVersion = '';
   const podfileLockPath = path.join(iosProjectDirectory, 'Podfile.lock');
   try {
@@ -366,7 +355,7 @@ async function _getIosExpoKitVersionThrowErrorAsync(iosProjectDirectory: string)
   return expoKitVersion;
 }
 
-async function prepareDetachedBuildIosAsync(projectDir: string, args: any) {
+async function prepareDetachedBuildIosAsync(projectDir, args) {
   const { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
   if (exp) {
     return prepareDetachedUserContextIosAsync(projectDir, exp, args);
@@ -375,7 +364,7 @@ async function prepareDetachedBuildIosAsync(projectDir: string, args: any) {
   }
 }
 
-async function prepareDetachedServiceContextIosAsync(projectDir: string, args: any) {
+async function prepareDetachedServiceContextIosAsync(projectDir, args) {
   // service context
   // TODO: very brittle hack: the paths here are hard coded to match the single workspace
   // path generated inside IosShellApp. When we support more than one path, this needs to
@@ -426,7 +415,7 @@ async function prepareDetachedServiceContextIosAsync(projectDir: string, args: a
   });
 }
 
-async function _readDefaultApiKeysAsync(jsonFilePath: string) {
+async function _readDefaultApiKeysAsync(jsonFilePath) {
   if (fs.existsSync(jsonFilePath)) {
     let keys = {};
     const allKeys = await new JsonFile(jsonFilePath).readAsync();
@@ -441,7 +430,7 @@ async function _readDefaultApiKeysAsync(jsonFilePath: string) {
   return null;
 }
 
-async function prepareDetachedUserContextIosAsync(projectDir: string, exp: any, args: any) {
+async function prepareDetachedUserContextIosAsync(projectDir, exp, args) {
   const context = StandaloneContext.createUserContext(projectDir, exp);
   let { iosProjectDirectory, supportingDirectory } = IosWorkspace.getPaths(context);
 
@@ -490,7 +479,7 @@ async function prepareDetachedUserContextIosAsync(projectDir: string, exp: any, 
   }
 }
 
-export async function prepareDetachedBuildAsync(projectDir: string, args: any) {
+export async function prepareDetachedBuildAsync(projectDir, args) {
   if (args.platform === 'ios') {
     await prepareDetachedBuildIosAsync(projectDir, args);
   } else {
@@ -510,17 +499,13 @@ export async function prepareDetachedBuildAsync(projectDir: string, args: any) {
   }
 }
 
-type BundleAssetsArgs = {
-  platform: 'ios' | 'android',
-  // This is the path where assets will be copied to. It should be
-  // `$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH` on iOS
-  // (see `exponent-view-template.xcodeproj/project.pbxproj` for an example)
-  // and `$buildDir/intermediates/assets/$targetPath` on Android (see
-  // `android/app/expo.gradle` for an example).
-  dest: string,
-};
-
-export async function bundleAssetsAsync(projectDir: string, args: BundleAssetsArgs) {
+// args.dest: string,
+// This is the path where assets will be copied to. It should be
+// `$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH` on iOS
+// (see `exponent-view-template.xcodeproj/project.pbxproj` for an example)
+// and `$buildDir/intermediates/assets/$targetPath` on Android (see
+// `android/app/expo.gradle` for an example).
+export async function bundleAssetsAsync(projectDir, args) {
   let { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
   if (!exp) {
     // Don't run assets bundling for the service context.
@@ -530,9 +515,7 @@ export async function bundleAssetsAsync(projectDir: string, args: BundleAssetsAr
     args.platform === 'ios' ? exp.ios.publishManifestPath : exp.android.publishManifestPath;
   if (!publishManifestPath) {
     logger.warn(
-      `Skipped assets bundling because the '${
-        args.platform
-      }.publishManifestPath' key is not specified in the app manifest.`
+      `Skipped assets bundling because the '${args.platform}.publishManifestPath' key is not specified in the app manifest.`
     );
     return;
   }
@@ -542,9 +525,7 @@ export async function bundleAssetsAsync(projectDir: string, args: BundleAssetsAr
     manifest = JSON.parse(await fs.readFile(bundledManifestPath, 'utf8'));
   } catch (ex) {
     throw new Error(
-      `Error reading the manifest file. Make sure the path '${bundledManifestPath}' is correct.\n\nError: ${
-        ex.message
-      }`
+      `Error reading the manifest file. Make sure the path '${bundledManifestPath}' is correct.\n\nError: ${ex.message}`
     );
   }
   await AssetBundle.bundleAsync(null, manifest.bundledAssets, args.dest);

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -111,9 +111,9 @@ async function _detachAsync(projectRoot, options) {
     throw new Error(`${configName} is missing \`sdkVersion\``);
   }
 
-  if (!Versions.gteSdkVersion(exp, '24.0.0')) {
+  if (!Versions.gteSdkVersion(exp, '25.0.0')) {
     throw new Error(
-      `The app must be updated to SDK 24.0.0 or newer to be compatible with this tool.`
+      `The app must be updated to SDK 25.0.0 or newer to be compatible with this tool.`
     );
   }
 

--- a/packages/xdl/src/detach/ExponentTools.ts
+++ b/packages/xdl/src/detach/ExponentTools.ts
@@ -154,7 +154,7 @@ async function spawnAsync(
   }
 }
 
-function createSpawner(buildPhase: string, logger: Logger) {
+function createSpawner(buildPhase: string, logger?: Logger) {
   return (command: string, ...args: any[]) => {
     const lastArg = _.last(args);
     const optionsFromArg = _.isObject(lastArg) ? args.pop() : {};

--- a/packages/xdl/src/detach/IosAssetArchive.ts
+++ b/packages/xdl/src/detach/IosAssetArchive.ts
@@ -45,20 +45,21 @@ async function buildAssetArchiveAsync(
   const deploymentTarget = sdkMajorVersion > 30 ? '10.0' : '9.0'; // SDK31 drops support for iOS 9.0
 
   // compile asset archive
-  let xcrunargs = ([] as string[]).concat(
-    ['actool'],
-    ['--minimum-deployment-target', deploymentTarget],
-    ['--platform', 'iphoneos'],
-    ['--app-icon', 'AppIcon'],
-    ['--output-partial-info-plist', 'assetcatalog_generated_info.plist'],
-    ['--compress-pngs'],
-    ['--enable-on-demand-resources', 'YES'],
-    ['--product-type', 'com.apple.product-type.application'],
-    ['--target-device', 'iphone'],
-    ['--target-device', 'ipad'],
-    ['--compile', path.relative(intermediatesDirectory, destinationCARPath)],
-    ['Images.xcassets']
-  );
+  // prettier-ignore
+  const xcrunargs = [
+    'actool',
+    '--minimum-deployment-target', deploymentTarget,
+    '--platform', 'iphoneos',
+    '--app-icon', 'AppIcon',
+    '--output-partial-info-plist', 'assetcatalog_generated_info.plist',
+    '--compress-pngs',
+    '--enable-on-demand-resources', 'YES',
+    '--product-type', 'com.apple.product-type.application',
+    '--target-device', 'iphone',
+    '--target-device', 'ipad',
+    '--compile', path.relative(intermediatesDirectory, destinationCARPath),
+    'Images.xcassets',
+  ]
   /*
    *  Note: if you want to debug issues with `actool`, try changing to stdio: 'inherit'.
    *  In both success and failure cases, actool will write an enormous .plist to stdout

--- a/packages/xdl/src/detach/IosAssetArchive.ts
+++ b/packages/xdl/src/detach/IosAssetArchive.ts
@@ -1,13 +1,12 @@
-/**
- *  @flow
- */
-
 import fs from 'fs-extra';
 import path from 'path';
 
 import { spawnAsyncThrowError, parseSdkMajorVersion } from './ExponentTools';
 import * as IosIcons from './IosIcons';
-import StandaloneContext from './StandaloneContext';
+import StandaloneContext, {
+  StandaloneContextDataUser,
+  StandaloneContextDataService,
+} from './StandaloneContext';
 
 /**
  *  Compile a .car file from the icons in a manifest.
@@ -20,6 +19,7 @@ async function buildAssetArchiveAsync(
   if (context.type !== 'service') {
     throw new Error('buildAssetArchive is only supported for service standalone contexts.');
   }
+  const data = context.data as StandaloneContextDataService;
   fs.mkdirpSync(intermediatesDirectory);
 
   // copy expoSourceRoot/.../Images.xcassets into intermediates
@@ -27,7 +27,7 @@ async function buildAssetArchiveAsync(
     '/bin/cp',
     [
       '-R',
-      path.join(context.data.expoSourcePath, 'Exponent', 'Images.xcassets'),
+      path.join(data.expoSourcePath, 'Exponent', 'Images.xcassets'),
       path.join(intermediatesDirectory, 'Images.xcassets'),
     ],
     {
@@ -41,11 +41,11 @@ async function buildAssetArchiveAsync(
     path.join(intermediatesDirectory, 'Images.xcassets', 'AppIcon.appiconset')
   );
 
-  const sdkMajorVersion = parseSdkMajorVersion(context.data.manifest.sdkVersion);
+  const sdkMajorVersion = parseSdkMajorVersion(data.manifest.sdkVersion);
   const deploymentTarget = sdkMajorVersion > 30 ? '10.0' : '9.0'; // SDK31 drops support for iOS 9.0
 
   // compile asset archive
-  let xcrunargs = [].concat(
+  let xcrunargs = ([] as string[]).concat(
     ['actool'],
     ['--minimum-deployment-target', deploymentTarget],
     ['--platform', 'iphoneos'],

--- a/packages/xdl/src/detach/IosKeychain.ts
+++ b/packages/xdl/src/detach/IosKeychain.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import _logger from './Logger';
 import { spawnAsyncThrowError, createSpawner } from './ExponentTools';
 
-export async function createKeychain(appUUID, saveResultToFile = true) {
+export async function createKeychain(appUUID: string, saveResultToFile = true) {
   const BUILD_PHASE = 'creating keychain';
   const logger = _logger.withFields({ buildPhase: BUILD_PHASE });
   const spawn = createSpawner(BUILD_PHASE, logger);
@@ -41,7 +41,7 @@ export async function createKeychain(appUUID, saveResultToFile = true) {
   return keychainInfo;
 }
 
-export async function deleteKeychain({ path, appUUID }) {
+export async function deleteKeychain({ path, appUUID }: { path: string; appUUID?: string }) {
   const BUILD_PHASE = 'deleting keychain';
   const logger = _logger.withFields({ buildPhase: BUILD_PHASE });
 
@@ -54,7 +54,15 @@ export async function deleteKeychain({ path, appUUID }) {
   }
 }
 
-export async function importIntoKeychain({ keychainPath, certPath, certPassword }) {
+export async function importIntoKeychain({
+  keychainPath,
+  certPath,
+  certPassword,
+}: {
+  keychainPath: string;
+  certPath: string;
+  certPassword?: string;
+}) {
   const BUILD_PHASE = 'importing certificate into keychain';
   const logger = _logger.withFields({ buildPhase: BUILD_PHASE });
   const spawn = createSpawner(BUILD_PHASE);
@@ -79,7 +87,9 @@ export async function cleanUpKeychains() {
       ['list-keychains'],
       { stdio: 'pipe' }
     );
-    const allKeychainsList = keychainsListRaw.match(/"(.*)"/g).map(i => i.slice(1, i.length - 1));
+    const allKeychainsList = (keychainsListRaw.match(/"(.*)"/g) || []).map(i =>
+      i.slice(1, i.length - 1)
+    );
     const turtleKeychainsList = keychainsListRaw.match(/\/private\/tmp\/xdl\/(.*).keychain/g);
     let shouldCleanSearchList = false;
     if (turtleKeychainsList) {
@@ -106,11 +116,11 @@ export async function cleanUpKeychains() {
   }
 }
 
-async function runFastlane(fastlaneArgs) {
+async function runFastlane(fastlaneArgs: string[]) {
   const fastlaneEnvVars = {
-    FASTLANE_DISABLE_COLORS: 1,
-    FASTLANE_SKIP_UPDATE_CHECK: 1,
-    CI: 1,
+    FASTLANE_DISABLE_COLORS: '1',
+    FASTLANE_SKIP_UPDATE_CHECK: '1',
+    CI: '1',
     LC_ALL: 'en_US.UTF-8',
   };
   await spawnAsyncThrowError('fastlane', fastlaneArgs, {
@@ -118,5 +128,5 @@ async function runFastlane(fastlaneArgs) {
   });
 }
 
-const getKeychainPath = name => `/private/tmp/xdl/${name}.keychain`;
-const getKeychainInfoPath = appUUID => `/private/tmp/${appUUID}-keychain-info.json`;
+const getKeychainPath = (name: string) => `/private/tmp/xdl/${name}.keychain`;
+const getKeychainInfoPath = (appUUID: string) => `/private/tmp/${appUUID}-keychain-info.json`;

--- a/packages/xdl/src/detach/IosLaunchScreen.js
+++ b/packages/xdl/src/detach/IosLaunchScreen.js
@@ -1,6 +1,3 @@
-/**
- *  @flow
- */
 import fs from 'fs-extra';
 import path from 'path';
 import rimraf from 'rimraf';
@@ -75,7 +72,7 @@ function _setBackgroundColor(manifest, dom) {
   }
 }
 
-async function _saveImageAssetsAsync(context: StandaloneContext) {
+async function _saveImageAssetsAsync(context) {
   let tabletImagePathOrUrl, phoneImagePathOrUrl;
 
   if (context.type === 'user') {
@@ -156,10 +153,7 @@ function _setBackgroundImageResizeMode(manifest, dom) {
   }
 }
 
-async function _copyIntermediateLaunchScreenAsync(
-  context: StandaloneContext,
-  launchScreenPath: string
-) {
+async function _copyIntermediateLaunchScreenAsync(context, launchScreenPath) {
   let splashTemplateFilename;
   if (context.type === 'user') {
     const { supportingDirectory } = IosWorkspace.getPaths(context);
@@ -185,10 +179,7 @@ async function _copyIntermediateLaunchScreenAsync(
   });
 }
 
-async function configureLaunchAssetsAsync(
-  context: StandaloneContext,
-  intermediatesDirectory: string
-) {
+async function configureLaunchAssetsAsync(context, intermediatesDirectory) {
   logger.info('Configuring iOS Launch Screen...');
 
   fs.mkdirpSync(intermediatesDirectory);

--- a/packages/xdl/src/detach/IosNSBundle.js
+++ b/packages/xdl/src/detach/IosNSBundle.js
@@ -1,7 +1,3 @@
-/**
- * @flow
- */
-
 import fs from 'fs-extra';
 import path from 'path';
 import get from 'lodash/get';
@@ -27,7 +23,7 @@ import logger from './Logger';
 const DEFAULT_FABRIC_KEY = '81130e95ea13cd7ed9a4f455e96214902c721c99';
 const KERNEL_URL = 'https://expo.io/@exponent/home';
 
-function _configureInfoPlistForLocalDevelopment(config: any, exp: any) {
+function _configureInfoPlistForLocalDevelopment(config, exp) {
   // add detached scheme
   if (exp.isDetached && exp.detach.scheme) {
     if (!config.CFBundleURLTypes) {
@@ -49,7 +45,7 @@ function _configureInfoPlistForLocalDevelopment(config: any, exp: any) {
 /**
  *  Prints warnings or info about the configured environment for local development.
  */
-function _logDeveloperInfoForLocalDevelopment(infoPlist: any) {
+function _logDeveloperInfoForLocalDevelopment(infoPlist) {
   // warn about *UsageDescription changes
   let usageKeysConfigured = [];
   for (let key in infoPlist) {
@@ -68,7 +64,7 @@ function _logDeveloperInfoForLocalDevelopment(infoPlist: any) {
   }
 }
 
-async function _cleanPropertyListBackupsAsync(context: StandaloneContext, backupPath: string) {
+async function _cleanPropertyListBackupsAsync(context, backupPath) {
   if (get(context, 'build.ios.buildType') !== 'client') {
     await IosPlist.cleanBackupAsync(backupPath, 'EXShell', false);
   }
@@ -84,10 +80,10 @@ async function _cleanPropertyListBackupsAsync(context: StandaloneContext, backup
  * Write the manifest and JS bundle to the NSBundle.
  */
 async function _preloadManifestAndBundleAsync(
-  manifest: any,
-  supportingDirectory: string,
-  manifestFilename: string,
-  bundleFilename: string
+  manifest,
+  supportingDirectory,
+  manifestFilename,
+  bundleFilename
 ) {
   const bundleUrl = manifest.bundleUrl;
   await fs.writeFile(path.join(supportingDirectory, manifestFilename), JSON.stringify(manifest));
@@ -98,9 +94,9 @@ async function _preloadManifestAndBundleAsync(
  *  This method only makes sense when operating on a context with sdk version < 26.
  */
 async function _maybeLegacyPreloadKernelManifestAndBundleAsync(
-  context: StandaloneContext,
-  manifestFilename: string,
-  bundleFilename: string
+  context,
+  manifestFilename,
+  bundleFilename
 ) {
   const { supportingDirectory } = IosWorkspace.getPaths(context);
   let sdkVersionSupported = await IosWorkspace.getNewestSdkVersionSupportedAsync(context);
@@ -124,7 +120,7 @@ async function _maybeLegacyPreloadKernelManifestAndBundleAsync(
 /**
  * Configure a standalone entitlements file.
  */
-async function _configureEntitlementsAsync(context: StandaloneContext) {
+async function _configureEntitlementsAsync(context) {
   if (context.type === 'user') {
     // don't modify .entitlements, print info/instructions
     const exp = context.data.exp;
@@ -205,7 +201,7 @@ async function _configureEntitlementsAsync(context: StandaloneContext) {
  *  For standalone apps, this is copied into a separate context field context.data.privateConfig
  *  by the turtle builder. For a local project, this is available in app.json under ios.config.
  */
-function _getPrivateConfig(context: StandaloneContext): any {
+function _getPrivateConfig(context) {
   let privateConfig;
   if (context.type === 'service') {
     privateConfig = context.data.privateConfig;
@@ -218,14 +214,14 @@ function _getPrivateConfig(context: StandaloneContext): any {
   return privateConfig;
 }
 
-function _isAppleUsageDescriptionKey(key: string): boolean {
+function _isAppleUsageDescriptionKey(key) {
   return key.indexOf('UsageDescription') !== -1;
 }
 
 /**
  * Configure an iOS Info.plist for a standalone app.
  */
-async function _configureInfoPlistAsync(context: StandaloneContext) {
+async function _configureInfoPlistAsync(context) {
   const { supportingDirectory } = IosWorkspace.getPaths(context);
   const config = context.config;
   const privateConfig = _getPrivateConfig(context);
@@ -393,7 +389,7 @@ async function _configureInfoPlistAsync(context: StandaloneContext) {
 /**
  *  Configure EXShell.plist for a standalone app.
  */
-async function _configureShellPlistAsync(context: StandaloneContext) {
+async function _configureShellPlistAsync(context) {
   const { supportingDirectory } = IosWorkspace.getPaths(context);
   const config = context.config;
   const buildPhaseLogger = logger.withFields({ buildPhase: 'configuring NSBundle' });
@@ -435,7 +431,7 @@ async function _configureShellPlistAsync(context: StandaloneContext) {
   });
 }
 
-async function _configureConstantsPlistAsync(context: StandaloneContext) {
+async function _configureConstantsPlistAsync(context) {
   if (context.type === 'user') {
     return;
   }
@@ -450,7 +446,7 @@ async function _configureConstantsPlistAsync(context: StandaloneContext) {
   });
 }
 
-async function _configureGoogleServicesPlistAsync(context: StandaloneContext) {
+async function _configureGoogleServicesPlistAsync(context) {
   if (context.type === 'user') {
     return;
   }
@@ -464,7 +460,7 @@ async function _configureGoogleServicesPlistAsync(context: StandaloneContext) {
   }
 }
 
-async function configureAsync(context: StandaloneContext) {
+async function configureAsync(context) {
   const buildPhaseLogger = logger.withFields({ buildPhase: 'configuring NSBundle' });
 
   let {
@@ -517,8 +513,7 @@ async function configureAsync(context: StandaloneContext) {
         await AssetBundle.bundleAsync(
           context,
           context.data.manifest.bundledAssets,
-          supportingDirectory,
-          context.data.manifest.sdkVersion === '24.0.0'
+          supportingDirectory
         );
       } catch (e) {
         throw new Error(`Asset bundling failed: ${e}`);

--- a/packages/xdl/src/detach/IosPlist.ts
+++ b/packages/xdl/src/detach/IosPlist.ts
@@ -5,7 +5,7 @@ import plist from 'plist';
 import { spawnAsyncThrowError } from './ExponentTools';
 import logger from './Logger';
 
-function _getNormalizedPlistFilename(plistName) {
+function _getNormalizedPlistFilename(plistName: string) {
   let plistFilename;
   if (plistName.indexOf('.') !== -1) {
     plistFilename = plistName;
@@ -18,7 +18,7 @@ function _getNormalizedPlistFilename(plistName) {
 /**
  *  @param plistName base filename of property list. if no extension, assumes .plist
  */
-async function modifyAsync(plistPath, plistName, transform) {
+async function modifyAsync(plistPath: string, plistName: string, transform: (config: any) => any) {
   let plistFilename = _getNormalizedPlistFilename(plistName);
   let configPlistName = path.join(plistPath, plistFilename);
   let configFilename = path.join(plistPath, `${plistName}.json`);
@@ -67,7 +67,7 @@ async function modifyAsync(plistPath, plistName, transform) {
   return config;
 }
 
-async function createBlankAsync(plistPath, plistName) {
+async function createBlankAsync(plistPath: string, plistName: string) {
   // write empty json file
   const emptyConfig = {};
   const tmpConfigFile = path.join(plistPath, `${plistName}.json`);
@@ -92,13 +92,13 @@ async function createBlankAsync(plistPath, plistName) {
   await spawnAsyncThrowError('/bin/rm', [tmpConfigFile]);
 }
 
-async function cleanBackupAsync(plistPath, plistName, restoreOriginal = true) {
+async function cleanBackupAsync(plistPath: string, plistName: string, restoreOriginal = true) {
   let plistFilename = _getNormalizedPlistFilename(plistName);
   let configPlistName = path.join(plistPath, plistFilename);
   let configFilename = path.join(plistPath, `${plistName}.json`);
   const backupPlistPath = `${configPlistName}.bak`;
 
-  if (restoreOriginal && (await fs.exists(backupPlistPath))) {
+  if (restoreOriginal && (await fs.pathExists(backupPlistPath))) {
     await fs.copy(backupPlistPath, configPlistName);
   }
 

--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -1,7 +1,3 @@
-// Copyright 2015-present 650 Industries. All rights reserved.
-
-'use strict';
-
 import fs from 'fs-extra';
 import glob from 'glob-promise';
 import indentString from 'indent-string';

--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -1,7 +1,3 @@
-// Copyright 2015-present 650 Industries. All rights reserved.
-
-'use strict';
-
 import fs from 'fs-extra';
 import path from 'path';
 import rimraf from 'rimraf';

--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -1,6 +1,3 @@
-/**
- * @flow
- */
 import fs from 'fs-extra';
 import invariant from 'invariant';
 import path from 'path';
@@ -23,10 +20,7 @@ import * as Versions from '../Versions';
 import * as Modules from '../modules/Modules';
 import installPackagesAsync from './installPackagesAsync';
 
-async function _getVersionedExpoKitConfigAsync(
-  sdkVersion: string,
-  skipServerValidation: boolean
-): any {
+async function _getVersionedExpoKitConfigAsync(sdkVersion, skipServerValidation) {
   const versions = await Versions.versionsAsync();
   let sdkVersionConfig = versions.sdkVersions[sdkVersion];
   if (!sdkVersionConfig) {
@@ -44,10 +38,7 @@ async function _getVersionedExpoKitConfigAsync(
   };
 }
 
-async function _getOrCreateTemplateDirectoryAsync(
-  context: StandaloneContext,
-  iosExpoViewUrl: ?string
-) {
+async function _getOrCreateTemplateDirectoryAsync(context, iosExpoViewUrl) {
   if (context.type === 'service') {
     return path.join(context.data.expoSourcePath, '..');
   } else if (context.type === 'user') {
@@ -72,11 +63,7 @@ async function _getOrCreateTemplateDirectoryAsync(
   }
 }
 
-async function _renameAndMoveProjectFilesAsync(
-  context: StandaloneContext,
-  projectDirectory: string,
-  projectName: string
-) {
+async function _renameAndMoveProjectFilesAsync(context, projectDirectory, projectName) {
   // remove .gitignore, as this actually pertains to internal expo template management
   try {
     const gitIgnorePath = path.join(projectDirectory, '.gitignore');
@@ -139,11 +126,7 @@ async function _renameAndMoveProjectFilesAsync(
   });
 }
 
-async function _configureVersionsPlistAsync(
-  configFilePath: string,
-  standaloneSdkVersion: string,
-  isServiceContext: boolean
-) {
+async function _configureVersionsPlistAsync(configFilePath, standaloneSdkVersion) {
   await IosPlist.modifyAsync(configFilePath, 'EXSDKVersions', versionConfig => {
     versionConfig.sdkVersions = [standaloneSdkVersion];
     versionConfig.detachedNativeVersions = {
@@ -154,10 +137,7 @@ async function _configureVersionsPlistAsync(
   });
 }
 
-async function _configureBuildConstantsPlistAsync(
-  configFilePath: string,
-  context: StandaloneContext
-) {
+async function _configureBuildConstantsPlistAsync(configFilePath, context) {
   await IosPlist.modifyAsync(configFilePath, 'EXBuildConstants', constantsConfig => {
     constantsConfig.STANDALONE_CONTEXT_TYPE = context.type;
     return constantsConfig;
@@ -165,14 +145,14 @@ async function _configureBuildConstantsPlistAsync(
 }
 
 async function _renderPodfileFromTemplateAsync(
-  context: StandaloneContext,
-  expoRootTemplateDirectory: string,
-  sdkVersion: string,
-  iosClientVersion: ?string
+  context,
+  expoRootTemplateDirectory,
+  sdkVersion,
+  iosClientVersion
 ) {
   const { iosProjectDirectory, projectName } = getPaths(context);
   let podfileTemplateFilename;
-  let podfileSubstitutions: any = {
+  let podfileSubstitutions = {
     TARGET_NAME: projectName,
   };
   let reactNativeDependencyPath;
@@ -257,7 +237,7 @@ async function _renderPodfileFromTemplateAsync(
   );
 }
 
-async function createDetachedAsync(context: StandaloneContext) {
+async function createDetachedAsync(context) {
   const { iosProjectDirectory, projectName, supportingDirectory, projectRootDirectory } = getPaths(
     context
   );
@@ -309,7 +289,7 @@ async function createDetachedAsync(context: StandaloneContext) {
   logger.info('Configuring iOS dependencies...');
   // this configuration must happen prior to build time because it affects which
   // native versions of RN we depend on.
-  await _configureVersionsPlistAsync(supportingDirectory, standaloneSdkVersion, isServiceContext);
+  await _configureVersionsPlistAsync(supportingDirectory, standaloneSdkVersion);
   await _configureBuildConstantsPlistAsync(supportingDirectory, context);
   await _renderPodfileFromTemplateAsync(
     context,
@@ -347,7 +327,7 @@ async function _installRequiredPackagesAsync(projectRoot, sdkVersion) {
   }
 }
 
-function addDetachedConfigToExp(exp: Object, context: StandaloneContext): Object {
+function addDetachedConfigToExp(exp, context) {
   if (context.type !== 'user') {
     logger.warn(`Tried to modify exp for a non-user StandaloneContext, ignoring`);
     return exp;
@@ -374,7 +354,7 @@ function addDetachedConfigToExp(exp: Object, context: StandaloneContext): Object
  *    intermediatesDirectory - temporary spot to write whatever files are needed during the
  *      detach/build process but can be discarded afterward.
  */
-function getPaths(context: StandaloneContext) {
+function getPaths(context) {
   let iosProjectDirectory;
   let projectName;
   let supportingDirectory;
@@ -426,7 +406,7 @@ function getPaths(context: StandaloneContext) {
  *  Get the newest sdk version supported given the standalone context.
  *  Not all contexts support the newest sdk version.
  */
-async function getNewestSdkVersionSupportedAsync(context: StandaloneContext) {
+async function getNewestSdkVersionSupportedAsync(context) {
   if (context.type === 'user') {
     return context.data.exp.sdkVersion;
   } else if (context.type === 'service') {

--- a/packages/xdl/src/detach/StandaloneContext.ts
+++ b/packages/xdl/src/detach/StandaloneContext.ts
@@ -8,7 +8,7 @@ type StandaloneContextTestEnvironment = 'none' | 'local' | 'ci';
  *  A user context is used when we are configuring a standalone app locally on a user's machine,
  *  such as during `exp detach`.
  */
-type StandaloneContextDataUser = {
+export type StandaloneContextDataUser = {
   projectPath: string;
   exp: any;
 };
@@ -17,7 +17,7 @@ type StandaloneContextDataUser = {
  *  A service context is used when we are generating a standalone app remotely on an Expo
  *  service machine, such as during `exp build`.
  */
-type StandaloneContextDataService = {
+export type StandaloneContextDataService = {
   expoSourcePath: string;
   archivePath: string | null;
   manifest: any;

--- a/packages/xdl/src/detach/installPackagesAsync.ts
+++ b/packages/xdl/src/detach/installPackagesAsync.ts
@@ -1,5 +1,3 @@
-// @flow
-
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import path from 'path';
@@ -10,7 +8,7 @@ import logger from './Logger';
 export default async function installPackagesAsync(
   projectDir: string,
   packages: string[],
-  options?: any = {}
+  options: any = {}
 ): Promise<void> {
   let packageManager = 'npm';
   if (options.packageManager) {
@@ -31,7 +29,7 @@ export default async function installPackagesAsync(
     });
   } else {
     logger.info(`Installing dependencies using npm...`);
-    if (!(await fs.pathExists(path.join(projectDir, 'node_modules')))) {
+    if (!await fs.pathExists(path.join(projectDir, 'node_modules'))) {
       await spawnAsync('npm', ['install', '--loglevel', 'error'], {
         cwd: projectDir,
         stdio: 'inherit',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,6 +2167,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/globby@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@types/globby/-/globby-6.1.0.tgz#7c25b975512a89effea2a656ca8cf6db7fb29d11"
+  integrity sha512-j3XSDNoK4LO5T+ZviQD6PqfEjm07QFEacOTbJR3hnLWuWX0ZMLJl9oRPgj1PyrfGbXhfHFkksC9QZ9HFltJyrw==
+  dependencies:
+    "@types/glob" "*"
+
 "@types/globby@^9.1.0":
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/@types/globby/-/globby-9.1.0.tgz#08e2cf99c64f8e45c6cfbe05e9d8ac763aca6482"


### PR DESCRIPTION
This PR removes Flow from the `xdl/src/detach` folder. The files that could be converted to TypeScript with minor changes have been converted to TypeScript and renamed to the `.ts` extension, and the rest of the files have been kept `.js` and the Flow types have been stripped out.

After this, there's just a handful of other files with Flow types left in the XDL. I'll soon open a separate PR that removes those and removes the `@babel/preset-flow` from the build configuration.