### PR TITLE
fix(expo-cli): make reuse build log only instead of blocking

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.js
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.js
@@ -15,7 +15,6 @@ import * as UrlUtils from '../utils/url';
 import log from '../../log';
 import { action as publishAction } from '../publish';
 import BuildError from './BuildError';
-import prompt from '../../prompt';
 
 const secondsToMilliseconds = seconds => seconds * 1000;
 
@@ -163,20 +162,6 @@ Please see the docs (${chalk.underline(
           reuseStatus.downloadUrl
         )}`
       );
-
-      let questions = [
-        {
-          type: 'confirm',
-          name: 'confirm',
-          message: 'Do you want to build app anyway?',
-        },
-      ];
-
-      const answers = await prompt(questions);
-      if (!answers.confirm) {
-        log('Stopping the build process');
-        process.exit(0);
-      }
     }
   }
 


### PR DESCRIPTION
This should fix #1251, making the warning log only (non-blocking) as Brent mentioned:
> yeah i think these are good enough reasons to make this a non-blocking warning for now, thanks for getting back to me

~~It's also related to #1224, but I'll open another PR to add the `--force` flag Ville mentioned.~~

I also created PR #1273 to fix this exact issue. But instead of removing the question, I've added a `--force` flag. Maybe we can integrate it even better, making it a bit nicer if we encounter similar problems again. 😄 