### PR TITLE
[Web] Service Worker: Conditionally parse event.data as JSON

### DIFF
--- a/packages/webpack-config/web-default/expo-service-worker.js
+++ b/packages/webpack-config/web-default/expo-service-worker.js
@@ -5,9 +5,14 @@
  * Ref: https://stackoverflow.com/a/35729334/2603230
  */
 self.addEventListener('message', event => {
-  let data = JSON.parse(event.data);
+  let data;
+  if (typeof event.data === 'string') {
+    try {
+      data = JSON.parse(event.data);
+    } catch (e) {}
+  }
 
-  if (data.fromExpoWebClient) {
+  if (data && data.fromExpoWebClient) {
     self.notificationIcon = data.fromExpoWebClient.notificationIcon;
   }
 });


### PR DESCRIPTION
It's not safe to assume that event.data is a string, and it's certainly not safe to assume it's valid JSON (for example, I noticed this when implementing Google Signin using Firebase; see screenshots below).

This PR makes it so that we check that it is a string and wrap the JSON.parse in a try/catch in case it's not JSON at all, but just some arbitrary string message sent by a library on the page.

Screenshots from some example exceptions caused by this issue:
<img width="516" alt="Screen Shot 2019-11-27 at 22 30 05" src="https://user-images.githubusercontent.com/369384/69783047-893cfa80-1167-11ea-9183-a6e067d8fa8f.png">
<img width="746" alt="Screen Shot 2019-11-27 at 22 29 53" src="https://user-images.githubusercontent.com/369384/69783046-893cfa80-1167-11ea-9da7-744f10a004ef.png">

