### PR TITLE
[config] use package description for config description

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -554,19 +554,25 @@ function ensureConfigHasDefaultValues(
   pkg: JSONObject,
   skipNativeValidation: boolean = false
 ): { exp: ExpoConfig; pkg: PackageJSONConfig } {
-  if (exp && !exp.name && typeof pkg.name === 'string') {
+  if (!exp) exp = {};
+
+  if (!exp.name && typeof pkg.name === 'string') {
     exp.name = pkg.name;
   }
 
-  if (exp && !exp.slug && typeof exp.name === 'string') {
+  if (!exp.description && typeof pkg.description === 'string') {
+    exp.description = pkg.description;
+  }
+
+  if (!exp.slug && typeof exp.name === 'string') {
     exp.slug = slug(exp.name.toLowerCase());
   }
 
-  if (exp && !exp.version) {
+  if (!exp.version) {
     exp.version = pkg.version;
   }
 
-  if (exp && exp.nodeModulesPath) {
+  if (exp.nodeModulesPath) {
     exp.nodeModulesPath = path.resolve(projectRoot, exp.nodeModulesPath);
   }
 
@@ -576,7 +582,7 @@ function ensureConfigHasDefaultValues(
     if (!skipNativeValidation) throw error;
   }
 
-  if (exp && !exp.platforms) {
+  if (!exp.platforms) {
     exp.platforms = ['android', 'ios'];
   }
 

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -5,6 +5,7 @@ export type BareAppConfig = { name: string; displayName: string; [key: string]: 
 export type ExpoConfig = {
   name?: string;
   slug?: string;
+  description?: string;
   sdkVersion?: string;
   platforms?: Array<Platform>;
   nodeModulesPath?: string;

--- a/packages/config/src/__tests__/Config-test.js
+++ b/packages/config/src/__tests__/Config-test.js
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 
-import { readConfigJson, getWebOutputPath } from '../Config';
+import { getWebOutputPath, readConfigJson } from '../Config';
 
 jest.mock('fs');
 jest.mock('resolve-from');
@@ -68,6 +68,7 @@ describe('readConfigJson', () => {
         {
           name: 'testing123',
           version: '0.1.0',
+          description: 'fake description',
           main: 'index.js',
         },
         null,
@@ -142,11 +143,13 @@ describe('readConfigJson', () => {
     it(`can skip throwing when the app.json is missing`, () => {
       const { exp, pkg } = readConfigJson('/no-config', true);
       expect(exp.name).toBe(pkg.name);
+      expect(exp.description).toBe(pkg.description);
     });
 
     it(`can skip throwing when the app.json is missing and expo isn't installed`, () => {
       const { exp, pkg } = readConfigJson('/no-package', true, true);
       expect(exp.name).toBe(pkg.name);
+      expect(exp.description).toBe(pkg.description);
     });
 
     it(`will throw if the app.json is missing`, () => {


### PR DESCRIPTION
## Why

- Help to ease off of using `app.json`
- Reduce the amount of web apps using expo default description 