### PR TITLE
[expo-cli] Remove manual CLI parsing

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -365,7 +365,7 @@ function runAsync(programName: string) {
       process.exit(0);
     });
 
-    program.on('command:*', (subCommand) => {
+    program.on('command:*', subCommand => {
       log.warn(
         `"${subCommand}" is not an ${programName} command. See "${programName} --help" for the full list of commands.`
       );


### PR DESCRIPTION
why
===
Manual argument parsing (parsing outside of the `commander` framework) is tough to get right as the ordering of arguments and options and commands isn't well-defined (purposeful, best practice for a CLI). In the CLI, the following code is used to accomplish this:
```
let subCommand = process.argv[2];
```
Unfortunately, this results in a bug when the third arg is not the sub command. For example,
```
> expo --non-interactive whoami
[14:53:07] "--non-interactive" is not an expo command. See "expo --help" for the full list of commands.
[14:53:08] Logged in as wschurman
```

The instructions in the help page instruct the user to place global options before the subcommand, so the bug occurs in the recommended format:
```
> expo

  Usage: expo [options] [command]

  Options:

    -V, --version                                       output the version number
    -o, --output [format]                               Output format. pretty (default), raw
    --non-interactive                                   Fail, if an interactive prompt would be required to continue. Enabled by default if stdin is not a TTY.
    -h, --help
```
how
===
`subCommand` was being used for a few things:
1. Detecting unrecognized sub commands
2. Detecting `detach` sub command and alerting the user that they should use `eject` instead.
3. Detecting when `--github` argument is passed to `login` or `register` sub commands and alerting the user that it is no longer available.
4. Showing help when no command is specified.

To handle case 1, we subscribe to the emitted catch all event as detailed and suggested in the official documentation: https://github.com/tj/commander.js#custom-event-listeners

To handle case 2, we subscribe to the `command:detach` event and print a custom warning.

Case 3 is more difficult as deprecating commands and command options isn't supported in `commander.js` (would be a cool contribution to that repo). Instead of adding back in the options and warning in the command action itself, I decided to just allow the CLI default unknown option to show, which is a worse user experience but not too bad IMO. Justification here is that it has been over 1.5 years since the option was available so sacrificing a slightly worse experience for a bugfix is probably worth it.

Case 4 is described in official repo issue: https://github.com/tj/commander.js/issues/7

test plan
===
```
$ ~/expo/expo-cli/packages/expo-cli/bin/expo.js wat
"wat" is not an expo command. See "expo --help" for the full list of commands.
```
```
$ ~/expo/expo-cli/packages/expo-cli/bin/expo.js detach
To eject your project to ExpoKit (previously "detach"), use `expo eject`.
```
```
$ ~/expo/expo-cli/packages/expo-cli/bin/expo.js login --github

  error: unknown option `--github'
```
```
$ ~/expo/expo-cli/packages/expo-cli/bin/expo.js

  Usage: expo [options] [command]
...
```

regression test (sanity check)
===
```
$ ~/expo/expo-cli/packages/expo-cli/bin/expo.js --non-interactive whoami
[15:09:29] Logged in as wschurman
```