### PR TITLE
Create @expo/package-manager

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -70,6 +70,7 @@
     "@expo/config": "^2.5.1",
     "@expo/dev-tools": "0.8.0",
     "@expo/json-file": "^8.2.1",
+    "@expo/package-manager": "0.0.0",
     "@expo/simple-spinner": "1.0.2",
     "@expo/spawn-async": "1.5.0",
     "@expo/xdl": "57.0.0",

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -8,7 +8,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import log from '../log';
-import * as PackageManager from '../PackageManager';
+import * as PackageManager from '@expo/package-manager';
 
 type Options = { force: boolean };
 
@@ -64,7 +64,7 @@ async function generateFilesAsync({
       );
 
       if (file in dependencyMap) {
-        const packageManager = PackageManager.createForProject(projectDir);
+        const packageManager = PackageManager.createForProject(projectDir, { log });
         for (const dependency of dependencyMap[file]) {
           promises.push(packageManager.addDevAsync(dependency));
         }

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -11,7 +11,7 @@ import temporary from 'tempy';
 
 import { loginOrRegisterIfLoggedOut } from '../../accounts';
 import log from '../../log';
-import * as PackageManager from '../../PackageManager';
+import * as PackageManager from '@expo/package-manager';
 import prompt, { Question } from '../../prompt';
 import { validateGitStatusAsync } from '../utils/ProjectUtils';
 
@@ -312,7 +312,7 @@ if (Platform.OS === 'web') {
   await fse.remove('node_modules');
 
   log('Installing new packages...');
-  const packageManager = PackageManager.createForProject(projectRoot);
+  const packageManager = PackageManager.createForProject(projectRoot, { log });
   await packageManager.installAsync();
   log.newLine();
 }

--- a/packages/expo-cli/src/commands/install.js
+++ b/packages/expo-cli/src/commands/install.js
@@ -7,8 +7,8 @@ import npmPackageArg from 'npm-package-arg';
 import path from 'path';
 import { Versions } from '@expo/xdl';
 
+import * as PackageManager from '@expo/package-manager';
 import CommandError from '../CommandError';
-import * as PackageManager from '../PackageManager';
 import { findProjectRootAsync } from './utils/ProjectUtils';
 import log from '../log';
 
@@ -17,6 +17,7 @@ async function installAsync(packages, options) {
   const packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,
     yarn: options.yarn,
+    log,
   });
 
   if (workflow === 'bare') {

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import semver from 'semver';
 import _ from 'lodash';
 
-import * as PackageManager from '../PackageManager';
+import * as PackageManager from '@expo/package-manager';
 import CommandError from '../CommandError';
 import prompt from '../prompt';
 import log from '../log';
@@ -139,7 +139,9 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
   // Can't upgrade if we don't have a SDK version (tapping on head meme)
   if (!exp.sdkVersion) {
     if (workflow === 'bare') {
-      log.error('This command only works for bare workflow projects that also have the expo package installed and sdkVersion configured in app.json.');
+      log.error(
+        'This command only works for bare workflow projects that also have the expo package installed and sdkVersion configured in app.json.'
+      );
       throw new CommandError('SDK_VERSION_REQUIRED_FOR_UPGRADE_COMMAND_IN_BARE');
     } else {
       log.error('No sdkVersion field is present in app.json, cannot upgrade project.');
@@ -151,7 +153,11 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
   let status = await Project.currentStatus(projectRoot);
   if (status === 'running') {
     await Project.stopAsync(projectRoot);
-    log(chalk.bold.underline('We found an existing expo-cli instance running for this project and closed it to continue.'));
+    log(
+      chalk.bold.underline(
+        'We found an existing expo-cli instance running for this project and closed it to continue.'
+      )
+    );
     log.addNewLineIfNone();
   }
 
@@ -230,6 +236,7 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
   let packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,
     yarn: options.yarn,
+    log,
   });
 
   log.addNewLineIfNone();
@@ -302,9 +309,15 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
 
   // Add some basic additional instructions for bare workflow
   if (workflow === 'bare') {
-      log.addNewLineIfNone();
-      log(chalk.bold(`It will be necessary to re-build your native projects to compile the updated dependencies. You will need to run ${chalk.grey('pod install')} in your ios directory before re-building the iOS project.`));
-      log.addNewLineIfNone();
+    log.addNewLineIfNone();
+    log(
+      chalk.bold(
+        `It will be necessary to re-build your native projects to compile the updated dependencies. You will need to run ${chalk.grey(
+          'pod install'
+        )} in your ios directory before re-building the iOS project.`
+      )
+    );
+    log.addNewLineIfNone();
   }
 
   if (targetSdkVersion && targetSdkVersion.releaseNoteUrl) {

--- a/packages/package-manager/.gitignore
+++ b/packages/package-manager/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+build
+/*.tgz
+/package/

--- a/packages/package-manager/LICENSE
+++ b/packages/package-manager/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-present 650 Industries, Inc. (aka Expo)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/package-manager/README.md
+++ b/packages/package-manager/README.md
@@ -1,0 +1,57 @@
+<!-- Title -->
+<h1 align="center">
+👋 Welcome to <br><code>@expo/package-manager</code>
+</h1>
+
+<!-- Header -->
+
+<p align="center">
+    <b>A library for installing and finding packages in a node project</b>
+    <br/>
+    <br/>
+    <a aria-label="Circle CI" href="https://circleci.com/gh/expo/expo-cli/tree/master">
+        <img alt="Circle CI" src="https://flat.badgen.net/circleci/github/expo/expo-cli?label=Circle%20CI&labelColor=555555&icon=circleci">
+    </a>
+</p>
+
+---
+
+<!-- Body -->
+
+## 🏁 Setup
+
+Install `@expo/package-manager` in your project.
+
+```sh
+yarn add @expo/package-manager
+```
+
+## ⚽️ Usage
+
+```ts
+import * as PackageManager from '@expo/package-manager';
+
+const manager = await PackageManager.createForProject(projectRoot);
+
+await Promise.all([
+  manager.addDevAsync('@expo/webpack-config'),
+  manager.addAsync('expo', 'expo-camera'),
+]);
+```
+
+## License
+
+The Expo source code is made available under the [MIT license](LICENSE). Some of the dependencies are licensed differently, with the BSD license, for example.
+
+<!-- Footer -->
+
+---
+
+<p>
+    <a aria-label="sponsored by expo" href="http://expo.io">
+        <img src="https://img.shields.io/badge/SPONSORED%20BY%20EXPO-4630EB.svg?style=for-the-badge" target="_blank" />
+    </a>
+    <a aria-label="@expo/package-manager is free to use" href="/LICENSE" target="_blank">
+        <img align="right" alt="License: MIT" src="https://img.shields.io/badge/License-MIT-success.svg?style=for-the-badge&color=33CC12" target="_blank" />
+    </a>
+</p>

--- a/packages/package-manager/babel.config.js
+++ b/packages/package-manager/babel.config.js
@@ -1,0 +1,11 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    // Only use this when running tests
+    env: {
+      test: {
+        presets: ['@expo/babel-preset-cli'],
+      },
+    },
+  };
+};

--- a/packages/package-manager/jest.config.js
+++ b/packages/package-manager/jest.config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+module.exports = {
+  displayName: require('./package.json').name,
+  testRegex: '/__tests__/.*(test|spec)\\.(j|t)sx?$',
+  moduleNameMapper: {
+    '^jest/(.*)': path.join(__dirname, '../../jest/$1'),
+  },
+  testEnvironment: 'node',
+  resetModules: false,
+};

--- a/packages/package-manager/package.json
+++ b/packages/package-manager/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@expo/package-manager",
+  "version": "0.0.0",
+  "description": "A library for installing and finding packages in a node project",
+  "main": "build/PackageManager.js",
+  "types": "build/PackageManager.d.ts",
+  "scripts": {
+    "watch": "tsc --watch",
+    "build": "tsc",
+    "prepare": "yarn run clean && yarn build",
+    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "lint": "eslint .",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo-cli.git",
+    "directory": "packages/package-manager"
+  },
+  "keywords": [
+    "react-native",
+    "package-manager",
+    "package-json",
+    "node",
+    "yarn",
+    "yarnpkg"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/expo/expo-cli/issues"
+  },
+  "homepage": "https://github.com/expo/expo-cli/tree/master/packages/package-manager#readme",
+  "files": [
+    "build"
+  ],
+  "dependencies": {
+    "@expo/spawn-async": "^1.5.0",
+    "ansi-regex": "^5.0.0",
+    "detect-indent": "^6.0.0",
+    "detect-newline": "^3.1.0",
+    "find-yarn-workspace-root": "^1.2.1",
+    "fs-extra": "^8.1.0",
+    "npm-package-arg": "^7.0.0",
+    "split": "^1.0.1",
+    "stream": "^0.0.2"
+  },
+  "devDependencies": {
+    "@expo/babel-preset-cli": "^0.2.0",
+    "typescript": "3.4.5"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/package-manager/tsconfig.json
+++ b/packages/package-manager/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@expo/babel-preset-cli/tsconfig.base",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4273,6 +4273,11 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -8359,6 +8364,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.0.0.tgz#8ae477c089e51872c264531cd6547719c0b86b2f"
   integrity sha512-JAP22dVPAqvhdRFFxK1G5GViIokyUn0UWXRNW0ztK96fsqi9cuM8w8ESbSk+T2w5OVorcMcL6m7yUg1RrX+2CA==
 
+detect-newline@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
@@ -8749,6 +8759,11 @@ elliptic@^6.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+emitter-component@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/emitter-component/-/emitter-component-1.1.1.tgz#065e2dbed6959bf470679edabeaf7981d1003ab6"
+  integrity sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=
 
 emitter-mixin@0.0.3:
   version "0.0.3"
@@ -11218,6 +11233,13 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
+
+hosted-git-info@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.2.tgz#8b7e3bd114b59b51786f8bade0f39ddc80275a97"
+  integrity sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==
+  dependencies:
+    lru-cache "^5.1.1"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -15971,6 +15993,16 @@ npm-package-arg@6.1.0, "npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", npm-package
     semver "^5.5.0"
     validate-npm-package-name "^3.0.0"
 
+npm-package-arg@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-7.0.0.tgz#52cdf08b491c0c59df687c4c925a89102ef794a5"
+  integrity sha512-xXxr8y5U0kl8dVkz2oK7yZjPBvqM2fwaO5l3Yg13p03v8+E3qQcD0JNhHzjL1vyGgxcKkD0cco+NLR72iuPk3g==
+  dependencies:
+    hosted-git-info "^3.0.2"
+    osenv "^0.1.5"
+    semver "^5.6.0"
+    validate-npm-package-name "^3.0.0"
+
 npm-packlist@^1.1.12, npm-packlist@^1.1.6, npm-packlist@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
@@ -20036,7 +20068,7 @@ split@0.2.x:
   dependencies:
     through "2"
 
-split@1.0.1, split@^1.0.0:
+split@1.0.1, split@^1.0.0, split@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
@@ -20185,6 +20217,13 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+stream@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stream/-/stream-0.0.2.tgz#7f5363f057f6592c5595f00bc80a27f5cec1f0ef"
+  integrity sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=
+  dependencies:
+    emitter-component "^1.1.1"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## Why

- Required for installing packages in next-adapter (also electron-adapter will need this) #1254 

## How

- Moved `PackageManager` from `expo-cli` to a new package called `@expo/package-manager`
