### PR TITLE
refactor(cli) create a dist cert selector

### DIFF
--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -9,11 +9,11 @@ export interface IView {
 }
 
 export interface ISelect<T> {
-  select(ctx: Context, options: ISelectOptions<T>): Promise<ISelect<T> | T>;
+  select(ctx: Context, options: ISelectOptions<T>): Promise<ISelect<T> | T | null>;
 }
 
 export type ISelectOptions<T> = {
-  backSelect: (ctx: Context, options: any) => Promise<ISelect<T> | T>;
+  goBack?: (ctx: Context, options: any) => Promise<ISelect<T> | T | null>;
 };
 
 type AppleCtxOptions = {
@@ -53,6 +53,10 @@ export class Context {
       throw new Error('Apple context not initialized.');
     }
     return this._appleCtx;
+  }
+
+  hasAppleCtx(): boolean {
+    return !!this._appleCtx;
   }
 
   async ensureAppleCtx(options: AppleCtxOptions = {}) {

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -8,6 +8,23 @@ export interface IView {
   open(ctx: Context): Promise<IView | null>;
 }
 
+export interface ISelect<T> {
+  select(ctx: Context, options: ISelectOptions<T>): Promise<ISelect<T> | T>;
+}
+
+export type ISelectOptions<T> = {
+  backSelect: (ctx: Context, options: any) => Promise<ISelect<T> | T>;
+};
+
+type AppleCtxOptions = {
+  appleId?: string;
+  appleIdPassword?: string;
+};
+
+type CtxOptions = {
+  allowAnonymous?: boolean;
+};
+
 export class Context {
   _hasProjectContext: boolean = false;
   _user?: User;
@@ -38,13 +55,13 @@ export class Context {
     return this._appleCtx;
   }
 
-  async ensureAppleCtx() {
+  async ensureAppleCtx(options: AppleCtxOptions = {}) {
     if (!this._appleCtx) {
-      this._appleCtx = await authenticate();
+      this._appleCtx = await authenticate(options);
     }
   }
 
-  async init(projectDir: string) {
+  async init(projectDir: string, options: CtxOptions = {}) {
     const status = await Doctor.validateLowLatencyAsync(projectDir);
     if (status !== Doctor.FATAL) {
       /* This manager does not need to work in project context */
@@ -53,8 +70,12 @@ export class Context {
       this._hasProjectContext = true;
     }
 
-    this._user = await UserManager.ensureLoggedInAsync();
+    if (options.allowAnonymous) {
+      this._user = (await UserManager.getCurrentUserAsync()) || undefined;
+    } else {
+      this._user = await UserManager.ensureLoggedInAsync();
+    }
     this._apiClient = ApiV2.clientForUser(this.user);
-    this._iosApiClient = new IosApi(this._user);
+    this._iosApiClient = new IosApi(this.user);
   }
 }

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -1,17 +1,20 @@
+import open from 'open';
 import chalk from 'chalk';
 import dateformat from 'dateformat';
 import get from 'lodash/get';
+import ora from 'ora';
 import { IosCodeSigning } from '@expo/xdl';
 
 import prompt, { Question } from '../../prompt';
 import log from '../../log';
-import { Context, IView } from '../context';
+import { Context, IView, ISelect } from '../context';
 import { distCertSchema, IosCredentials, IosDistCredentials } from '../credentials';
 import { askForUserProvided } from '../actions/promptForCredentials';
 import { displayIosUserCredentials } from '../actions/list';
-import { DistCertManager, DistCertInfo, DistCert } from '../../appleApi';
+import { DistCertManager, DistCertInfo, DistCert, AppleCtx } from '../../appleApi';
 import { RemoveProvisioningProfile } from './IosProvisioningProfile';
 import { CreateAppCredentialsIos } from './IosAppCredentials';
+import { DistCertOptions } from './SelectDistributionCert';
 
 const APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR = `
 You can have only ${chalk.underline(
@@ -21,7 +24,7 @@ Please revoke the old ones or reuse existing from your other apps.
 Please remember that Apple Distribution Certificates are not application specific!
 `;
 
-export class CreateIosDist implements IView {
+export class CreateIosDist implements IView, ISelect<DistCert> {
   async create(ctx: Context): Promise<IosDistCredentials> {
     const newDistCert = await this.provideOrGenerate(ctx);
     return await ctx.ios.createDistCert(newDistCert);
@@ -36,10 +39,23 @@ export class CreateIosDist implements IView {
     return null;
   }
 
+  // TODO(quin): support the option to go 'back'
+  async select(ctx: Context, options: DistCertOptions): Promise<ISelect<DistCert> | DistCert> {
+    return ctx.user ? await this.create(ctx) : await this.provideOrGenerate(ctx);
+  }
+
   async provideOrGenerate(ctx: Context): Promise<DistCert> {
     const userProvided = await promptForDistCert(ctx);
     if (userProvided) {
-      return userProvided;
+      if (!ctx.appleCtx) {
+        log(
+          "WARNING! Unable to validate Distribution Certificate due to insufficient Apple Credentials. Please double check that you're uploading valid files for your app otherwise you may encounter strange errors!"
+        );
+        return userProvided;
+      }
+
+      const isValid = await validateDistributionCertificate(ctx.appleCtx, userProvided);
+      return isValid ? userProvided : await this.provideOrGenerate(ctx);
     }
     return await generateDistCert(ctx);
   }
@@ -53,7 +69,7 @@ export class RemoveIosDist implements IView {
   }
 
   async open(ctx: Context): Promise<IView | null> {
-    const selected = await selectDistCertFromList(ctx.ios.credentials);
+    const selected = await selectDistCertFromList(ctx.ios.credentials, ctx.appleCtx);
     if (selected) {
       await this.removeSpecific(ctx, selected);
       log(chalk.green('Successfully removed Distribution Certificate\n'));
@@ -116,7 +132,7 @@ export class RemoveIosDist implements IView {
 
 export class UpdateIosDist implements IView {
   async open(ctx: Context): Promise<IView | null> {
-    const selected = await selectDistCertFromList(ctx.ios.credentials);
+    const selected = await selectDistCertFromList(ctx.ios.credentials, ctx.appleCtx);
     if (selected) {
       await this.updateSpecific(ctx, selected);
 
@@ -170,7 +186,15 @@ export class UpdateIosDist implements IView {
   async provideOrGenerate(ctx: Context): Promise<DistCert> {
     const userProvided = await promptForDistCert(ctx);
     if (userProvided) {
-      return userProvided;
+      if (!ctx.appleCtx) {
+        log(
+          "WARNING! Unable to validate Distribution Certificate due to insufficient Apple Credentials. Please double check that you're uploading valid files for your app otherwise you may encounter strange errors!"
+        );
+        return userProvided;
+      }
+
+      const isValid = await validateDistributionCertificate(ctx.appleCtx, userProvided);
+      return isValid ? userProvided : await this.provideOrGenerate(ctx);
     }
     return await generateDistCert(ctx);
   }
@@ -191,7 +215,9 @@ export class UseExistingDistributionCert implements IView {
       return null;
     }
 
-    const selected = await selectDistCertFromList(ctx.ios.credentials);
+    const selected = await selectDistCertFromList(ctx.ios.credentials, ctx.appleCtx, {
+      filterInvalid: true,
+    });
     if (selected) {
       await ctx.ios.useDistCert(experienceName, bundleIdentifier, selected.id);
       log(
@@ -202,29 +228,87 @@ export class UseExistingDistributionCert implements IView {
     }
     return null;
   }
+
+  async select(ctx: Context, options: DistCertOptions): Promise<ISelect<DistCert> | DistCert> {
+    const { experienceName, bundleIdentifier, backSelect } = options;
+
+    const selected = await selectDistCertFromList(ctx.ios.credentials, ctx.appleCtx, {
+      filterInvalid: true,
+      allowSelectNone: !!backSelect,
+    });
+    if (selected) {
+      await ctx.ios.useDistCert(experienceName, bundleIdentifier, selected.id);
+      log(
+        chalk.green(
+          `Successfully assigned Distribution Certificate to ${experienceName} (${bundleIdentifier})`
+        )
+      );
+      return selected;
+    }
+    if (!backSelect) {
+      throw new Error('No existing certificate was selected. Exiting...');
+    }
+    return await backSelect(ctx, options);
+  }
 }
 
-async function selectDistCertFromList(
-  iosCredentials: IosCredentials
-): Promise<IosDistCredentials | null> {
+export async function getValidDistCerts(iosCredentials: IosCredentials, appleCtx?: AppleCtx) {
   const distCerts = iosCredentials.userCredentials.filter(
     (cred): cred is IosDistCredentials => cred.type === 'dist-cert'
   );
+  if (!appleCtx) {
+    return distCerts;
+  }
+  return await filterRevokedDistributionCerts<IosDistCredentials>(appleCtx, distCerts);
+}
+
+type ListOptions = {
+  filterInvalid?: boolean;
+  allowSelectNone?: boolean;
+};
+
+async function selectDistCertFromList(
+  iosCredentials: IosCredentials,
+  appleCtx?: AppleCtx,
+  options: ListOptions = {}
+): Promise<IosDistCredentials | null> {
+  let distCerts = iosCredentials.userCredentials.filter(
+    (cred): cred is IosDistCredentials => cred.type === 'dist-cert'
+  );
+  const validDistCerts = appleCtx
+    ? await filterRevokedDistributionCerts<IosDistCredentials>(appleCtx, distCerts)
+    : null;
+
+  if (options.filterInvalid && validDistCerts) {
+    distCerts = validDistCerts;
+  }
   if (distCerts.length === 0) {
     log.warn('There are no Distribution Certificates available in your expo account');
     return null;
+  }
+
+  const NONE_SELECTED = -1;
+  const choices = distCerts.map((entry, index) => ({
+    name: formatDistCert(entry, iosCredentials, validDistCerts),
+    value: index,
+  }));
+  if (options.allowSelectNone) {
+    choices.push({
+      name: '↩️ [Go back]',
+      value: NONE_SELECTED,
+    });
   }
 
   const question: Question = {
     type: 'list',
     name: 'credentialsIndex',
     message: 'Select certificate from the list.',
-    choices: distCerts.map((entry, index) => ({
-      name: formatDistCert(entry, iosCredentials),
-      value: index,
-    })),
+    choices: choices,
   };
   const { credentialsIndex } = await prompt(question);
+  if (credentialsIndex === NONE_SELECTED) {
+    return null;
+  }
   return distCerts[credentialsIndex];
 }
 
@@ -254,7 +338,11 @@ function formatDistCertFromApple(appleInfo: DistCertInfo, credentials: IosCreden
   ${usedByString}`;
 }
 
-function formatDistCert(distCert: IosDistCredentials, credentials: IosCredentials): string {
+function formatDistCert(
+  distCert: IosDistCredentials,
+  credentials: IosCredentials,
+  validDistCerts: IosDistCredentials[] | null
+): string {
   const appCredentials = credentials.appCredentials.filter(
     cred => cred.distCredentialsId === distCert.id
   );
@@ -277,9 +365,19 @@ function formatDistCert(distCert: IosDistCredentials, credentials: IosCredential
   } catch (error) {
     serialNumber = chalk.red('invalid serial number');
   }
+
+  let validityStatus = chalk.gray(
+    "\n    ❓ Unable to validate this certificate on Apple's servers."
+  );
+  if (validDistCerts) {
+    const isValidCert = validDistCerts.includes(distCert);
+    validityStatus = isValidCert
+      ? chalk.gray("\n    ✅ Currently valid on Apple's servers.")
+      : chalk.gray("\n    ❌ No longer valid on Apple's servers.");
+  }
   return `Distribution Certificate (Cert ID: ${
     distCert.certId
-  }, Serial number: ${serialNumber}, Team ID: ${distCert.teamId})${usedByString}`;
+  }, Serial number: ${serialNumber}, Team ID: ${distCert.teamId})${usedByString}${validityStatus}`;
 }
 
 async function generateDistCert(ctx: Context): Promise<DistCert> {
@@ -299,18 +397,34 @@ async function generateDistCert(ctx: Context): Promise<DistCert> {
           {}
         );
 
-      const { revoke } = await prompt([
+      const choices = certs.map((cert, index) => ({
+        value: index,
+        name: formatDistCertFromApple(cert, ctx.ios.credentials),
+      }));
+
+      const MORE_INFO = -1;
+      choices.push({
+        value: MORE_INFO,
+        name: 'Show me more info about these choices ℹ️',
+      });
+
+      let { revoke } = await prompt([
         {
           type: 'checkbox',
           name: 'revoke',
           message: 'Select certificates to revoke.',
-          choices: certs.map((cert, index) => ({
-            value: index,
-            name: formatDistCertFromApple(cert, ctx.ios.credentials),
-          })),
+          choices,
           pageSize: Infinity,
         },
       ]);
+
+      if (revoke.includes(MORE_INFO)) {
+        // TODO(quin): use cruzan's link
+        open(
+          'https://docs.expo.io/versions/latest/guides/adhoc-builds/#distribution-certificate-cli-options'
+        );
+        revoke = revoke.filter((index: number) => index !== MORE_INFO);
+      }
 
       for (const index of revoke) {
         const certInfo = certs[index];
@@ -336,12 +450,58 @@ async function promptForDistCert(ctx: Context): Promise<DistCert | null> {
         userProvided.certPassword
       );
     } catch (error) {
-      log.warn('Unable to access certificate serial number.')
-      log.warn('Make sure that certificate and password are correct.')
+      log.warn('Unable to access certificate serial number.');
+      log.warn('Make sure that certificate and password are correct.');
       log.warn(error);
     }
     return userProvided;
   } else {
     return null;
   }
+}
+
+async function validateDistributionCertificate(appleContext: AppleCtx, distributionCert: DistCert) {
+  const spinner = ora(
+    `Checking validity of distribution certificate on Apple Developer Portal...`
+  ).start();
+
+  const validDistributionCerts = await filterRevokedDistributionCerts(appleContext, [
+    distributionCert,
+  ]);
+  const isValidCert = validDistributionCerts.length > 0;
+  if (isValidCert) {
+    const successMsg = `Successfully validated Distribution Certificate you uploaded against Apple Servers`;
+    spinner.succeed(successMsg);
+  } else {
+    const failureMsg = `The Distribution Certificate you uploaded is not valid. Please check that you uploaded your certificate to the Apple Servers. See docs.expo.io/versions/latest/guides/adhoc-builds for more details on uploading your credentials.`;
+    spinner.fail(failureMsg);
+  }
+  return isValidCert;
+}
+
+export async function filterRevokedDistributionCerts<T extends DistCert>(
+  appleCtx: AppleCtx,
+  distributionCerts: T[]
+): Promise<T[]> {
+  if (distributionCerts.length === 0) {
+    return [];
+  }
+
+  // if the credentials are valid, check it against apple to make sure it hasnt been revoked
+  const distCertManager = new DistCertManager(appleCtx);
+  const certsOnAppleServer = await distCertManager.list();
+  const validCertSerialsOnAppleServer = certsOnAppleServer
+    .filter(
+      // remove expired certs
+      cert => cert.expires > Math.floor(Date.now() / 1000)
+    )
+    .map(cert => cert.serialNumber);
+  const validDistributionCerts = distributionCerts.filter(cert => {
+    const serialNumber = cert.distCertSerialNumber;
+    if (!serialNumber) {
+      return false;
+    }
+    return validCertSerialsOnAppleServer.includes(serialNumber);
+  });
+  return validDistributionCerts;
 }

--- a/packages/expo-cli/src/credentials/views/SelectDistributionCert.ts
+++ b/packages/expo-cli/src/credentials/views/SelectDistributionCert.ts
@@ -1,0 +1,96 @@
+import open from 'open';
+import prompt, { Question } from '../../prompt';
+import log from '../../log';
+
+import * as iosDistView from './IosDistCert';
+
+import { Context, ISelect, ISelectOptions } from '../context';
+import { DistCert } from '../../appleApi';
+import { IosDistCredentials, IosAppCredentials } from '../credentials';
+
+export type DistCertOptions = {
+  experienceName: string;
+  bundleIdentifier: string;
+  disableAutomode?: boolean;
+} & ISelectOptions<DistCert>;
+
+export class SelectDistributionCert implements ISelect<DistCert> {
+  async _choosePreferredCreds(
+    distCerts: IosDistCredentials[],
+    appCredentials: IosAppCredentials[],
+    experienceName: string
+  ) {
+    // prefer the one that matches our experienceName
+    const appCredentialsForExperience = appCredentials.filter(
+      cred => cred.experienceName === experienceName
+    );
+    for (let distCert of distCerts) {
+      if (appCredentialsForExperience.some(cred => cred.distCredentialsId === distCert.id)) {
+        return distCert;
+      }
+    }
+    // else choose an arbitrary one
+    return distCerts[0];
+  }
+
+  async select(ctx: Context, options: DistCertOptions): Promise<ISelect<DistCert> | DistCert> {
+    const backSelect = async (ctx: Context, options: DistCertOptions) =>
+      await this.select(ctx, options);
+    const newOptions = { ...options, disableAutomode: true, backSelect };
+
+    const expoUsername = ctx.user && ctx.user.username;
+    const existingCertificates = expoUsername
+      ? await iosDistView.getValidDistCerts(ctx.ios.credentials, ctx.appleCtx)
+      : [];
+    const choices = [];
+
+    if (existingCertificates.length > 0) {
+      choices.push({
+        name: '[Choose existing certificate] (Recommended)',
+        value: 'CHOOSE_EXISTING',
+      });
+      if (!options.disableAutomode) {
+        // autoselect creds if we find valid ones
+        const { experienceName } = options;
+        const autoselectedCertificate = await this._choosePreferredCreds(
+          existingCertificates,
+          ctx.ios.credentials.appCredentials,
+          experienceName
+        );
+        log(`Using Distribution Certificate: ${autoselectedCertificate.certId}`);
+        return autoselectedCertificate;
+      }
+    } else {
+      // If there aren't any existing certs, this is the only option available
+      return await this.handleAction(ctx, 'GENERATE', newOptions);
+    }
+
+    choices.push({ name: '[Add a new certificate]', value: 'GENERATE' });
+
+    const question: Question = {
+      type: 'list',
+      name: 'action',
+      message: 'Select an iOS distribution certificate to use for code signing:',
+      choices: choices,
+      pageSize: Infinity,
+    };
+
+    const { action } = await prompt(question);
+    return await this.handleAction(ctx, action, newOptions);
+  }
+
+  async handleAction(
+    ctx: Context,
+    action: string,
+    options: DistCertOptions
+  ): Promise<ISelect<DistCert> | DistCert> {
+    switch (action) {
+      case 'CHOOSE_EXISTING':
+        return await new iosDistView.UseExistingDistributionCert().select(ctx, options);
+      case 'GENERATE':
+        return await new iosDistView.CreateIosDist().select(ctx, options);
+      default:
+        throw new Error('Unknown action selected');
+    }
+  }
+}

--- a/packages/expo-cli/src/credentials/views/SelectDistributionCert.ts
+++ b/packages/expo-cli/src/credentials/views/SelectDistributionCert.ts
@@ -24,7 +24,7 @@ export class SelectDistributionCert implements ISelect<DistCert> {
     const appCredentialsForExperience = appCredentials.filter(
       cred => cred.experienceName === experienceName
     );
-    for (let distCert of distCerts) {
+    for (const distCert of distCerts) {
       if (appCredentialsForExperience.some(cred => cred.distCredentialsId === distCert.id)) {
         return distCert;
       }
@@ -33,10 +33,13 @@ export class SelectDistributionCert implements ISelect<DistCert> {
     return distCerts[0];
   }
 
-  async select(ctx: Context, options: DistCertOptions): Promise<ISelect<DistCert> | DistCert> {
-    const backSelect = async (ctx: Context, options: DistCertOptions) =>
+  async select(
+    ctx: Context,
+    options: DistCertOptions
+  ): Promise<ISelect<DistCert> | DistCert | null> {
+    const goBack = async (ctx: Context, options: DistCertOptions) =>
       await this.select(ctx, options);
-    const newOptions = { ...options, disableAutomode: true, backSelect };
+    const newOptions = { ...options, disableAutomode: true, goBack };
 
     const expoUsername = ctx.user && ctx.user.username;
     const existingCertificates = expoUsername
@@ -71,7 +74,7 @@ export class SelectDistributionCert implements ISelect<DistCert> {
       type: 'list',
       name: 'action',
       message: 'Select an iOS distribution certificate to use for code signing:',
-      choices: choices,
+      choices,
       pageSize: Infinity,
     };
 
@@ -83,7 +86,7 @@ export class SelectDistributionCert implements ISelect<DistCert> {
     ctx: Context,
     action: string,
     options: DistCertOptions
-  ): Promise<ISelect<DistCert> | DistCert> {
+  ): Promise<ISelect<DistCert> | DistCert | null> {
     switch (action) {
       case 'CHOOSE_EXISTING':
         return await new iosDistView.UseExistingDistributionCert().select(ctx, options);

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -1,4 +1,11 @@
-import { resolveModule, configFilename, fileExistsAsync, ExpoConfig, PackageJSONConfig, readConfigJsonAsync } from '@expo/config';
+import {
+  resolveModule,
+  configFilename,
+  fileExistsAsync,
+  ExpoConfig,
+  PackageJSONConfig,
+  readConfigJsonAsync,
+} from '@expo/config';
 import Schemer, { SchemerError, ValidationError } from '@expo/schemer';
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
@@ -346,9 +353,7 @@ async function _validateReactNativeVersionAsync(
         ProjectUtils.logWarning(
           projectRoot,
           'expo',
-          `Warning: Invalid version of react-native for sdkVersion ${sdkVersion}. Use github:expo/react-native#${
-            sdkVersionObject['expoReactNativeTag']
-          }`,
+          `Warning: Invalid version of react-native for sdkVersion ${sdkVersion}. Use github:expo/react-native#${sdkVersionObject['expoReactNativeTag']}`,
           'doctor-invalid-version-of-react-native'
         );
         return WARNING;
@@ -434,7 +439,20 @@ async function validateAsync(projectRoot: string, allowNetwork: boolean): Promis
     return NO_ISSUES;
   }
 
-  let { exp, pkg } = await readConfigJsonAsync(projectRoot);
+  let exp, pkg;
+  try {
+    const config = await readConfigJsonAsync(projectRoot);
+    exp = config.exp;
+    pkg = config.pkg;
+  } catch (e) {
+    ProjectUtils.logError(
+      projectRoot,
+      'expo',
+      `Error: could not load config json at ${projectRoot}: ${e.toString()}`,
+      'doctor-config-json-not-read'
+    );
+    return FATAL;
+  }
 
   let status = await _checkNpmVersionAsync(projectRoot);
   if (status === FATAL) {


### PR DESCRIPTION
# Overview
This is part of the effort to refactor the credentials codebase - we want all our credentials code to live in `packages/expo-cli/src/credentials` and be written in Typescript. This PR:
- creates a distribution certificate selector that we will use to replace the selector in adhoc builds, and will eventually be used as the selector for `expo build:ios`. 
- polls Apple to check the validity of certificates on Expo server when possible (ie) upload, selecting existing credentials, etc
- works when user is not logged in (adhoc builds need to support anonymous users). The `Doctor.validateLowLatencyAsync` we call in `context.ts` throws an error when not in a project directory instead of returning fatal. We change `Doctor.ts` to return `FATAL` in this case.
- the selector gives the user the option to 'go back' to the previous UI
- give the user the option to see more information when presented with 'high risk' actions. For example, users are hesitant to revoke credentials and would like to see the consequences of their actions in that case.