### PR TITLE
Fix CI caching parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,18 @@ executors:
   node-10:
     docker:
       - image: circleci/node:10
+    environment:
+      EXECUTOR_NAME: node-10
   node-12:
     docker:
       - image: circleci/node:12
+    environment:
+      EXECUTOR_NAME: node-12
   puppeteer:
     docker:
       - image: circleci/node:latest-browsers
+    environment:
+      EXECUTOR_NAME: puppeteer
 workflows:
   version: 2
   build-and-test:
@@ -79,7 +85,7 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-{{ << parameters.e >> }}-{{ checksum "yarn.lock" }}
+            - yarn-{{ "$EXECUTOR_NAME" }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
@@ -92,7 +98,7 @@ jobs:
             - expo-cli
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-{{ << parameters.e >> }}-{{ checksum "yarn.lock" }}
+          key: yarn-{{ "$EXECUTOR_NAME" }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
   test-dev-tools:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-{{ parameters.e }}-{{ checksum "yarn.lock" }}
+            - yarn-{{ << parameters.e >> }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
@@ -92,7 +92,7 @@ jobs:
             - expo-cli
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-{{ parameters.e }}-{{ checksum "yarn.lock" }}
+          key: yarn-{{ << parameters.e >> }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
   test-dev-tools:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,15 @@ jobs:
     working_directory: ~/expo-cli
     steps:
       - checkout
+      - run:
+          # https://discuss.circleci.com/t/cannot-use-circle-yml-environment-variables-in-cache-keys/10994/20
+          name: Configure env
+          command: |
+            echo "$EXECUTOR_NAME" >> ~/__circle_ci_hack.txt
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-{{ $EXECUTOR_NAME }}-{{ checksum "yarn.lock" }}
+            - yarn-{{ checksum "~/__circle_ci_hack.txt" }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
@@ -98,7 +103,7 @@ jobs:
             - expo-cli
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-{{ $EXECUTOR_NAME }}-{{ checksum "yarn.lock" }}
+          key: yarn-{{ checksum "~/__circle_ci_hack.txt" }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
   test-dev-tools:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,11 @@ jobs:
           # https://discuss.circleci.com/t/cannot-use-circle-yml-environment-variables-in-cache-keys/10994/20
           name: Configure env
           command: |
-            echo "$EXECUTOR_NAME" >> ~/__circle_ci_hack.txt
+            echo "$EXECUTOR_NAME" > /tmp/.executor_name
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-{{ checksum "~/__circle_ci_hack.txt" }}-{{ checksum "yarn.lock" }}
+            - yarn-{{ checksum "/tmp/.executor_name" }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
@@ -103,7 +103,7 @@ jobs:
             - expo-cli
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-{{ checksum "~/__circle_ci_hack.txt" }}-{{ checksum "yarn.lock" }}
+          key: yarn-{{ checksum "/tmp/.executor_name" }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
   test-dev-tools:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-{{ "$EXECUTOR_NAME" }}-{{ checksum "yarn.lock" }}
+            - yarn-{{ $EXECUTOR_NAME }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
@@ -98,7 +98,7 @@ jobs:
             - expo-cli
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-{{ "$EXECUTOR_NAME" }}-{{ checksum "yarn.lock" }}
+          key: yarn-{{ $EXECUTOR_NAME }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
   test-dev-tools:


### PR DESCRIPTION
# Why

https://circleci.com/gh/expo/expo-cli/7454?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

- error computing cache key: template: cacheKey:1: function "parameters" not defined
