### PR TITLE
fix(xdl): fix Exp.determineEntryPoint regression

### DIFF
--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -39,7 +39,7 @@ export function determineEntryPoint(projectRoot: string, platform?: string): str
       `The project entry file could not be resolved. Please either define it in the \`package.json\` (main), \`app.json\` (expo.entryPoint), create an \`index.js\`, or install the \`expo\` package.`
     );
 
-  return entry;
+  return path.relative(projectRoot, entry);
 }
 
 class Transformer extends Minipass {


### PR DESCRIPTION
Exp.determineEntryPoint needs to return a relative path, because it's
passed to UrlUtils.guessMainModulePath, which expects a path relative
to the project root. This path is used in the bundle URL, assets URLs
and source map URLs.