### PR TITLE
fix(xdl): detect LAN IP from default gateway

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -61,6 +61,7 @@
     "idx": "2.4.0",
     "indent-string": "3.2.0",
     "inquirer": "5.2.0",
+    "internal-ip": "4.3.0",
     "invariant": "2.2.4",
     "joi": "14.0.4",
     "latest-version": "5.1.0",

--- a/packages/xdl/src/ip.ts
+++ b/packages/xdl/src/ip.ts
@@ -1,55 +1,7 @@
-import os from 'os';
-
-type IpFamily = 'IPv4' | 'IPv6';
-
-function priority(name: string) {
-  if (name.startsWith('en') || name.startsWith('eth')) {
-    return 0;
-  }
-  if (name.startsWith('wlan')) {
-    return 1;
-  }
-
-  return 2;
-}
-
-function isLoopback(addr: string) {
-  return (
-    /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-    /^fe80::1$/.test(addr) ||
-    /^::1$/.test(addr) ||
-    /^::$/.test(addr)
-  );
-}
-
-function loopback(family: IpFamily = 'IPv4') {
-  if (family === 'IPv4') {
-    return '127.0.0.1';
-  } else if (family === 'IPv6') {
-    return 'fe80::1';
-  } else {
-    throw new Error('IP family must be IPv4 or IPv6');
-  }
-}
-
-function address(family: IpFamily = 'IPv4') {
-  const interfaces = os.networkInterfaces();
-  const sortedInterfaces = Object.keys(interfaces).sort(function(a, b) {
-    return priority(a) - priority(b);
-  });
-
-  const all = sortedInterfaces
-    .map(function(nic) {
-      const addresses = interfaces[nic].filter(
-        details => details.family === family && !isLoopback(details.address)
-      );
-      return addresses.length ? addresses[0].address : undefined;
-    })
-    .filter(Boolean);
-
-  return all.length ? all[0] : loopback(family);
-}
+import internalIp from 'internal-ip';
 
 export default {
-  address,
+  address() {
+    return internalIp.v4.sync() || '127.0.0.1';
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10050,7 +10050,7 @@ inquirer@^6.2.0, inquirer@^6.2.2:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
-internal-ip@^4.0.0:
+internal-ip@4.3.0, internal-ip@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
   integrity sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==


### PR DESCRIPTION
This should fix many problems related to showing the wrong
IP address (e.g. Docker, VMWare or Virtualbox network interface).

Using the `internal-ip` module, we choose the network interface that has
the same subnet as the default gateway.

See #712.