### PR TITLE
[webpack-config] Fix public path for service workers and favicon

### DIFF
--- a/packages/webpack-config/src/addons/withWorkbox.ts
+++ b/packages/webpack-config/src/addons/withWorkbox.ts
@@ -11,6 +11,7 @@ import {
 import { AnyConfiguration } from '../types';
 import { resolveEntryAsync } from '../utils';
 import { getPaths } from '../env';
+import { ensureSlash } from '@expo/config/paths';
 
 export type OfflineOptions = {
   projectRoot?: string;
@@ -77,7 +78,7 @@ export default function withWorkbox(
     projectRoot,
     autoRegister = true,
     publicUrl = '',
-    scope = '/',
+    scope,
     useServiceWorker = true,
     generateSWOptions = {},
     injectManifestOptions = {},
@@ -119,7 +120,7 @@ export default function withWorkbox(
         await readFile(require.resolve(locations.template.registerServiceWorker), 'utf8')
       )
         .replace('SW_PUBLIC_URL', publicUrl)
-        .replace('SW_PUBLIC_SCOPE', scope);
+        .replace('SW_PUBLIC_SCOPE', ensureSlash(scope || publicUrl, true));
       await ensureDir(locations.production.folder);
       await writeFile(swPath, content, 'utf8');
 

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -2,7 +2,7 @@ import { Configuration } from 'webpack';
 
 import { Arguments, DevConfiguration, Environment, InputEnvironment } from './types';
 import * as Diagnosis from './Diagnosis';
-import { validateEnvironment } from './env';
+import { validateEnvironment, getPublicPaths } from './env';
 import webpackConfig from './webpack.config';
 import { withWorkbox } from './addons';
 
@@ -18,5 +18,9 @@ export default async function(
     Diagnosis.reportAsync(config, environment);
   }
 
-  return withWorkbox(config, { projectRoot: environment.projectRoot, ...argv.workbox });
+  const { workbox = {} } = argv;
+
+  const publicUrl = workbox.publicUrl || getPublicPaths(environment).publicUrl;
+
+  return withWorkbox(config, { projectRoot: environment.projectRoot, ...workbox, publicUrl });
 }

--- a/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
@@ -15,7 +15,7 @@ export default class ExpoInterpolateHtmlPlugin extends InterpolateHtmlPlugin {
     HtmlWebpackPlugin: HtmlWebpackPlugin
   ): ExpoInterpolateHtmlPlugin => {
     const config = env.config || getConfig(env);
-    const { publicUrl } = getPublicPaths(env);
+    const { publicPath } = getPublicPaths(env);
 
     const { build: buildConfig = {}, lang } = config.web;
     const { rootId } = buildConfig;
@@ -24,7 +24,7 @@ export default class ExpoInterpolateHtmlPlugin extends InterpolateHtmlPlugin {
 
     // Add variables to the `index.html`
     return new ExpoInterpolateHtmlPlugin(HtmlWebpackPlugin, {
-      WEB_PUBLIC_URL: publicUrl,
+      WEB_PUBLIC_URL: publicPath,
       WEB_TITLE: config.web.name,
       NO_SCRIPT: noJSComponent,
       LANG_ISO_CODE: lang,


### PR DESCRIPTION
fix https://github.com/expo/expo-cli/issues/1330

## Test Plan

- deploying to GH Pages should install the SW correctly https://evanbacon.github.io/expo-web-sdk-36-gh-pages-test/
- favicon should be found 