### PR TITLE
[xdl] Fix waiting for Expo app to be installed on the simulator

### DIFF
--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -267,7 +267,7 @@ export async function _isExpoAppInstalledOnCurrentBootedSimulatorAsync() {
   }
   let simDir = await _dirForSimulatorDevice(device.udid);
   let matches = await glob(
-    './data/Containers/Data/Application/*/Library/Caches/Snapshots/host.exp.Exponent',
+    './data/Containers/Data/Application/**/Snapshots/host.exp.Exponent{,**}',
     { cwd: simDir }
   );
 
@@ -489,11 +489,11 @@ export async function openProjectAsync(
 export async function openWebProjectAsync(
   projectRoot: string
 ): Promise<{ success: true; url: string } | { success: false; error: string }> {
-  const projectUrl = await getWebpackUrlAsync(projectRoot);  
+  const projectUrl = await getWebpackUrlAsync(projectRoot);
   if (projectUrl === null) {
-    return { 
-      success: false, 
-      error: `The web project has not been started yet`
+    return {
+      success: false,
+      error: `The web project has not been started yet`,
     };
   }
   const result = await openUrlInSimulatorSafeAsync(projectUrl, true);


### PR DESCRIPTION
Looks like in iOS13 simulators, the glob path (`./data/Containers/Data/Application/*/Library/Caches/Snapshots/host.exp.Exponent`) that we used to check whether the app has been installed is no longer working. In iOS13, the `Snapshots` directory is not under `Caches` but under `SplashBoard` directory. Also, directory whose name was a bundle identifier can now contain some other stuff (it is `host.exp.Exponent - {DEFAULT GROUP}` in my case 🤔)