### PR TITLE
  Convert publish endpoint to apiV2

### DIFF
--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -89,11 +89,11 @@ async function _callMethodAsync(
 
   if (requestOptions) {
     if (requestOptions.formData) {
-      let convertedFormData = await convertFormDataToBuffer(requestOptions.formData);
+      let convertedFormData = await _convertFormDataToBuffer(requestOptions.formData);
       let { data } = convertedFormData;
       options.headers = {
         ...options.headers,
-        ...requestOptions.formData.getHeaders(), //<------this is what is missing!
+        ...requestOptions.formData.getHeaders(),
       };
       options = { ...options, data };
     } else {
@@ -130,7 +130,7 @@ async function _callMethodAsync(
   }
 }
 
-export async function convertFormDataToBuffer(formData: FormData): Promise<{ data: Buffer }> {
+async function _convertFormDataToBuffer(formData: FormData): Promise<{ data: Buffer }> {
   return new Promise(resolve => {
     formData.pipe(concat({ encoding: 'buffer' }, data => resolve({ data })));
   });

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -89,11 +89,11 @@ async function _callMethodAsync(
 
   if (requestOptions) {
     if (requestOptions.formData) {
-      let convertedFormData = await _convertFormDataToBuffer(requestOptions.formData);
+      let convertedFormData = await convertFormDataToBuffer(requestOptions.formData);
       let { data } = convertedFormData;
       options.headers = {
         ...options.headers,
-        ...requestOptions.formData.getHeaders(),
+        ...requestOptions.formData.getHeaders(), //<------this is what is missing!
       };
       options = { ...options, data };
     } else {
@@ -130,7 +130,7 @@ async function _callMethodAsync(
   }
 }
 
-async function _convertFormDataToBuffer(formData: FormData): Promise<{ data: Buffer }> {
+export async function convertFormDataToBuffer(formData: FormData): Promise<{ data: Buffer }> {
   return new Promise(resolve => {
     formData.pipe(concat({ encoding: 'buffer' }, data => resolve({ data })));
   });

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -186,8 +186,7 @@ export default class ApiV2Client {
       reqOptions.data = options.body;
     }
 
-    reqOptions = merge({}, reqOptions, extraRequestOptions);
-    reqOptions = merge({}, reqOptions, uploadOptions);
+    reqOptions = merge({}, reqOptions, extraRequestOptions, uploadOptions);
 
     let response;
     let result;

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -132,10 +132,24 @@ export default class ApiV2Client {
     );
   }
 
+  async uploadAsync(
+    methodName: string,
+    extraOptions?: any //Partial<RequestOptions>,
+  ) {
+    const url = `${_apiBaseUrl()}/${methodName}`;
+    let extraRequestOptions: AxiosRequestConfig = {
+      url,
+      method: 'post',
+    };
+    extraRequestOptions = { ...extraRequestOptions, ...extraOptions };
+
+    return await this._requestAsync(methodName, { httpMethod: 'post' }, extraRequestOptions);
+  }
+
   async _requestAsync(
     methodName: string,
     options: RequestOptions,
-    extraRequestOptions?: Partial<RequestOptions>,
+    extraRequestOptions?: any, //Partial<RequestOptions>,
     returnEntireResponse: boolean = false
   ) {
     const url = `${_apiBaseUrl()}/${methodName}`;
@@ -146,7 +160,6 @@ export default class ApiV2Client {
         'Exponent-Client': ApiV2Client.exponentClient,
       },
     };
-
     if (this.sessionSecret) {
       reqOptions.headers['Expo-Session'] = this.sessionSecret;
     }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -44,8 +44,7 @@ import uuid from 'uuid';
 
 import * as Analytics from './Analytics';
 import * as Android from './Android';
-import Api, { convertFormDataToBuffer } from './Api';
-
+import Api from './Api';
 import ApiV2 from './ApiV2';
 import Config from './Config';
 import * as ExponentTools from './detach/ExponentTools';
@@ -944,29 +943,23 @@ async function _uploadArtifactsAsync({
   options: PublishOptions;
   pkg: PackageJSONConfig;
 }) {
-  console.log('TEST <-----------------------------------------------------');
   logger.global.info('Uploading JavaScript bundles');
   let formData = new FormData();
 
   formData.append('expJson', JSON.stringify(exp));
   formData.append('packageJson', JSON.stringify(pkg));
-  formData.append('iosBundle', iosBundle.slice(0, 10), 'iosBundle');
-  formData.append('androidBundle', androidBundle.slice(0, 10), 'androidBundle');
+  formData.append('iosBundle', iosBundle, 'iosBundle');
+  formData.append('androidBundle', androidBundle, 'androidBundle');
   formData.append('options', JSON.stringify(options));
 
   let response: any;
-  console.log('WTF');
-  if (false) {
+  if (process.env.EXPO_LEGACY_API) {
     response = await Api.callMethodAsync('publish', null, 'post', null, { formData });
   } else {
-    console.log('V2?');
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
-    const { data } = await convertFormDataToBuffer(formData);
-    response = await api.uploadAsync('publish/new', { headers: formData.getHeaders(), data });
-    //response = await api.postAsync('publish/new',null,{headers:formData.getHeaders(), data} )
+    response = await api.uploadFormDataAsync('publish/new', formData);
   }
-  console.log({ response });
   return response;
 }
 

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -958,7 +958,7 @@ async function _uploadArtifactsAsync({
     const api = ApiV2.clientForUser(user);
     response = await api.uploadFormDataAsync('publish/new', formData);
   } else {
-    response = await Api.callMethodAsync('publish', null, 'post', null, { formData });
+    response = await Api.callMethodAsync('publish', null, 'put', null, { formData });
   }
   return response;
 }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -44,7 +44,8 @@ import uuid from 'uuid';
 
 import * as Analytics from './Analytics';
 import * as Android from './Android';
-import Api from './Api';
+import Api, { convertFormDataToBuffer } from './Api';
+
 import ApiV2 from './ApiV2';
 import Config from './Config';
 import * as ExponentTools from './detach/ExponentTools';
@@ -943,17 +944,29 @@ async function _uploadArtifactsAsync({
   options: PublishOptions;
   pkg: PackageJSONConfig;
 }) {
+  console.log('TEST <-----------------------------------------------------');
   logger.global.info('Uploading JavaScript bundles');
   let formData = new FormData();
 
   formData.append('expJson', JSON.stringify(exp));
   formData.append('packageJson', JSON.stringify(pkg));
-  formData.append('iosBundle', iosBundle, 'iosBundle');
-  formData.append('androidBundle', androidBundle, 'androidBundle');
+  formData.append('iosBundle', iosBundle.slice(0, 10), 'iosBundle');
+  formData.append('androidBundle', androidBundle.slice(0, 10), 'androidBundle');
   formData.append('options', JSON.stringify(options));
-  let response = await Api.callMethodAsync('publish', null, 'put', null, {
-    formData,
-  });
+
+  let response: any;
+  console.log('WTF');
+  if (false) {
+    response = await Api.callMethodAsync('publish', null, 'post', null, { formData });
+  } else {
+    console.log('V2?');
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    const { data } = await convertFormDataToBuffer(formData);
+    response = await api.uploadAsync('publish/new', { headers: formData.getHeaders(), data });
+    //response = await api.postAsync('publish/new',null,{headers:formData.getHeaders(), data} )
+  }
+  console.log({ response });
   return response;
 }
 

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -953,12 +953,12 @@ async function _uploadArtifactsAsync({
   formData.append('options', JSON.stringify(options));
 
   let response: any;
-  if (process.env.EXPO_LEGACY_API) {
-    response = await Api.callMethodAsync('publish', null, 'post', null, { formData });
-  } else {
+  if (process.env.EXPO_NEXT_API) {
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
     response = await api.uploadFormDataAsync('publish/new', formData);
+  } else {
+    response = await Api.callMethodAsync('publish', null, 'post', null, { formData });
   }
   return response;
 }


### PR DESCRIPTION
Following @ide's advice, added a EXPO_LEGACY_API variable that we can tell people to set to true while a fix is deployed.

(the server side APIv2 is being reviewed here: https://github.com/expo/universe/pull/3938)