### PR TITLE
Implement apple-app-site-association for web to iOS

### DIFF
--- a/packages/webpack-config/src/plugins/AasaPlugin.ts
+++ b/packages/webpack-config/src/plugins/AasaPlugin.ts
@@ -1,5 +1,4 @@
 import JsonPlugin from './JsonPlugin';
-import { Mode } from '../types';
 
 const domains = [
   // https://developer.apple.com/documentation/security/password_autofill/setting_up_an_app_s_associated_domains?language=objc
@@ -111,12 +110,15 @@ export function createAasaObjectForMultiApp({
   }
 
   if (hasUniversalLinks) {
-    const details = appIDs.map(appID => ({
-      appID,
-      // Repeating the paths for every app is based on popular websites like wikipedia:
-      // https://www.wikipedia.org/apple-app-site-association
-      paths,
-    }));
+    const details = appIDs.reduce(
+      (prev, appID) => ({
+        ...prev,
+        // Repeating the paths for every app is based on popular websites like wikipedia:
+        // https://www.wikipedia.org/apple-app-site-association
+        [appID]: { paths },
+      }),
+      {}
+    );
     aasa.applinks = {
       // The apps array must be present, but will always be empty.
       apps: [],
@@ -129,33 +131,23 @@ export function createAasaObjectForMultiApp({
 
 // Should always comply with https://search.developer.apple.com/appsearch-validation-tool
 class AasaPlugin extends JsonPlugin {
-  static createSingleApp = (props: SingleAppAasaPluginProps & { mode: Mode }): AasaPlugin => {
+  static createSingleApp = (props: SingleAppAasaPluginProps): AasaPlugin => {
     const aasa = createAasaObjectForSingleApp(props);
     return new AasaPlugin({
-      mode: props.mode,
       aasa,
     });
   };
 
-  static createMultiApp = (props: MultiAppAasaPluginProps & { mode: Mode }): AasaPlugin => {
+  static createMultiApp = (props: MultiAppAasaPluginProps): AasaPlugin => {
     const aasa = createAasaObjectForMultiApp(props);
     return new AasaPlugin({
-      mode: props.mode,
       aasa,
     });
   };
 
-  constructor({
-    mode,
-    useWellKnown = true,
-    aasa = {},
-  }: {
-    mode: Mode;
-    useWellKnown?: boolean;
-    aasa: AasaObject;
-  }) {
+  constructor({ useWellKnown = true, aasa = {} }: { useWellKnown?: boolean; aasa: AasaObject }) {
     super({
-      pretty: mode === 'development',
+      pretty: true,
       path: useWellKnown
         ? '/.well-known/apple-app-site-association'
         : '/apple-app-site-association',

--- a/packages/webpack-config/src/plugins/AasaPlugin.ts
+++ b/packages/webpack-config/src/plugins/AasaPlugin.ts
@@ -1,0 +1,167 @@
+import JsonPlugin from './JsonPlugin';
+import { Mode } from '../types';
+
+const domains = [
+  // https://developer.apple.com/documentation/security/password_autofill/setting_up_an_app_s_associated_domains?language=objc
+  'webcredentials',
+  // https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/Handoff/AdoptingHandoff/AdoptingHandoff.html#//apple_ref/doc/uid/TP40014338-CH2-SW10
+  'activitycontinuation',
+];
+
+export type AasaObject = {
+  webcredentials?: { apps: string[] };
+  activitycontinuation?: { apps: string[] };
+  applinks?: {
+    apps: [];
+    details: Array<{ appID: string; paths: string[] }>;
+  };
+};
+
+// mode: Mode;
+
+type AnyAppAasaPluginProps = {
+  // Array of strings that specify which paths are included or excluded from association.
+  // You can use NOT to disable paths.
+  paths: string[];
+  associatedDomains: string[];
+};
+
+type SingleAppAasaPluginProps = AnyAppAasaPluginProps & {
+  teamId: string;
+  bundleId: string;
+};
+
+type MultiAppAasaPluginProps = AnyAppAasaPluginProps & {
+  appIDs: string[];
+};
+
+function isDomainValid(domain: string, associatedDomains: string[]): boolean {
+  return associatedDomains.some(link => link.startsWith(`${domain}:`));
+}
+
+function getValidFieldsFromDomains(associatedDomains: string[]): string[] {
+  const validDomains: string[] = [];
+  for (const domain of domains) {
+    const hasDomains = isDomainValid(domain, associatedDomains);
+    if (hasDomains) {
+      validDomains.push(domain);
+    }
+  }
+  return validDomains;
+}
+
+export function createAasaObjectForSingleApp({
+  teamId,
+  bundleId,
+  paths,
+  associatedDomains,
+}: SingleAppAasaPluginProps): AasaObject {
+  // Detect if we even need to create an aasa file before possibly throwing errors for missing fields.
+  const validDomains: string[] = getValidFieldsFromDomains(associatedDomains);
+  const nativeAppHasLinks = isDomainValid('applinks', associatedDomains);
+  const hasUniversalLinks = !!paths.length && nativeAppHasLinks;
+  const shouldCreateAasaFile = validDomains.length || hasUniversalLinks;
+
+  if (!shouldCreateAasaFile) {
+    // skip writing file
+    return {};
+  }
+
+  if (!bundleId)
+    throw new Error(
+      'Cannot generate apple-app-site-association file unless the `expo.ios.bundleIdentifier` field is defined in your `app.json`'
+    );
+  if (!teamId)
+    throw new Error(
+      'Cannot generate apple-app-site-association file unless the `expo.ios.teamId` field is defined in your `app.json`'
+    );
+
+  // Built by combining your app’s Team ID (or the Apple App Prefix) and the Bundle Identifier.
+  // <Team Identifier>.<Bundle Identifier>
+  const appID = [teamId, bundleId].join('.');
+
+  return createAasaObjectForMultiApp({
+    appIDs: [appID],
+    paths,
+    associatedDomains,
+  });
+}
+
+export function createAasaObjectForMultiApp({
+  appIDs,
+  paths,
+  associatedDomains,
+}: MultiAppAasaPluginProps): AasaObject {
+  if (!Array.isArray(appIDs) || !appIDs.length) return {};
+
+  const validDomains: string[] = getValidFieldsFromDomains(associatedDomains);
+  const nativeAppHasLinks = isDomainValid('applinks', associatedDomains);
+  const hasUniversalLinks = !!paths.length && nativeAppHasLinks;
+  const shouldCreateAasaFile = validDomains.length || hasUniversalLinks;
+
+  if (!shouldCreateAasaFile) {
+    // skip writing file
+    return {};
+  }
+
+  const aasa: { [key: string]: any } = {};
+
+  for (const domain of validDomains) {
+    aasa[domain] = { apps: appIDs };
+  }
+
+  if (hasUniversalLinks) {
+    const details = appIDs.map(appID => ({
+      appID,
+      // Repeating the paths for every app is based on popular websites like wikipedia:
+      // https://www.wikipedia.org/apple-app-site-association
+      paths,
+    }));
+    aasa.applinks = {
+      // The apps array must be present, but will always be empty.
+      apps: [],
+      details,
+    };
+  }
+
+  return aasa;
+}
+
+// Should always comply with https://search.developer.apple.com/appsearch-validation-tool
+class AasaPlugin extends JsonPlugin {
+  static createSingleApp = (props: SingleAppAasaPluginProps & { mode: Mode }): AasaPlugin => {
+    const aasa = createAasaObjectForSingleApp(props);
+    return new AasaPlugin({
+      mode: props.mode,
+      aasa,
+    });
+  };
+
+  static createMultiApp = (props: MultiAppAasaPluginProps & { mode: Mode }): AasaPlugin => {
+    const aasa = createAasaObjectForMultiApp(props);
+    return new AasaPlugin({
+      mode: props.mode,
+      aasa,
+    });
+  };
+
+  constructor({
+    mode,
+    useWellKnown = true,
+    aasa = {},
+  }: {
+    mode: Mode;
+    useWellKnown?: boolean;
+    aasa: AasaObject;
+  }) {
+    super({
+      pretty: mode === 'development',
+      path: useWellKnown
+        ? '/.well-known/apple-app-site-association'
+        : '/apple-app-site-association',
+      object: Object.keys(aasa).length ? aasa : null,
+    });
+  }
+}
+
+export default AasaPlugin;

--- a/packages/webpack-config/src/plugins/JsonPlugin.ts
+++ b/packages/webpack-config/src/plugins/JsonPlugin.ts
@@ -1,0 +1,43 @@
+class JsonPlugin {
+  constructor(private options: any = {}) {
+    if (!this.options.path) {
+      throw new Error('Failed to write json in webpack.');
+    }
+    this.options.path = options.path || 'data.json';
+    this.options.pretty = options.pretty;
+  }
+
+  apply(compiler: any) {
+    if (!this.options.object) {
+      return;
+    }
+    if (compiler.hooks) {
+      compiler.hooks.emit.tapAsync(this.constructor.name, this.writeContents);
+    } else {
+      compiler.plugin('emit', this.writeContents);
+    }
+  }
+
+  private writeContents = (compilation: any, callback: any) => {
+    const json = JSON.stringify(
+      this.options.object,
+      undefined,
+      this.options.pretty ? 2 : undefined
+    );
+
+    Object.assign(compilation.assets, {
+      [this.options.path]: {
+        source() {
+          return json;
+        },
+        size() {
+          return json.length;
+        },
+      },
+    });
+
+    callback();
+  };
+}
+
+export default JsonPlugin;

--- a/packages/webpack-config/src/plugins/index.ts
+++ b/packages/webpack-config/src/plugins/index.ts
@@ -2,3 +2,5 @@ export { default as ExpoDefinePlugin } from './ExpoDefinePlugin';
 export { default as ExpoProgressBarPlugin } from './ExpoProgressBarPlugin';
 export { default as ExpoHtmlWebpackPlugin } from './ExpoHtmlWebpackPlugin';
 export { default as ExpoInterpolateHtmlPlugin } from './ExpoInterpolateHtmlPlugin';
+export { default as AasaPlugin } from './AasaPlugin';
+export { default as JsonPlugin } from './JsonPlugin';

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -324,10 +324,7 @@ export default async function(
   });
 }
 
-function withAasa(
-  config: AnyConfiguration,
-  env: Pick<Environment, 'mode' | 'config'>
-): AnyConfiguration {
+function withAasa(config: AnyConfiguration, env: Pick<Environment, 'config'>): AnyConfiguration {
   const { ios = {} } = env.config;
 
   if (!config.plugins) config.plugins = [];
@@ -335,7 +332,6 @@ function withAasa(
   config.plugins.push(
     AasaPlugin.createSingleApp({
       associatedDomains: ios.associatedDomains || [],
-      mode: env.mode,
       bundleId: ios.bundleIdentifier,
       teamId: ios.teamId,
       paths: ios.aasaPaths || [],


### PR DESCRIPTION
## Why

- Share passwords, and implement deep-linking between iOS and web.

## How

- [ ] Add Android support https://developer.android.com/training/app-links/verify-site-associations
- create a `apple-app-site-association` in the `webpack-config`
- add `expo.ios.teamId` and `expo.ios.aasaPaths`
- add docs https://github.com/expo/expo/pull/6472

## Test Plan

- [ ] Unit test the shape of the aasa file