### PR TITLE
fix(expo-cli): clear metro cache after upgrade

### DIFF
--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { Versions } from '@expo/xdl';
+import { Project, Versions } from '@expo/xdl';
 import JsonFile from '@expo/json-file';
 import * as ConfigUtils from '@expo/config';
 import chalk from 'chalk';
@@ -256,6 +256,12 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
   if (dependenciesAsStringArray.length) {
     await packageManager.addAsync(...dependenciesAsStringArray);
   }
+
+  // Clear metro bundler cache
+  log.addNewLineIfNone();
+  log(chalk.bold.underline('Clearing your cache to remove old references...'));
+  await Project.startReactNativeServerAsync(projectRoot, { reset: true, nonPersistent: true });
+  await Project.stopReactNativeServerAsync(projectRoot);
 
   log.addNewLineIfNone();
   log(chalk.underline.bold.green(`Automated upgrade steps complete.`));

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -259,7 +259,7 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
 
   // Clear metro bundler cache
   log.addNewLineIfNone();
-  log(chalk.bold.underline('Clearing your cache to remove old references...'));
+  log(chalk.bold.underline('Clearing the packager cache...'));
   await Project.startReactNativeServerAsync(projectRoot, { reset: true, nonPersistent: true });
   await Project.stopReactNativeServerAsync(projectRoot);
 


### PR DESCRIPTION
Fixes #1099, the part about "stopping expo service" is receiving some love and attention here #1108.

#### Some context
This change starts the Metro server with the `reset` flag and instantly closes it. It also adds the `nonPersistent` flag, but I think that might be getting deprecated now. Doing this _should_ be sufficient, the [Metro Server is resetting the cache within the server's constructor](https://github.com/facebook/metro/blob/master/packages/metro/src/Server.js#L109-L114).

It might be better if we wait until PR #1111 is merged before merging this one. I didn't check if Expo is running and sort-of assumed it isn't. The prompt asking the user about running servers is still in PR review in PR #1111. (My semi-OCD is so happy I got PR #1111).