### PR TITLE
chore: bump lodash from 4.17.11 to 4.17.15

### DIFF
--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -27,7 +27,7 @@
     "graphql": "0.13.2",
     "graphql-tools": "3.0.0",
     "iterall": "1.2.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "subscriptions-transport-ws": "0.9.8"
   },
   "peerDependencies": {

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -95,7 +95,7 @@
     "inflection": "^1.12.0",
     "inquirer": "5.2.0",
     "klaw-sync": "6.0.0",
-    "lodash": "4.17.11",
+    "lodash": "4.17.15",
     "match-require": "2.1.0",
     "npm-package-arg": "6.1.0",
     "open": "6.3.0",

--- a/packages/json-file/package.json
+++ b/packages/json-file/package.json
@@ -32,7 +32,7 @@
     "@babel/code-frame": "^7.0.0-beta.44",
     "fs-extra": "^8.0.1",
     "json5": "^1.0.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "util.promisify": "^1.0.0",
     "write-file-atomic": "^2.3.0"
   },

--- a/packages/schemer/package.json
+++ b/packages/schemer/package.json
@@ -33,7 +33,7 @@
     "ajv": "^5.2.2",
     "es6-error": "^4.0.2",
     "json-schema-traverse": "0.3.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "probe-image-size": "^3.1.0",
     "read-chunk": "^3.2.0"
   },

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -64,7 +64,7 @@
     "invariant": "2.2.4",
     "joi": "14.0.4",
     "latest-version": "5.1.0",
-    "lodash": "4.17.11",
+    "lodash": "4.17.15",
     "md5hex": "1.0.0",
     "minimatch": "3.0.4",
     "minipass": "2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12862,12 +12862,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@4.x, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
-lodash@^4.17.12:
+lodash@4.17.15, lodash@4.x, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
See https://www.npmjs.com/advisories/1065

## What I did

Updated to the latest published Lodash version. I could've just bumped to `^4.17.12` as per the advisory, but figured I might as well use the latest version. Although `^4.17.11` does allow the installation of newer non-vulnerable versions, `4.17.11` satisfies that version range and seems to cause `Snyk` to produce warnings.