### PR TITLE
fix(expo-cli): correctly import @expo/config

### DIFF
--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import spawnAsync from '@expo/spawn-async';
-import ConfigUtils from '@expo/config';
+import * as ConfigUtils from '@expo/config';
 import chalk from 'chalk';
 // @ts-ignore enquirer has no exported member 'MultiSelect'
 import { MultiSelect } from 'enquirer';


### PR DESCRIPTION
## The problem

```sh
$ expo customize:web
Cannot read property 'readConfigJsonAsync' of undefined
TypeError: Cannot read property 'readConfigJsonAsync' of undefined
    at action (/expo-cli@3.0.10/src/commands/customize.ts:126:3)
    at Command.action (/expo-cli@3.0.10/src/exp.ts:82:13)
```

## Changes

I looked for every import to `@expo/config` and fixed the import, however, only one file needed a fix.

Related to #822 (Which I think this should be closed)