### PR TITLE
enhancement: add jsx to sourceExts by default

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1722,7 +1722,18 @@ export async function startReactNativeServerAsync(
     port: packagerPort,
     customLogReporterPath,
     assetExts: ['ttf'],
-    sourceExts: ['expo.js', 'expo.ts', 'expo.tsx', 'expo.json', 'js', 'json', 'ts', 'tsx'],
+    sourceExts: [
+      'expo.js',
+      'expo.jsx',
+      'expo.ts',
+      'expo.tsx',
+      'expo.json',
+      'js',
+      'jsx',
+      'json',
+      'ts',
+      'tsx',
+    ],
   };
 
   if (options.nonPersistent && Versions.lteSdkVersion(exp, '32.0.0')) {


### PR DESCRIPTION
Adding `jsx` as a source file extension is a reason why some people need to modify the `sourceExts` settings (see #191) 

We might as well add it to the default extensions. (I believe we already do this in the Webpack configuration, so this also makes the Metro config more consistent with web.)

Fixes #191.