### PR TITLE
Revert back to checking if client installed in Snapshots directory

### DIFF
--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -259,8 +259,17 @@ export async function _quitSimulatorAsync() {
 
 // Expo installed
 export async function _isExpoAppInstalledOnCurrentBootedSimulatorAsync() {
-  let expoClientVersion = await _expoVersionOnCurrentBootedSimulatorAsync();
-  return !!expoClientVersion;
+  let device = await _bootedSimulatorDeviceAsync();
+  if (!device) {
+    return false;
+  }
+  let simDir = await _dirForSimulatorDevice(device.udid);
+  let matches = await glob(
+    './data/Containers/Data/Application/**/Snapshots/host.exp.Exponent{,**}',
+    { cwd: simDir }
+  );
+
+  return matches.length > 0;
 }
 
 export async function _waitForExpoAppInstalledOnCurrentBootedSimulatorAsync(): Promise<boolean> {


### PR DESCRIPTION
"fix(xdl): Check if Client is installed via application directory [iOS 13/Xcode 11 compatibility] (#957)"

This reverts commit 3ea697625e760877f04e1468bac8b24f6989fee0.