### PR TITLE
[webpack-config] Add ability to optionally include resize-observer-polyfill

### DIFF
--- a/packages/webpack-config/src/addons/__tests__/withEntry-test.js
+++ b/packages/webpack-config/src/addons/__tests__/withEntry-test.js
@@ -1,0 +1,80 @@
+import { resolveEntryAsync } from '../../utils';
+import withEntry from '../withEntry';
+
+it(`Ignores a missing custom entry without strict mode`, async () => {
+  const config = withEntry(
+    {
+      mode: 'production',
+      entry: {
+        app: [],
+      },
+    },
+    {},
+    { entryPath: 'foo' }
+  );
+
+  const entry = await resolveEntryAsync(config.entry);
+  expect(entry.app.length).toBe(0);
+});
+
+it(`Throws when a custom entry is missing in strict mode`, async () => {
+  expect(() =>
+    withEntry(
+      {
+        mode: 'production',
+        entry: {
+          app: [],
+        },
+      },
+      {},
+      { entryPath: 'foo', strict: true }
+    )
+  ).toThrow(/The required app entry module: "foo" couldn't be found/);
+});
+
+it(`Adds a custom entry point when it can be found`, async () => {
+  const Config = require('@expo/config');
+  Config.projectHasModule = jest.fn(customPath => {
+    return customPath;
+  });
+  const withEntry = require('../withEntry').default;
+
+  const config = withEntry(
+    {
+      mode: 'production',
+      entry: {
+        app: ['bar'],
+      },
+    },
+    {},
+    { entryPath: 'foo', strict: true }
+  );
+
+  const entry = await resolveEntryAsync(config.entry);
+  expect(entry.app.length).toBe(2);
+  // Should add to the beginning
+  expect(entry.app[0]).toBe('foo');
+});
+
+it(`Throws when app is missing from entry in strict mode`, async () => {
+  const Config = require('@expo/config');
+  Config.projectHasModule = jest.fn(customPath => {
+    return customPath;
+  });
+  const withEntry = require('../withEntry').default;
+
+  const config = withEntry(
+    {
+      mode: 'production',
+      entry: {
+        otherValue: ['bar'],
+      },
+    },
+    {},
+    { entryPath: 'foo', strict: true }
+  );
+
+  expect(resolveEntryAsync(config.entry)).rejects.toThrow(
+    /Failed to include required app entry module: "foo" because the webpack entry object doesn't contain an \`app\` field/
+  );
+});

--- a/packages/webpack-config/src/addons/index.ts
+++ b/packages/webpack-config/src/addons/index.ts
@@ -6,3 +6,4 @@ export { default as withCompression } from './withCompression';
 export { default as withAlias } from './withAlias';
 export { default as withDevServer } from './withDevServer';
 export { default as withNodeMocks } from './withNodeMocks';
+export { default as withEntry } from './withEntry';

--- a/packages/webpack-config/src/addons/withUnimodules.ts
+++ b/packages/webpack-config/src/addons/withUnimodules.ts
@@ -1,29 +1,29 @@
 import path from 'path';
-import { Configuration } from 'webpack';
 
-import { createBabelLoader, createFontLoader } from '../loaders';
-import { ExpoDefinePlugin } from '../plugins';
-import { Arguments, DevConfiguration, Environment, InputEnvironment } from '../types';
 import {
-  validateEnvironment,
+  getConfig,
+  getMode,
+  getModuleFileExtensions,
   getPaths,
   getPublicPaths,
-  getMode,
-  getConfig,
-  getModuleFileExtensions,
+  validateEnvironment,
 } from '../env';
+import { createBabelLoader, createFontLoader } from '../loaders';
+import { ExpoDefinePlugin } from '../plugins';
+import { AnyConfiguration, Arguments, Environment, InputEnvironment } from '../types';
 import { rulesMatchAnyFiles } from '../utils';
 import withAlias from './withAlias';
+import withEntry from './withEntry';
 
 // import ManifestPlugin from 'webpack-manifest-plugin';
 
 // Wrap your existing webpack config with support for Unimodules.
 // ex: Storybook `({ config }) => withUnimodules(config)`
 export default function withUnimodules(
-  inputWebpackConfig: DevConfiguration | Configuration = {},
+  inputWebpackConfig: AnyConfiguration = {},
   env: InputEnvironment = {},
   argv: Arguments = {}
-): DevConfiguration | Configuration {
+): AnyConfiguration {
   inputWebpackConfig = withAlias(inputWebpackConfig);
 
   if (!inputWebpackConfig.module) inputWebpackConfig.module = { rules: [] };
@@ -159,6 +159,11 @@ export default function withUnimodules(
       };
     });
   }
