### PR TITLE
fix: stop overriding assetExts

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1700,7 +1700,6 @@ export async function startReactNativeServerAsync(
   let packagerOpts: { [key: string]: any } = {
     port: packagerPort,
     customLogReporterPath,
-    assetExts: ['ttf'],
     // TODO: Bacon: Support .mjs (short-lived JS modules extension that some packages use)
     sourceExts: getManagedExtensions([], { isTS: true, isReact: true, isModern: false }),
   };
@@ -1732,11 +1731,6 @@ export async function startReactNativeServerAsync(
     packagerOpts = {
       ...packagerOpts,
       ...userPackagerOpts,
-      ...userPackagerOpts.assetExts
-        ? {
-            assetExts: uniq([...packagerOpts.assetExts, ...userPackagerOpts.assetExts]),
-          }
-        : {},
     };
 
     if (userPackagerOpts.port !== undefined && userPackagerOpts.port !== null) {


### PR DESCRIPTION
Expo CLI has been passing the `--assetExts` setting to React Native CLI
and Metro, with the default value `ttf`. The consequence of this was
that any `assetExts` value set in `metro.config.js` was overwritten by
the command-line option set by Expo CLI.

It turns out that for a long time now, Metro has included `ttf` in
`assetExts` *by default*. Therefore we can just stop passing it
without changing the default setting and now the configuration
defined in `metro.config.js` will work again.