### PR TITLE
fix: remove the --nonPersistent bundler option

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1682,14 +1682,16 @@ export async function startReactNativeServerAsync(
     logger.global.warn(`Expo is not installed: Using default reporter to format logs.`);
   }
 
-
   let packagerOpts: { [key: string]: any } = {
     port: packagerPort,
     customLogReporterPath,
     assetExts: ['ttf'],
     sourceExts: ['expo.js', 'expo.ts', 'expo.tsx', 'expo.json', 'js', 'json', 'ts', 'tsx'],
-    nonPersistent: !!options.nonPersistent,
   };
+
+  if (options.nonPersistent && Versions.lteSdkVersion(exp, '32.0.0')) {
+    packagerOpts.nonPersistent = true;
+  }
 
   if (Versions.gteSdkVersion(exp, '33.0.0')) {
     packagerOpts.assetPlugins = ConfigUtils.resolveModule(


### PR DESCRIPTION
### Summary

Stop passing the `--nonPersistent` option to the React Native CLI for SDK 33 and newer projects.

### Why

React Native CLI and Metro no longer support this option, starting from Metro v0.47.0, which corresponds to `react-native@0.57.2`. Therefore, from SDK 33 this flag should have no effect, so we can stop using it. And from SDK 36, passing the `--nonPersistent` option would be an error anyway because it has been removed in React Native CLI, so this change is necessary for supporting SDK 36.

Fixes #1128.

### Background

React Native used to translate the `--nonPersistent` flag to the `watch` option of Metro. `watch` was removed here: https://github.com/facebook/metro/commit/0d6c135045a33f2b9effa8ca31b648e6b29ec24c

Then later, the `--nonPersistent` flag was completely removed here: https://github.com/react-native-community/cli/commit/b306c99fda3057e6ffda36c5d1958339815dcc37#diff-9141060e37d5c1c916e13ae8c98fbf92 (in an inconspicuously named commit "docs: update and rearrange documentation".)