### PR TITLE
feat(web): add supports for push notifications for Next.js with Expo for Web

### DIFF
--- a/packages/webpack-config/tests/__tests__/basic-test.js
+++ b/packages/webpack-config/tests/__tests__/basic-test.js
@@ -26,3 +26,10 @@ it(`should be aware of process.env.CI`, async () => {
     text: 'Has CI env',
   });
 });
+
+if (config.hasServerSideRendering) {
+  it(`should be aware of process.env.CI server-side`, async () => {
+    const sourceCode = await response.text();
+    expect(sourceCode).toEqual(expect.stringContaining('Has CI env'));
+  });
+}

--- a/packages/webpack-config/web-default/expo-service-worker.js
+++ b/packages/webpack-config/web-default/expo-service-worker.js
@@ -29,8 +29,8 @@ self.addEventListener('push', event => {
   let options = {
     body: payload.body,
     data: payload.data || {},
-    icon: payload.data._icon || self.notificationIcon || null,
   };
+  options.icon = options.data._icon || self.notificationIcon || null;
   if (options.data._tag) {
     options.tag = options.data._tag;
     options.renotify = options.data._renotify;

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -14,7 +14,7 @@ import createWebpackCompiler, {
   printInstructions,
   printSuccessMessages,
 } from './createWebpackCompiler';
-import ip from './ip'; 
+import ip from './ip';
 // @ts-ignore
 import * as Doctor from './project/Doctor';
 import * as ProjectUtils from './project/ProjectUtils';
@@ -539,6 +539,11 @@ async function startNextJsAsync({
   await app.prepare();
 
   const server = express();
+
+  server.get('/expo-service-worker.js', (req, res) => {
+    res.sendFile(path.resolve(projectRoot, '.expo', 'expo-service-worker.js'));
+  });
+
   server.get('*', handle);
 
   webpackDevServerInstance = server.listen(port, err => {
@@ -708,6 +713,15 @@ async function _copyCustomNextJsTemplatesAsync(projectRoot: string) {
     } catch (e) {
       throw new Error(`Could not write to pages/_document.js: ${e.toString()}`);
     }
+  }
+
+  try {
+    await fs.copyFile(
+      require.resolve('@expo/webpack-config/web-default/expo-service-worker.js'),
+      path.join(projectRoot, '.expo', 'expo-service-worker.js')
+    );
+  } catch (e) {
+    throw new Error(`Could not copy expo-service-worker.js: ${e.toString()}`);
   }
 }
 

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -741,11 +741,14 @@ async function _copyCustomNextJsTemplatesAsync(projectRoot: string) {
     throw new Error(`Could not copy expo-service-worker.js: ${e.toString()}`);
   }
 
-  // Write a blank service-worker.js file for users who do not use any other service worker.
-  try {
-    await fs.writeFile(path.join(staticFolder, 'service-worker.js'), '');
-  } catch (e) {
-    throw new Error(`Could not write to service-worker.js: ${e.toString()}`);
+  const serviceWorkerPath = path.join(staticFolder, 'service-worker.js');
+  if (!fs.existsSync(serviceWorkerPath)) {
+    // Write a blank service-worker.js file for users who do not use any other service worker.
+    try {
+      await fs.writeFile(serviceWorkerPath, '');
+    } catch (e) {
+      throw new Error(`Could not write to service-worker.js: ${e.toString()}`);
+    }
   }
 }
 

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -549,7 +549,7 @@ async function startNextJsAsync({
     const serviceWorkerPath = path.resolve(projectRoot, '.next', 'service-worker.js');
     if (!fs.existsSync(serviceWorkerPath)) {
       // Simply return a blank service worker file if the user is not using `next-offline`.
-      res.type('.js').send();
+      res.sendFile(path.resolve(projectRoot, '.expo', 'service-worker.js'));
       return;
     }
     res.sendFile(serviceWorkerPath);
@@ -733,6 +733,13 @@ async function _copyCustomNextJsTemplatesAsync(projectRoot: string) {
     );
   } catch (e) {
     throw new Error(`Could not copy expo-service-worker.js: ${e.toString()}`);
+  }
+
+  // Write a blank service-worker.js file for users who do not use any other service worker.
+  try {
+    await fs.writeFile(path.join(projectRoot, '.expo', 'service-worker.js'), "");
+  } catch (e) {
+    throw new Error(`Could not write to service-worker.js: ${e.toString()}`);
   }
 }
 

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -544,6 +544,17 @@ async function startNextJsAsync({
     res.sendFile(path.resolve(projectRoot, '.expo', 'expo-service-worker.js'));
   });
 
+  server.get('/service-worker.js', (req, res) => {
+    // This file should be provided by https://github.com/hanford/next-offline if installed.
+    const serviceWorkerPath = path.resolve(projectRoot, '.next', 'service-worker.js');
+    if (!fs.existsSync(serviceWorkerPath)) {
+      // Simply return a blank service worker file if the user is not using `next-offline`.
+      res.type('.js').send();
+      return;
+    }
+    res.sendFile(serviceWorkerPath);
+  });
+
   server.get('*', handle);
 
   webpackDevServerInstance = server.listen(port, err => {

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -541,7 +541,7 @@ async function startNextJsAsync({
   const server = express();
 
   server.get('/expo-service-worker.js', (req, res) => {
-    res.sendFile(path.resolve(projectRoot, '.expo', 'expo-service-worker.js'));
+    res.sendFile(path.resolve(projectRoot, 'static', 'expo-service-worker.js'));
   });
 
   server.get('/service-worker.js', (req, res) => {
@@ -549,7 +549,7 @@ async function startNextJsAsync({
     const serviceWorkerPath = path.resolve(projectRoot, '.next', 'service-worker.js');
     if (!fs.existsSync(serviceWorkerPath)) {
       // Simply return a blank service worker file if the user is not using `next-offline`.
-      res.sendFile(path.resolve(projectRoot, '.expo', 'service-worker.js'));
+      res.sendFile(path.resolve(projectRoot, 'static', 'service-worker.js'));
       return;
     }
     res.sendFile(serviceWorkerPath);
@@ -726,10 +726,16 @@ async function _copyCustomNextJsTemplatesAsync(projectRoot: string) {
     }
   }
 
+  // TODO: Use `public/` folder when Next.js eventually deprecates `static/` folder.
+  const staticFolder = path.join(projectRoot, 'static');
+  if (!fs.existsSync(staticFolder)) {
+    fs.mkdirSync(staticFolder);
+  }
+
   try {
     await fs.copyFile(
       require.resolve('@expo/webpack-config/web-default/expo-service-worker.js'),
-      path.join(projectRoot, '.expo', 'expo-service-worker.js')
+      path.join(staticFolder, 'expo-service-worker.js')
     );
   } catch (e) {
     throw new Error(`Could not copy expo-service-worker.js: ${e.toString()}`);
@@ -737,7 +743,7 @@ async function _copyCustomNextJsTemplatesAsync(projectRoot: string) {
 
   // Write a blank service-worker.js file for users who do not use any other service worker.
   try {
-    await fs.writeFile(path.join(projectRoot, '.expo', 'service-worker.js'), "");
+    await fs.writeFile(path.join(staticFolder, 'service-worker.js'), '');
   } catch (e) {
     throw new Error(`Could not write to service-worker.js: ${e.toString()}`);
   }


### PR DESCRIPTION
(See also https://github.com/expo/expo-cli/pull/844 and https://github.com/expo/expo-cli/pull/926.)

We copy and serve `/expo-service-worker.js` (and `/service-worker.js`) with Express when using Next.js. This means that `expo start --dev` and `expo start --no-dev` will both support the service worker without any additional configurations.

For services like Now.sh, configurations like https://github.com/hanford/next-offline#now-20 are needed. See docs from https://github.com/expo/expo/pull/5501.

Problem:
- `/static/expo-service-worker.js` will always get created even if the user is not using web Notifications.