### PR TITLE
[dev-tools] Add informative error page when root GQL query fails

### DIFF
--- a/packages/dev-tools/components/IndexPageErrors.js
+++ b/packages/dev-tools/components/IndexPageErrors.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { css } from 'react-emotion';
+
+import * as Constants from 'app/common/constants';
+
+const STYLES_ERROR_CONTAINER = css`
+  background: ${Constants.colors.foreground};
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  height: 100%;
+  width: 100%;
+  padding: 40px 60px;
+  font-family: ${Constants.fontFamilies.regular};
+  color: ${Constants.colors.white};
+`;
+
+const STYLE_MESSAGE = css`
+  font-family: ${Constants.fontFamilies.mono};
+  color: ${Constants.colors.white};
+  line-height: 14px;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+  margin-top: 20px;
+`;
+
+const STYLES_ERROR = css`
+  color: ${Constants.colors.red};
+`;
+
+export default props => (
+  <div className={STYLES_ERROR_CONTAINER}>
+    <div className={STYLE_MESSAGE}>Error loading DevTools</div>
+    {props.error.graphQLErrors.map(error => {
+      return <div className={`${STYLE_MESSAGE} ${STYLES_ERROR}`}>{error.message}</div>;
+    })}
+  </div>
+);

--- a/packages/dev-tools/pages/index.js
+++ b/packages/dev-tools/pages/index.js
@@ -11,6 +11,7 @@ import { initStore } from 'app/common/store';
 import withRedux from 'app/higher-order/withRedux';
 
 import Root from 'app/components/Root';
+import IndexPageErrors from 'app/components/IndexPageErrors';
 import ProjectManager from 'app/components/ProjectManager';
 
 const MessageFragment = gql`
@@ -513,8 +514,10 @@ export default class IndexPage extends React.Component {
           {result => {
             if (!result.loading && !result.error) {
               return <IndexPageContents {...result} disconnected={this.state.disconnected} />;
+            } else if (result.error) {
+              return <IndexPageErrors error={result.error} />;
             } else {
-              // TODO(freiksenet): fix loading states
+              // TODO(wschurman): maybe add a loading state
               return null;
             }
           }}


### PR DESCRIPTION
why
===

Previously, when the root GraphQL query resulted in an error, the resulting interface in dev-tools would be a blank black page (null component). 

how
===

This PR adds a new component to handle that case which displays errors in a more informative way to users (the same way the CLI does in the shell).

test plan
===

1. Create blank test expo project via `expo init`
1. `cd` into `dev-tools` directory within this repo in a new terminal tab.
1. `yarn run dev <path-to-expo-project>`
1. Change the `expo` key to `blah` in `app.json` within the expo project.
1. See that the errors are displayed to the user rather than a blank page.

Also test the production build:
1. In this repo, `yarn start`
1. In expo project from above, run `<path-to-expo-cli-repo>/packages/expo-cli/bin/expo.js start`
1. Toggle between a valid and invalid `app.json` via same method as above, ensure errors are shown in the error case and not in the valid case.

Before:
<img width="924" alt="Screen Shot 2019-11-15 at 5 01 09 PM" src="https://user-images.githubusercontent.com/189568/68985515-dc0fcd00-07cb-11ea-9a62-63e75b2baeb5.png">
After:
<img width="924" alt="Screen Shot 2019-11-15 at 5 00 23 PM" src="https://user-images.githubusercontent.com/189568/68985518-e16d1780-07cb-11ea-96f0-5fcffd14e796.png">
