### PR TITLE
fix(dev-tools): fix publish failing when "optimize assets" is selected

### DIFF
--- a/packages/expo-cli/src/commands/optimize.ts
+++ b/packages/expo-cli/src/commands/optimize.ts
@@ -32,10 +32,10 @@ export async function action(projectDir = './', options: Options = {}) {
   const optimizeOptions = await Project.optimizeAsync(projectDir, optimizationOptions);
 }
 
-function parseQuality(options: Options): number {
+function parseQuality(options: Options): number | undefined {
   const defaultQuality = 80;
   if (options.quality == null) {
-    return defaultQuality;
+    return undefined;
   }
   const quality = Number(options.quality);
   if (!(Number.isInteger(quality) && quality > 0 && quality <= 100)) {

--- a/packages/xdl/src/AssetUtils.ts
+++ b/packages/xdl/src/AssetUtils.ts
@@ -36,7 +36,7 @@ export async function optimizeImageAsync(inputPath: string, quality: number): Pr
 }
 
 export type OptimizationOptions = {
-  quality: number;
+  quality?: number;
   include?: string;
   exclude?: string;
   save?: boolean;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2264,7 +2264,7 @@ export async function getUrlAsync(projectRoot: string, options: object = {}): Pr
 
 export async function optimizeAsync(
   projectRoot: string = './',
-  options: AssetUtils.OptimizationOptions
+  options: AssetUtils.OptimizationOptions = {}
 ): Promise<void> {
   logger.global.info(chalk.green('Optimizing assets...'));
 
@@ -2288,7 +2288,8 @@ export async function optimizeAsync(
     delete assetInfo[outdatedHash];
   });
 
-  const { quality, include, exclude, save } = options;
+  const { include, exclude, save } = options;
+  const quality = options.quality == null ? 80 : options.quality;
 
   const images = include || exclude ? selectedFiles : allFiles;
   for (const image of images) {


### PR DESCRIPTION
Not passing an options object caused an error in `Project.optimizeAsync`.

Changed the quality option to be non-mandatory so that the default needs to be defined in just one place and made the options object optional.