### PR TITLE
fix: device logging with React Native v0.61.x

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1585,7 +1585,7 @@ function _logPackagerOutput(projectRoot: string, level: string, data: object) {
 
 function _isIgnorableMetroConsoleOutput(output: string) {
   // As of React Native 0.61.x, Metro prints console logs from the device to console, without
-  // passing them through the custom log rgeporter.
+  // passing them through the custom log reporter.
   //
   // Managed apps have a separate remote logging implementation included in the Expo SDK,
   // (see: _handleDeviceLogs), so we can just ignore these device logs from Metro.


### PR DESCRIPTION
As of React Native 0.61.x, Metro prints console logs from the
device to console.

Managed apps have a separate remote logging implementation
included in the Expo SDK, so we can just ignore these logs
(otherwise they would be printed twice).

Currently this has to be done by looking for log lines that
look like device logs, i.e. they start with " LOG ", " WARN "
or similar. This is less than ideal, but I plan submit a PR to
Metro to make it use the custom log reporter (if configured)
for these logs so LogReporter is able to filter what gets
printed to the console.

Additionally, the AppRegistry logging was changed recently
(https://github.com/facebook/react-native/commit/1f25d3c4ce605fc3bd2a4deefc754bd07cfbf1cf),
so the code detecting these logs had to be changed as well.