### PR TITLE
default sdkVersion to expo package version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,14 @@ workflows:
           e: node-10
           requires:
             - build10
+      - test-config:
+          e: node-12
+          requires:
+            - build12
+      - test-config:
+          e: node-10
+          requires:
+            - build10
       - test-json-file:
           e: node-12
           requires:
@@ -128,6 +136,16 @@ jobs:
         type: executor
     executor: << parameters.e >>
     working_directory: ~/expo-cli/packages/dev-tools
+    steps:
+      - attach_workspace:
+          at: '~'
+      - run: yarn test
+  test-config:
+    parameters:
+      e:
+        type: executor
+    executor: << parameters.e >>
+    working_directory: ~/expo-cli/packages/config
     steps:
       - attach_workspace:
           at: '~'

--- a/packages/config/babel.config.js
+++ b/packages/config/babel.config.js
@@ -1,0 +1,11 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    // Only use this when running tests
+    env: {
+      test: {
+        presets: ['@expo/babel-preset-cli'],
+      },
+    },
+  };
+};

--- a/packages/config/jest.config.js
+++ b/packages/config/jest.config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+module.exports = {
+  displayName: require('./package.json').name,
+  testRegex: '/__tests__/.*(test|spec)\\.(j|t)sx?$',
+  moduleNameMapper: {
+    '^jest/(.*)': path.join(__dirname, '../../jest/$1'),
+  },
+  testEnvironment: 'node',
+  resetModules: false,
+};

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rm -rf build ./tsconfig.tsbuildinfo",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -501,6 +501,14 @@ export function readConfigJson(
     exp.version = pkg.version;
   }
 
+  if (exp && !exp.sdkVersion) {
+    try {
+      const packageJsonPath = resolveModule('expo/package.json', projectRoot, exp);
+      const expoPackageJson = require(packageJsonPath);
+      exp.sdkVersion = expoPackageJson.version;
+    } catch (_) {}
+  }
+
   if (exp && !exp.platforms) {
     exp.platforms = ['android', 'ios'];
   }
@@ -553,6 +561,14 @@ export async function readConfigJsonAsync(
 
   if (exp && !exp.version) {
     exp.version = pkg.version;
+  }
+
+  if (exp && !exp.sdkVersion) {
+    try {
+      const packageJsonPath = resolveModule('expo/package.json', projectRoot, exp);
+      const expoPackageJson = require(packageJsonPath);
+      exp.sdkVersion = expoPackageJson.version;
+    } catch (_) {}
   }
 
   if (exp && !exp.platforms) {

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -1,0 +1,14 @@
+export type PackageJSONConfig = { [key: string]: any };
+export type ProjectConfig = { exp: ExpoConfig; pkg: PackageJSONConfig; rootConfig: AppJSONConfig };
+export type AppJSONConfig = { expo: ExpoConfig; [key: string]: any };
+export type BareAppConfig = { name: string; displayName: string; [key: string]: any };
+export type ExpoConfig = {
+  name?: string;
+  slug?: string;
+  sdkVersion?: string;
+  platforms?: Array<Platform>;
+  nodeModulesPath?: string;
+  [key: string]: any;
+};
+export type ExpRc = { [key: string]: any };
+export type Platform = 'android' | 'ios' | 'web';

--- a/packages/config/src/Modules.ts
+++ b/packages/config/src/Modules.ts
@@ -26,7 +26,6 @@ export function projectHasModule(
   }
 }
 
-// TODO: Bacon: Unit test
 export function moduleNameFromPath(modulePath: string): string {
   if (modulePath.startsWith('@')) {
     const [org, packageName] = modulePath.split('/');

--- a/packages/config/src/Modules.ts
+++ b/packages/config/src/Modules.ts
@@ -1,0 +1,40 @@
+import resolveFrom from 'resolve-from';
+
+import { ExpoConfig } from './Config.types';
+
+export function resolveModule(request: string, projectRoot: string, exp: ExpoConfig): string {
+  const fromDir = exp.nodeModulesPath ? exp.nodeModulesPath : projectRoot;
+  return resolveFrom(fromDir, request);
+}
+
+// TODO: Bacon: E2E test
+export function projectHasModule(
+  modulePath: string,
+  projectRoot: string,
+  exp: ExpoConfig
+): string | false {
+  try {
+    return resolveModule(modulePath, projectRoot, exp);
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      const moduleName = moduleNameFromPath(modulePath);
+      if (error.message.includes(moduleName)) {
+        return false;
+      }
+    }
+    throw error;
+  }
+}
+
+// TODO: Bacon: Unit test
+export function moduleNameFromPath(modulePath: string): string {
+  if (modulePath.startsWith('@')) {
+    const [org, packageName] = modulePath.split('/');
+    if (org && packageName) {
+      return [org, packageName].join('/');
+    }
+    return modulePath;
+  }
+  const [packageName] = modulePath.split('/');
+  return packageName ? packageName : modulePath;
+}

--- a/packages/config/src/__tests__/Modules-test.js
+++ b/packages/config/src/__tests__/Modules-test.js
@@ -1,0 +1,14 @@
+import { moduleNameFromPath } from '../Modules';
+
+describe('moduleNameFromPath', () => {
+  it(`returns the module name from a path`, () => {
+    expect(moduleNameFromPath('foo/bar/expo.js')).toBe('foo');
+    expect(moduleNameFromPath('foo')).toBe('foo');
+  });
+  it(`returns the module name from a path with org`, () => {
+    expect(moduleNameFromPath('@myorg/somn/bar/expo.js')).toBe('@myorg/somn');
+  });
+  it(`returns the org name if the package is missing`, () => {
+    expect(moduleNameFromPath('@myorg')).toBe('@myorg');
+  });
+});

--- a/packages/schemer/__tests__/files/schema.json
+++ b/packages/schemer/__tests__/files/schema.json
@@ -470,10 +470,6 @@
       }
     },
     "additionalProperties": false,