+
+  // Add a loose requirement on the ResizeObserver polyfill if it's installed...
+  inputWebpackConfig = withEntry(inputWebpackConfig, env, {
+    entryPath: 'resize-observer-polyfill/dist/ResizeObserver.global',
+  });
 
   return inputWebpackConfig;
 }

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -36,6 +36,7 @@ import {
 
 import { Arguments, DevConfiguration, Environment, FilePaths, Mode } from './types';
 import { overrideWithPropertyOrConfig } from './utils';
+import { projectHasModule } from '@expo/config';
 
 function getDevtool(
   { production, development }: { production: boolean; development: boolean },
@@ -129,6 +130,17 @@ export default async function(
     throw new Error(
       `The entry point for your project couldn't be found. Please define it in the package.json main field`
     );
+  }
+
+  // Add a loose requirement on the ResizeObserver polyfill if it's installed...
+  // Avoid `withEntry` as we don't need so much complexity with this config.
+  const resizeObserverPolyfill = projectHasModule(
+    'resize-observer-polyfill/dist/ResizeObserver.global',
+    env.projectRoot,
+    config
+  );
+  if (resizeObserverPolyfill) {
+    appEntry.unshift(resizeObserverPolyfill);
   }
 
   if (isDev) {
@@ -265,7 +277,6 @@ export default async function(
         },
       ].filter(Boolean),
     },
-
     resolveLoader: {
       plugins: [
         // Also related to Plug'n'Play, but this time it tells Webpack to load its loaders

--- a/packages/webpack-config/tests/__tests__/basic-test.js
+++ b/packages/webpack-config/tests/__tests__/basic-test.js
@@ -25,6 +25,19 @@ if (config.hasServerSideRendering) {
   });
 }
 
+describe('Optional polyfills', () => {
+  it(`should have resize-observer polyfill added`, async () => {
+    const ciID = 'div[data-testid="has-resize-observer"]';
+    if (isInCI) {
+      await expect(page).toMatchElement(ciID, {
+        text: 'Has ResizeObserver polyfill',
+      });
+    } else {
+      await expect(page).not.toMatchElement(ciID);
+    }
+  });
+});
+
 describe('DefinePlugin', () => {
   it(`should be aware of process.env.CI`, async () => {
     const ciID = 'div[data-testid="has-ci-text"]';

--- a/packages/webpack-config/tests/__tests__/basic-test.js
+++ b/packages/webpack-config/tests/__tests__/basic-test.js
@@ -26,16 +26,18 @@ if (config.hasServerSideRendering) {
 }
 
 describe('Optional polyfills', () => {
-  it(`should have resize-observer polyfill added`, async () => {
-    const ciID = 'div[data-testid="has-resize-observer"]';
-    if (isInCI) {
-      await expect(page).toMatchElement(ciID, {
-        text: 'Has ResizeObserver polyfill',
-      });
-    } else {
-      await expect(page).not.toMatchElement(ciID);
-    }
-  });
+  if (!config.hasServerSideRendering) {
+    it(`should have resize-observer polyfill added`, async () => {
+      const ciID = 'div[data-testid="has-resize-observer"]';
+      if (isInCI) {
+        await expect(page).toMatchElement(ciID, {
+          text: 'Has ResizeObserver polyfill',
+        });
+      } else {
+        await expect(page).not.toMatchElement(ciID);
+      }
+    });
+  }
 });
 
 describe('DefinePlugin', () => {

--- a/packages/webpack-config/tests/basic/App.js
+++ b/packages/webpack-config/tests/basic/App.js
@@ -1,15 +1,39 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import Constants from 'expo-constants';
-import getenv from 'getenv';
+import { boolish } from 'getenv';
+
+function AspectView(props) {
+  const [layout, setLayout] = React.useState(null);
+
+  const { aspectRatio = 1, ...inputStyle } = StyleSheet.flatten(props.style) || {};
+  const style = [inputStyle, { aspectRatio }];
+
+  if (layout) {
+    const { width = 0, height = 0 } = layout;
+    if (width === 0) {
+      style.push({ width: height * aspectRatio, height });
+    } else {
+      style.push({ width, height: width * aspectRatio });
+    }
+  }
+
+  return (
+    <View {...props} style={style} onLayout={({ nativeEvent: { layout } }) => setLayout(layout)} />
+  );
+}
 
 export default function App() {
   return (
     <LinearGradient colors={['orange', 'blue']} style={styles.container}>
+      <AspectView style={{ aspectRatio: 1, backgroundColor: 'green', width: 40 }} />
       <Text testID="basic-text">Open up App.js to start working on your app!</Text>
       <Text testID="expo-constants-manifest">{JSON.stringify(Constants.manifest)}</Text>
-      {getenv.boolish('CI', false) && <Text testID="has-ci-text">Has CI env</Text>}
+      {boolish('CI', false) && <Text testID="has-ci-text">Has CI env</Text>}
+      {global.ResizeObserver && (
+        <Text testID="has-resize-observer">Has ResizeObserver polyfill</Text>
+      )}
     </LinearGradient>
   );
 }

--- a/packages/webpack-config/tests/basic/package.json
+++ b/packages/webpack-config/tests/basic/package.json
@@ -16,7 +16,8 @@
     "react": "16.8.3",
     "react-dom": "^16.8.6",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
-    "react-native-web": "^0.11.5"
+    "react-native-web": "^0.11.5",
+    "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {
     "babel-preset-expo": "^6.0.0"

--- a/packages/webpack-config/tests/basic/yarn.lock
+++ b/packages/webpack-config/tests/basic/yarn.lock
@@ -4792,6 +4792,11 @@ reselect@^3.0.1:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
   integrity sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"


### PR DESCRIPTION
fix #1198 

If the project has `resize-observer-polyfill` installed, then `@expo/webpack-config` will automatically include it as a global polyfill.