### PR TITLE
[expo-cli] upload:ios - auto resolve itc team id

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -121,8 +121,8 @@
     "wordwrap": "1.0.0"
   },
   "optionalDependencies": {
-    "@expo/traveling-fastlane-darwin": "1.11.2",
-    "@expo/traveling-fastlane-linux": "1.11.2"
+    "@expo/traveling-fastlane-darwin": "1.11.3",
+    "@expo/traveling-fastlane-linux": "1.11.3"
   },
   "gitHead": "613642fe06827cc231405784b099cf71c29072df"
 }

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -121,8 +121,8 @@
     "wordwrap": "1.0.0"
   },
   "optionalDependencies": {
-    "@expo/traveling-fastlane-darwin": "1.11.0",
-    "@expo/traveling-fastlane-linux": "1.11.0"
+    "@expo/traveling-fastlane-darwin": "1.11.1",
+    "@expo/traveling-fastlane-linux": "1.11.1"
   },
   "gitHead": "613642fe06827cc231405784b099cf71c29072df"
 }

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -121,8 +121,8 @@
     "wordwrap": "1.0.0"
   },
   "optionalDependencies": {
-    "@expo/traveling-fastlane-darwin": "1.11.1",
-    "@expo/traveling-fastlane-linux": "1.11.1"
+    "@expo/traveling-fastlane-darwin": "1.11.2",
+    "@expo/traveling-fastlane-linux": "1.11.2"
   },
   "gitHead": "613642fe06827cc231405784b099cf71c29072df"
 }

