### PR TITLE
Ensure "Run on web browser" respects network setting

### DIFF
--- a/packages/dev-tools/components/ProjectManagerSidebarOptions.js
+++ b/packages/dev-tools/components/ProjectManagerSidebarOptions.js
@@ -139,7 +139,7 @@ export default class ProjectManagerSidebarOptions extends React.Component {
         {this.props.processInfo.webAppUrl ? (
           <a
             className={STYLES_CONTENT_GROUP}
-            href={this.props.processInfo.webAppUrl}
+            href={getWebAppUrl(this.props.hostType, this.props.processInfo.webAppUrl)}
             target="_blank">
             <span className={STYLES_CONTENT_GROUP_LEFT}>Run on web browser</span>
           </a>
@@ -203,5 +203,13 @@ export default class ProjectManagerSidebarOptions extends React.Component {
         </div>
       </div>
     );
+  }
+}
+
+function getWebAppUrl(hostType, webAppUrl) {
+  if (hostType === 'localhost') {
+    return webAppUrl.replace(/^https?:\/\/[^:/]+/, 'http://localhost');
+  } else {
+    return webAppUrl;
   }
 }


### PR DESCRIPTION
The current behavior is that clicking "Run on web browser" will always use the computer's LAN address, even if the user selected "Local" for the network setting. This even happens when the option `--host localhost` was specified on the `expo start` command, which is probably not what the user expects.

Note: this is a client-side hack, but it seems less intrusive than messing with `packages/dev-tools/server/graphql/GraphQLSchema.js`.