### PR TITLE
[xdl][detach] fix a couple of local detach issues

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -371,6 +371,22 @@ function shellPathForContext(context) {
   }
 }
 
+/**
+ *  Resolve the private config for a project.
+ *  For standalone apps, this is copied into a separate context field context.data.privateConfig
+ *  by the turtle builder. For a local project, this is available in app.json under android.config.
+ */
+function getPrivateConfig(context) {
+  if (context.data.privateConfig) {
+    return context.data.privateConfig;
+  } else {
+    const exp = context.data.exp;
+    if (exp && exp.android) {
+      return exp.android.config;
+    }
+  }
+}
+
 export async function runShellAppModificationsAsync(context, sdkVersion, buildMode) {
   const fnLogger = logger.withFields({ buildPhase: 'running shell app modifications' });
 
@@ -383,7 +399,8 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
   // In SDK32 we've unified build process for shell and ejected apps
   const isDetached = ExponentTools.parseSdkMajorVersion(sdkVersion) >= 32 || isRunningInUserContext;
 
-  if (!context.data.privateConfig) {
+  const privateConfig = getPrivateConfig(context);
+  if (!privateConfig) {
     fnLogger.info('No config file specified.');
   }
 
@@ -914,7 +931,6 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
 
   let certificateHash = '';
   let googleAndroidApiKey = '';
-  let privateConfig = context.data.privateConfig;
   if (privateConfig) {
     let branch = privateConfig.branch;
     let fabric = privateConfig.fabric;

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -259,11 +259,13 @@ async function _detachAsync(projectRoot, options) {
     packagesToInstall.push(sdkVersionConfig.expokitNpmPackage);
   }
 
-  const { packagesToInstallWhenEjecting } = sdkVersionConfig;
-  if (isPlainObject(packagesToInstallWhenEjecting)) {
-    Object.keys(packagesToInstallWhenEjecting).forEach(packageName => {
-      packagesToInstall.push(`${packageName}@${packagesToInstallWhenEjecting[packageName]}`);
-    });
+  if (sdkVersionConfig) {
+    const { packagesToInstallWhenEjecting } = sdkVersionConfig;
+    if (isPlainObject(packagesToInstallWhenEjecting)) {
+      Object.keys(packagesToInstallWhenEjecting).forEach(packageName => {
+        packagesToInstall.push(`${packageName}@${packagesToInstallWhenEjecting[packageName]}`);
+      });
+    }
   }
 
   if (packagesToInstall.length) {

--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -6,8 +6,8 @@ import rimraf from 'rimraf';
 import Api from '../Api';
 import {
   isDirectory,
-  rimrafDontThrow,
   parseSdkMajorVersion,
+  rimrafDontThrow,
   spawnAsyncThrowError,
   transformFileContentsAsync,
 } from './ExponentTools';
@@ -272,7 +272,7 @@ async function createDetachedAsync(context) {
 
   const projectPackageJsonPath = path.join(projectRootDirectory, 'package.json');
 
-  if (!await fs.exists(projectPackageJsonPath)) {
+  if (!(await fs.exists(projectPackageJsonPath))) {
     logger.info('Copying blank package.json...');
     await fs.copy(
       path.join(expoRootTemplateDirectory, 'exponent-view-template', 'package.json'),
@@ -308,7 +308,9 @@ async function createDetachedAsync(context) {
 
 async function _getPackagesToInstallWhenEjecting(sdkVersion) {
   const versions = await Versions.versionsAsync();
-  return versions.sdkVersions[sdkVersion].packagesToInstallWhenEjecting;
+  return versions.sdkVersions[sdkVersion]
+    ? versions.sdkVersions[sdkVersion].packagesToInstallWhenEjecting
+    : null;
 }
 
 // @tsapeta: Temporarily copied from Detach._detachAsync. This needs to be invoked also when creating a shell app workspace


### PR DESCRIPTION
Fixes a couple of small issues with XDL/detaching that I found while testing yesterday:
- If you try to detach & provide a local EXPO_VIEW_DIR but the SDK version does not exist on the server, it errors with `Could not read property `packagesToInstallWhenEjecting` of undefined`. This should work, so I changed this code to handle the case where the SDK version config is undefined.
- When detaching, the Android shell app modifier uses the local manifest, except for the `android.config` field for which it uses the published manifest. This was probably an oversight. Fixed this to use the local manifest for everything, in order to be consistent.

Note to self: rebase & merge without squashing