### PR TITLE
[metro][xdl] Move custom log reporter to XDL

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -88,6 +88,7 @@
     "request-promise-native": "1.0.5",
     "resolve-from": "5.0.0",
     "semver": "5.5.0",
+    "serialize-error": "^5.0.0",
     "slugid": "1.1.0",
     "slugify": "1.3.1",
     "source-map-support": "0.4.18",

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -291,9 +291,9 @@ async function _resolveManifestAssets(
 ) {
   try {
     // Asset fields that the user has set
-    const assetSchemas = (
-      await ExpSchema.getAssetSchemasAsync(manifest.sdkVersion)
-    ).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
+    const assetSchemas = (await ExpSchema.getAssetSchemasAsync(
+      manifest.sdkVersion
+    )).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
 
     // Get the URLs
     const urls = await Promise.all(
@@ -1335,11 +1335,9 @@ async function uploadAssetsAsync(projectRoot: string, assets: Asset[]) {
   });
 
   // Collect list of assets missing on host
-  const metas = (
-    await Api.callMethodAsync('assetsMetadata', [], 'post', {
-      keys: Object.keys(paths),
-    })
-  ).metadata;
+  const metas = (await Api.callMethodAsync('assetsMetadata', [], 'post', {
+    keys: Object.keys(paths),
+  })).metadata;
   const missing = Object.keys(paths).filter(key => !metas[key].exists);
 
   if (missing.length === 0) {
@@ -1689,9 +1687,7 @@ export async function startReactNativeServerAsync(
 
   let packagerPort = await _getFreePortAsync(19001); // Create packager options
 
-  const customLogReporterPath: string = require.resolve(
-    path.join(__dirname, 'reporter')
-  );
+  const customLogReporterPath: string = require.resolve(path.join(__dirname, 'reporter'))
 
   let packagerOpts: { [key: string]: any } = {
     port: packagerPort,
@@ -1771,7 +1767,7 @@ export async function startReactNativeServerAsync(
       ...process.env,
       REACT_NATIVE_APP_ROOT: projectRoot,
       ELECTRON_RUN_AS_NODE: '1',
-      ...(nodePath ? { NODE_PATH: nodePath } : {}),
+      ...nodePath ? { NODE_PATH: nodePath } : {},
     },
     silent: true,
   });
@@ -2317,7 +2313,7 @@ export async function stopWebOnlyAsync(projectDir: string): Promise<void> {
 export async function stopAsync(projectDir: string): Promise<void> {
   const result = await Promise.race([
     _stopInternalAsync(projectDir),
-    new Promise(resolve => setTimeout(resolve, 2000, 'stopFailed')),
+    new Promise((resolve) => setTimeout(resolve, 2000, 'stopFailed')),
   ]);
   if (result === 'stopFailed') {
     // find RN packager and ngrok pids, attempt to kill them manually

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -291,9 +291,9 @@ async function _resolveManifestAssets(
 ) {
   try {
     // Asset fields that the user has set
-    const assetSchemas = (await ExpSchema.getAssetSchemasAsync(
-      manifest.sdkVersion
-    )).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
+    const assetSchemas = (
+      await ExpSchema.getAssetSchemasAsync(manifest.sdkVersion)
+    ).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
 
     // Get the URLs
     const urls = await Promise.all(
@@ -1335,9 +1335,11 @@ async function uploadAssetsAsync(projectRoot: string, assets: Asset[]) {
   });
 
   // Collect list of assets missing on host
-  const metas = (await Api.callMethodAsync('assetsMetadata', [], 'post', {
-    keys: Object.keys(paths),
-  })).metadata;
+  const metas = (
+    await Api.callMethodAsync('assetsMetadata', [], 'post', {
+      keys: Object.keys(paths),
+    })
+  ).metadata;
   const missing = Object.keys(paths).filter(key => !metas[key].exists);
 
   if (missing.length === 0) {
@@ -1687,15 +1689,9 @@ export async function startReactNativeServerAsync(
 
   let packagerPort = await _getFreePortAsync(19001); // Create packager options
 
-  let customLogReporterPath: string | undefined;
-
-  const possibleLogReporterPath = projectHasModule('expo/tools/LogReporter', projectRoot, exp);
-  if (possibleLogReporterPath) {
-    customLogReporterPath = possibleLogReporterPath;
-  } else {
-    // TODO: Bacon: Prompt to install expo?
-    logger.global.warn(`Expo is not installed: Using default reporter to format logs.`);
-  }
+  const customLogReporterPath: string = require.resolve(
+    path.join(__dirname, 'reporter')
+  );
 
   let packagerOpts: { [key: string]: any } = {
     port: packagerPort,
@@ -1775,7 +1771,7 @@ export async function startReactNativeServerAsync(
       ...process.env,
       REACT_NATIVE_APP_ROOT: projectRoot,
       ELECTRON_RUN_AS_NODE: '1',
-      ...nodePath ? { NODE_PATH: nodePath } : {},
+      ...(nodePath ? { NODE_PATH: nodePath } : {}),
     },
     silent: true,
   });
@@ -2321,7 +2317,7 @@ export async function stopWebOnlyAsync(projectDir: string): Promise<void> {
 export async function stopAsync(projectDir: string): Promise<void> {
   const result = await Promise.race([
     _stopInternalAsync(projectDir),
-    new Promise((resolve) => setTimeout(resolve, 2000, 'stopFailed')),
+    new Promise(resolve => setTimeout(resolve, 2000, 'stopFailed')),
   ]);
   if (result === 'stopFailed') {
     // find RN packager and ngrok pids, attempt to kill them manually

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1687,7 +1687,7 @@ export async function startReactNativeServerAsync(
 
   let packagerPort = await _getFreePortAsync(19001); // Create packager options
 
-  const customLogReporterPath: string = require.resolve(__dirname, 'reporter');
+  const customLogReporterPath: string = require.resolve(path.join(__dirname, 'reporter'))
 
   let packagerOpts: { [key: string]: any } = {
     port: packagerPort,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1687,7 +1687,7 @@ export async function startReactNativeServerAsync(
 
   let packagerPort = await _getFreePortAsync(19001); // Create packager options
 
-  const customLogReporterPath: string = require.resolve(path.join(__dirname, 'reporter'))
+  const customLogReporterPath: string = require.resolve(__dirname, 'reporter');
 
   let packagerOpts: { [key: string]: any } = {
     port: packagerPort,

--- a/packages/xdl/src/reporter/index.ts
+++ b/packages/xdl/src/reporter/index.ts
@@ -1,0 +1,13 @@
+import { serializeError } from 'serialize-error';
+
+class LogReporter {
+  update(event: any) {
+    if (event.error instanceof Error) {
+      event.error = serializeError(event.error);
+    }
+
+    console.log(JSON.stringify(event));
+  }
+}
+
+module.exports = LogReporter;

--- a/yarn.lock
+++ b/yarn.lock
@@ -19497,6 +19497,13 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+serialize-error@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-5.0.0.tgz#a7ebbcdb03a5d71a6ed8461ffe0fc1a1afed62ac"
+  integrity sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==
+  dependencies:
+    type-fest "^0.8.0"
+
 serialize-javascript@^1.4.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
@@ -21154,6 +21161,11 @@ type-fest@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
+
+type-fest@^0.8.0:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type-is@~1.6.16:
   version "1.6.16"


### PR DESCRIPTION
Not sure why half of the log reporter was included in the expo package and the other half is in XDL. Moving this will help simplify the `expo/metro-config` package I'm working on.

## Test Plan

- `expod start --ios`
- test that `console.logs` show in the terminal
- test that `console.logs` show in the dev tools screen under the device
- ensure Metro custom logging looks like before (loading bar)

