### PR TITLE
[dev-tools] Option to choose devtools bind address

### DIFF
--- a/packages/dev-tools/server/DevToolsServer.js
+++ b/packages/dev-tools/server/DevToolsServer.js
@@ -51,29 +51,7 @@ export async function createAuthenticationContextAsync({ graphqlHostname, port }
 export async function startAsync(projectDir) {
   const port = await freeportAsync(19002, { hostnames: [null, 'localhost'] });
   const server = express();
-
-  const devtoolsHost = () => {
-    let devtoolHost;
-    if (process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS) {
-      devtoolHost = process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS.trim();
-    } else {
-      devtoolHost = `localhost`;
-    }
-    return devtoolHost;
-  };
   const listenHostname = devtoolsHost();
-
-  const devtoolsGraphQLHost = () => {
-    let devtoolsGraphQLHost;
-    if (process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS && process.env.REACT_NATIVE_PACKAGER_HOSTNAME) {
-      devtoolsGraphQLHost = process.env.REACT_NATIVE_PACKAGER_HOSTNAME.trim();
-    } else if (process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS) {
-      devtoolsGraphQLHost = process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS;
-    } else {
-      devtoolsGraphQLHost = `localhost`;
-    }
-    return devtoolsGraphQLHost;
-  };
   const graphqlHostname = devtoolsGraphQLHost();
 
   const authenticationContext = await createAuthenticationContextAsync({ graphqlHostname, port });
@@ -138,6 +116,28 @@ export function startGraphQLServer(projectDir, httpServer, authenticationContext
       },
     }
   );
+}
+
+function devtoolsHost() {
+  let devtoolHost;
+  if (process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS) {
+    devtoolHost = process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS.trim();
+  } else {
+    devtoolHost = `localhost`;
+  }
+  return devtoolHost;
+}
+
+function devtoolsGraphQLHost() {
+  let devtoolsGraphQLHost;
+  if (process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS && process.env.REACT_NATIVE_PACKAGER_HOSTNAME) {
+    devtoolsGraphQLHost = process.env.REACT_NATIVE_PACKAGER_HOSTNAME.trim();
+  } else if (process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS) {
+    devtoolsGraphQLHost = process.env.EXPO_DEVTOOLS_LISTEN_ADDRESS;
+  } else {
+    devtoolsGraphQLHost = `localhost`;
+  }
+  return devtoolsGraphQLHost;
 }
 
 function createLayout() {


### PR DESCRIPTION
### Why
As it was reported and discussed in #1081, recent changes break compatibility with Docker.

### How
Adds one new environment variable, `EXPO_DEVTOOLS_LISTEN_ADDRESS` that can be used to give different ip where devtools bind. If no environment variable is given, defaults to `localhost`, which is currently hardcoded value in codebase.

This fix takes use of already used environment variable `REACT_NATIVE_PACKAGER_HOSTNAME`, as it is already needed when using `expo-cli` in Docker container.

### Test plan
- Run expo-cli as usual in normal environment, and check that port 19002 listens only 127.0.0.1
- Run expo-cli with `EXPO_DEVTOOLS_LISTEN_ADDRESS=0.0.0.0 expo-cli start` and check that port 19002 listens all interfaces

Fixes #1081 