### PR TITLE
[cli] Tidy and unify command strings

### DIFF
--- a/packages/expo-cli/src/commands/android.ts
+++ b/packages/expo-cli/src/commands/android.ts
@@ -8,7 +8,7 @@ async function action(projectDir: string) {
 export default function(program: Command) {
   program
     .command('android [project-dir]')
-    .description('Opens your app in Expo on a connected Android device')
+    .description('Opens your app in the Expo client on a connected Android device.')
     .allowOffline()
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/build/index.js
+++ b/packages/expo-cli/src/commands/build/index.js
@@ -26,30 +26,27 @@ export default (program: any) => {
       'Revoke credentials on developer.apple.com, select appropriate using --clear-* options.'
     )
     .option(
-      '--apple-id <login>',
-      'Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable).'
+      '--apple-id [id]',
+      'Apple ID username. Set your Apple ID password as EXPO_APPLE_PASSWORD env variable.'
     )
     .option(
-      '-t --type <build>',
-      'Type of build: [archive|simulator].',
+      '-t --type [type]',
+      'Select the type of build: [archive or simulator]',
       /^(archive|simulator)$/i,
       'archive'
     )
-    .option('--release-channel <channel-name>', 'Pull from specified release channel.', 'default')
-    .option('--no-publish', 'Disable automatic publishing before building.')
+    .option('--release-channel [channel]', 'Pull bundle from specified release channel.', 'default')
+    .option('--no-publish', 'Prevents an OTA update from occurring during the build process.')
     .option('--no-wait', 'Exit immediately after scheduling build.')
-    .option('--team-id <apple-teamId>', 'Apple Team ID.')
+    .option('--team-id [id]', 'Apple Team ID.')
     .option(
-      '--dist-p12-path <dist.p12>',
-      'Path to your Distribution Certificate P12 (set password as EXPO_IOS_DIST_P12_PASSWORD environment variable).'
+      '--dist-p12-path [path]',
+      'Path to your Distribution Certificate. Set password as EXPO_IOS_DIST_P12_PASSWORD env variable.'
     )
-    .option('--push-id <push-id>', 'Push Key ID (ex: 123AB4C56D).')
-    .option('--push-p8-path <push.p12>', 'Path to your Push Key .p8 file.')
-    .option('--provisioning-profile-path <.mobileprovision>', 'Path to your Provisioning Profile.')
-    .option(
-      '--public-url <url>',
-      'The URL of an externally hosted manifest (for self-hosted apps).'
-    )
+    .option('--push-id [id]', 'Push Notification Key. Ex: 123AB4C56D')
+    .option('--push-p8-path [path]', 'Path to your Push Notification Key .p8 file.')
+    .option('--provisioning-profile-path [path]', 'Path to your Provisioning Profile.')
+    .option('--public-url [url]', 'The url of an externally hosted manifest for self-hosted apps.')
     .description(
       'Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.'
     )
@@ -80,13 +77,18 @@ export default (program: any) => {
     .command('build:android [project-dir]')
     .alias('ba')
     .option('-c, --clear-credentials', 'Clear stored credentials.')
-    .option('--release-channel <channel-name>', 'Pull from specified release channel.', 'default')
-    .option('--no-publish', 'Disable automatic publishing before building.')
+    .option('--release-channel [channel]', 'Pull bundle from specified release channel.', 'default')
+    .option('--no-publish', 'Prevents an OTA update from occurring during the build process.')
     .option('--no-wait', 'Exit immediately after triggering build.')
-    .option('--keystore-path <app.jks>', 'Path to your Keystore.')
-    .option('--keystore-alias <alias>', 'Keystore Alias')
-    .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
-    .option('-t --type <build>', 'Type of build: [app-bundle|apk].', /^(app-bundle|apk)$/i, 'apk')
+    .option('--keystore-path [path]', 'Path to your Keystore .jks file.')
+    .option('--keystore-alias [alias]', 'Keystore Alias')
+    .option('--public-url [url]', 'The url of an externally hosted manifest for self-hosted apps.')
+    .option(
+      '-t --type [type]',
+      'Select the type of build: [app-bundle|apk].',
+      /^(app-bundle|apk)$/i,
+      'apk'
+    )
     .description(
       'Build a standalone APK or App Bundle for your project, signed and ready for submission to the Google Play Store.'
     )
@@ -127,10 +129,7 @@ export default (program: any) => {
   program
     .command('build:status [project-dir]')
     .alias('bs')
-    .option(
-      '--public-url <url>',
-      'The URL of an externally hosted manifest (for self-hosted apps).'
-    )
+    .option('--public-url [url]', 'The url of an externally hosted manifest for self-hosted apps.')
     .description(`Gets the status of a current (or most recently finished) build for your project.`)
     .asyncActionProjectDir(async (projectDir, options) => {
       if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {

--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -13,8 +13,8 @@ async function action(projectDir: string, options: Options) {
 export default function(program: Command) {
   program
     .command('bundle-assets [project-dir]')
-    .option('--dest [dest]', 'Destination directory for assets')
-    .option('--platform [platform]', 'detached project platform')
+    .option('--dest [dir]', 'Destination directory for assets')
+    .option('--platform [platform]', 'Detached project platform')
     .description(
       'Bundles assets for a detached app. This command should be executed from xcode or gradle.'
     )

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -27,8 +27,8 @@ export default program => {
   program
     .command('client:ios [project-dir]')
     .option(
-      '--apple-id <login>',
-      'Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable).'
+      '--apple-id [username]',
+      'Apple ID username. Set your Apple ID password as EXPO_APPLE_PASSWORD env variable.'
     )
     .description(
       'Build a custom version of the Expo Client for iOS using your own Apple credentials and install it on your mobile device using Safari.'
@@ -242,7 +242,7 @@ export default program => {
 
   program
     .command('client:install:ios')
-    .description('Install the latest version of Expo Client for iOS on the simulator')
+    .description('Install the latest version of Expo client for iOS on the simulator.')
     .asyncAction(async () => {
       if (await Simulator.upgradeExpoAsync()) {
         log('Done!');
@@ -252,7 +252,7 @@ export default program => {
   program
     .command('client:install:android')
     .description(
-      'Install the latest version of Expo Client for Android on a connected device or emulator'
+      'Install the latest version of Expo client for Android on a connected device or emulator.'
     )
     .asyncAction(async () => {
       if (await Android.upgradeExpoAsync()) {

--- a/packages/expo-cli/src/commands/credentials.ts
+++ b/packages/expo-cli/src/commands/credentials.ts
@@ -12,8 +12,8 @@ type Options = {
 export default function (program: CommanderStatic) {
   program
     .command('credentials:manager')
-    .description('Manage your credentials')
-    .option('-p --platform <platform>', 'Platform: [android|ios]', /^(android|ios)$/i)
+    .description('Manage your iOS or Android credentials.')
+    .option('-p --platform [platform]', 'Select platform [android or ios]', /^(android|ios)$/i)
     .asyncAction(async (options: Options) => {
       const projectDir = process.cwd();
       const context = new Context();

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -142,7 +142,7 @@ export default function(program: Command) {
   program
     .command('customize:web [project-dir]')
     .description('Generate static web files into your project.')
-    .option('-f, --force', 'Allows replacing existing files')
+    .option('-f, --force', 'Allows replacing existing files.')
     .allowOffline()
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/commands/diagnostics.js
+++ b/packages/expo-cli/src/commands/diagnostics.js
@@ -20,6 +20,6 @@ async function action(options) {
 export default program => {
   program
     .command('diagnostics [project-dir]')
-    .description('Prints environment info to console.')
+    .description('Prints environment info to the console.')
     .asyncAction(action);
 };

--- a/packages/expo-cli/src/commands/export.js
+++ b/packages/expo-cli/src/commands/export.js
@@ -152,15 +152,11 @@ export default (program: any) => {
   program
     .command('export [project-dir]')
     .description('Exports the static files of the app for hosting it on a web server.')
-    .option('-p, --public-url <url>', 'The public url that will host the static files. (Required)')
+    .option('-p, --public-url [url]', 'The public url that will host the static files. (Required)')
+    .option('--output-dir [dir]', 'The directory to export the static files to.', 'dist')
     .option(
-      '--output-dir <dir>',
-      'The directory to export the static files to. Default directory is `dist`',
-      'dist'
-    )
-    .option(
-      '-a, --asset-url <url>',
-      "The absolute or relative url that will host the asset files. Default is './assets', which will be resolved against the public-url.",
+      '-a, --asset-url [url]',
+      "The absolute or relative url that will host the asset files. Defaults to './assets', which will be resolved against the public-url.",
       './assets'
     )
     .option('-d, --dump-assetmap', 'Dump the asset map for further processing.')

--- a/packages/expo-cli/src/commands/generate-module.js
+++ b/packages/expo-cli/src/commands/generate-module.js
@@ -4,8 +4,8 @@ export default program => {
   program
     .command('generate-module [new-module-project]')
     .option(
-      '--template [localTemplateDirectory]',
-      'Local directory or npm package containing template for universal Expo module'
+      '--template [dir]',
+      'Local directory or npm package containing template for universal Expo module.'
     )
     .description(
       'Generate a universal module for Expo from a template in [new-module-project] directory.'

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -404,11 +404,11 @@ export default function(program: Command) {
     )
     .option(
       '-t, --template [name]',
-      'Specify which template to use. Valid options are "blank", "tabs", "bare-minimum" or any npm package that includes an Expo project template.'
+      'Specify which template to use. Options: "blank", "tabs", "bare-minimum" or any npm package that includes an Expo project template.'
     )
-    .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
-    .option('--yarn', 'Use Yarn to install dependencies. (default when Yarn is installed)')
-    .option('--workflow [name]', '(Deprecated) The workflow to use. managed (default) or advanced')
+    .option('--npm', 'Use npm to install dependencies. Used by default when Yarn is not installed.')
+    .option('--yarn', 'Use Yarn to install dependencies. Used by default when Yarn is installed.')
+    .option('--workflow [name]', '(Deprecated) The workflow to use. managed (default) or advanced.')
     .option('--name [name]', 'The name of your app visible on the home screen.')
     .option('--android-package [name]', 'The package name for your Android app.')
     .option('--ios-bundle-identifier [name]', 'The bundle identifier for your iOS app.')

--- a/packages/expo-cli/src/commands/install.js
+++ b/packages/expo-cli/src/commands/install.js
@@ -79,8 +79,11 @@ export default program => {
   program
     .command('install [packages...]')
     .alias('add')
-    .option('--npm', 'Use npm to install dependencies. (default when package-lock.json exists)')
-    .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
+    .option(
+      '--npm',
+      'Use npm to install dependencies. Used by default when package-lock.json exists.'
+    )
+    .option('--yarn', 'Use Yarn to install dependencies. Used by default when yarn.lock exists.')
     .description('Installs a unimodule or other package to a project.')
     .asyncAction(installAsync);
 };

--- a/packages/expo-cli/src/commands/ios.ts
+++ b/packages/expo-cli/src/commands/ios.ts
@@ -8,7 +8,7 @@ async function action(projectDir: string) {
 export default function(program: Command) {
   program
     .command('ios [project-dir]')
-    .description('Opens your app in Expo in an iOS simulator on your computer')
+    .description('Opens your app in the Expo client in an iOS simulator on your computer')
     .allowOffline()
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/ios.ts
+++ b/packages/expo-cli/src/commands/ios.ts
@@ -8,7 +8,7 @@ async function action(projectDir: string) {
 export default function(program: Command) {
   program
     .command('ios [project-dir]')
-    .description('Opens your app in the Expo client in an iOS simulator on your computer')
+    .description('Opens your app in the Expo client in an iOS simulator on your computer.')
     .allowOffline()
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/login.ts
+++ b/packages/expo-cli/src/commands/login.ts
@@ -6,8 +6,8 @@ export default function(program: Command) {
   program
     .command('login')
     .alias('signin')
-    .description('Login with your Expo account')
-    .option('-u, --username [string]', 'Username')
-    .option('-p, --password [string]', 'Password')
+    .description('Log in with your Expo account.')
+    .option('-u, --username [username]', 'Expo username.')
+    .option('-p, --password [password]', 'Expo password.')
     .asyncAction(login);
 }

--- a/packages/expo-cli/src/commands/logout.ts
+++ b/packages/expo-cli/src/commands/logout.ts
@@ -15,6 +15,6 @@ async function action() {
 export default function(program: Command) {
   program
     .command('logout')
-    .description('Logout from your Expo account')
+    .description('Log out from your Expo account.')
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/commands/opt-into-google-play-signing.js
+++ b/packages/expo-cli/src/commands/opt-into-google-play-signing.js
@@ -6,7 +6,7 @@ export default (program: any) => {
   program
     .command('opt-in-google-play-signing [project-dir]')
     .description(
-      'Switch from the old method of signing APKs to the new App Signing by Google Play. The APK will be signed with an upload key and after uploading it to the store, app will be re-signed with the key from the original keystore.'
+      'Switch from the old method of signing APKs to the new App Signing by Google Play. The APK will be signed with an upload key and after its uploaded it to the store, the app will be re-signed with the key from the original keystore.'
     )
     .asyncActionProjectDir(async (projectDir: string) => {
       const optInProcess = new AppSigningOptInProcess(projectDir);

--- a/packages/expo-cli/src/commands/optimize.ts
+++ b/packages/expo-cli/src/commands/optimize.ts
@@ -48,19 +48,19 @@ export default function(program: Command) {
   program
     .command('optimize [project-dir]')
     .alias('o')
-    .description('Compress the assets in your Expo project')
-    .option('-s, --save', 'Save the original assets with a .orig extension')
+    .description('Compress the assets in your Expo project.')
+    .option('-s, --save', 'Saves the original assets with a .orig file extension.')
     .option(
-      '--quality [number]',
-      'Specify the quality the compressed image is reduced to. Default is 80'
+      '--quality [num]',
+      'Specify the quality the compressed image is reduced to. Default: 80'
     )
     .option(
       '--include [pattern]',
-      'Include only assets that match this glob pattern relative to the project root'
+      'Include only assets that match this glob pattern relative to the project root.'
     )
     .option(
       '--exclude [pattern]',
-      'Exclude all assets that match this glob pattern relative to the project root'
+      'Exclude all assets that match this glob pattern relative to the project root.'
     )
     .allowOffline()
     .asyncAction(action);

--- a/packages/expo-cli/src/commands/prepare-detached-build.js
+++ b/packages/expo-cli/src/commands/prepare-detached-build.js
@@ -7,8 +7,8 @@ async function action(projectDir, options) {
 export default program => {
   program
     .command('prepare-detached-build [project-dir]')
-    .option('--platform [platform]', 'detached project platform')
-    .option('--skipXcodeConfig [bool]', '[iOS only] if true, do not configure Xcode project')
-    .description('Prepares a detached project for building')
+    .option('--platform [platform]', 'Detached project platform.')
+    .option('--skipXcodeConfig [bool]', '[iOS only] If true, do not configure the Xcode project.')
+    .description('Prepares a detached project for building.')
     .asyncActionProjectDir(action, true);
 };

--- a/packages/expo-cli/src/commands/publish-info.js
+++ b/packages/expo-cli/src/commands/publish-info.js
@@ -15,15 +15,11 @@ export default (program: any) => {
     .alias('ph')
     .description('View a log of your published releases.')
     .option(
-      '-c, --release-channel <channel-name>',
-      'Filter by release channel. If this flag is not included, the most recent publications will be shown.'
+      '-c, --release-channel [channel]',
+      'Filter by release channel. If this option is not included, the most recent publications will be shown.'
     )
-    .option(
-      '-count, --count <number-of-logs>',
-      'Number of logs to view, maximum 100, default 5.',
-      parseInt
-    )
-    .option('-p, --platform <ios|android>', 'Filter by platform, android or ios.')
+    .option('-count, --count [number]', 'Number of logs to view. Default: 5. Max: 100.', parseInt)
+    .option('-p, --platform [platform]', 'Filter by platform. Options: android or ios.')
     .option('-r, --raw', 'Produce some raw output.')
     .asyncActionProjectDir(async (projectDir, options) => {
       if (options.count && (isNaN(options.count) || options.count < 1 || options.count > 100)) {
@@ -103,7 +99,7 @@ export default (program: any) => {
     .command('publish:details [project-dir]')
     .alias('pd')
     .description('View the details of a published release.')
-    .option('--publish-id <publish-id>', 'Publication id. (Required)')
+    .option('--publish-id [id]', 'Publication id. (Required)')
     .option('-r, --raw', 'Produce some raw output.')
     .asyncActionProjectDir(async (projectDir, options) => {
       if (!options.publishId) {

--- a/packages/expo-cli/src/commands/publish-modify.js
+++ b/packages/expo-cli/src/commands/publish-modify.js
@@ -12,11 +12,11 @@ export default (program: any) => {
     .alias('ps')
     .description('Set a published release to be served from a specified channel.')
     .option(
-      '-c, --release-channel <channel-name>',
+      '-c, --release-channel [channel]',
       'The channel to set the published release. (Required)'
     )
     .option(
-      '-p, --publish-id <publish-id>',
+      '-p, --publish-id [id]',
       'The id of the published release to serve from the channel. (Required)'
     )
     .asyncActionProjectDir(async (projectDir, options) => {
@@ -48,7 +48,7 @@ export default (program: any) => {
     .command('publish:rollback [project-dir]')
     .alias('pr')
     .description('Rollback an update to a channel.')
-    .option('--channel-id <channel-id>', 'The channel id to rollback in the channel. (Required)')
+    .option('--channel-id [channel]', 'The channel id to rollback in the channel. (Required)')
     .asyncActionProjectDir(async (projectDir, options) => {
       if (!options.channelId) {
         throw new Error('You must specify a channel id. You can find ids using publish:history.');

--- a/packages/expo-cli/src/commands/publish.js
+++ b/packages/expo-cli/src/commands/publish.js
@@ -124,14 +124,10 @@ export default (program: any) => {
     .alias('p')
     .description('Publishes your project to exp.host')
     .option('-q, --quiet', 'Suppress verbose output from the React Native packager.')
-    .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')
-    .option('-c, --clear', 'Clear the React Native packager cache')
+    .option('-s, --send-to [dest]', 'A phone number or email address to send a link to.')
+    .option('-c, --clear', 'Clear the React Native packager cache.')
     // TODO(anp) set a default for this dynamically based on whether we're inside a container?
     .option('--max-workers [num]', 'Maximum number of tasks to allow Metro to spawn.')
-    .option(
-      '--release-channel <release channel>',
-      "The release channel to publish to. Default is 'default'.",
-      'default'
-    )
+    .option('--release-channel [channel]', 'The release channel to publish to.', 'default')
     .asyncActionProjectDir(action, true);
 };

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -16,7 +16,7 @@ export default function(program: Command) {
   program
     .command('push:android:upload [project-dir]')
     .description('Uploads a Firebase Cloud Messaging key for Android push notifications.')
-    .option('--api-key [api-key]', 'Server API key for FCM.')
+    .option('--api-key [key]', 'Server API key for FCM.')
     .asyncActionProjectDir(async (projectDir: string, options: { apiKey?: string }) => {
       if (!options.apiKey || options.apiKey.length === 0) {
         throw new Error('Must specify an API key to upload with --api-key.');
@@ -44,7 +44,7 @@ export default function(program: Command) {
 
   program
     .command('push:android:show [project-dir]')
-    .description('Print the value currently in use for FCM notifications for this project.')
+    .description('Prints the value currently in use for FCM notifications for this project.')
     .asyncActionProjectDir(async (projectDir: string) => {
       const {
         args: { remotePackageName },
@@ -87,9 +87,9 @@ export default function(program: Command) {
   program
     .command('push:web:upload [project-dir]')
     .description('Uploads VAPID key pair and VAPID subject for web push notifications.')
-    .option('--vapid-pubkey [vapid-public-key]', 'URL-safe base64-encoded VAPID public key.')
-    .option('--vapid-pvtkey [vapid-private-key]', 'URL-safe base64-encoded VAPID private key.')
-    .option('--vapid-subject [vapid-subject]', vapidSubjectDescription)
+    .option('--vapid-pubkey [key]', 'URL-safe base64-encoded VAPID public key.')
+    .option('--vapid-pvtkey [key]', 'URL-safe base64-encoded VAPID private key.')
+    .option('--vapid-subject [subject]', vapidSubjectDescription)
     .asyncActionProjectDir(async (projectDir: string, options: VapidData) => {
       if (!options.vapidPubkey || !options.vapidPvtkey || !options.vapidSubject) {
         throw new Error(
@@ -103,7 +103,7 @@ export default function(program: Command) {
   program
     .command('push:web:generate [project-dir]')
     .description('Generates VAPID key pair for web push notifications.')
-    .option('--vapid-subject [vapid-subject]', vapidSubjectDescription)
+    .option('--vapid-subject [subject]', vapidSubjectDescription)
     .asyncActionProjectDir(async (projectDir: string, options: VapidData) => {
       if (!options.vapidSubject) {
         throw new Error('Must specify --vapid-subject.');

--- a/packages/expo-cli/src/commands/register.ts
+++ b/packages/expo-cli/src/commands/register.ts
@@ -5,6 +5,6 @@ import { register } from '../accounts';
 export default function(program: Command) {
   program
     .command('register')
-    .description('Sign up for a new Expo account')
+    .description('Sign up for a new Expo account.')
     .asyncAction(() => register());
 }

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -47,9 +47,9 @@ async function action(projectDir: string, options: { sendTo?: string }) {
 export default function(program: Command) {
   program
     .command('send [project-dir]')
-    .description('Sends a link to your project to an email address')
+    .description('Sends a link to your project to an email address.')
     //.help('You must have the server running for this command to work')
-    .option('-s, --send-to  [dest]', 'Specifies the email address to send this URL to')
+    .option('-s, --send-to  [email]', 'Specifies the email address to send this url to.')
     .urlOpts()
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -210,9 +210,9 @@ export default (program: any) => {
   program
     .command('start [project-dir]')
     .alias('r')
-    .description('Starts or restarts a local server for your app and gives you a URL to it')
-    .option('-s, --send-to [dest]', 'An email address to send a link to')
-    .option('-c, --clear', 'Clear the React Native packager cache')
+    .description('Starts or restarts a local server for your app and gives you a url to it.')
+    .option('-s, --send-to [email]', 'An email address to send a link to.')
+    .option('-c, --clear', 'Clear the React Native packager cache.')
     .option(
       '--web-only',
       'Only start the Webpack dev server for web. [Deprecated]: use `expo start:web`'
@@ -236,7 +236,7 @@ export default (program: any) => {
   program
     .command('start:web [project-dir]')
     .alias('web')
-    .description('Starts the Webpack dev server for web projects')
+    .description('Starts the Webpack dev server for web projects.')
     .urlOpts()
     .allowOffline()
     .asyncActionProjectDir(

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -339,8 +339,8 @@ export default function(program: Command) {
   program
     .command('upgrade [targetSdkVersion]')
     .alias('update')
-    .option('--npm', 'Use npm to install dependencies. (default when package-lock.json exists)')
-    .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
-    .description('Upgrades your project dependencies and app.json and to the given SDK version')
+    .option('--npm', 'Use npm to install dependencies. Used by default when package-lock.json exists.')
+    .option('--yarn', 'Use Yarn to install dependencies. Used by default when yarn.lock exists.')
+    .description('Upgrades your project dependencies and app.json and to the given SDK version.')
     .asyncAction(upgradeAsync);
 }

--- a/packages/expo-cli/src/commands/upload.js
+++ b/packages/expo-cli/src/commands/upload.js
@@ -12,10 +12,10 @@ export default program => {
   const androidCommand = program.command('upload:android [projectDir]').alias('ua');
   setCommonOptions(androidCommand, '.apk');
   androidCommand
-    .option('--key <key>', 'path to the JSON key used to authenticate with Google Play')
+    .option('--key [key]', 'Path to the JSON key used to authenticate with Google Play.')
     .option(
-      '--track <track>',
-      'the track of the application to use, choose from: production, beta, alpha, internal, rollout',
+      '--track [track]',
+      'The track of the application to use. Options: production, beta, alpha, internal, rollout.',
       /^(production|beta|alpha|internal|rollout)$/i,
       'internal'
     )
@@ -38,34 +38,34 @@ export default program => {
   setCommonOptions(iosCommand, '.ipa');
   iosCommand
     .option(
-      '--apple-id <apple-id>',
-      'your Apple ID username (you can also set EXPO_APPLE_ID env variable)'
+      '--apple-id [id]',
+      'Apple ID username. You can also set your username as `EXPO_APPLE_ID` env variable.'
     )
     // apple unified App Store Connect and Developer Portal teams, this is temporary solution until fastlane implements those changes
     // https://github.com/fastlane/fastlane/issues/14229
     // after updating fastlane this value will be unnecessary
     .option(
-      '--itc-team-id <itc-team-id>',
-      'App Store Connect Team ID (optional if there is only one team available)'
+      '--itc-team-id [id]',
+      'App Store Connect Team ID (optional if there is only one team available).'
     )
     .option(
-      '--apple-id-password <apple-id-password>',
-      'your Apple ID password (you can also set EXPO_APPLE_ID_PASSWORD env variable)'
+      '--apple-id-password [password]',
+      'Apple ID password. You can also set your password as `EXPO_APPLE_ID_PASSWORD` env variable.'
     )
     .option(
-      '--app-name <app-name>',
-      `the name of your app as it will appear on the App Store, this can't be longer than 30 characters (default: expo.name from app.json)`
+      '--app-name [name]',
+      `The name of your app as it will appear on the App Store. Max character limit: 30. Default: expo.name from app.json.`
     )
     .option(
       '--sku <sku>',
-      'a unique ID for your app that is not visible on the App Store, will be generated unless provided'
+      'A unique ID for your app that is not visible on the App Store which will be generated unless provided.'
     )
     .option(
       '--language <language>',
-      `primary language (e.g. English, German; run \`expo upload:ios --help\` to see the list of available languages)`,
+      `Sets the primary language. Run \`expo upload:ios --help\` to see the list of available languages.`,
       'English'
     )
-    .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
+    .option('--public-url [url]', 'The url of an externally hosted manifest for self-host apps.')
     .description(
       'Uploads a standalone app to Apple TestFlight (works on macOS only). Uploads the latest build by default.'
     )
@@ -79,9 +79,9 @@ export default program => {
 
 function setCommonOptions(command, fileExtension) {
   command
-    .option('--latest', 'uploads the latest build (default)')
-    .option('--id <id>', 'id of the build to upload')
-    .option('--path <path>', `path to the ${fileExtension} file`);
+    .option('--latest', 'Uploads the latest build. This is the default behavior.')
+    .option('--id [id]', 'Id of the build to upload.')
+    .option('--path [path]', `Path to the ${fileExtension} file.`);
 }
 
 function createUploadAction(UploaderClass, optionKeys) {

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -83,23 +83,23 @@ export default function(program: Command) {
   program
     .command('url [project-dir]')
     .alias('u')
-    .option('-w, --web', 'Return the URL of the web app')
-    .description('Displays the URL you can use to view your project in Expo')
+    .option('-w, --web', 'Returns the url of the web app.')
+    .description('Displays the url you can use to view your project in Expo.')
     .urlOpts()
     .allowOffline()
     .asyncActionProjectDir(action, /* skipProjectValidation: */ true, /* skipAuthCheck: */ true);
 
   program
     .command('url:ipa [project-dir]')
-    .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
-    .description('Displays the standalone iOS binary URL you can use to download your app binary')
+    .option('--public-url [url]', 'The url of an externally hosted manifest for self-host apps.')
+    .description('Displays the standalone iOS binary URL you can use to download your app binary.')
     .asyncActionProjectDir(logArtifactUrl('ios'), true);
 
   program
     .command('url:apk [project-dir]')
-    .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
+    .option('--public-url [url]', 'The url of an externally hosted manifest for self-host apps.')
     .description(
-      'Displays the standalone Android binary URL you can use to download your app binary'
+      'Displays the standalone Android binary URL you can use to download your app binary.'
     )
     .asyncActionProjectDir(logArtifactUrl('android'), true);
 }

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -13,13 +13,13 @@ const WEBHOOK_TYPES = ['build'];
 export default function(program: Command) {
   program
     .command('webhooks:set [project-dir]')
-    .option('--url <webhook-url>', 'Webhook to be called after building the app.')
-    .option('--event <webhook-type>', 'Type of webhook: [build].')
+    .option('--url [url]', 'Webhook to be called after building the app.')
+    .option('--event [type]', 'Type of webhook. Only current option is: build.')
     .option(
-      '--secret <webhook-secret>',
-      'Secret to be used to calculate the webhook request payload signature (check docs for more details). It has to be at least 16 characters long.'
+      '--secret [secret]',
+      'Secret to be used to calculate the webhook request payload signature. See docs for more details. Must be at least 16 characters long.'
     )
-    .description(`Set a webhook for the project.`)
+    .description(`Sets a webhook for the project.`)
     .asyncActionProjectDir(async (projectDir: string, _options: Options) => {
       const options = await _sanitizeOptions(_options);
       const secret = options.secret;
@@ -40,7 +40,7 @@ export default function(program: Command) {
 
   program
     .command('webhooks:show [project-dir]')
-    .description(`Show webhooks for the project.`)
+    .description(`Shows webhooks for the project.`)
     .asyncActionProjectDir(async (projectDir: string) => {
       const {
         args: { remoteFullPackageName: experienceName },
@@ -69,8 +69,8 @@ export default function(program: Command) {
 
   program
     .command('webhooks:clear [project-dir]')
-    .option('--event <webhook-type>', 'Type of webhook: [build].')
-    .description(`Clear a webhook associated with this project.`)
+    .option('--event [type]', 'Type of webhook. Only current option is: build.')
+    .description(`Clears a webhook associated with this project.`)
     .asyncActionProjectDir(async (projectDir: string, options: { event?: string }) => {
       const event = _sanitizeEvent(options.event);
       const {

--- a/packages/expo-cli/src/commands/whoami.ts
+++ b/packages/expo-cli/src/commands/whoami.ts
@@ -19,6 +19,6 @@ export default function(program: Command) {
   program
     .command('whoami')
     .alias('w')
-    .description('Checks with the server and then says who you are logged in as')
+    .description('Checks with the server to see if you are logged in to an Expo account and if you are, returns the account name.')
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/commonOptions.ts
+++ b/packages/expo-cli/src/commonOptions.ts
@@ -2,5 +2,5 @@
  * Adds common options
  */
 export default function addOptions(program: any) {
-  program.option('--config [file]', 'Specify a path to app.json');
+  program.option('--config [path]', 'Specify a path to app.json.');
 }

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -49,7 +49,7 @@ Command.prototype.urlOpts = function() {
 };
 
 Command.prototype.allowOffline = function() {
-  this.option('--offline', 'Allows this command to run while offline');
+  this.option('--offline', 'Allows this command to run while offline.');
   return this;
 };
 
@@ -120,7 +120,7 @@ Command.prototype.asyncActionProjectDir = function(
   skipProjectValidation: boolean,
   skipAuthCheck: boolean
 ) {
-  this.option('--config [file]', 'Specify a path to app.json');
+  this.option('--config [path]', 'Specify a path to app.json.');
   return this.asyncAction(async (projectDir: string, ...args: any[]) => {
     const opts = args[0];
 

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -8,25 +8,25 @@ import CommandError from './CommandError';
 
 function addOptions(program: Command) {
   program
-    .option('-a, --android', 'Opens your app in Expo on a connected Android device')
+    .option('-a, --android', 'Opens your app in the Expo client on a connected Android device.')
     .option(
       '-i, --ios',
-      'Opens your app in Expo in a currently running iOS simulator on your computer'
+      'Opens your app in the Expo client in a currently running iOS simulator on your computer.'
     )
-    .option('-w, --web', 'Opens your app in a web browser')
+    .option('-w, --web', 'Opens your app in a web browser.')
     .option(
       '-m, --host [mode]',
-      'lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks'
+      'Type of host to use. Options: lan, localhost or tunnel. Tunnel allows you to view your link from other networks. Default: lan.'
     )
-    .option('--tunnel', 'Same as --host tunnel')
-    .option('--lan', 'Same as --host lan')
-    .option('--localhost', 'Same as --host localhost')
-    .option('--dev', 'Turns dev flag on')
-    .option('--no-dev', 'Turns dev flag off')
-    .option('--minify', 'Turns minify flag on')
-    .option('--no-minify', 'Turns minify flag off')
-    .option('--https', 'To start webpack with https protocol')
-    .option('--no-https', 'To start webpack with http protocol');
+    .option('--tunnel', 'Same as --host tunnel.')
+    .option('--lan', 'Same as --host lan.')
+    .option('--localhost', 'Same as --host localhost.')
+    .option('--dev', 'Turns dev flag on.')
+    .option('--no-dev', 'Turns dev flag off.')
+    .option('--minify', 'Turns minify flag on.')
+    .option('--no-minify', 'Turns minify flag off.')
+    .option('--https', 'To start webpack with https protocol.')
+    .option('--no-https', 'To start webpack with http protocol.');
 }
 
 function hasBooleanArg(rawArgs: string[], argName: string) {


### PR DESCRIPTION
Gave the command descriptions and options strings some grammar, punctation in order to be presented in our cli cmd docs page. Also migrated from using `<>` to `[]` in options as it breaks markdown in the docs.