### PR TITLE
[xdl] Fix Facebook buildtime customizations being applied to apps < SDK36

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1099,6 +1099,9 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
   );
 
   // Facebook configuration
+
+  // There's no such pattern to replace in shell apps below SDK 36,
+  // so this will not have any effect on these apps.
   if (manifest.facebookAppId) {
     await regexFileAsync(
       '<!-- ADD FACEBOOK APP ID CONFIG HERE -->',
@@ -1106,6 +1109,8 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
     );
   }
+  // There's no such pattern to replace in shell apps below SDK 36,
+  // so this will not have any effect on these apps.
   if (manifest.facebookDisplayName) {
     await regexFileAsync(
       '<!-- ADD FACEBOOK APP DISPLAY NAME CONFIG HERE -->',
@@ -1113,6 +1118,8 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
     );
   }
+  // There's no such pattern to replace in shell apps below SDK 36,
+  // so this will not have any effect on these apps.
   if (manifest.facebookAutoInitEnabled) {
     await regexFileAsync(
       '<meta-data android:name="com.facebook.sdk.AutoInitEnabled" android:value="false"/>',
@@ -1120,6 +1127,8 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
     );
   }
+  // There's no such pattern to replace in shell apps below SDK 36,
+  // so this will not have any effect on these apps.
   if (manifest.facebookAutoLogAppEventsEnabled) {
     await regexFileAsync(
       '<meta-data android:name="com.facebook.sdk.AutoLogAppEventsEnabled" android:value="false"/>',
@@ -1127,6 +1136,8 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
     );
   }
+  // There's no such pattern to replace in shell apps below SDK 36,
+  // so this will not have any effect on these apps.
   if (manifest.facebookAdvertiserIDCollectionEnabled) {
     await regexFileAsync(
       '<meta-data android:name="com.facebook.sdk.AdvertiserIDCollectionEnabled" android:value="false"/>',

--- a/packages/xdl/src/detach/IosNSBundle.ts
+++ b/packages/xdl/src/detach/IosNSBundle.ts
@@ -330,10 +330,12 @@ async function _configureInfoPlistAsync(context: AnyStandaloneContext): Promise<
       delete infoPlist['FacebookDisplayName'];
     }
 
-    infoPlist.FacebookAutoInitEnabled = config.facebookAutoInitEnabled || false;
-    infoPlist.FacebookAutoLogAppEventsEnabled = config.facebookAutoLogAppEventsEnabled || false;
-    infoPlist.FacebookAdvertiserIDCollectionEnabled =
-      config.facebookAdvertiserIDCollectionEnabled || false;
+    if (parseSdkMajorVersion(config.sdkVersion) >= 36) {
+      infoPlist.FacebookAutoInitEnabled = config.facebookAutoInitEnabled || false;
+      infoPlist.FacebookAutoLogAppEventsEnabled = config.facebookAutoLogAppEventsEnabled || false;
+      infoPlist.FacebookAdvertiserIDCollectionEnabled =
+        config.facebookAdvertiserIDCollectionEnabled || false;
+    }
 
     // set ITSAppUsesNonExemptEncryption to let people skip manually
     // entering it in iTunes Connect


### PR DESCRIPTION
Buildtime customizations introduced in 70af3e83.

https://github.com/expo/expo-cli/commit/70af3e83628ed51d665331264f7230c1f0f22144

Fixes issue described in https://github.com/expo/expo/pull/5924#issuecomment-562125716.