### PR TITLE
Use custom package for customize command

### DIFF
--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -1,4 +1,5 @@
-import * as ConfigUtils from '@expo/config';
+import { readConfigJsonAsync } from '@expo/config';
+import { createForProject } from '@expo/package-manager';
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import { Command } from 'commander';
@@ -6,11 +7,12 @@ import { Command } from 'commander';
 import { MultiSelect } from 'enquirer';
 import fs from 'fs-extra';
 import path from 'path';
+// @ts-ignore
+import resolveFrom from 'resolve-from';
 
 import log from '../log';
-import * as PackageManager from '@expo/package-manager';
 
-type Options = { force: boolean };
+type Options = { yes: boolean; force: boolean; package: string };
 
 async function maybeWarnToCommitAsync(projectRoot: string) {
   let workingTreeStatus = 'unknown';
@@ -64,7 +66,7 @@ async function generateFilesAsync({
       );
 
       if (file in dependencyMap) {
-        const packageManager = PackageManager.createForProject(projectDir, { log });
+        const packageManager = createForProject(projectDir, { log });
         for (const dependency of dependencyMap[file]) {
           promises.push(packageManager.addDevAsync(dependency));
         }
@@ -83,8 +85,40 @@ async function generateFilesAsync({
   await Promise.all(promises);
 }
 
-export async function action(projectDir: string = './', options: Options = { force: false }) {
-  const { exp } = await ConfigUtils.readConfigJsonAsync(projectDir);
+export async function action(
+  projectDir: string = './',
+  options: Options = { yes: false, force: false, package: '' }
+) {
+  if (options.package) {
+    const [root, adapter] = (() => {
+      for (const root of [projectDir, path.resolve(__dirname, '../../../')]) {
+        const packagePath =
+          resolveFrom.silent(root, `${options.package}/customize`) ||
+          resolveFrom.silent(root, `@expo/${options.package}/customize`) ||
+          resolveFrom.silent(root, `@expo/${options.package}-adapter/customize`);
+        if (packagePath) return [root, packagePath];
+      }
+      return [];
+    })();
+
+    if (adapter) {
+      console.log(
+        chalk.magenta(
+          `\n\u203A Using customization from package ${chalk.bold(path.relative(root, adapter))}\n`
+        )
+      );
+      await require(adapter).runAsync({
+        projectRoot: projectDir,
+        force: options.force,
+        yes: options.yes,
+      });
+      return;
+    } else {
+      throw new Error(`No installed package had a valid customize folder to read from.`);
+    }
+  }
+
+  const { exp } = await readConfigJsonAsync(projectDir);
 
   const templateFolder = path.dirname(
     require.resolve('@expo/webpack-config/web-default/index.html')
@@ -143,6 +177,8 @@ export default function(program: Command) {
     .command('customize:web [project-dir]')
     .description('Generate static web files into your project.')
     .option('-f, --force', 'Allows replacing existing files')
+    .option('-y, --yes', 'Use the default features')
+    .option('--package [package-name]', 'Use a custom workflow')
     .allowOffline()
     .asyncAction(action);
 }


### PR DESCRIPTION
Moved from #1254

Because the adapters have different needs, this helps to unify the customize functionality. Just for continuity (because naming is different between electron, next, future libs...), if the package `@expo/next-adapter` is installed in your project you can run the following to start the CLI:
```
expo customize:web --package next
```
This will invoke the customize feature of `@expo/next-adapter`
