### PR TITLE
fix(dev-tools): add authentication to the WebSocket API

### DIFF
--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@expo/config": "^2.1.5-alpha.0",
+    "base64url": "3.0.1",
     "express": "4.16.4",
     "freeport-async": "1.1.1",
     "graphql": "0.13.2",
@@ -58,6 +59,7 @@
     "http-proxy-middleware": "^0.18.0",
     "jest": "^22.4.3",
     "next": "^5.1.0",
+    "p-timeout": "3.1.0",
     "qrcode.react": "0.8.0",
     "react": "16.2.0",
     "react-apollo": "^2.1.3",

--- a/packages/dev-tools/pages/index.js
+++ b/packages/dev-tools/pages/index.js
@@ -463,9 +463,10 @@ export default class IndexPage extends React.Component {
       client: null,
     };
     this.unsubscribers = [];
-    if (process.browser) {
-      this.connect().catch(error => this.setState({ disconnected: true }));
-    }
+  }
+
+  componentDidMount() {
+    this.connect().catch(error => this.setState({ disconnected: true }));
   }
 
   async connect() {
@@ -493,6 +494,7 @@ export default class IndexPage extends React.Component {
 
   componentWillUnmount() {
     this.unsubscribers.forEach(unsubscribe => unsubscribe());
+    this.unsubscribers = [];
   }
 
   render() {

--- a/packages/dev-tools/server/DevToolsServer.js
+++ b/packages/dev-tools/server/DevToolsServer.js
@@ -5,6 +5,8 @@ import express from 'express';
 import freeportAsync from 'freeport-async';
 import path from 'path';
 import http from 'http';
+import crypto from 'crypto';
+import base64url from 'base64url';
 
 import AsyncIterableRingBuffer from './graphql/AsyncIterableRingBuffer';
 import GraphQLSchema from './graphql/GraphQLSchema';
@@ -19,10 +21,40 @@ function setHeaders(res) {
   res.setHeader('Last-Modified', serverStartTimeUTCString);
 }
 
+async function generateSecureRandomTokenAsync() {
+  return new Promise((resolve, reject) => {
+    crypto.randomBytes(32, (error, buffer) => {
+      if (error) reject(error);
+      else resolve(base64url.fromBase64(buffer.toString('base64')));
+    });
+  });
+}
+
+export async function createAuthenticationContextAsync({ port }) {
+  const clientAuthenticationToken = await generateSecureRandomTokenAsync();
+  const endpointUrlToken = await generateSecureRandomTokenAsync();
+  const graphQLEndpointPath = `/${endpointUrlToken}/graphql`;
+  const hostname = `localhost:${port}`;
+  const webSocketGraphQLUrl = `ws://${hostname}${graphQLEndpointPath}`;
+  const allowedOrigin = `http://${hostname}`;
+  return {
+    clientAuthenticationToken,
+    graphQLEndpointPath,
+    webSocketGraphQLUrl,
+    allowedOrigin,
+    requestHandler: (request, response) => {
+      response.json({ webSocketGraphQLUrl, clientAuthenticationToken });
+    },
+  };
+}
+
 export async function startAsync(projectDir) {
   const port = await freeportAsync(19002);
   const server = express();
 
+  const authenticationContext = await createAuthenticationContextAsync({ port });
+  const { webSocketGraphQLUrl, clientAuthenticationToken } = authenticationContext;
+  server.get('/dev-tools-info', authenticationContext.requestHandler);
   server.use(
     '/_next',
     express.static(path.join(__dirname, '../client/_next'), {
@@ -38,18 +70,17 @@ export async function startAsync(projectDir) {
   await new Promise((resolve, reject) => {
     httpServer.once('error', reject);
     httpServer.once('listening', resolve);
-    httpServer.listen(port);
+    httpServer.listen(port, 'localhost');
   });
-  startGraphQLServer(projectDir, httpServer);
+  startGraphQLServer(projectDir, httpServer, authenticationContext);
   await ProjectSettings.setPackagerInfoAsync(projectDir, { devToolsPort: port });
   return `http://localhost:${port}`;
 }
 
-export function startGraphQLServer(projectDir, httpServer) {
+export function startGraphQLServer(projectDir, httpServer, authenticationContext) {
   const layout = createLayout();
   const issues = new Issues();
   const messageBuffer = createMessageBuffer(projectDir, issues);
-
   SubscriptionServer.create(
     {
       schema: GraphQLSchema,
@@ -64,8 +95,24 @@ export function startGraphQLServer(projectDir, httpServer) {
           issues,
         }),
       }),
+      onConnect: connectionParams => {
+        if (
+          !connectionParams.clientAuthenticationToken ||
+          connectionParams.clientAuthenticationToken !==
+            authenticationContext.clientAuthenticationToken
+        ) {
+          throw new Error('Dev Tools API authentication failed.');
+        }
+        return true;
+      },
     },
-    { server: httpServer, path: '/graphql' }
+    {
+      server: httpServer,
+      path: authenticationContext.graphQLEndpointPath,
+      verifyClient: info => {
+        return info.origin === authenticationContext.allowedOrigin;
+      },
+    }
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5072,6 +5072,11 @@ base64-js@^1.0.2, base64-js@^1.1.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
+base64url@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"


### PR DESCRIPTION
This patch adds four measures to limit access to the local WebSocket
API of Dev Tools.

- The WebSocket API endpoint URL now includes a secret token.
  Requests to the API without the ticket are unauthorized, for example:
  ws://localhost:19002/M2vbMDtkD-hVJGCegdw3BytRFV5JbQXPM2pLbYwgQDo/graphql
- WebSocket connections without a correct `Origin` header are rejected.
- After a connection is established, the client needs to inclue
  `clientAuthenticationToken`, another secret token.
- The HTTP server of Dev Tools is only listening connections to `localhost`.

The secret tokens are obtained from a new HTTP endpoint `/dev-tools-info`.

Thanks to Spencer von der Ohe for reporting this issue.