### PR TITLE
Ensure webAppUrl respects network setting (LAN/Local)

### DIFF
--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -153,9 +153,9 @@ export async function constructWebAppUrlAsync(projectRoot: string): Promise<stri
     return null;
   }
 
-  const host = ip.address();
+  const { https, hostType } = await ProjectSettings.readAsync(projectRoot);
+  const host = hostType === 'localhost' ? 'localhost' : ip.address();
 
-  const { https } = await ProjectSettings.readAsync(projectRoot);
   let urlType = 'http';
   if (https === true) {
     urlType = 'https';


### PR DESCRIPTION
The current behavior of `constructWebAppUrlAsync` is to always use the LAN IP, even if the user selected "Local" for the network setting (either in the UI or the option `--host localhost` was specified). This is probably not what the user expects.

Note: This is a better solution than #1190 since it fixes the issue at the source, where the URL is generated.