### PR TITLE
fix(xdl): Check development mode correctly for Next.js

### DIFF
--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -158,7 +158,7 @@ export async function startAsync(
     server = await startNextJsAsync({
       projectRoot,
       port: webpackServerPort,
-      dev: env.development,
+      dev: env.mode !== "production",
     });
     printSuccessMessages({
       projectRoot,


### PR DESCRIPTION
Fix https://github.com/expo/expo-cli/issues/1048.

`env.development` seems to be always `undefined`.