### PR TITLE
[dev-tools] Fix graphql errors when config is invalid

### DIFF
--- a/packages/dev-tools/server/graphql/GraphQLSchema.js
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.js
@@ -438,7 +438,7 @@ const resolvers = {
         const { exp } = await readConfigJsonAsync(project.projectDir);
         return exp;
       } catch (error) {
-        ProjectUtils.logError(project.projectRoot, 'expo', error.message);
+        ProjectUtils.logError(project.projectDir, 'expo', error.message);
         return null;
       }
     },
@@ -514,11 +514,19 @@ const resolvers = {
     },
     async processInfo(parent, args, context) {
       const currentProject = context.getCurrentProject();
-      const { exp } = await ProjectUtils.readConfigJsonAsync(currentProject.projectDir);
+
+      let platforms = [];
+      try {
+        const { exp } = await readConfigJsonAsync(currentProject.projectDir);
+        platforms = exp.platforms;
+      } catch (error) {
+        ProjectUtils.logError(currentProject.projectDir, 'expo', error.message);
+      }
+
       return {
         isAndroidSimulatorSupported: Android.isPlatformSupported(),
         isIosSimulatorSupported: Simulator.isPlatformSupported(),
-        webAppUrl: exp.platforms.includes('web')
+        webAppUrl: platforms.includes('web')
           ? await UrlUtils.constructWebAppUrlAsync(currentProject.projectDir)
           : null,
       };


### PR DESCRIPTION
why
===

Two issues:
- `project.projectRoot` isn't a valid property, making the call to `ProjectUtils.logError` invalid. `project.projectDir` is the closest (and only available) property.
- Calls to `readConfigJsonAsync` can throw, so a similar try/catch treatment in necessary in `processInfo` which reads the config to determine whether the web platform is supported.

how
===

change the variables and add the try catch. New behavior is to return null `webAppUrl` when config is invalid rather than throwing and returning a GQL error.

test plan
===

1. Create blank expo project
1. Inside `dev-tools` package directory, run `yarn run dev <path to blank project>`
1. Change `app.config` to be invalid. See console errors no longer contain null/undefined object exceptions.

Before: 
```
Uncaught (in promise) Error: GraphQL error: The "path" argument must be of type string. Received type undefined
GraphQL error: Cannot read property 'platforms' of null
GraphQL error: Property 'expo' in app.json is not an object. Please make sure app.json includes a managed Expo app config like this: {"expo":{"name":"My app","slug":"my-app","sdkVersion":"..."}}
```
After:
```
Uncaught (in promise) Error: GraphQL error: Property 'expo' in app.json is not an object. Please make sure app.json includes a managed Expo app config like this: {"expo":{"name":"My app","slug":"my-app","sdkVersion":"..."}}
```