### PR TITLE
fix: eject failing to validate dependencies

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -140,23 +140,24 @@ export async function ejectAsync(
   }
 }
 
-function ensureDependenciesMap(value: any): DependenciesMap {
-  if (typeof value !== 'object') {
-    throw new Error(`Dependency map is invalid, expected object but got ${typeof value}`);
+function ensureDependenciesMap(dependencies: any): DependenciesMap {
+  if (typeof dependencies !== 'object') {
+    throw new Error(`Dependency map is invalid, expected object but got ${typeof dependencies}`);
   }
 
   const outputMap: DependenciesMap = {};
-  if (!value) return outputMap;
+  if (!dependencies) return outputMap;
 
-  for (const key of Object.keys(value)) {
-    if (key in value) {
-      if (typeof value === 'string') {
-        outputMap[key] = value;
-      } else {
-        throw new Error(
-          `Dependency for key \`${key}\` should be a \`string\`, instead got: \`{ ${key}: ${value} }\``
-        );
-      }
+  for (const key of Object.keys(dependencies)) {
+    const value = dependencies[key];
+    if (typeof value === 'string') {
+      outputMap[key] = value;
+    } else {
+      throw new Error(
+        `Dependency for key \`${key}\` should be a \`string\`, instead got: \`{ ${key}: ${JSON.stringify(
+          value
+        )} }\``
+      );
     }
   }
   return outputMap;


### PR DESCRIPTION
`expo eject` was failing with the following error:
```
Dependency for key `expo` should be a `string`, instead got: `{ expo: [object Object] }`
```
because the code tested `if (typeof value === 'string')` where `value` was the dependencies object such as `{"expo":"^35.0.0","react":"16.8.3","react-dom":"16.8.3","react-native":"0.59.10","react-native-gesture-handler":"~1.4.1","react-native-reanimated":"~1.3.0","react-native-screens":"1.0.0-alpha.23","react-native-unimodules":"0.6.0","react-native-web":"^0.11.7"}`.