### PR TITLE
refactor(expo-cli): break functionality in client install for reusabilty

### DIFF
--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -334,132 +334,83 @@ export default program => {
     .command('client:install:android')
     .description('Install the Expo Client for Android on a connected device or emulator')
     .asyncAction(async () => {
-      let currentSdk;
-      const getAndroidVersion = sdkVersion =>
-        sdkVersion.androidClientVersion || sdkVersion.androidVersion || 'version unknown';
+      const currentSdkConfig = await ClientUpgradeUtils.getExpoSdkConfig(process.cwd());
+      const currentSdkVersion = currentSdkConfig ? currentSdkConfig.sdkVersion : undefined;
 
-      try {
-        const { projectRoot } = await findProjectRootAsync(process.cwd());
-        const { exp } = await ConfigUtils.readConfigJsonAsync(projectRoot);
-        currentSdk = exp;
-      } catch (error) {
-        // When a developer runs the installs command outside the project,
-        // they should be able to install any version
-        if (error.code !== 'NO_PROJECT') {
-          throw error;
-        }
+      if (!currentSdkVersion) {
         log(
-          'Could not find your Expo project. If you run this command from a project, we can help pick the right Expo Client version!'
+          'Could not find your Expo project. If you run this from a project, we can help pick the right Expo Client version!'
         );
       }
 
-      let targetSdkVersion;
-      let targetSdkVersionString;
-
-      const latestSdk = await Versions.newestSdkVersionAsync();
       const sdkVersions = await Versions.sdkVersionsAsync();
-      const currentSdkVersion = currentSdk.sdkVersion ? sdkVersions[currentSdk.sdkVersion] : null;
+      const latestSdk = await Versions.newestSdkVersionAsync();
+      const currentSdk = sdkVersions[currentSdkVersion];
+      const recommendedClient = currentSdk
+        ? ClientUpgradeUtils.getClient(currentSdk, 'android')
+        : undefined;
 
-      if (!currentSdk.sdkVersion || currentSdk.sdkVersion === latestSdk.version) {
+      if (currentSdk && !recommendedClient) {
+        log(
+          `You are currently using SDK ${currentSdkVersion}. Unfortunately, we couldn't detect the proper client version for this SDK.`
+        );
+      }
+
+      if (currentSdk && recommendedClient) {
         const answer = await prompt({
           type: 'confirm',
-          name: 'updateToLatestClient',
-          message:
-            currentSdk && currentSdk.sdkVersion === latestSdk.version
-              ? 'You are using the latest SDK. Do you want to install the latest client?'
-              : 'Do you want to install the latest client?',
+          name: 'upgradeToRecommended',
+          message: `You are currently using SDK ${currentSdkVersion}. Would you like to install client ${recommendedClient.version} released for this SDK?`,
         });
-        if (answer.updateToLatestClient) {
+        if (answer.upgradeToRecommended) {
+          await Android.upgradeExpoAsync(recommendedClient.url);
+          log('Done!');
+          return;
+        }
+      } else {
+        const answer = await prompt({
+          type: 'confirm',
+          name: 'upgradeToLatest',
+          message: 'Do you want to install the latest client?',
+        });
+        if (answer.upgradeToLatest) {
           await Android.upgradeExpoAsync();
           log('Done!');
           return;
         }
-      } else if (currentSdkVersion && currentSdkVersion.androidClientUrl) {
+      }
+
+      const availableClients = ClientUpgradeUtils.getAvailableClients({
+        sdkVersions,
+        project: currentSdkConfig,
+        platform: 'android',
+      });
+
+      if (availableClients.length === 0) {
         const answer = await prompt({
           type: 'confirm',
-          name: 'updateToRecommendedVersion',
-          message: `You are currently using SDK ${
-            currentSdk.sdkVersion
-          }. Would you like to install the client version ${getAndroidVersion(
-            currentSdkVersion
-          )} released for this SDK?`,
+          name: 'updateToAClient',
+          message: currentSdk
+            ? `We don't have a compatible client for SDK ${currentSdkVersion}. Do you want to try the latest client?`
+            : "It looks like we don't have a compatible client. Do you want to try the latest client?",
         });
-        if (answer.updateToRecommendedVersion) {
-          targetSdkVersion = currentSdkVersion;
-          targetSdkVersionString = currentSdk.sdkVersion;
-        }
-      } else {
-        log(
-          `You are currently using SDK ${currentSdk.sdkVersion}. Unfortunately, we couldn't detect the proper client version for this SDK.`
-        );
-      }
-
-      if (!targetSdkVersion) {
-        const sdkVersionStringOptions = Object.keys(sdkVersions)
-          .reverse()
-          .filter(version => {
-            const versionHasClient =
-              !sdkVersions[version].isDeprecated && sdkVersions[version].androidClientUrl;
-
-            const versionIsCompatible = currentSdk
-              ? Versions.lteSdkVersion(currentSdk, version)
-              : null;
-
-            return versionHasClient && versionIsCompatible;
-          });
-        if (sdkVersionStringOptions.length === 0) {
-          const answer = await prompt({
-            type: 'confirm',
-            name: 'updateToAClient',
-            message:
-              "It looks like we don't have a compatible client for your project. Do you want to try the latest client?",
-          });
-
-          if (answer.updateToAClient) {
-            await Android.upgradeExpoAsync();
-            log('Done!');
-            return;
-          }
+        if (answer.updateToAClient) {
+          await Android.upgradeExpoAsync();
+          log('Done!');
         } else {
-          const answer = await prompt({
-            type: 'list',
-            name: 'selectedSdkVersionString',
-            message: 'Choose an SDK version to install the client for:',
-            pageSize: 20,
-            choices: sdkVersionStringOptions.map(optionSdkVersionString => {
-              const optionClientVersion = getAndroidVersion(sdkVersions[optionSdkVersionString]);
-              const message =
-                optionSdkVersionString === latestSdk.version
-                  ? `${chalk.bold(optionSdkVersionString)} ${chalk.grey(
-                      `- client ${optionClientVersion} (latest)`
-                    )}`
-                  : `${chalk.bold(optionSdkVersionString)} ${chalk.grey(
-                      `- client ${optionClientVersion}`
-                    )}`;
-
-              return {
-                value: optionSdkVersionString,
-                name: message,
-              };
-            }),
-          });
-
-          targetSdkVersion = sdkVersions[answer.selectedSdkVersionString];
-          targetSdkVersionString = answer.selectedSdkVersionString;
+          log('No client to install');
         }
-      }
-
-      if (!targetSdkVersion) {
-        log('No client to install.');
         return;
       }
 
-      if (await Android.upgradeExpoAsync(targetSdkVersion.androidClientUrl)) {
-        log(
-          `Done! We installed the client for SDK ${targetSdkVersionString}, version ${getAndroidVersion(
-            targetSdkVersion
-          )}`
-        );
+      const targetClient = await ClientUpgradeUtils.askClientToInstall({
+        currentSdkVersion,
+        latestSdkVersion: latestSdk.version,
+        clients: availableClients,
+      });
+
+      if (await Android.upgradeExpoAsync(targetClient.clientUrl)) {
+        log('Done!');
       }
     }, true);
 };

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -319,30 +319,13 @@ export default program => {
         return;
       }
 
-      const { targetClientUrl } = await prompt({
-        type: 'list',
-        name: 'targetClientUrl',
-        message: 'Choose an SDK version to install the client for:',
-        pageSize: 20,
-        choices: availableClients.map(client => {
-          const clientVersion = `- client ${client.clientVersion || 'version unknown'}`;
-          const clientLabels = [
-            client.sdkVersionString === latestSdk.version && 'latest',
-            client.sdkVersionString === currentSdkVersion && 'recommended',
-          ].filter(Boolean);
-
-          const clientMessage = clientLabels.length
-            ? `${clientVersion} (${clientLabels.join(', ')})`
-            : clientVersion;
-
-          return {
-            value: client.clientUrl,
-            name: `${chalk.bold(client.sdkVersionString)} ${chalk.gray(clientMessage)}`,
-          };
-        }),
+      const targetClient = await ClientUpgradeUtils.askClientToInstall({
+        currentSdkVersion,
+        latestSdkVersion: latestSdk.version,
+        clients: availableClients,
       });
 
-      if (await Simulator.upgradeExpoAsync(targetClientUrl)) {
+      if (await Simulator.upgradeExpoAsync(targetClient.clientUrl)) {
         log('Done!');
       }
     }, true);

--- a/packages/expo-cli/src/commands/client/index.js
+++ b/packages/expo-cli/src/commands/client/index.js
@@ -273,10 +273,11 @@ export default program => {
       }
 
       if (currentSdk && recommendedClient) {
+        const recommendedClientVersion = recommendedClient.version || 'version unknown';
         const answer = await prompt({
           type: 'confirm',
           name: 'upgradeToRecommended',
-          message: `You are currently using SDK ${currentSdkVersion}. Would you like to install client ${recommendedClient.version} released for this SDK?`,
+          message: `You are currently using SDK ${currentSdkVersion}. Would you like to install client ${recommendedClientVersion} released for this SDK?`,
         });
         if (answer.upgradeToRecommended) {
           await Simulator.upgradeExpoAsync(recommendedClient.url);
@@ -357,10 +358,11 @@ export default program => {
       }
 
       if (currentSdk && recommendedClient) {
+        const recommendedClientVersion = recommendedClient.version || 'version unknown';
         const answer = await prompt({
           type: 'confirm',
           name: 'upgradeToRecommended',
-          message: `You are currently using SDK ${currentSdkVersion}. Would you like to install client ${recommendedClient.version} released for this SDK?`,
+          message: `You are currently using SDK ${currentSdkVersion}. Would you like to install client ${recommendedClientVersion} released for this SDK?`,
         });
         if (answer.upgradeToRecommended) {
           await Android.upgradeExpoAsync(recommendedClient.url);

--- a/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
+++ b/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
@@ -1,0 +1,66 @@
+import * as ConfigUtils from '@expo/config';
+import { Versions } from '@expo/xdl';
+import { findProjectRootAsync } from './ProjectUtils';
+
+export async function getExpoSdkConfig(path: string) {
+  try {
+    const { projectRoot } = await findProjectRootAsync(path);
+    const { exp } = await ConfigUtils.readConfigJsonAsync(projectRoot);
+    return exp;
+  } catch (error) {
+    if (error.code !== 'NO_PROJECT') {
+      throw error;
+    }
+  }
+  return undefined;
+}
+
+type ClientPlatform = 'android' | 'ios';
+
+export function getClient(sdk: Versions.SDKVersion, platform: ClientPlatform) {
+  if (platform === 'android' && sdk.androidClientUrl) {
+    return {
+      url: sdk.androidClientUrl,
+      version: sdk.androidClientVersion,
+    };
+  }
+
+  if (platform === 'ios' && sdk.iosClientUrl) {
+    return {
+      url: sdk.iosClientUrl,
+      version: sdk.iosClientVersion,
+    };
+  }
+
+  return undefined;
+}
+
+interface AvailableClientOptions {
+  sdkVersions: Versions.SDKVersions;
+  platform: ClientPlatform;
+  project?: ConfigUtils.ExpoConfig;
+}
+
+export function getAvailableClients(options: AvailableClientOptions) {
+  return Object.keys(options.sdkVersions)
+    .reverse()
+    .map(version => {
+      const client = getClient(options.sdkVersions[version], options.platform);
+
+      return {
+        sdkVersionString: version,
+        sdkVersion: options.sdkVersions[version],
+        clientUrl: client ? client.url : undefined,
+        clientVersion: client ? client.version : undefined,
+      };
+    })
+    .filter(client => {
+      const hasUrl = !!client.clientUrl;
+      const isDeprecated = !!client.sdkVersion.isDeprecated;
+      const IsCompatible = options.project
+        ? Versions.lteSdkVersion(options.project, client.sdkVersionString)
+        : true;
+
+      return !isDeprecated && IsCompatible && hasUrl;
+    });
+}


### PR DESCRIPTION
This is a refactor for the `expo client:install:{android|ios}` command. Should make it way more readable and separates some functionality for reuse in both install commands. Right now, I only refactored the simulator (ios) version. Mainly to check if I'm doing the right things here.

#### Highlights
- No more hard-to-read stacked `if ... else if` statements
- Gone with some duplicate code, like getting a list of available clients from sdk versions
- Bye to excessive fallback-values for possibly undefined properties

#### Other changes
- Added a "recommended" flag, next to "latest", to point developers to the most probable-to-work version. This was one of the nested if-else-if logic, by moving it here we make it easier for us and the developer I think. But I'm not sure if the "recommended" text is the best one, its based on their current sdk version. (if this is something "not desired", i'd be happy to revert it)
- Removed some extraneous logging related to "you are using the latest sdk" and "pick one of these clients, where this one is latest"


#### Scenarios

<details>
<summary>1. run from outside a project (with installing latest early etc)</summary>
<img alt="scenario-1-no-sdk" src="https://user-images.githubusercontent.com/1203991/70758663-078ec480-1d44-11ea-8d6b-4516d1bf6925.png" />
</details>

<details>
<summary>2. run from sdk 32 project</summary>
<img alt="scenario-2-sdk-32" src="https://user-images.githubusercontent.com/1203991/70758698-14abb380-1d44-11ea-9622-6cf372a8c800.png" />
</details>

<details>
<summary>3. run from sdk 33 project</summary>
<img alt="scenario-3-sdk-33" src="https://user-images.githubusercontent.com/1203991/70865182-ca504f80-1f5a-11ea-86ba-82a7e0a768d9.png" />
</details>

<details>
<summary>4. run from sdk 34 project</summary>
<img alt="scenario-4-sdk-34" src="https://user-images.githubusercontent.com/1203991/70758704-1c6b5800-1d44-11ea-8dbf-8c5c2fc3df17.png" />
</details>

<details>
<summary>5. run from sdk 35 project</summary>
<img alt="scenario-5-sdk-35" src="https://user-images.githubusercontent.com/1203991/70758709-1f664880-1d44-11ea-89b4-8739593f8fa3.png" />
</details>

<details>
<summary>6. run from sdk 36 project</summary>
<img alt="scenario-6-sdk-36" src="https://user-images.githubusercontent.com/1203991/70758715-24c39300-1d44-11ea-8352-2703a38c2f37.png" />
</details>
