### PR TITLE
[config] Created getConfig methods for future config evaluation requirement

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -543,6 +543,9 @@ export async function getConfigAsync(
   };
 }
 
+/**
+ * @deprecated: use `getConfig` instead.
+ */
 export function readConfigJson(
   projectRoot: string,
   skipValidation: boolean = false,
@@ -554,6 +557,9 @@ export function readConfigJson(
   });
 }
 
+/**
+ * @deprecated: use `getConfigAsync` instead.
+ */
 export async function readConfigJsonAsync(
   projectRoot: string,
   skipValidation: boolean = false,

--- a/packages/config/src/__tests__/Config-test.js
+++ b/packages/config/src/__tests__/Config-test.js
@@ -153,7 +153,9 @@ describe('readConfigJson', () => {
     });
 
     it(`will throw if the app.json is missing`, () => {
-      expect(() => readConfigJson('/no-config')).toThrow(/app.json must include a JSON object./);
+      expect(() => readConfigJson('/no-config')).toThrow(
+        /An app.json is required for this action. Learn more about creating one/
+      );
     });
 
     it(`will throw if the expo package is missing`, () => {


### PR DESCRIPTION
## Why

Split out of https://github.com/expo/expo-cli/pull/1213 to simplify the transition and PR.

- This helps to maintain functionality without changing how every module works.
- Deprecate `readConfigJsonAsync` and `readConfigJson` so we can cleanly move to a system where the Expo config isn't required and can also be evaluated from a file like `app.config.js`
