### PR TITLE
Fix NPM interpretation of semver ranges

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -82,6 +82,8 @@
     "commander": "2.17.1",
     "dateformat": "3.0.3",
     "delay-async": "1.2.0",
+    "detect-indent": "^6.0.0",
+    "detect-newline": "^3.0.0",
     "enquirer": "2.1.1",
     "envinfo": "5.10.0",
     "es6-error": "3.2.0",

--- a/packages/expo-cli/src/PackageManager.ts
+++ b/packages/expo-cli/src/PackageManager.ts
@@ -87,7 +87,6 @@ export class NpmPackageManager implements PackageManager {
     const specs = names.map(name => npmPackageArg(name)).filter(spec => spec.rawSpec);
     if (specs.length) {
       const pkgPath = path.join(this.options.cwd, 'package.json');
-      log(`> patching ${specs.map(spec => spec.raw).join(' ')}`);
       const pkgRaw = await fs.readFile(pkgPath, { encoding: 'utf8', flag: 'r' });
       const pkgPatched = specs.reduce((pkg, spec) => {
         if (isDev) {


### PR DESCRIPTION
This fixes #1054. Whenever the NPM package manager needs to install a dependency, it says no to [NPM's](https://github.com/npm/npm/issues/16813) [weird](https://stackoverflow.com/questions/22343224/whats-the-difference-between-tilde-and-caret-in-package-json#answer-31733623) [interpretation](https://github.com/npm/npm/issues/19585) of [semver ranges](https://nodesource.com/blog/semver-tilde-and-caret#caretisthenewnorm).

### The patch(tm)

I split my patch into two commits. The first is the actual patch in the package manager, and the second one is to keep the developer's package indentation and newlines intact. The fix in the second commit is [based on the awesome guys at semantic release](https://github.com/semantic-release/npm/issues/70), it also works fine in [`semantic-release-expo`](https://github.com/byCedric/semantic-release-expo/blob/develop/src/expo.ts#L79-L83) (had no angry issues/PRs yet).

> The second commit is actually up to you guys if you want to support it. But let's say that indentation is a "sensitive" discussion and I don't want people to get mad at Expo or me.

### AMA

#### Why did you let NPM still install the "faulty" version?
Well, the funny thing here is that _NPM actually installs the requested range_. But it saves the [user-set save prefix config](https://github.com/npm/npmconf/blob/master/config-defs.js#L207) (defaults to `^`) to the `package.json`. So instead of manually patching _all dependencies_, I tried to be less intrusive and only patch the ones with a specific range (like `npm install --save react-native-gesture-handler@~1.3.0`).

<details>
<summary>You can validate the version being installed with these set of commands.</summary>

```bash
$ npm init
// spam enter for some time
$ npm install --save lodash@~3.9.0

// lodash 3.9.3 (last 3.9.x) should be installed now
$ npm list lodash

// check if npm saves "that" version too, its not but check it anyways
$ cat package.json | grep lodash

// spoiler: yes, it's `^3.9.3`, the caret is wrong, but the version itself is correct (last 3.9.x)
```
</details>

#### Why didn't you just run `npm config set save-prefix="~"` or `=""`?
Well, I tried that, it failed. Not because the code failed, but setting it to `=""` defaulted back to carets... Yes, you can run `save-prefix="~"` and force all dependencies installed to carets. But that's also messing up version specified with carets. 🙃

#### Why do you care about indentation/newlines?
Again, this is totally up to you if you want it or not. Personally, I like to not-overwrite or force a specific format to all devs. [I'm one of those devs which you can call "tabbers"](https://tabs.sexy), so I prefer tabs. But others prefer an indentation of 2, 3, 4 or even 8 spaces. It's not up to me to judge about that I think.