### PR TITLE
fix: EADDRINUSE when running Expo CLI in two projects at the same time

### DIFF
--- a/packages/babel-preset-cli/ts-declarations/freeport-async/index.d.ts
+++ b/packages/babel-preset-cli/ts-declarations/freeport-async/index.d.ts
@@ -1,4 +1,8 @@
 declare module 'freeport-async' {
-  function freePortAsync(rangeStart: number): Promise<number>;
+  interface FreePortOptions {
+    hostnames?: Array<string | null>;
+  }
+
+  function freePortAsync(rangeStart: number, options?: FreePortOptions): Promise<number>;
   export = freePortAsync;
 }

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -23,7 +23,7 @@
     "@expo/config": "^2.2.0",
     "base64url": "3.0.1",
     "express": "4.16.4",
-    "freeport-async": "1.1.1",
+    "freeport-async": "2.0.0",
     "graphql": "0.13.2",
     "graphql-tools": "3.0.0",
     "iterall": "1.2.2",

--- a/packages/dev-tools/server/DevToolsServer.js
+++ b/packages/dev-tools/server/DevToolsServer.js
@@ -49,7 +49,7 @@ export async function createAuthenticationContextAsync({ port }) {
 }
 
 export async function startAsync(projectDir) {
-  const port = await freeportAsync(19002);
+  const port = await freeportAsync(19002, { hostnames: [null, 'localhost'] });
   const server = express();
 
   const authenticationContext = await createAuthenticationContextAsync({ port });

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -50,7 +50,7 @@
     "es6-error": "4.1.1",
     "express": "4.16.4",
     "form-data": "2.3.2",
-    "freeport-async": "1.1.1",
+    "freeport-async": "2.0.0",
     "fs-extra": "6.0.1",
     "getenv": "0.7.0",
     "glob": "7.1.2",

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -198,7 +198,7 @@ async function _assertValidProjectRoot(projectRoot: string) {
 }
 
 async function _getFreePortAsync(rangeStart: number) {
-  let port = await freeportAsync(rangeStart);
+  let port = await freeportAsync(rangeStart, { hostnames: [null, 'localhost'] });
   if (!port) {
     throw new XDLError('NO_PORT_FOUND', 'No available port found');
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8528,10 +8528,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-freeport-async@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/freeport-async/-/freeport-async-1.1.1.tgz#5c8cf4fc1aba812578317bd4d7a1e5597baf958e"
-  integrity sha1-XIz0/Bq6gSV4MXvU16HlWXuvlY4=
+freeport-async@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/freeport-async/-/freeport-async-2.0.0.tgz#6adf2ec0c629d11abff92836acd04b399135bab4"
+  integrity sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==
 
 fresh@0.5.2:
   version "0.5.2"


### PR DESCRIPTION
Fixes #1097.

Blocked on https://github.com/expo/freeport-async/pull/3 to be merged and published.