### PR TITLE
hotfix for not a constructor function

### DIFF
--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -204,7 +204,7 @@ export default async function(env: Environment, argv: Arguments = {}): Promise<C
         ROOT_ID: rootId,
       }),
 
-      new WebpackPWAManifestPlugin(config, {
+      new WebpackPWAManifestPlugin.default(config, {
         publicPath,
         noResources: isDev || !env.pwa,
         filename: locations.production.manifest,


### PR DESCRIPTION
#### Bug:
Running `expo start --web` fails to build

Error Msg: `WebpackPWAManifestPlugin is not a constructor`

Resolution:
instantiate function by calling `.default`

Steps to reproduce:
1. `yarn install`
2. `expo start --web`