### PR TITLE
[xdl] Do not add fbScheme to MainActivity's intent-filter

### DIFF
--- a/packages/xdl/CHANGELOG.md
+++ b/packages/xdl/CHANGELOG.md
@@ -22,6 +22,7 @@ For guidelines on how to update this file, visit http://keepachangelog.com/en/0.
 - `ProjectUtils.readConfigJsonAsync` from `xdl` in favor of `readConfigJsonAsync` from `@expo/config`
 - `ProjectUtils.readExpRcAsync` from `xdl` in favor of `readExpRcAsync` from `@expo/config`
 - Dropped support for SDK 24, `Detach.detachAsync` now requires SDK version 25.0.0 or newer.
+- Removed adding `facebookScheme` to `MainActivity`'s intent-filters.
 
 ## [51.1.0] - 2018-08-28
 

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -756,7 +756,7 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
   }
 
   // Add shell app scheme
-  const schemes = [scheme, manifest.facebookScheme].filter(e => e);
+  const schemes = [scheme].filter(e => e);
   if (schemes.length > 0) {
     const searchLine = isDetached
       ? '<!-- ADD DETACH SCHEME HERE -->'


### PR DESCRIPTION
It was recently added in https://github.com/expo/expo-cli/commit/70af3e83628ed51d665331264f7230c1f0f22144 and isn't needed (no [Facebook setup instruction](https://developers.facebook.com/docs/facebook-login/android?sdk=maven) mentions it should be added. Instead, developers are expected to add fully qualified name of the activity in Facebook developers console — see https://github.com/expo/expo/pull/6453).