### PR TITLE
[next-adapter] added build script to required customizations

### DIFF
--- a/packages/next-adapter/src/customize/manifest.ts
+++ b/packages/next-adapter/src/customize/manifest.ts
@@ -1,6 +1,6 @@
-import { projectHasModule, readConfigJsonAsync, PackageJSONConfig } from '@expo/config';
-import chalk from 'chalk';
+import { projectHasModule, readConfigJsonAsync } from '@expo/config';
 import { createForProject } from '@expo/package-manager';
+import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 


### PR DESCRIPTION
When running `yarn next-expo` a build script will be added to your `package.json` for deployment continuity.