### PR TITLE
feat(expo-cli): add force flag to ios and android build

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.js
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.js
@@ -40,6 +40,7 @@ export default class BaseBuilder {
     clearCredentials: false,
     releaseChannel: 'default',
     publish: false,
+    force: false,
   };
   manifest: Object = {};
   user: Object;
@@ -164,18 +165,17 @@ Please see the docs (${chalk.underline(
         )}`
       );
 
-      let questions = [
-        {
+      if (!this.options.force) {
+        const answer = await prompt({
           type: 'confirm',
           name: 'confirm',
           message: 'Do you want to build app anyway?',
-        },
-      ];
+        });
 
-      const answers = await prompt(questions);
-      if (!answers.confirm) {
-        log('Stopping the build process');
-        process.exit(0);
+        if (!answer.confirm) {
+          log('Stopping the build process');
+          process.exit(0);
+        }
       }
     }
   }

--- a/packages/expo-cli/src/commands/build/index.js
+++ b/packages/expo-cli/src/commands/build/index.js
@@ -50,6 +50,7 @@ export default (program: any) => {
       '--public-url <url>',
       'The URL of an externally hosted manifest (for self-hosted apps).'
     )
+    .option('--force', 'Will attempt to perform the action without questioning, use at own risk')
     .description(
       'Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.'
     )
@@ -88,6 +89,7 @@ export default (program: any) => {
     .option('--generate-keystore', 'Generate Keystore if one does not exist')
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     .option('-t --type <build>', 'Type of build: [app-bundle|apk].', /^(app-bundle|apk)$/i, 'apk')
+    .option('--force', 'Will attempt to perform the action without questioning, use at own risk')
     .description(
       'Build a standalone APK or App Bundle for your project, signed and ready for submission to the Google Play Store.'
     )


### PR DESCRIPTION
Fixes #1224, it adds a simple `--force` flag to `expo build:android` and `expo build:ios` commands like Ville mentioned:
> Looks like we need to add a --force flag for non-interactive mode. It would correspond to choosing “yes build anyway” in the prompt.

It might be better if we expand the `prompt` script, and add a force flag there. That way we can handle forces within the prompt and we don't have to add if statements over the questions? I think that might work just fine, you can even include a default value for the questions right? Maybe we can auto-pick that as answer?

I also added another PR, with an alternative solution for this exact problem (the reuse question in the base builder). You can check it out here, PR #1272. We should pick either this one, or that one to fix the current issue.