### PR TITLE
Refactor: convert some Expo CLI commands to TypeScript

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -50,6 +50,7 @@
     "@types/ansi-regex": "^4.0.0",
     "@types/dateformat": "^3.0.0",
     "@types/inquirer": "6.0.3",
+    "@types/inflection": "^1.5.28",
     "@types/npm-package-arg": "^6.1.0",
     "@types/progress": "^2.0.3",
     "@types/slash": "^2.0.0",

--- a/packages/expo-cli/src/PackageManager.ts
+++ b/packages/expo-cli/src/PackageManager.ts
@@ -165,10 +165,7 @@ export class YarnPackageManager implements PackageManager {
 
 export type CreateForProjectOptions = { npm?: boolean; yarn?: boolean };
 
-export function createForProject(
-  projectRoot: string,
-  options: CreateForProjectOptions = {}
-) {
+export function createForProject(projectRoot: string, options: CreateForProjectOptions = {}) {
   console.warn(
     '`createForProject` is deprecated in favor of `createForProject` from `@expo/package-manager`'
   );

--- a/packages/expo-cli/src/PackageManager.ts
+++ b/packages/expo-cli/src/PackageManager.ts
@@ -163,9 +163,11 @@ export class YarnPackageManager implements PackageManager {
   }
 }
 
+export type CreateForProjectOptions = { npm?: boolean; yarn?: boolean };
+
 export function createForProject(
   projectRoot: string,
-  options: { npm?: boolean; yarn?: boolean } = {}
+  options: CreateForProjectOptions = {}
 ) {
   console.warn(
     '`createForProject` is deprecated in favor of `createForProject` from `@expo/package-manager`'

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -1,11 +1,12 @@
 import * as Eject from './eject/Eject';
+import { Command } from 'commander';
 
 // Set EXPO_VIEW_DIR to universe/exponent to pull expo view code locally instead of from S3
-async function action(projectDir, options) {
+async function action(projectDir: string, options: Eject.EjectAsyncOptions) {
   await Eject.ejectAsync(projectDir, options);
 }
 
-export default program => {
+export default function (program: Command) {
   program
     .command('eject [project-dir]')
     .description(

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -19,6 +19,13 @@ type ValidationErrorMessage = string;
 
 type DependenciesMap = { [key: string]: string | number };
 
+export type EjectAsyncOptions = {
+  ejectMethod: 'bare' | 'expokit' | 'cancel';
+  verbose?: boolean;
+  force?: boolean;
+  packageManager?: 'npm' | 'yarn';
+};
+
 const EXPO_APP_ENTRY = 'node_modules/expo/AppEntry.js';
 
 async function warnIfDependenciesRequireAdditionalSetupAsync(projectRoot: string): Promise<void> {
@@ -62,12 +69,7 @@ async function warnIfDependenciesRequireAdditionalSetupAsync(projectRoot: string
 
 export async function ejectAsync(
   projectRoot: string,
-  options: {
-    ejectMethod: 'bare' | 'expokit' | 'cancel';
-    verbose?: boolean;
-    force?: boolean;
-    packageManager?: 'npm' | 'yarn';
-  }
+  options: EjectAsyncOptions,
 ) {
   await validateGitStatusAsync();
   log.nested('');

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -1,4 +1,3 @@
-/* @flow */
 import * as ConfigUtils from '@expo/config';
 import fs from 'fs';
 import { inflect } from 'inflection';
@@ -6,13 +5,14 @@ import JsonFile from '@expo/json-file';
 import npmPackageArg from 'npm-package-arg';
 import path from 'path';
 import { Versions } from '@expo/xdl';
+import { Command } from 'commander';
 
 import * as PackageManager from '@expo/package-manager';
 import CommandError from '../CommandError';
 import { findProjectRootAsync } from './utils/ProjectUtils';
 import log from '../log';
 
-async function installAsync(packages, options) {
+async function installAsync(packages: string[], options: PackageManager.CreateForProjectOptions) {
   const { projectRoot, workflow } = await findProjectRootAsync(process.cwd());
   const packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,
@@ -74,7 +74,7 @@ async function installAsync(packages, options) {
   await packageManager.addAsync(...versionedPackages);
 }
 
-export default program => {
+export default function (program: Command) {
   program
     .command('install [packages...]')
     .alias('add')

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -74,7 +74,7 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   await packageManager.addAsync(...versionedPackages);
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('install [packages...]')
     .alias('add')
@@ -82,4 +82,4 @@ export default function (program: Command) {
     .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
     .description('Installs a unimodule or other package to a project.')
     .asyncAction(installAsync);
-};
+}

--- a/packages/expo-cli/tsconfig.json
+++ b/packages/expo-cli/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@expo/babel-preset-cli/tsconfig.base",
   "include": ["src/**/*.ts", "package.json"],
   "compilerOptions": {
-    "outDir": "build"
+    "outDir": "build",
+    "resolveJsonModule": true
   },
   "references": [
     { "path": "../xdl" }

--- a/packages/package-manager/src/PackageManager.ts
+++ b/packages/package-manager/src/PackageManager.ts
@@ -176,10 +176,9 @@ export class YarnPackageManager implements PackageManager {
   }
 }
 
-export function createForProject(
-  projectRoot: string,
-  options: { npm?: boolean; yarn?: boolean; log?: Logger } = {}
-) {
+export type CreateForProjectOptions = { npm?: boolean; yarn?: boolean; log?: Logger };
+
+export function createForProject(projectRoot: string, options: CreateForProjectOptions = {}) {
   let PackageManager;
   if (options.npm) {
     PackageManager = NpmPackageManager;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,6 +2443,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/inflection@^1.5.28":
+  version "1.5.28"
+  resolved "https://registry.yarnpkg.com/@types/inflection/-/inflection-1.5.28.tgz#43d55e0d72cf333a2dffd9c4ec0407455a1b0931"
+  integrity sha1-Q9VeDXLPMzot/9nE7AQHRVobCTE=
+
 "@types/inquirer@6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-6.0.3.tgz#597b3c1aa4a575899841ab99bb4f1774d0b8c090"


### PR DESCRIPTION
why
===

Relatively easy to convert, so why not.

how
===

Rename the `eject` and `install` commands to `.ts` and run typechecker on them.

test plan
======
In local sample project, run the following to test the commands, ensure they behave normally:
`~/expo/expo-cli/packages/expo-cli/bin/expo.js install await-lock`
`~/expo/expo-cli/packages/expo-cli/bin/expo.js eject`