### PR TITLE
feat(xdl): support custom notification sounds

### DIFF
--- a/packages/schemer/src/index.ts
+++ b/packages/schemer/src/index.ts
@@ -241,6 +241,7 @@ export default class Schemer {
 
   async _validateAssetAsync({ fieldPath, data, meta }: AssetField) {
     if (meta && meta.asset && data) {
+      // TODO: Validate the length and size of the audio file(s) for custom notification sounds.
       if (meta.contentTypePattern && meta.contentTypePattern.startsWith('^image')) {
         await this._validateImageAsync({ fieldPath, data, meta });
       }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -315,7 +315,7 @@ async function _resolveManifestAssets(
     // Get the URLs
     const urls = await Promise.all(
       assetSchemas.map(async (assetSchema: ExpSchema.AssetSchema) => {
-        if (assetSchema.isArray) {
+        if (assetSchema.schema.type === 'array') {
           const pathsOrURLs: string[] = get(manifest, assetSchema.fieldPath);
           return await Promise.all(
             pathsOrURLs.map(async pathOrURL => {

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -312,6 +312,7 @@ async function _resolveManifestAssets(
     const assetSchemas = (await ExpSchema.getAssetSchemasAsync(
       manifest.sdkVersion
     )).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
+
     // Get the URLs
     const urls = await Promise.all(
       assetSchemas.map(async (assetSchema: ExpSchema.AssetSchema) => {

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -6,6 +6,7 @@ import globby from 'globby';
 import uuid from 'uuid';
 
 import { createAndWriteIconsToPathAsync } from './AndroidIcons';
+import * as NotificationSounds from './NotificationSounds';
 import * as AssetBundle from './AssetBundle';
 import * as ExponentTools from './ExponentTools';
 import StandaloneBuildFlags from './StandaloneBuildFlags';
@@ -902,6 +903,11 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       })
     );
   }
+
+  await NotificationSounds.copyNotificationSoundsAsync(
+    context,
+    path.join(shellPath, 'app', 'src', 'main', 'res', 'raw')
+  );
 
   await AssetBundle.bundleAsync(
     context,

--- a/packages/xdl/src/detach/NotificationSounds.ts
+++ b/packages/xdl/src/detach/NotificationSounds.ts
@@ -1,0 +1,60 @@
+import fs from 'fs-extra';
+import path from 'path';
+import StandaloneContext, {
+  StandaloneContextDataUser,
+  StandaloneContextDataService,
+} from './StandaloneContext';
+import { saveUrlToPathAsync } from './ExponentTools';
+import logger from './Logger';
+
+/**
+ * Copy sound files for notifications to the bundle.
+ */
+export async function copyNotificationSoundsAsync(
+  context: StandaloneContext,
+  distDirectory: string
+) {
+  let bundledSounds: string[];
+  if (context.type === 'user') {
+    // copy images from local project
+    const data = context.data as StandaloneContextDataUser;
+    bundledSounds = data.exp.notification && data.exp.notification.bundledSounds;
+  } else {
+    const data = context.data as StandaloneContextDataService;
+    bundledSounds = data.manifest.notification && data.manifest.notification.bundledSounds;
+  }
+
+  if (!bundledSounds) {
+    return;
+  }
+
+  let bundledSoundsUrls: string[] | null = null;
+  if (context.type === 'service') {
+    const data = context.data as StandaloneContextDataService;
+    bundledSoundsUrls = data.manifest.notification && data.manifest.notification.bundledSoundsUrl;
+    if (!bundledSoundsUrls || bundledSoundsUrls.length !== bundledSounds.length) {
+      throw new Error('`bundledSoundsUrl` not found.');
+    }
+  }
+
+  logger.info('Copying sound files for notifications to the bundle...');
+  if (!fs.existsSync(distDirectory)) {
+    fs.mkdirSync(distDirectory);
+  }
+
+  await Promise.all(
+    bundledSounds.map(async (bundledSound, index) => {
+      const bundledSoundFilename = path.join(distDirectory, path.basename(bundledSound));
+      if (context.type === 'user') {
+        const sourcePath = path.resolve(
+          (context.data as StandaloneContextDataUser).projectPath,
+          bundledSound
+        );
+        await fs.copy(sourcePath, bundledSoundFilename);
+      } else {
+        const bundledSoundUrl = bundledSoundsUrls![index];
+        await saveUrlToPathAsync(bundledSoundUrl, bundledSoundFilename);
+      }
+    })
+  );
+}

--- a/packages/xdl/src/project/ExpSchema.ts
+++ b/packages/xdl/src/project/ExpSchema.ts
@@ -5,12 +5,7 @@ import Api from '../Api';
 import * as ConfigUtils from '@expo/config';
 
 export type Schema = any;
-export type AssetSchema = {
-  schema: Schema;
-  fieldPath: string;
-  // Whether the asset is an array which contains multiple filepaths.
-  isArray: boolean;
-};
+export type AssetSchema = { schema: Schema; fieldPath: string };
 
 let _xdlSchemaJson: { [sdkVersion: string]: Schema } = {};
 
@@ -32,24 +27,15 @@ export async function getSchemaAsync(sdkVersion: string): Promise<Schema> {
 export async function getAssetSchemasAsync(sdkVersion: string): Promise<AssetSchema[]> {
   const schema = await getSchemaAsync(sdkVersion);
   const assetSchemas: AssetSchema[] = [];
-  const visit = (node: Schema, fieldPath: string, isArray: boolean = false) => {
+  const visit = (node: Schema, fieldPath: string) => {
     if (node.meta && node.meta.asset) {
-      assetSchemas.push({
-        schema: node,
-        fieldPath,
-        isArray,
-      });
+      assetSchemas.push({ schema: node, fieldPath });
     }
     const properties = node.properties;
     if (properties) {
       Object.keys(properties).forEach(property =>
         visit(properties[property], `${fieldPath}${fieldPath.length > 0 ? '.' : ''}${property}`)
       );
-    }
-
-    if (node.items) {
-      // Check if an array's item is an asset
-      visit(node.items, fieldPath, true);
     }
   };
   visit(schema, '');

--- a/packages/xdl/src/project/ExpSchema.ts
+++ b/packages/xdl/src/project/ExpSchema.ts
@@ -5,7 +5,12 @@ import Api from '../Api';
 import * as ConfigUtils from '@expo/config';
 
 export type Schema = any;
-export type AssetSchema = { schema: Schema; fieldPath: string };
+export type AssetSchema = {
+  schema: Schema;
+  fieldPath: string;
+  // Whether the asset is an array which contains multiple filepaths.
+  isArray: boolean;
+};
 
 let _xdlSchemaJson: { [sdkVersion: string]: Schema } = {};
 
@@ -27,15 +32,24 @@ export async function getSchemaAsync(sdkVersion: string): Promise<Schema> {
 export async function getAssetSchemasAsync(sdkVersion: string): Promise<AssetSchema[]> {
   const schema = await getSchemaAsync(sdkVersion);
   const assetSchemas: AssetSchema[] = [];
-  const visit = (node: Schema, fieldPath: string) => {
+  const visit = (node: Schema, fieldPath: string, isArray: boolean = false) => {
     if (node.meta && node.meta.asset) {
-      assetSchemas.push({ schema: node, fieldPath });
+      assetSchemas.push({
+        schema: node,
+        fieldPath,
+        isArray,
+      });
     }
     const properties = node.properties;
     if (properties) {
       Object.keys(properties).forEach(property =>
         visit(properties[property], `${fieldPath}${fieldPath.length > 0 ? '.' : ''}${property}`)
       );
+    }
+
+    if (node.items) {
+      // Check if an array's item is an asset
+      visit(node.items, fieldPath, true);
     }
   };
   visit(schema, '');


### PR DESCRIPTION
See also https://github.com/expo/expo/pull/5597 and https://github.com/expo/universe/pull/3679.

Copy/download the audio files during eject/build to `NotificationSounds/` folder on iOS and to `app/src/main/res/raw/` folder on Android.

I haven't been able to test it in `service` context in `xdl`, but it should work as expected.