### PR TITLE
fix: no iPhone devices available in Simulator

### DIFF
--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -193,7 +193,10 @@ async function _getFirstAvailableDeviceAsync() {
   const devices = simulatorDeviceInfo[iOSRuntimesNewestToOldest[0]];
   for (let i = 0; i < devices.length; i++) {
     const device = devices[i];
-    if (device.isAvailable && device.name.includes('iPhone')) {
+    if (
+      (device.isAvailable || device.availability === '(available)') &&
+      device.name.includes('iPhone')
+    ) {
       return device;
     }
   }


### PR DESCRIPTION
Older Xcode versions report device availability differently (see https://github.com/expo/expo-cli/issues/1225#issuecomment-554068190). This PR should address the differences by looking for `availability: '(available)'` in addition to `isAvailable: true`.