### PR TITLE
[xdl] Android app-bundle builds failing with SDK 36

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1161,7 +1161,10 @@ async function buildShellAppAsync(context, sdkVersion, buildType, buildMode) {
   let gradleBuildCommand;
   let outputPath;
   if (buildType === 'app-bundle') {
-    if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 33) {
+    if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 36) {
+      gradleBuildCommand = `bundle${debugOrRelease}`;
+      outputPath = path.join(outputDirPath, debugOrReleaseL, `app-${debugOrReleaseL}.aab`);
+    } else if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 33) {
       gradleBuildCommand = `bundle${debugOrRelease}`;
       outputPath = path.join(outputDirPath, debugOrReleaseL, `app.aab`);
     } else if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 32) {


### PR DESCRIPTION
When building Android app bundles with turtle-cli and SDK 36, both locally and in cloud, the build fails with.

> Error: ENOENT: no such file or directory, lstat '/app/turtle/workingdir/android/sdk36/android-shell-app/app/build/outputs/bundle/release/app.aab'

The problem is that the app bundle is saved as 

> /app/turtle/workingdir/android/sdk36/android-shell app/app/build/outputs/bundle/release/app-release.aab

This pull request fixes the issue.

The fix has been tested by modifying `node_modules/turtle-cli/node_modules/@expo/xdl/build/detach/AndroidShellApp.js` locally.

See https://forums.expo.io/t/android-build-fail-with-sdk36/30980/3?u=hilmarh for more information.