### PR TITLE
Prevent prod builds from using dev flag

### DIFF
--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -466,6 +466,10 @@ async function getWebpackConfigEnvFromBundlingOptionsAsync(
   projectRoot: string,
   options: BundlingOptions
 ): Promise<Web.WebEnvironment> {
+  // Bacon: Prevent dev flag from being used in production
+  if (options.mode === 'production') {
+    options.dev = false;
+  }
   let { dev, https } = await applyOptionsToProjectSettingsAsync(projectRoot, options);
 
   const mode = typeof options.mode === 'string' ? options.mode : dev ? 'development' : 'production';


### PR DESCRIPTION
- Dev flag doesn't provide enough control for debugging a prod build.
- Persistent dev flag causes a lot of confusion