### PR TITLE
fix: Respect owner field in build commands with --no-publish option

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.js
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.js
@@ -280,6 +280,7 @@ ${job.id}
       const release = await Project.getLatestReleaseAsync(this.projectDir, {
         releaseChannel: this.options.releaseChannel,
         platform: this.platform(),
+        owner: this.manifest.owner,
       });
       if (!release) {
         throw new BuildError('No releases found. Please create one using `expo publish` first.');

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -370,12 +370,16 @@ export async function getLatestReleaseAsync(
   options: {
     releaseChannel: string;
     platform: string;
+    owner?: string;
   }
 ): Promise<Release | null> {
   // TODO(ville): move request from multipart/form-data to JSON once supported by the endpoint.
   let formData = new FormData();
   formData.append('queryType', 'history');
   formData.append('slug', await getSlugAsync(projectRoot));
+  if (options.owner) {
+    formData.append('owner', options.owner);
+  }
   formData.append('version', '2');
   formData.append('count', '1');
   formData.append('releaseChannel', options.releaseChannel);


### PR DESCRIPTION
The no-publish option on build commands is not being respected currently when looking up the most recent release