### PR TITLE
Removed case-sensitive-paths-webpack-plugin

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -42,7 +42,6 @@
     "babel-loader": "^8.0.5",
     "babel-preset-expo": "^7.0.0",
     "brotli-webpack-plugin": "^1.1.0",
-    "case-sensitive-paths-webpack-plugin": "^2.2.0",
     "chalk": "^2.4.2",
     "clean-webpack-plugin": "^1.0.1",
     "compression-webpack-plugin": "^2.0.0",

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -12,8 +12,6 @@ import ModuleNotFoundPlugin from 'react-dev-utils/ModuleNotFoundPlugin';
 import PnpWebpackPlugin from 'pnp-webpack-plugin';
 import ModuleScopePlugin from 'react-dev-utils/ModuleScopePlugin';
 import ManifestPlugin from 'webpack-manifest-plugin';
-// @ts-ignore
-import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
 import WatchMissingNodeModulesPlugin from 'react-dev-utils/WatchMissingNodeModulesPlugin';
 // @ts-ignore
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
@@ -224,10 +222,6 @@ export default async function(env: Environment, argv: Arguments = {}): Promise<C
 
       // This is necessary to emit hot updates (currently CSS only):
       isDev && new HotModuleReplacementPlugin(),
-      // Watcher doesn't work well if you mistype casing in a path so we use
-      // a plugin that prints an error when you attempt to do this.
-      // See https://github.com/facebook/create-react-app/issues/240
-      isDev && new CaseSensitivePathsPlugin(),
 
       // If you require a missing module and then `npm install` it, you still have
       // to restart the development server for Webpack to discover it. This plugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,17 +1569,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@expo/babel-preset-cli@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@expo/babel-preset-cli/-/babel-preset-cli-0.2.0.tgz#a9ee7e3ac93ca55e69c42e5edd32e6ecd04a12d9"
-  integrity sha512-13XJl6UxwA0mzDHr3IV63yuk9TwcRfehf8w+jPHjue9HQ84RoCwRo5+kUenWQubS69YQZlNWUmpE4G/U/b25zg==
-  dependencies:
-    "@babel/core" "^7.4.5"
-    "@babel/plugin-proposal-class-properties" "^7.4.4"
-    "@babel/plugin-transform-modules-commonjs" "^7.5.0"
-    "@babel/preset-env" "^7.4.4"
-    "@babel/preset-typescript" "^7.3.3"
-
 "@expo/bunyan@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@expo/bunyan/-/bunyan-3.0.2.tgz#775680bd479a8b79ada4a5676936a58eef1579c9"
@@ -6405,11 +6394,6 @@ case-sensitive-paths-webpack-plugin@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz#3d29ced8c1f124bf6f53846fb3f5894731fdc909"
   integrity sha1-PSnO2MHxJL9vU4Rvs/WJRzH9yQk=
-
-case-sensitive-paths-webpack-plugin@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz#3371ef6365ef9c25fa4b81c16ace0e9c7dc58c3e"
-  integrity sha512-u5ElzokS8A1pm9vM3/iDgTcI3xqHxuCao94Oz8etI3cf0Tio0p8izkDYbTIn09uP3yUUr6+veaE6IkjnTYS46g==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -19387,7 +19371,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry@0.12.0:
+retry@0.12.0, retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
@@ -19396,11 +19380,6 @@ retry@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
-
-retry@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
-  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 rewire@2.5.2:
   version "2.5.2"


### PR DESCRIPTION
# Why

This module does suboptimal path checks across all `node_modules` which scales exponentially across large projects. 


# Test

- `EXPO_DEBUG=true expo start:web --dev`

`index.js`
```jsx
import * as React from 'react';
import { AppRegistry, Text } from 'react-native';
AppRegistry.registerComponent('main', () => <Text>Test min</Text>);
const rootTag = global.document.getElementById('root');
AppRegistry.runApplication('main', { rootTag });
```

`webpack.config.js`
```js
const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
const createExpoWebpackConfigAsync = require('@expo/webpack-config');

module.exports = async function(env, argv) {
  const config = await createExpoWebpackConfigAsync(env, argv);
  const smp = new SpeedMeasurePlugin();
  return smp.wrap(config);
};
```
## Before

```sh
 SMP  ⏱  
General output time took 3.81 secs

 SMP  ⏱  Plugins
CaseSensitivePathsPlugin took 1.66 secs
ExpoHtmlWebpackPlugin took 0.061 secs
ExpoProgressBarPlugin took 0.032 secs
ManifestPlugin took 0.021 secs
HotModuleReplacementPlugin took 0.015 secs
ModuleNotFoundPlugin took 0.001 secs
WebpackPWAManifest took 0.001 secs
InterpolateHtmlPlugin took 0 secs
ExpoDefinePlugin took 0 secs
WatchMissingNodeModulesPlugin took 0 secs

 SMP  ⏱  Loaders
babel-loader took 2.64 secs
  module count = 80
modules with no loaders took 2.57 secs
  module count = 127
```

<img width="344" alt="Screen Shot 2019-10-16 at 2 37 04 PM" src="https://user-images.githubusercontent.com/9664363/66961103-c075a300-f022-11e9-965b-2c41b3a4ed06.png">

## After

```sh
 SMP  ⏱  
General output time took 3.39 secs

 SMP  ⏱  Plugins
ExpoHtmlWebpackPlugin took 0.066 secs
ExpoProgressBarPlugin took 0.03 secs
ManifestPlugin took 0.025 secs
HotModuleReplacementPlugin took 0.014 secs
WebpackPWAManifest took 0.001 secs
ModuleNotFoundPlugin took 0 secs
InterpolateHtmlPlugin took 0 secs
ExpoDefinePlugin took 0 secs
WatchMissingNodeModulesPlugin took 0 secs

 SMP  ⏱  Loaders
modules with no loaders took 2.56 secs
  module count = 127
babel-loader took 2.23 secs
  module count = 80
```

<img width="354" alt="Screen Shot 2019-10-16 at 2 39 14 PM" src="https://user-images.githubusercontent.com/9664363/66961113-c3709380-f022-11e9-92db-8745ab0d2687.png">