-    "required": [
-      "name",
-      "slug",
-      "sdkVersion"
-    ]
+    "required": []
   }
 }

--- a/packages/schemer/__tests__/test.js
+++ b/packages/schemer/__tests__/test.js
@@ -36,7 +36,7 @@ describe('Holistic Unit Test', () => {
     } catch (e) {
       console.log(e);
       expect(e).toBeTruthy();
-      expect(e.errors.length).toBe(5);
+      expect(e.errors.length).toBe(4);
     }
   });
 });

--- a/packages/webpack-config/src/utils/Diagnosis.ts
+++ b/packages/webpack-config/src/utils/Diagnosis.ts
@@ -138,7 +138,7 @@ function setDeepValue(pathComponents: string[], object: { [key: string]: any }, 
 async function logAutoConfigValuesAsync(env: Environment) {
   const locations = env.locations || (await getPathsAsync(env.projectRoot));
 
-  const { exp: config } = readConfigJson(env.projectRoot);
+  const { exp: config } = readConfigJson(env.projectRoot, true, true);
 
   const standardConfig = ensurePWAConfig({}, locations.absolute, {
     templateIcon: locations.template.get('icon.png'),

--- a/packages/webpack-config/src/utils/__tests__/__snapshots__/getConfigAsync-test.js.snap
+++ b/packages/webpack-config/src/utils/__tests__/__snapshots__/getConfigAsync-test.js.snap
@@ -12,6 +12,7 @@ Object {
     "supportsTablet": true,
   },
   "name": "basic",
+  "nodeModulesPath": "tests/basic/package.json",
   "orientation": "portrait",
   "platforms": Array [
     "ios",

--- a/packages/webpack-config/src/utils/paths.ts
+++ b/packages/webpack-config/src/utils/paths.ts
@@ -118,7 +118,7 @@ function parsePaths(projectRoot: string, nativeAppManifest?: ExpoConfig): FilePa
 }
 
 export function getEntryPoint(projectRoot: string): string | null {
-  const { exp, pkg } = readConfigJson(projectRoot, true);
+  const { exp, pkg } = readConfigJson(projectRoot, true, true);
 
   /**
    *  The main file is resolved like so:
@@ -145,20 +145,20 @@ export function getEntryPoint(projectRoot: string): string | null {
 }
 
 export function getPaths(projectRoot: string): FilePaths {
-  const { exp } = readConfigJson(projectRoot, true);
+  const { exp } = readConfigJson(projectRoot, true, true);
   return parsePaths(projectRoot, exp);
 }
 
 export async function getPathsAsync(projectRoot: string): Promise<FilePaths> {
   let exp;
   try {
-    exp = (await readConfigJsonAsync(projectRoot, true)).exp;
+    exp = (await readConfigJsonAsync(projectRoot, true, true)).exp;
   } catch (error) {}
   return parsePaths(projectRoot, exp);
 }
 
 export function getServedPath(projectRoot: string): string {
-  const { pkg } = readConfigJson(projectRoot, true);
+  const { pkg } = readConfigJson(projectRoot, true, true);
   const envPublicUrl = process.env.WEB_PUBLIC_URL;
 
   // We use `WEB_PUBLIC_URL` environment variable or "homepage" field to infer
@@ -202,6 +202,6 @@ export function getPublicPaths({
 }
 
 export function getProductionPath(projectRoot: string): string {
-  const { exp, pkg } = readConfigJson(projectRoot, true);
+  const { exp } = readConfigJson(projectRoot, true, true);
   return getAbsolutePathWithProjectRoot(projectRoot, getWebOutputPath(exp));
 }

--- a/packages/xdl/src/Env.ts
+++ b/packages/xdl/src/Env.ts
@@ -13,3 +13,7 @@ export function isStaging(): boolean {
 export function isLocal(): boolean {
   return getenv.boolish('EXPO_LOCAL', false);
 }
+
+export function skipManifestValidation(): boolean {
+  return !!getenv.string('EXPO_SKIP_MANIFEST_VALIDATION_TOKEN');
+}

--- a/packages/xdl/src/Env.ts
+++ b/packages/xdl/src/Env.ts
@@ -14,6 +14,6 @@ export function isLocal(): boolean {
   return getenv.boolish('EXPO_LOCAL', false);
 }
 
-export function skipManifestValidation(): boolean {
+export function maySkipManifestValidation(): boolean {
   return !!getenv.string('EXPO_SKIP_MANIFEST_VALIDATION_TOKEN');
 }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1672,9 +1672,20 @@ export async function startReactNativeServerAsync(
 
   let packagerPort = await _getFreePortAsync(19001); // Create packager options
 
+  let customLogReporterPath: string | undefined;
+
+  const possibleLogReporterPath = ConfigUtils.projectHasModule('expo/tools/LogReporter', projectRoot, exp);
+  if (possibleLogReporterPath) {
+    customLogReporterPath = possibleLogReporterPath;
+  } else {
+    // TODO: Bacon: Prompt to install expo?
+    logger.global.warn(`Expo is not installed: Using default reporter to format logs.`);
+  }
+
+
   let packagerOpts: { [key: string]: any } = {
     port: packagerPort,
-    customLogReporterPath: ConfigUtils.resolveModule('expo/tools/LogReporter', projectRoot, exp),
+    customLogReporterPath,
     assetExts: ['ttf'],
     sourceExts: ['expo.js', 'expo.ts', 'expo.tsx', 'expo.json', 'js', 'json', 'ts', 'tsx'],
     nonPersistent: !!options.nonPersistent,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -42,7 +42,7 @@ import Config from './Config';
 import * as ExponentTools from './detach/ExponentTools';
 import StandaloneContext from './detach/StandaloneContext';
 import * as DevSession from './DevSession';
-import { skipManifestValidation } from './Env';
+import { maySkipManifestValidation } from './Env';
 import { ErrorCode } from './ErrorCode';
 import * as Exp from './Exp';
 import logger from './Logger';
@@ -1009,7 +1009,7 @@ async function _getPublishExpConfigAsync(
   }
 
   // Only allow projects to be published with UNVERSIONED if a correct token is set in env
-  if (sdkVersion === 'UNVERSIONED' && !skipManifestValidation()) {
+  if (sdkVersion === 'UNVERSIONED' && !maySkipManifestValidation()) {
     throw new XDLError('INVALID_OPTIONS', 'Cannot publish with sdkVersion UNVERSIONED.');
   }
   exp.locales = await ExponentTools.getResolvedLocalesAsync(exp);


### PR DESCRIPTION
If the `sdkVersion` is not defined in the `app.json` then we should attempt to read it from the installed `expo` version.