### PR TITLE
[xdl][config] Updated entry point to reuse Webpack entry resolver

### DIFF
--- a/packages/config/src/Modules.ts
+++ b/packages/config/src/Modules.ts
@@ -2,7 +2,11 @@ import resolveFrom from 'resolve-from';
 
 import { ExpoConfig } from './Config.types';
 
-export function resolveModule(request: string, projectRoot: string, exp: ExpoConfig): string {
+export function resolveModule(
+  request: string,
+  projectRoot: string,
+  exp: Pick<ExpoConfig, 'nodeModulesPath'>
+): string {
   const fromDir = exp.nodeModulesPath ? exp.nodeModulesPath : projectRoot;
   return resolveFrom(fromDir, request);
 }
@@ -10,7 +14,7 @@ export function resolveModule(request: string, projectRoot: string, exp: ExpoCon
 export function projectHasModule(
   modulePath: string,
   projectRoot: string,
-  exp: ExpoConfig
+  exp: Pick<ExpoConfig, 'nodeModulesPath'>
 ): string | undefined {
   const fromDir = exp.nodeModulesPath ? exp.nodeModulesPath : projectRoot;
   return resolveFrom.silent(fromDir, modulePath);

--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -1,5 +1,6 @@
-import * as ConfigUtils from '@expo/config';
+import { configFilename, readConfigJsonAsync } from '@expo/config';
 import { AppJSONConfig, BareAppConfig } from '@expo/config';
+import { getEntryPoint } from '@expo/config/paths';
 import fs from 'fs-extra';
 import merge from 'lodash/merge';
 import path from 'path';
@@ -12,47 +13,33 @@ import tar from 'tar';
 import Api from './Api';
 import Logger from './Logger';
 import NotificationCode from './NotificationCode';
-import * as ThirdParty from './ThirdParty';
 import UserManager from './User';
 import * as UrlUtils from './UrlUtils';
 import UserSettings from './UserSettings';
 import * as ProjectSettings from './ProjectSettings';
 
-// FIXME(perry) eliminate usage of this template
-export const ENTRY_POINT_PLATFORM_TEMPLATE_STRING = 'PLATFORM_GOES_HERE';
-
 // TODO(ville): update when this has landed: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36598
 type ReadEntry = any;
 
-// TODO(Bacon): Add support for index.ts, index.tsx, index.jsx, index.mjs, index.ios.js...
-// TODO(Bacon): Test monorepos with expo/AppEntry module path
-export async function determineEntryPointAsync(projectRoot: string): Promise<string> {
-  let { exp, pkg } = await ConfigUtils.readConfigJsonAsync(projectRoot);
+const supportedPlatforms = ['ios', 'android', 'web'];
 
-  // entryPoint is relative to the packager root and main is relative
-  // to the project root. So if your rn-cli.config.js points to a different
-  // root than the project root, these can be different. Most of the time
-  // you should use main.
-  let entryPoint = pkg.main || 'index.js';
-  if (exp && exp.entryPoint) {
-    entryPoint = exp.entryPoint;
+export function determineEntryPoint(projectRoot: string, platform?: string): string {
+  if (platform && !supportedPlatforms.includes(platform)) {
+    throw new Error(
+      `Failed to resolve the project's entry file: The platform "${platform}" is not supported.`
+    );
   }
+  // TODO: Bacon: support platform extension resolution like .ios, .native
+  // const platforms = [platform, 'native'].filter(Boolean) as string[];
+  const platforms: string[] = [];
 
-  const userDefinedEntryPointExists = await fs.pathExists(path.resolve(projectRoot, entryPoint));
-  if (!userDefinedEntryPointExists) {
-    entryPoint = ConfigUtils.resolveModule('expo/AppEntry', projectRoot, exp);
-    const expoEntryPointExists = await fs.pathExists(entryPoint);
-    // Remove project root from file path
-    entryPoint = path.relative(projectRoot, entryPoint);
-    // Final existence check
-    if (!expoEntryPointExists) {
-      throw new Error(
-        `The project entry file could not be resolved. Please either define it in the \`package.json\` (main), \`app.json\` (expo.entryPoint), create an \`index.js\`, or install the \`expo\` package.`
-      );
-    }
-  }
+  const entry = getEntryPoint(projectRoot, ['./index'], platforms);
+  if (!entry)
+    throw new Error(
+      `The project entry file could not be resolved. Please either define it in the \`package.json\` (main), \`app.json\` (expo.entryPoint), create an \`index.js\`, or install the \`expo\` package.`
+    );
 
-  return entryPoint;
+  return entry;
 }
 
 class Transformer extends Minipass {
@@ -221,45 +208,6 @@ export async function saveRecentExpRootAsync(root: string) {
   return await recentExpsJsonFile.writeAsync(recentExps.slice(0, 100));
 }
 
-function getHomeDir(): string {
-  return process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'] || '';
-}
-
-function makePathReadable(pth: string) {
-  let homedir = getHomeDir();
-  if (pth.substr(0, homedir.length) === homedir) {
-    return `~${pth.substr(homedir.length)}`;
-  } else {
-    return pth;
-  }
-}
-
-export async function expInfoSafeAsync(root: string) {
-  try {
-    let {
-      exp: { name, description, icon, iconUrl },
-    } = await ConfigUtils.readConfigJsonAsync(root);
-    let pathOrUrl =
-      icon || iconUrl || 'https://d3lwq5rlu14cro.cloudfront.net/ExponentEmptyManifest_192.png';
-    let resolvedPath = path.resolve(root, pathOrUrl);
-    if (fs.existsSync(resolvedPath)) {
-      icon = `file://${resolvedPath}`;
-    } else {
-      icon = pathOrUrl; // Assume already a URL
-    }
-
-    return {
-      readableRoot: makePathReadable(root),
-      root,
-      name,
-      description,
-      icon,
-    };
-  } catch (e) {
-    return null;
-  }
-}
-
 type PublishInfo = {
   args: {
     username: string;
@@ -272,45 +220,6 @@ type PublishInfo = {
   };
 };
 
-export async function getThirdPartyInfoAsync(publicUrl: string): Promise<PublishInfo> {
-  const user = await UserManager.ensureLoggedInAsync();
-
-  if (!user) {
-    throw new Error('Attempted to login in offline mode. This is a bug.');
-  }
-
-  const { username } = user;
-
-  const exp = await ThirdParty.getManifest(publicUrl);
-  const { slug, sdkVersion, version } = exp;
-  if (!sdkVersion) {
-    throw new Error(`sdkVersion is missing from ${publicUrl}`);
-  }
-
-  if (!slug) {
-    // slug is made programmatically for app.json
-    throw new Error(`slug field is missing from exp.json.`);
-  }
-
-  if (!version) {
-    throw new Error(`Can't get version of package.`);
-  }
-
-  const iosBundleIdentifier = exp.ios ? exp.ios.bundleIdentifier : null;
-  const androidPackage = exp.android ? exp.android.package : null;
-  return {
-    args: {
-      username,
-      remoteUsername: username,
-      remotePackageName: slug,
-      remoteFullPackageName: `@${username}/${slug}`,
-      sdkVersion,
-      iosBundleIdentifier,
-      androidPackage,
-    },
-  };
-}
-
 // TODO: remove / change, no longer publishInfo, this is just used for signing
 export async function getPublishInfoAsync(root: string): Promise<PublishInfo> {
   const user = await UserManager.ensureLoggedInAsync();
@@ -321,12 +230,12 @@ export async function getPublishInfoAsync(root: string): Promise<PublishInfo> {
 
   let { username } = user;
 
-  const { exp } = await ConfigUtils.readConfigJsonAsync(root);
+  const { exp } = await readConfigJsonAsync(root);
 
   const name = exp.slug;
   const { version, sdkVersion } = exp;
 
-  const configName = ConfigUtils.configFilename(root);
+  const configName = configFilename(root);
 
   if (!sdkVersion) {
     throw new Error(`sdkVersion is missing from ${configName}`);
@@ -360,15 +269,6 @@ export async function getPublishInfoAsync(root: string): Promise<PublishInfo> {
   };
 }
 
-export async function recentValidExpsAsync() {
-  let recentExpsJsonFile = UserSettings.recentExpsJsonFile();
-  let recentExps = await recentExpsJsonFile.readAsync();
-
-  let results = await Promise.all(recentExps.map(expInfoSafeAsync));
-  let filteredResults = results.filter(result => result);
-  return filteredResults;
-}
-
 export async function sendAsync(recipient: string, url_: string, allowUnauthed: boolean = true) {
   let result = await Api.callMethodAsync('send', [recipient, url_, allowUnauthed]);
   return result;
@@ -389,12 +289,4 @@ export async function resetProjectRandomnessAsync(projectRoot: string) {
   let randomness = UrlUtils.someRandomness();
   ProjectSettings.setAsync(projectRoot, { urlRandomness: randomness });
   return randomness;
-}
-
-export async function clearXDLCacheAsync() {
-  let dotExpoHomeDirectory = UserSettings.dotExpoHomeDirectory();
-  fs.removeSync(path.join(dotExpoHomeDirectory, 'ios-simulator-app-cache'));
-  fs.removeSync(path.join(dotExpoHomeDirectory, 'android-apk-cache'));
-  fs.removeSync(path.join(dotExpoHomeDirectory, 'starter-app-cache'));
-  Logger.notifications.info(`Cleared cache`);
 }

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -1,11 +1,10 @@
-import * as ConfigUtils from '@expo/config';
+import { readConfigJsonAsync, resolveModule } from '@expo/config';
 import joi from 'joi';
 import os from 'os';
 import url from 'url';
 import validator from 'validator';
 
 import Config from './Config';
-import * as Exp from './Exp';
 import ip from './ip';
 import * as ProjectUtils from './project/ProjectUtils';
 import * as ProjectSettings from './ProjectSettings';
@@ -126,7 +125,7 @@ export async function constructBundleQueryParamsAsync(projectRoot: string, opts:
 
   queryParams += '&hot=false';
 
-  let { exp } = await ConfigUtils.readConfigJsonAsync(projectRoot);
+  let { exp } = await readConfigJsonAsync(projectRoot);
 
   // SDK11 to SDK32 require us to inject hashAssetFiles through the params, but this is not
   // needed with SDK33+
@@ -134,7 +133,7 @@ export async function constructBundleQueryParamsAsync(projectRoot: string, opts:
   let usesAssetPluginsQueryParam = supportsAssetPlugins && Versions.lteSdkVersion(exp, '32.0.0');
   if (usesAssetPluginsQueryParam) {
     // Use an absolute path here so that we can not worry about symlinks/relative requires
-    let pluginModule = ConfigUtils.resolveModule('expo/tools/hashAssetFiles', projectRoot, exp);
+    let pluginModule = resolveModule('expo/tools/hashAssetFiles', projectRoot, exp);
     queryParams += `&assetPlugin=${encodeURIComponent(pluginModule)}`;
   } else if (!supportsAssetPlugins) {
     // Only sdk-10.1.0+ supports the assetPlugin parameter. We use only the
@@ -208,7 +207,7 @@ export async function constructUrlAsync(
   } else {
     protocol = 'exp';
 
-    let { exp } = await ConfigUtils.readConfigJsonAsync(projectRoot);
+    let { exp } = await readConfigJsonAsync(projectRoot);
     if (exp.detach) {
       if (exp.scheme && Versions.gteSdkVersion(exp, '27.0.0')) {
         protocol = exp.scheme;
@@ -338,14 +337,6 @@ export function domainify(s: string): string {
     .replace(/[^a-z0-9-]/g, '-')
     .replace(/^-+/, '')
     .replace(/-+$/, '');
-}
-
-export function getPlatformSpecificBundleUrl(url: string, platform: string): string {
-  if (url.includes(Exp.ENTRY_POINT_PLATFORM_TEMPLATE_STRING)) {
-    return url.replace(Exp.ENTRY_POINT_PLATFORM_TEMPLATE_STRING, platform);
-  } else {
-    return url;
-  }
 }
 
 export function isHttps(url: string): boolean {

--- a/packages/xdl/src/__tests__/Exp-test.js
+++ b/packages/xdl/src/__tests__/Exp-test.js
@@ -5,7 +5,7 @@ jest.mock('fs');
 const fs = require('fs');
 const mockfs = require('mock-fs');
 
-describe('determineEntryPointAsync', () => {
+describe('determineEntryPoint', () => {
   beforeEach(() => {
     const packageJson = JSON.stringify(
       {
@@ -89,33 +89,33 @@ describe('determineEntryPointAsync', () => {
     mockfs.restore();
   });
 
-  it('exists-no-platform', async () => {
-    const entryPoint = await Exp.determineEntryPointAsync('/exists-no-platform');
+  it('exists-no-platform', () => {
+    const entryPoint = Exp.determineEntryPoint('/exists-no-platform');
     expect(entryPoint).toBe('index.js');
   });
 
-  it('exists-no-platform-no-main', async () => {
-    const entryPoint = await Exp.determineEntryPointAsync('/exists-no-platform-no-main');
+  it('exists-no-platform-no-main', () => {
+    const entryPoint = Exp.determineEntryPoint('/exists-no-platform-no-main');
     expect(entryPoint).toBe('index.js');
   });
 
-  it('exists-android', async () => {
-    const entryPoint = await Exp.determineEntryPointAsync('/exists-android');
+  it('exists-android', () => {
+    const entryPoint = Exp.determineEntryPoint('/exists-android');
     expect(entryPoint).toBe('index.android.js');
   });
 
-  it('exists-ios', async () => {
-    const entryPoint = await Exp.determineEntryPointAsync('/exists-ios');
+  it('exists-ios', () => {
+    const entryPoint = Exp.determineEntryPoint('/exists-ios');
     expect(entryPoint).toBe('index.ios.js');
   });
 
-  it('exists-expjson', async () => {
-    const entryPoint = await Exp.determineEntryPointAsync('/exists-expjson');
+  it('exists-expjson', () => {
+    const entryPoint = Exp.determineEntryPoint('/exists-expjson');
     expect(entryPoint).toBe('main.js');
   });
 
-  it('uses node_modules/expo/AppEntry as a last resort', async () => {
-    const entryPoint = await Exp.determineEntryPointAsync('/expo-app-entry');
+  it('uses node_modules/expo/AppEntry as a last resort', () => {
+    const entryPoint = Exp.determineEntryPoint('/expo-app-entry');
     expect(entryPoint).toBe('node_modules/expo/AppEntry.js');
   });
 });

--- a/packages/xdl/src/project/ProjectUtils.ts
+++ b/packages/xdl/src/project/ProjectUtils.ts
@@ -1,5 +1,3 @@
-import * as ConfigUtils from '@expo/config';
-
 import chalk from 'chalk';
 import path from 'path';
 
@@ -144,27 +142,4 @@ export function clearNotification(projectRoot: string, id: string) {
 
 export function attachLoggerStream(projectRoot: string, stream: LogStream) {
   _getLogger(projectRoot).addStream(stream);
-}
-
-// Wrap with logger
-
-export async function readExpRcAsync(projectRoot: string): Promise<any> {
-  try {
-    return await ConfigUtils.readExpRcAsync(projectRoot);
-  } catch (e) {
-    logError(projectRoot, 'expo', e.message);
-    return {};
-  }
-}
-
-export async function readConfigJsonAsync(
-  projectRoot: string,
-  skipValidation: boolean = false
-): Promise<ConfigUtils.ProjectConfig | { exp: null; pkg: null }> {
-  try {
-    return await ConfigUtils.readConfigJsonAsync(projectRoot, skipValidation);
-  } catch (error) {
-    logError(projectRoot, 'expo', error.message);
-    return { exp: null, pkg: null };
-  }
 }


### PR DESCRIPTION
- `determineEntryPointAsync` -> `determineEntryPoint`
- `determineEntryPoint` now uses `getEntryPoint` without platforms
- remove unused methods 