--- a/packages/expo-cli/src/commands/upload.js
+++ b/packages/expo-cli/src/commands/upload.js
@@ -28,7 +28,6 @@ export default program => {
     ...COMMON_OPTIONS,
     'appleId',
     'appleIdPassword',
-    'itcTeamId',
     'appName',
     'sku',
     'language',
@@ -46,7 +45,7 @@ export default program => {
     // after updating fastlane this value will be unnecessary
     .option(
       '--itc-team-id <itc-team-id>',
-      'App Store Connect Team ID (optional if there is only one team available)'
+      'App Store Connect Team ID - this option is deprecated, the proper ID is resolved automatically'
     )
     .option(
       '--apple-id-password <apple-id-password>',

--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -183,15 +183,27 @@ export default class IOSUploader extends BaseUploader {
 
     const appleCreds = { appleId, appleIdPassword, appleTeamId };
 
+    log('Resolving the ITC team ID...');
+    const { itc_team_id: itcTeamId } = await runFastlaneAsync(
+      fastlane.resolveItcTeamId,
+      [],
+      appleCreds
+    );
+    log(`ITC team ID is ${itcTeamId}`);
+    const updatedAppleCreds = {
+      ...appleCreds,
+      itcTeamId,
+    };
+
     log('Ensuring the app exists on App Store Connect, this may take a while...');
     await runFastlaneAsync(
       fastlane.appProduce,
       [bundleIdentifier, appName, appleId, language],
-      appleCreds
+      updatedAppleCreds
     );
 
     log('Uploading the app to Testflight, hold tight...');
-    await runFastlaneAsync(fastlane.pilotUpload, [buildPath, appleId], appleCreds);
+    await runFastlaneAsync(fastlane.pilotUpload, [buildPath, appleId], updatedAppleCreds);
 
     log(
       `All done! You may want to go to App Store Connect (${chalk.underline(

--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -83,7 +83,6 @@ export type IosPlatformOptions = PlatformOptions & {
   appName: string;
   language?: string;
   appleTeamId?: string;
-  itcTeamId?: string;
   publicUrl?: string;
 };
 
@@ -182,7 +181,7 @@ export default class IOSUploader extends BaseUploader {
     const { appleId, appleIdPassword, appName, language, appleTeamId } = platformData;
     const { bundleIdentifier } = this._exp && this._exp.ios;
 
-    const appleCreds = { appleId, appleIdPassword, appleTeamId, itcTeamId: this.options.itcTeamId };
+    const appleCreds = { appleId, appleIdPassword, appleTeamId };
 
     log('Ensuring the app exists on App Store Connect, this may take a while...');
     await runFastlaneAsync(

--- a/packages/expo-cli/src/commands/upload/utils.ts
+++ b/packages/expo-cli/src/commands/upload/utils.ts
@@ -29,7 +29,8 @@ export async function runFastlaneAsync(
     appleId,
     appleIdPassword,
     appleTeamId,
-  }: { appleId?: string; appleIdPassword?: string; appleTeamId?: string },
+    itcTeamId,
+  }: { appleId?: string; appleIdPassword?: string; appleTeamId?: string; itcTeamId?: string },
   pipeToLogger = false
 ): Promise<{ [key: string]: any }> {
   const pipeToLoggerOptions: any = pipeToLogger
@@ -43,6 +44,7 @@ export async function runFastlaneAsync(
           FASTLANE_PASSWORD: appleIdPassword,
           FASTLANE_DONT_STORE_PASSWORD: '1',
           FASTLANE_TEAM_ID: appleTeamId,
+          ...(itcTeamId && { FASTLANE_ITC_TEAM_ID: itcTeamId }),
         }
       : {};
 

--- a/packages/expo-cli/src/commands/upload/utils.ts
+++ b/packages/expo-cli/src/commands/upload/utils.ts
@@ -29,8 +29,7 @@ export async function runFastlaneAsync(
     appleId,
     appleIdPassword,
     appleTeamId,
-    itcTeamId,
-  }: { appleId?: string; appleIdPassword?: string; appleTeamId?: string; itcTeamId?: string },
+  }: { appleId?: string; appleIdPassword?: string; appleTeamId?: string },
   pipeToLogger = false
 ): Promise<{ [key: string]: any }> {
   const pipeToLoggerOptions: any = pipeToLogger
@@ -44,7 +43,6 @@ export async function runFastlaneAsync(
           FASTLANE_PASSWORD: appleIdPassword,
           FASTLANE_DONT_STORE_PASSWORD: '1',
           FASTLANE_TEAM_ID: appleTeamId,
-          FASTLANE_ITC_TEAM_ID: itcTeamId ? itcTeamId : undefined,
         }
       : {};
 

--- a/packages/traveling-fastlane/Rakefile
+++ b/packages/traveling-fastlane/Rakefile
@@ -2,7 +2,7 @@
 require 'bundler/setup'
 
 PACKAGE_NAME = "traveling-fastlane"
-VERSION = "1.11.1"
+VERSION = "1.11.2"
 TRAVELING_RUBY_VERSION = "20150715-2.2.2"
 JSON_VERSION = '1.8.2'
 UNF_VERSION = '0.0.6'

--- a/packages/traveling-fastlane/Rakefile
+++ b/packages/traveling-fastlane/Rakefile
@@ -2,7 +2,7 @@
 require 'bundler/setup'
 
 PACKAGE_NAME = "traveling-fastlane"
-VERSION = "1.11.0"
+VERSION = "1.11.1"
 TRAVELING_RUBY_VERSION = "20150715-2.2.2"
 JSON_VERSION = '1.8.2'
 UNF_VERSION = '0.0.6'

--- a/packages/traveling-fastlane/Rakefile
+++ b/packages/traveling-fastlane/Rakefile
@@ -2,24 +2,25 @@
 require 'bundler/setup'
 
 PACKAGE_NAME = "traveling-fastlane"
-VERSION = "1.11.2"
+VERSION = "1.11.3"
 TRAVELING_RUBY_VERSION = "20150715-2.2.2"
 JSON_VERSION = '1.8.2'
 UNF_VERSION = '0.0.6'
 
 # Be sure to add the name of a script here when you add it to actions
 SCRIPTS = [
-  'funcs',
-  'preload',
   'app_produce',
   'authenticate',
   'ensure_app_exists',
+  'funcs',
   'list_devices',
   'manage_ad_hoc_provisioning_profile',
   'manage_dist_certs',
   'manage_provisioning_profiles',
   'manage_push_keys',
   'pilot_upload',
+  'preload',
+  'resolve_itc_team_id',
   'supply_android',
 ]
 

--- a/packages/traveling-fastlane/actions/pilot_upload.rb
+++ b/packages/traveling-fastlane/actions/pilot_upload.rb
@@ -1,12 +1,21 @@
 # So that we can require funcs.rb
 $LOAD_PATH.unshift File.expand_path(__dir__, __FILE__)
 
+require 'spaceship'
 require 'pilot'
 require 'funcs'
 require 'json'
 
 $ipaPath, $username = ARGV
 $result = nil
+
+portal_client = Spaceship::Portal.login($username, ENV['FASTLANE_PASSWORD'])
+developer_team = portal_client.teams.find { |team| team['teamId'] == $teamId }
+
+Spaceship::Tunes.login($username, ENV['FASTLANE_PASSWORD'])
+itunes_team = Spaceship::Tunes.client.teams.find { |team| team['contentProvider']['name'].start_with? developer_team['name']  }
+
+ENV['FASTLANE_ITC_TEAM_ID'] = itunes_team['contentProvider']['contentProviderId']
 
 captured_stderr = with_captured_stderr{
   begin

--- a/packages/traveling-fastlane/actions/pilot_upload.rb
+++ b/packages/traveling-fastlane/actions/pilot_upload.rb
@@ -10,12 +10,12 @@ $ipaPath, $username = ARGV
 $result = nil
 
 portal_client = Spaceship::Portal.login($username, ENV['FASTLANE_PASSWORD'])
-developer_team = portal_client.teams.find { |team| team['teamId'] == $teamId }
+developer_team = portal_client.teams.find { |team| team['teamId'] == ENV['FASTLANE_TEAM_ID'] }
 
 Spaceship::Tunes.login($username, ENV['FASTLANE_PASSWORD'])
 itunes_team = Spaceship::Tunes.client.teams.find { |team| team['contentProvider']['name'].start_with? developer_team['name']  }
 
-ENV['FASTLANE_ITC_TEAM_ID'] = itunes_team['contentProvider']['contentProviderId']
+ENV['FASTLANE_ITC_TEAM_ID'] = itunes_team['contentProvider']['contentProviderId'].to_s
 
 captured_stderr = with_captured_stderr{
   begin
@@ -24,7 +24,8 @@ captured_stderr = with_captured_stderr{
       username: $username,
       skip_waiting_for_build_processing: true,
     }
-    Pilot::BuildManager.new.upload(config)
+    manager = Pilot::BuildManager.new
+    manager.upload(config)
     $result = JSON.generate({ result: 'success' })
   rescue Spaceship::Client::InvalidUserCredentialsError => invalid_cred
     $result = JSON.generate({

--- a/packages/traveling-fastlane/publishing/darwin/index.js
+++ b/packages/traveling-fastlane/publishing/darwin/index.js
@@ -8,6 +8,7 @@ const TRAVELING_FASTLANE = `traveling-fastlane-${version}-osx`;
 module.exports = () => {
   let p = join.bind(null, __dirname, TRAVELING_FASTLANE);
   return {
+    appProduce: p('app_produce'),
     authenticate: p('authenticate'),
     ensureAppExists: p('ensure_app_exists'),
     listDevices: p('list_devices'),
@@ -15,8 +16,8 @@ module.exports = () => {
     manageDistCerts: p('manage_dist_certs'),
     managePushKeys: p('manage_push_keys'),
     manageProvisioningProfiles: p('manage_provisioning_profiles'),
-    appProduce: p('app_produce'),
     pilotUpload: p('pilot_upload'),
+    resolveItcTeamId: p('resolve_itc_team_id'),
     supplyAndroid: p('supply_android'),
   };
 };

--- a/packages/traveling-fastlane/publishing/darwin/package.json
+++ b/packages/traveling-fastlane/publishing/darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/traveling-fastlane-darwin",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Bundled up fastlane",
   "main": "index.js",
   "os": [

--- a/packages/traveling-fastlane/publishing/darwin/package.json
+++ b/packages/traveling-fastlane/publishing/darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/traveling-fastlane-darwin",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Bundled up fastlane",
   "main": "index.js",
   "os": [

--- a/packages/traveling-fastlane/publishing/darwin/package.json
+++ b/packages/traveling-fastlane/publishing/darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/traveling-fastlane-darwin",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Bundled up fastlane",
   "main": "index.js",
   "os": [

--- a/packages/traveling-fastlane/publishing/linux/index.js
+++ b/packages/traveling-fastlane/publishing/linux/index.js
@@ -8,6 +8,7 @@ const TRAVELING_FASTLANE = `traveling-fastlane-${version}-linux-x86_64`;
 module.exports = () => {
   let p = join.bind(null, __dirname, TRAVELING_FASTLANE);
   return {
+    appProduce: p('app_produce'),
     authenticate: p('authenticate'),
     ensureAppExists: p('ensure_app_exists'),
     listDevices: p('list_devices'),
@@ -15,8 +16,8 @@ module.exports = () => {
     manageDistCerts: p('manage_dist_certs'),
     managePushKeys: p('manage_push_keys'),
     manageProvisioningProfiles: p('manage_provisioning_profiles'),
-    appProduce: p('app_produce'),
     pilotUpload: p('pilot_upload'),
+    resolveItcTeamId: p('resolve_itc_team_id'),
     supplyAndroid: p('supply_android'),
   };
 };

--- a/packages/traveling-fastlane/publishing/linux/package.json
+++ b/packages/traveling-fastlane/publishing/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/traveling-fastlane-linux",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Bundled up fastlane",
   "main": "index.js",
   "os": [

--- a/packages/traveling-fastlane/publishing/linux/package.json
+++ b/packages/traveling-fastlane/publishing/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/traveling-fastlane-linux",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Bundled up fastlane",
   "main": "index.js",
   "os": [

--- a/packages/traveling-fastlane/publishing/linux/package.json
+++ b/packages/traveling-fastlane/publishing/linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/traveling-fastlane-linux",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Bundled up fastlane",
   "main": "index.js",
   "os": [

--- a/packages/traveling-fastlane/wrappers/resolve_itc_team_id_wrapper.sh
+++ b/packages/traveling-fastlane/wrappers/resolve_itc_team_id_wrapper.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+# Figure out where this script is located.
+SELFDIR="`dirname \"$0\"`"
+SELFDIR="`cd \"$SELFDIR\" && pwd`"
+
+export BUNDLE_GEMFILE="$SELFDIR/lib/vendor/Gemfile"
+unset BUNDLE_IGNORE_CONFIG
+
+export FASTLANE_DISABLE_COLORS=1
+export FASTLANE_SKIP_UPDATE_CHECK=1
+export FASTLANE_DISABLE_ANIMATION=1
+
+script="$SELFDIR/lib/app/resolve_itc_team_id.rb"
+
+lib_loc="$SELFDIR/lib/app"
+
+exec "$SELFDIR/lib/ruby/bin/ruby" -W0 -I"$lib_loc" -rpreload "$script" "$@"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,15 +1154,15 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/traveling-fastlane-darwin@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.0.tgz#88f09e2332f2103fafac4759bbbc86832633768a"
-  integrity sha512-owQdOQ0Ag4XE9LtXQ0p1fWwWqa0uhJvEKEmvb5ugPbdkT8BSs92TNfULHPMkGohcHlB0/Q+VXTUbSnP4zczKbQ==
+"@expo/traveling-fastlane-darwin@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.1.tgz#68cb06c8add1cc99f345c30c40967fe926fae7b0"
+  integrity sha512-vM5pfRxdV3pTphs8TWXdeSu5b1bJb6GGZAT7Sxi91z4Ukbeqf3YGoxMRcbDa5yi+224ZCxCaqyU9B8njowg1Fg==
 
-"@expo/traveling-fastlane-linux@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.11.0.tgz#a714d87633b030b7190bc0c2b02540eb714bea2b"
-  integrity sha512-ia187s91eO3jxilI/rqqy3SSAUdXsq/5k2nPck2Fs9jWiGldks8Dop+6bAl2brUwzY9VrTDPB2u2z4V08XDZFA==
+"@expo/traveling-fastlane-linux@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.11.1.tgz#7d8d69cc94b7ebb5fed2f09928dae0a3e967ae75"
+  integrity sha512-JkY1+6H7I98WaSBAQr73JzT61AFmI4oVpkEVSDTt8hytopk7I/qAdPxxp/Zolu3Zrg1ViFjV/9cPrSbcQD8cUg==
 
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,15 +1154,15 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/traveling-fastlane-darwin@1.11.2":
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.2.tgz#3c23bd424750c94ef6ee9382a8d409d611eb19e0"
-  integrity sha512-zUDGSaSJ5kH+jA0maMLqn6nSQTX8chqfDExQ/FPZIIz1O/W/cQxtrJxBzmdzncYyoawBMSwoq82jdzsJkx6T2w==
+"@expo/traveling-fastlane-darwin@1.11.3":
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.3.tgz#b353bb9cc653883231bab1736fc835ec67d45320"
+  integrity sha512-7AEJk728ckjqAI45LFsxnNqu1tV6ftypRhaXaclsAAleHlWNUwpy88NX0lTqm66wcFBg6+mmiE8+aw/4zeL/JA==
 
-"@expo/traveling-fastlane-linux@1.11.2":
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.11.2.tgz#0cc3d2a3b7893caf2374fb21c2c1107fcf8522f6"
-  integrity sha512-NRlLalDmktyTl0z0XrL9rGhZ9W5hY4HQvdfxzqyEmJjW6B4LsMgAdO6PpWqNRKd/h42wJedKEDUMA1Kj9uMiDA==
+"@expo/traveling-fastlane-linux@1.11.3":
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.11.3.tgz#f1812db51db335628474e5ccde7b0762d96c77d4"
+  integrity sha512-cyr0WDkGOEaOjuVBc3m5Ud4Jrqvvz1RoQdgZ5IKhitW9ElLAQS97aKtgKDAAcQ8Yu7FBYRVt0ilJhP5eweI6+A==
 
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,15 +1154,15 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/traveling-fastlane-darwin@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.1.tgz#68cb06c8add1cc99f345c30c40967fe926fae7b0"
-  integrity sha512-vM5pfRxdV3pTphs8TWXdeSu5b1bJb6GGZAT7Sxi91z4Ukbeqf3YGoxMRcbDa5yi+224ZCxCaqyU9B8njowg1Fg==
+"@expo/traveling-fastlane-darwin@1.11.2":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.2.tgz#3c23bd424750c94ef6ee9382a8d409d611eb19e0"
+  integrity sha512-zUDGSaSJ5kH+jA0maMLqn6nSQTX8chqfDExQ/FPZIIz1O/W/cQxtrJxBzmdzncYyoawBMSwoq82jdzsJkx6T2w==
 
-"@expo/traveling-fastlane-linux@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.11.1.tgz#7d8d69cc94b7ebb5fed2f09928dae0a3e967ae75"
-  integrity sha512-JkY1+6H7I98WaSBAQr73JzT61AFmI4oVpkEVSDTt8hytopk7I/qAdPxxp/Zolu3Zrg1ViFjV/9cPrSbcQD8cUg==
+"@expo/traveling-fastlane-linux@1.11.2":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.11.2.tgz#0cc3d2a3b7893caf2374fb21c2c1107fcf8522f6"
+  integrity sha512-NRlLalDmktyTl0z0XrL9rGhZ9W5hY4HQvdfxzqyEmJjW6B4LsMgAdO6PpWqNRKd/h42wJedKEDUMA1Kj9uMiDA==
 
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"


### PR DESCRIPTION
**Why?** Fixes #971 

**How?** A user doesn't have to pass the ITC team id by himself. We can deduce the id on our own by matching the team names from Apple Developer Portal and iTunes Connect.
I deprecated the `--itc-team-id` option for `expo upload:ios`. Passing this option doesn't have any effect from now. 