### PR TITLE
Improve iOS PWA defaults

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -31,7 +31,8 @@ const DEFAULT_DESCRIPTION = 'A Neat Expo App';
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_START_URL = '.';
 const DEFAULT_DISPLAY = 'standalone';
-const DEFAULT_STATUS_BAR = 'default';
+// Enable full-screen iOS PWAs
+const DEFAULT_STATUS_BAR = 'black-translucent';
 const DEFAULT_LANG_DIR = 'auto';
 const DEFAULT_ORIENTATION = 'any';
 const ICON_SIZES = [192, 512];

--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -47,6 +47,11 @@
         -moz-osx-font-smoothing: grayscale;
         -ms-overflow-style: scrollbar;
       }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: black;
+        }
+      }
     </style>
   </head>
 


### PR DESCRIPTION
- Make `<body />` dark-mode compliant by default. Prevent white flashing when the rest of the app is dark-mode compliant.
- Enable full-screen iOS PWAs by default.