### PR TITLE
fix: respect the owner field specified in app.json

### DIFF
--- a/packages/expo-cli/src/commands/build/AndroidBuilder.js
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.js
@@ -61,7 +61,7 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
   }
 
   async _clearCredentials() {
-    const username = this.user.username;
+    const username = this.manifest.owner || this.user.username;
     const experienceName = `@${username}/${this.manifest.slug}`;
 
     const credentialMetadata = {
@@ -110,7 +110,7 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
   }
 
   async collectAndValidateCredentials() {
-    const username = this.user.username;
+    const username = this.manifest.owner || this.user.username;
     const experienceName = `@${username}/${this.manifest.slug}`;
 
     const credentialMetadata = {

--- a/packages/expo-cli/src/commands/build/AndroidBuilder.js
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.js
@@ -61,14 +61,10 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
   }
 
   async _clearCredentials() {
-    const username = this.manifest.owner || this.user.username;
-    const experienceName = `@${username}/${this.manifest.slug}`;
-
-    const credentialMetadata = {
-      username,
-      experienceName,
-      platform: ANDROID,
-    };
+    const credentialMetadata = await Credentials.getCredentialMetadataAsync(
+      this.projectDir,
+      ANDROID
+    );
 
     log.warn(
       `Clearing your Android build credentials from our build servers is a ${chalk.red(
@@ -110,14 +106,10 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
   }
 
   async collectAndValidateCredentials() {
-    const username = this.manifest.owner || this.user.username;
-    const experienceName = `@${username}/${this.manifest.slug}`;
-
-    const credentialMetadata = {
-      username,
-      experienceName,
-      platform: ANDROID,
-    };
+    const credentialMetadata = await Credentials.getCredentialMetadataAsync(
+      this.projectDir,
+      ANDROID
+    );
 
     const credentialsExist = await Credentials.credentialsExistForPlatformAsync(credentialMetadata);
 

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.js
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.js
@@ -51,9 +51,10 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
   }
 
   async prepareCredentials() {
+    const username = this.manifest.owner || this.user.username;
     const projectMetadata = {
-      username: this.user.username,
-      experienceName: `@${this.user.username}/${this.manifest.slug}`,
+      username,
+      experienceName: `@${username}/${this.manifest.slug}`,
       sdkVersion: this.manifest.sdkVersion,
       bundleIdentifier: get(this.manifest, 'ios.bundleIdentifier'),
     };

--- a/packages/expo-cli/src/commands/fetch/ios.js
+++ b/packages/expo-cli/src/commands/fetch/ios.js
@@ -8,19 +8,14 @@ import log from '../../log';
 
 async function fetchIosCerts(projectDir) {
   const {
-    args: {
-      username,
-      remotePackageName,
-      remoteFullPackageName: experienceName,
-      iosBundleIdentifier: bundleIdentifier,
-    },
+    args: { remotePackageName },
   } = await Exp.getPublishInfoAsync(projectDir);
 
   const inProjectDir = filename => path.resolve(projectDir, filename);
+  const credentialMetadata = await Credentials.getCredentialMetadataAsync(projectDir, 'ios');
+  const { experienceName } = credentialMetadata;
 
-  const credentialMetadata = { username, experienceName, platform: 'ios', bundleIdentifier };
-
-  log(`Retrieving iOS credentials for ${experienceName}`);
+  log(`Retrieving iOS credentials for ${credentialMetadata.experienceName}`);
 
   try {
     const {

--- a/packages/expo-cli/src/commands/publish-info.js
+++ b/packages/expo-cli/src/commands/publish-info.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import { Api, Project, FormData, UserManager } from '@expo/xdl';
+import { Api, Project, ProjectUtils, FormData, UserManager } from '@expo/xdl';
 import * as table from '../commands/utils/cli-table';
 
 const HORIZ_CELL_WIDTH_SMALL = 15;
@@ -36,6 +36,10 @@ export default (program: any) => {
       // TODO(ville): move request from multipart/form-data to JSON once supported by the endpoint.
       let formData = new FormData();
       formData.append('queryType', 'history');
+      let { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
+      if (exp.owner) {
+        formData.append('owner', exp.owner);
+      }
       formData.append('slug', await Project.getSlugAsync(projectDir, options));
       formData.append('version', VERSION);
       if (options.releaseChannel) {
@@ -111,6 +115,11 @@ export default (program: any) => {
 
       let formData = new FormData();
       formData.append('queryType', 'details');
+
+      let { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
+      if (exp.owner) {
+        formData.append('owner', exp.owner);
+      }
       formData.append('publishId', options.publishId);
       formData.append('slug', await Project.getSlugAsync(projectDir, options));
 

--- a/packages/expo-cli/src/commands/upload/IOSUploader.js
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.js
@@ -3,7 +3,7 @@ import pick from 'lodash/pick';
 import intersection from 'lodash/intersection';
 import chalk from 'chalk';
 
-import { Credentials, Exp, UrlUtils } from '@expo/xdl';
+import { Credentials, UrlUtils } from '@expo/xdl';
 import BaseUploader from './BaseUploader';
 import log from '../../log';
 import prompt from '../../prompt';
@@ -111,23 +111,8 @@ export default class IOSUploader extends BaseUploader {
   }
 
   async _getAppleTeamId() {
-    const publicUrl = this.options.publicUrl;
-    const {
-      args: {
-        username,
-        remoteFullPackageName: experienceName,
-        iosBundleIdentifier: bundleIdentifier,
-      },
-    } = publicUrl
-      ? await Exp.getThirdPartyInfoAsync(publicUrl)
-      : await Exp.getPublishInfoAsync(this.projectDir);
-
-    const { teamId } = await Credentials.getCredentialsForPlatform({
-      username,
-      experienceName,
-      bundleIdentifier,
-      platform: 'ios',
-    });
+    const credentialMetadata = await Credentials.getCredentialMetadataAsync(this.projectDir, 'ios');
+    const { teamId } = await Credentials.getCredentialsForPlatform(credentialMetadata);
 
     return teamId;
   }

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -184,7 +184,7 @@ export class DownloadKeystore implements IView {
   }
 
   async fetch(ctx: Context): Promise<void> {
-    const credentials = await ApiV2.clientForUser(ctx.user).getAsync(`credentials/android/@${ctx.user.username}/${ctx.manifest.slug}`);
+    const credentials = await ApiV2.clientForUser(ctx.user).getAsync(`credentials/android/@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`);
     if (credentials && credentials.keystore) {
       this.credentials = credentials.keystore;
     }

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -180,7 +180,8 @@ export class UseExistingDistributionCert implements IView {
       return null;
     }
     const experience = get(ctx, 'manifest.slug');
-    const experienceName = `@${ctx.user.username}/${experience}`;
+    const owner = get(ctx, 'manifest.owner')
+    const experienceName = `@${owner || ctx.user.username}/${experience}`;
     const bundleIdentifier = get(ctx, 'manifest.ios.bundleIdentifier');
     if (!experience || !bundleIdentifier) {
       log.error(`slug and ios.bundleIdentifier needs to be defined`);

--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -304,9 +304,12 @@ export async function getPublishInfoAsync(root: string): Promise<PublishInfo> {
     throw new Error('Attempted to login in offline mode. This is a bug.');
   }
 
-  const { username } = user;
+  let { username } = user;
 
   const { exp } = await ConfigUtils.readConfigJsonAsync(root);
+  if (exp.owner) {
+    username = exp.owner;
+  }
 
   const name = exp.slug;
   const { version, sdkVersion } = exp;

--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -307,9 +307,6 @@ export async function getPublishInfoAsync(root: string): Promise<PublishInfo> {
   let { username } = user;
 
   const { exp } = await ConfigUtils.readConfigJsonAsync(root);
-  if (exp.owner) {
-    username = exp.owner;
-  }
 
   const name = exp.slug;
   const { version, sdkVersion } = exp;

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -1,4 +1,8 @@
+import { Platform, readConfigJsonAsync } from '@expo/config';
+
 import Api from '../Api';
+
+import UserManager from '../User';
 import * as Ios from './IosCredentials';
 
 export type Credentials = Ios.Credentials; // can't import android types from typescript
@@ -11,6 +15,28 @@ export type CredentialMetadata = {
 };
 
 export { Ios };
+
+export async function getCredentialMetadataAsync(
+  projectRoot: string,
+  platform: Platform
+): Promise<CredentialMetadata> {
+  const { exp } = await readConfigJsonAsync(projectRoot);
+
+  const user = await UserManager.ensureLoggedInAsync();
+  let { username } = user;
+  if (exp.owner) {
+    username = exp.owner;
+  }
+
+  const bundleIdentifier = exp.ios ? exp.ios.bundleIdentifier : null;
+
+  return {
+    username,
+    experienceName: `@${username}/${exp.slug}`,
+    bundleIdentifier,
+    platform,
+  };
+}
 
 export async function credentialsExistForPlatformAsync(
   metadata: CredentialMetadata


### PR DESCRIPTION
Fix some cases where expo-cli commands would ignore an owner key specified in app.json