### PR TITLE
fix(xdl): filter out "deprecated rnpm config" warnings

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -37,7 +37,13 @@ import * as Android from './Android';
 import Api from './Api';
 import ApiV2 from './ApiV2';
 import * as AssetUtils from './AssetUtils';
-import { calculateHash, createNewFilename, getAssetFilesAsync, optimizeImageAsync, readAssetJsonAsync } from './AssetUtils';
+import {
+  calculateHash,
+  createNewFilename,
+  getAssetFilesAsync,
+  optimizeImageAsync,
+  readAssetJsonAsync,
+} from './AssetUtils';
 import Config from './Config';
 import * as ExponentTools from './detach/ExponentTools';
 import StandaloneContext from './detach/StandaloneContext';
@@ -1567,7 +1573,7 @@ function _logPackagerOutput(projectRoot: string, level: string, data: object) {
     );
     return;
   }
-  if (_isIgnorableMetroConsoleOutput(output)) {
+  if (_isIgnorableMetroConsoleOutput(output) || _isIgnorableRnpmWarning(output)) {
     ProjectUtils.logDebug(projectRoot, 'expo', output);
     return;
   }
@@ -1594,6 +1600,12 @@ function _isIgnorableMetroConsoleOutput(output: string) {
   // These logs originate from:
   // https://github.com/facebook/metro/blob/e8181fb9db7db31adf7d1ed9ab840f54449ef238/packages/metro/src/lib/logToConsole.js#L50
   return /^\s+(INFO|WARN|LOG|GROUP|DEBUG) /.test(output);
+}
+
+function _isIgnorableRnpmWarning(output: string) {
+  return output.startsWith(
+    'warn The following packages use deprecated "rnpm" config that will stop working from next release'
+  );
 }
 
 function _isIgnorableDuplicateModuleWarning(


### PR DESCRIPTION
These warnings get printed with React Native 0.61.
They are not relevant when developing managed apps, so we should just
remove them.