### PR TITLE
fix(expo-cli): alias raw template spec name in init

### DIFF
--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -106,6 +106,7 @@ async function action(projectDir: string, options: Options) {
     ) {
       templateSpec.escapedName = `expo-template-${templateSpec.name}`;
       templateSpec.name = templateSpec.escapedName;
+      templateSpec.raw = templateSpec.escapedName;
     }
   } else {
     let descriptionColumn =


### PR DESCRIPTION
Fixes #1133 

#### How to reproduce
I could only reproduce this issue in a Linux container, on MacOS it works fine. So to run it in a docker image, you can use this (or your own image ofc).

```bash
$ docker run -ti --rm -w /code/test bycedric/expo-cli \
	expo init . --template blank --name test --yarn --non-interactive
```

#### The fix (tm)
It replaces the template specification's raw property with the prefixed name. Again, no clue why this doesn't happen on MacOS. It's probably related to [this part](https://github.com/npm/npm-package-arg/blob/latest/npa.js#L58-L63) where it also uses the raw property.