### PR TITLE
[json-file] add new line at eof when writing a json to a file

### DIFF
--- a/packages/json-file/__tests__/JsonFile-test.ts
+++ b/packages/json-file/__tests__/JsonFile-test.ts
@@ -127,3 +127,13 @@ it('Continuous updating!', async () => {
     await expect(file.readAsync()).resolves.toEqual({ i });
   }
 });
+
+it('adds a new line at the eof', async () => {
+  let filename = path.join(FIXTURES, 'test.json');
+  let file = new JsonFile(filename, { json5: true });
+  await file.writeAsync(obj1);
+  expect(fs.existsSync(filename)).toBe(true);
+  const data = await fs.readFile(filename, 'utf-8');
+  const lastChar = data[data.length - 1];
+  expect(lastChar).toEqual('\n');
+});

--- a/packages/json-file/src/JsonFile.ts
+++ b/packages/json-file/src/JsonFile.ts
@@ -32,6 +32,7 @@ type Options<TJSONObject extends JSONObject> = {
   default?: TJSONObject;
   json5?: boolean;
   space?: number;
+  addNewLineAtEOF?: boolean;
 };
 
 const DEFAULT_OPTIONS = {
@@ -41,6 +42,7 @@ const DEFAULT_OPTIONS = {
   default: undefined,
   json5: false,
   space: 2,
+  addNewLineAtEOF: true,
 };
 
 /**
@@ -172,6 +174,7 @@ async function writeAsync<TJSONObject extends JSONObject>(
 ): Promise<TJSONObject> {
   const space = _getOption(options, 'space');
   const json5 = _getOption(options, 'json5');
+  const addNewLineAtEOF = _getOption(options, 'addNewLineAtEOF');
   let json;
   try {
     if (json5) {
@@ -182,7 +185,8 @@ async function writeAsync<TJSONObject extends JSONObject>(
   } catch (e) {
     throw new JsonFileError(`Couldn't JSON.stringify object for file: ${file}`, e);
   }
-  await writeFileAtomicAsync(file, json, {});
+  const data = addNewLineAtEOF ? `${json}\n` : json;
+  await writeFileAtomicAsync(file, data, {});
   return object;
 }
 


### PR DESCRIPTION
## Why

When we update templates with new expotools, we remove new line characters from the end of package.json and app.json file. This is bad. 
https://github.com/expo/expo/pull/5679/files

## How

- I added a new line at the end of the stringified object in `writeAsync` function.
- I introduced a new option (`addNewLineAtEOF`) which makes it possible not to add a new line at EOF.
- I added a test for this feature.

## Next

Update `@expo/json-file` in expotools once published to npm.