### PR TITLE
[webpack-pwa-manifest-plugin] cache images for rebuilds

### DIFF
--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -209,6 +209,7 @@ export default async function(
 
       new WebpackPWAManifestPlugin(config, {
         publicPath,
+        projectRoot: env.projectRoot,
         noResources: !generatePWAImageAssets,
         filename: locations.production.manifest,
         HtmlWebpackPlugin: ExpoHtmlWebpackPlugin,

--- a/packages/webpack-pwa-manifest-plugin/src/WebpackPWAManifestPlugin.ts
+++ b/packages/webpack-pwa-manifest-plugin/src/WebpackPWAManifestPlugin.ts
@@ -28,11 +28,13 @@ export default class WebpackPWAManifest {
   expoConfig: ExpoConfig;
   options: any;
   HtmlWebpackPlugin: any;
+  projectRoot: string;
 
   constructor(
     appJson: ExpoConfig,
-    { noResources, filename, publicPath, HtmlWebpackPlugin }: ManifestProps
+    { noResources, filename, publicPath, HtmlWebpackPlugin, projectRoot }: ManifestProps
   ) {
+    this.projectRoot = projectRoot || process.cwd();
     this.HtmlWebpackPlugin = HtmlWebpackPlugin;
 
     this.manifest = createPWAManifestFromExpoConfig(appJson);

--- a/packages/webpack-pwa-manifest-plugin/src/WebpackPWAManifestPlugin.types.ts
+++ b/packages/webpack-pwa-manifest-plugin/src/WebpackPWAManifestPlugin.types.ts
@@ -18,6 +18,7 @@ export interface ManifestProps {
   filename: string;
   publicPath: string;
   HtmlWebpackPlugin: any;
+  projectRoot: string;
 }
 
 export type Tags = { [key: string]: Tag[] | Tag };

--- a/packages/webpack-pwa-manifest-plugin/src/__tests__/icons-test.js
+++ b/packages/webpack-pwa-manifest-plugin/src/__tests__/icons-test.js
@@ -15,7 +15,7 @@ it(`matches`, async () => {
   const [icons] = retrieveIcons(manifest);
 
   const publicPath = '/DEMO_PATH';
-  const { icons: parsedIcons, assets } = await parseIconsAsync(icons, false, publicPath);
+  const { icons: parsedIcons, assets } = await parseIconsAsync(__dirname, icons, publicPath);
 
   for (const icon of parsedIcons) {
     const { sizes } = icon;

--- a/packages/webpack-pwa-manifest-plugin/src/injector.ts
+++ b/packages/webpack-pwa-manifest-plugin/src/injector.ts
@@ -80,7 +80,8 @@ export async function buildResourcesAsync(self: any, publicPath: string = '') {
     if (!self.options.noResources) {
       const [results, config] = retrieveIcons(self.manifest);
       self.manifest = config;
-      parsedIconsResult = await parseIconsAsync(results, self.options.fingerprints, publicPath);
+      // TODO: Bacon: Better dynamic path
+      parsedIconsResult = await parseIconsAsync(process.cwd(), results, publicPath);
     }
 
     const { icons, assets = [] } = parsedIconsResult;

--- a/packages/webpack-pwa-manifest-plugin/src/injector.ts
+++ b/packages/webpack-pwa-manifest-plugin/src/injector.ts
@@ -80,8 +80,7 @@ export async function buildResourcesAsync(self: any, publicPath: string = '') {
     if (!self.options.noResources) {
       const [results, config] = retrieveIcons(self.manifest);
       self.manifest = config;
-      // TODO: Bacon: Better dynamic path
-      parsedIconsResult = await parseIconsAsync(process.cwd(), results, publicPath);
+      parsedIconsResult = await parseIconsAsync(self.projectRoot, results, publicPath);
     }
 
     const { icons, assets = [] } = parsedIconsResult;


### PR DESCRIPTION
# Why 

- Reduces build time by a lot 
  - on a basic project:
    - before: 
      - first build: `0m22.948s`
      - rebuild: `0m15.136s`
    - after:
      - first build: `0m22.948s`
      - rebuild: `0m8.499s`
      - rebuild with new splash screen: `0m14.196s`
- Step 1 in removing sharp

# How

- Cache images based on hash and custom props like resizeMode and color
- Removes old caches after build
