### PR TITLE
feat: Allow custom webpack config & static dir paths

### DIFF
--- a/packages/webpack-config/src/utils/paths.ts
+++ b/packages/webpack-config/src/utils/paths.ts
@@ -55,7 +55,7 @@ export function getPossibleProjectRoot(): string {
 
 function parsePaths(
   projectRoot: string,
-  { exp: nativeAppManifest, pkg }: ConfigUtils.ExpoConfig
+  { exp: nativeAppManifest, pkg, web }: ConfigUtils.ExpoConfig
 ): FilePaths {
   const inputProjectRoot = projectRoot || getPossibleProjectRoot();
 
@@ -118,7 +118,8 @@ function parsePaths(
   const productionPath = absolute(config.web.build.output);
 
   function templatePath(filename: string = ''): string {
-    const overridePath = absolute('web', filename);
+    const staticDir = web.staticDir || 'web';
+    const overridePath = absolute(staticDir, filename);
     if (fs.existsSync(overridePath)) {
       return overridePath;
     }

--- a/packages/xdl/src/Web.ts
+++ b/packages/xdl/src/Web.ts
@@ -113,7 +113,9 @@ export async function invokeWebpackConfigAsync(
   argv?: string[]
 ): Promise<WebpackConfiguration> {
   // Check if the project has a webpack.config.js in the root.
-  const projectWebpackConfig = path.resolve(env.projectRoot, 'webpack.config.js');
+  const { exp } = await readConfigJsonAsync(env.projectRoot);
+  const webpackConfigPath = exp.web.webpackConfigPath || 'webpack.config.js';
+  const projectWebpackConfig = path.resolve(env.projectRoot, webpackConfigPath);
   let config: WebpackConfiguration;
   if (fs.existsSync(projectWebpackConfig)) {
     const webpackConfig = require(projectWebpackConfig);


### PR DESCRIPTION
Right now we can only use `webpack.config.js` and `web` directory from the project root. There is no way to use these files in other locations, e.g. in nested folders. This PR changes this behavior by allowing custom paths through `app.json`.

```json
{
  "expo": {
    ...

    "web": {
      "staticDir": "foo/static",
      "webpackConfigPath": "foo/webpack.config.js"
    }
  }
}
```