### PR TITLE
fix: logging in Fast Refresh mode

### DIFF
--- a/packages/xdl/src/logs/PackagerLogsStream.ts
+++ b/packages/xdl/src/logs/PackagerLogsStream.ts
@@ -315,27 +315,15 @@ export default class PackagerLogsStream {
     if (msg.type === 'bundle_build_started') {
       chunk._metroEventType = 'BUILD_STARTED';
       this._handleNewBundleTransformStarted(chunk);
-    } else if (msg.type === 'bundle_transform_progressed') {
+    } else if (msg.type === 'bundle_transform_progressed' && this._bundleBuildChunkID) {
       chunk._metroEventType = 'BUILD_PROGRESS';
-      if (this._bundleBuildChunkID) {
-        this._handleUpdateBundleTransformProgress(chunk);
-      } else {
-        this._handleNewBundleTransformStarted(chunk);
-      }
-    } else if (msg.type === 'bundle_build_failed') {
+      this._handleUpdateBundleTransformProgress(chunk);
+    } else if (msg.type === 'bundle_build_failed' && this._bundleBuildChunkID) {
       chunk._metroEventType = 'BUILD_FAILED';
-      if (!this._bundleBuildChunkID) {
-        // maybe?
-      } else {
-        this._handleUpdateBundleTransformProgress(chunk);
-      }
-    } else if (msg.type === 'bundle_build_done') {
+      this._handleUpdateBundleTransformProgress(chunk);
+    } else if (msg.type === 'bundle_build_done' && this._bundleBuildChunkID) {
       chunk._metroEventType = 'BUILD_DONE';
-      if (!this._bundleBuildChunkID) {
-        // maybe?
-      } else {
-        this._handleUpdateBundleTransformProgress(chunk);
-      }
+      this._handleUpdateBundleTransformProgress(chunk);
     }
   };
 


### PR DESCRIPTION
Editing files in Fast Refresh mode resulted in progress bars that did not go away (https://github.com/expo/expo-cli/issues/1157).

For regular JS builds, Metro first fires a `bundle_build_started` event, followed by a bunch of `bundle_transform_progressed` and ends with either `bundle_build_done` or `bundle_build_failed`. Additionally, there's the `bundling_error` that fires when there are errors. We start the progress bar after `bundle_build_started`, update it after `bundle_transform_progressed` and make it go away after `bundle_build_done`/`bundle_build_failed` events. Simple enough.

When Fast Reload builds a file incrementally and makes an update to the, it turns out, there's no `bundle_build_started`, `bundle_build_done` or `bundle_build_failed` events fired. Metro just spits out some `bundle_transform_progressed` events and optionally a `bundling_error` if there was an error, and that's it. It also turns out our `PackagerLogsStream` had some code that starts a progress bar even on a `bundle_transform_progressed` event, if it looks like there was no `bundle_build_started` fired. That's not good: the progress bar won't go away because `bundle_build_done` is never fired for these incremental updates. And we don't even want to show a progress bar every time you edit a file in Fast Refresh mode.

So I removed the code that starts a new build progress bar from a bare `bundle_transform_progressed` event and now for the initial build or a Reload, we show a progress bar, and for a Fast Refresh update the app just magically updates without anything logged to the terminal (unless there's an error).