### PR TITLE
Show NOTE when running fetch:android:hashes

### DIFF
--- a/packages/expo-cli/src/commands/fetch/android.js
+++ b/packages/expo-cli/src/commands/fetch/android.js
@@ -33,6 +33,7 @@ async function fetchAndroidHashesAsync(projectDir) {
       keystorePassword: get(view, 'credentials.keystorePassword'),
       keyAlias: get(view, 'credentials.keyAlias'),
     });
+    log(`\nNote: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console.`);
   } finally {
     try {
       fs.unlink(outputPath);

--- a/packages/xdl/src/credentials/AndroidCredentials.ts
+++ b/packages/xdl/src/credentials/AndroidCredentials.ts
@@ -209,8 +209,6 @@ export async function logKeystoreHashes(keystoreInfo: KeystoreInfo, linePrefix: 
     log.info(`${linePrefix}Google Certificate Hash (SHA-1):    ${googleHash}`);
     log.info(`${linePrefix}Google Certificate Hash (SHA-256):  ${googleHash256}`);
     log.info(`${linePrefix}Facebook Key Hash:                  ${fbHash}`);
-    log.info(`${linePrefix}`);
-    log.info(`${linePrefix}Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console.`);
   } catch (err) {
     if (err.code === 'ENOENT') {
       log.warn('Are you sure you have keytool installed?');

--- a/packages/xdl/src/credentials/AndroidCredentials.ts
+++ b/packages/xdl/src/credentials/AndroidCredentials.ts
@@ -209,6 +209,8 @@ export async function logKeystoreHashes(keystoreInfo: KeystoreInfo, linePrefix: 
     log.info(`${linePrefix}Google Certificate Hash (SHA-1):    ${googleHash}`);
     log.info(`${linePrefix}Google Certificate Hash (SHA-256):  ${googleHash256}`);
     log.info(`${linePrefix}Facebook Key Hash:                  ${fbHash}`);
+    log.info(`${linePrefix}`);
+    log.info(`${linePrefix}Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console.`);
   } catch (err) {
     if (err.code === 'ENOENT') {
       log.warn('Are you sure you have keytool installed?');


### PR DESCRIPTION
This bit me when trying to include a google maps api key that was restricted to our app hash. While this notice already shows in the `--help` for this command, it would be useful to show it when running the command directly to avoid confusion.