### PR TITLE
Fix workbox and icon cache bugs

### DIFF
--- a/packages/webpack-config/src/addons/withWorkbox.ts
+++ b/packages/webpack-config/src/addons/withWorkbox.ts
@@ -1,6 +1,5 @@
-import { ensureDir, readFile, writeFile } from 'fs-extra';
+import { ensureDirSync, readFileSync, writeFileSync } from 'fs-extra';
 import { join } from 'path';
-import { Entry } from 'webpack';
 import {
   GenerateSW,
   GenerateSWOptions,
@@ -116,13 +115,18 @@ export default function withWorkbox(
     const entries = await resolveEntryAsync(expoEntry);
     const swPath = join(locations.production.registerServiceWorker);
     if (entries.app && !entries.app.includes(swPath) && autoRegister) {
-      const content = (
-        await readFile(require.resolve(locations.template.registerServiceWorker), 'utf8')
-      )
-        .replace('SW_PUBLIC_URL', publicUrl)
-        .replace('SW_PUBLIC_SCOPE', ensureSlash(scope || publicUrl, true));
-      await ensureDir(locations.production.folder);
-      await writeFile(swPath, content, 'utf8');
+      let content = readFileSync(require.resolve(locations.template.registerServiceWorker), 'utf8');
+      if (content) {
+        content = content
+          .replace('SW_PUBLIC_URL', publicUrl)
+          .replace('SW_PUBLIC_SCOPE', ensureSlash(scope || publicUrl, true));
+        ensureDirSync(locations.production.folder);
+      } else {
+        content = `
+        console.warn("failed to load service-worker in @expo/webpack-config -> withWorkbox. This can be due to the environment the project was built in. Please try again with a globally installed instance of expo-cli. If you continue to run into problems open an issue in https://github.com/expo/expo-cli")
+        `;
+      }
+      writeFileSync(swPath, content, 'utf8');
 
       if (!Array.isArray(entries.app)) {
         entries.app = [entries.app];

--- a/packages/webpack-pwa-manifest-plugin/src/icons.ts
+++ b/packages/webpack-pwa-manifest-plugin/src/icons.ts
@@ -251,7 +251,7 @@ export async function parseIconsAsync(
     return {};
   }
 
-  if (!(await isAvailableAsync())) {
+  if (!await isAvailableAsync()) {
     // TODO: Bacon: Fallback to nodejs image resizing as native doesn't work in the host environment.
     console.log();
     console.log(
@@ -315,8 +315,12 @@ function sortByAttribute(arr: any[], key: string): any[] {
 async function clearUnusedCachesAsync(projectRoot: string): Promise<void> {
   // Clean up any old caches
   const cacheFolder = path.join(projectRoot, '.expo/web/cache/production/images');
-  const currentCaches = await fs.readdir(cacheFolder);
+  const currentCaches = fs.readdirSync(cacheFolder);
 
+  if (!Array.isArray(currentCaches)) {
+    console.warn('Failed to read the icon cache');
+    return;
+  }
   const deleteCachePromises: Promise<void>[] = [];
   for (const cache of currentCaches) {
     // skip hidden folders


### PR DESCRIPTION
## Why

- fix #1161 
- https://stackoverflow.com/questions/58612850/buildweb-fails-inside-npm-script-with-typescript
- https://github.com/tiepp/expo-cli-local-ts

## How

- convert reading methods to sync
- add warnings when things work unexpectedly

## Test Plan

- I couldn't repro the issue so this is based on the feedback provided by @brookemitchell and @rickysullivan
- Added bail-out cases to prevent halting development if the problem persists in the future.