### PR TITLE
fix(xdl): If `next.config.js` is a function, execute it first

### DIFF
--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -558,7 +558,6 @@ function _createNextJsConfig({
   }
   const includeFunc = expoBabelLoader.include as ((path: string) => boolean);
 
-  // TODO: IT DOES NOT WORK WHEN THERE'S NO `withTM`
   return {
     // https://github.com/zeit/next.js#configuring-extensions-looked-for-when-resolving-pages-in-pages
     // Remove the `.` before each file extension


### PR DESCRIPTION
This fixes the deployment issue.

When `next.config.js` is wrapped with function, we’ll have to execute it first to get the actual config object and then inject our own config.

It uses the code from https://github.com/zeit/next.js/blob/9efed17503f302bfbdca5795d4443a89d48f93fa/packages/next-server/server/config.ts#L86-L97. It would be better if we could use `normalizeConfig` function directly.