### PR TITLE
fix: pass owner name into API request

### DIFF
--- a/packages/expo-cli/src/commands/upload/BaseUploader.ts
+++ b/packages/expo-cli/src/commands/upload/BaseUploader.ts
@@ -58,8 +58,9 @@ export default class BaseUploader {
   async _downloadBuildById(id: string): Promise<string> {
     const { platform } = this;
     const slug = this._getSlug();
+    const owner = this._getOwner();
     // @ts-ignore: TODO: Fix the limit param
-    const build = await StandaloneBuild.getStandaloneBuilds({ id, slug, platform });
+    const build = await StandaloneBuild.getStandaloneBuilds({ id, slug, platform, owner });
     if (!build) {
       throw new Error(`We couldn't find build with id ${id}`);
     }
@@ -73,12 +74,21 @@ export default class BaseUploader {
     return this._exp.slug;
   }
 
+  _getOwner(): string | undefined {
+    if (!this._exp || !this._exp.owner) {
+      return undefined
+    }
+    return this._exp.owner;
+  }
+
   async _downloadLastestBuild() {
     const { platform } = this;
 
     const slug = this._getSlug();
+    const owner = this._getOwner();
     const build = await StandaloneBuild.getStandaloneBuilds({
       slug,
+      owner,
       platform,
       limit: 1,
     });

--- a/packages/xdl/src/StandaloneBuild.ts
+++ b/packages/xdl/src/StandaloneBuild.ts
@@ -4,20 +4,24 @@ import _ from 'lodash';
 import ApiV2Client from './ApiV2';
 import UserManager from './User';
 
+interface StandaloneBuildParams {
+  id?: string;
+  platform: Platform;
+  limit: number;
+  slug: string;
+  owner?: string;
+}
+
 export async function getStandaloneBuilds({
   id,
   platform,
   limit,
   slug,
-}: {
-  id?: string;
-  platform: Platform;
-  limit: number;
-  slug: string;
-}) {
+  owner,
+}: StandaloneBuildParams) {
   const user = await UserManager.ensureLoggedInAsync();
   const api = ApiV2Client.clientForUser(user);
-  const params = { id, slug, platform, limit, status: 'finished' };
+  const params = { id, slug, platform, limit, status: 'finished', owner };
   const { builds } = await api.getAsync('standalone-build/get', params);
   return id || limit === 1 ? _.first(builds) : builds;
 }


### PR DESCRIPTION
Docs stated that the owner id would be respected (and is respected on build) but they are currently not being accounted for when searching for built apps
This PR was created to pass the owner name from the app.json context within the files through to the API request to be handled there.
Currently, when uploading an app that belongs to another team you'll be prompted with:
``` 
Failed to upload the standalone app to the app store.
There are no builds on the Expo servers, please run 'expo build:ios' first 
```
The build ran fine with the owner name so I'm assuming some backend work still needs to be taken care of for this to take effect.