### PR TITLE
fix(xdl): add warning when install expo is taking longer than expected

### DIFF
--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -22,6 +22,8 @@ let _lastUrl: string | null = null;
 const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
 const CANT_START_ACTIVITY_ERROR = 'Activity not started, unable to resolve Intent';
 
+const INSTALL_WARNING_TIMEOUT = 30 * 1000;
+
 export function isPlatformSupported(): boolean {
   return (
     process.platform === 'darwin' || process.platform === 'win32' || process.platform === 'linux'
@@ -127,6 +129,11 @@ export async function downloadApkAsync(url?: string) {
 }
 
 export async function installExpoAsync(url?: string) {
+  const warningTimer = setTimeout(() => {
+    Logger.global.info(
+      'This takes longer than expected, you can also download the clients from the website at https://expo.io/tools'
+    );
+  }, INSTALL_WARNING_TIMEOUT);
   Logger.global.info(`Downloading latest version of Expo`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
   let path = await downloadApkAsync(url);
@@ -135,6 +142,7 @@ export async function installExpoAsync(url?: string) {
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
   let result = await getAdbOutputAsync(['install', path]);
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
+  clearTimeout(warningTimer);
   return result;
 }
 

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -139,18 +139,32 @@ export async function installExpoAsync(url?: string) {
     total: 100,
     width: 40,
   });
-  const warningTimer = setTimeout(() => {
-    Logger.global.info(
-      'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
+
+  let warningTimer: NodeJS.Timeout;
+  const setWarningTimer = () => {
+    if (warningTimer) {
+      clearTimeout(warningTimer);
+    }
+    return setTimeout(
+      () =>
+        Logger.global.info(
+          'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
+        ),
+      INSTALL_WARNING_TIMEOUT
     );
-  }, INSTALL_WARNING_TIMEOUT);
+  };
+
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
+  warningTimer = setWarningTimer();
   let path = await downloadApkAsync(url, progress => bar.tick(1, progress));
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
+
   Logger.global.info(`Installing Expo on device`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
+  warningTimer = setWarningTimer();
   let result = await getAdbOutputAsync(['install', path]);
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
+
   clearTimeout(warningTimer);
   return result;
 }

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import _ from 'lodash';
 import path from 'path';
 import semver from 'semver';
+import ProgressBar from 'progress';
 
 import * as Analytics from './Analytics';
 import Api from './Api';
@@ -113,7 +114,10 @@ function _apkCacheDirectory() {
   return dir;
 }
 
-export async function downloadApkAsync(url?: string) {
+export async function downloadApkAsync(
+  url?: string,
+  downloadProgressCallback?: (roundedProgress: number) => void
+) {
   let versions = await Versions.versionsAsync();
   let apkPath = path.join(_apkCacheDirectory(), `Exponent-${versions.androidVersion}.apk`);
 
@@ -123,20 +127,25 @@ export async function downloadApkAsync(url?: string) {
 
   await Api.downloadAsync(
     url || versions.androidUrl,
-    path.join(_apkCacheDirectory(), `Exponent-${versions.androidVersion}.apk`)
+    path.join(_apkCacheDirectory(), `Exponent-${versions.androidVersion}.apk`),
+    undefined,
+    downloadProgressCallback
   );
   return apkPath;
 }
 
 export async function installExpoAsync(url?: string) {
+  const bar = new ProgressBar('Downloading the Expo client app [:bar] :percent :etas', {
+    total: 100,
+    width: 40,
+  });
   const warningTimer = setTimeout(() => {
     Logger.global.info(
       'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
     );
   }, INSTALL_WARNING_TIMEOUT);
-  Logger.global.info(`Downloading latest version of Expo`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
-  let path = await downloadApkAsync(url);
+  let path = await downloadApkAsync(url, progress => bar.tick(1, progress));
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
   Logger.global.info(`Installing Expo on device`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -22,7 +22,7 @@ let _lastUrl: string | null = null;
 const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
 const CANT_START_ACTIVITY_ERROR = 'Activity not started, unable to resolve Intent';
 
-const INSTALL_WARNING_TIMEOUT = 30 * 1000;
+const INSTALL_WARNING_TIMEOUT = 60 * 1000;
 
 export function isPlatformSupported(): boolean {
   return (
@@ -131,7 +131,7 @@ export async function downloadApkAsync(url?: string) {
 export async function installExpoAsync(url?: string) {
   const warningTimer = setTimeout(() => {
     Logger.global.info(
-      'This takes longer than expected, you can also download the clients from the website at https://expo.io/tools'
+      'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
     );
   }, INSTALL_WARNING_TIMEOUT);
   Logger.global.info(`Downloading latest version of Expo`);

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -266,7 +266,7 @@ export default class ApiClient {
     if (extract) {
       let dotExpoHomeDirectory = UserSettings.dotExpoHomeDirectory();
       let tmpPath = path.join(dotExpoHomeDirectory, 'tmp-download-file');
-      await _downloadAsync(url, tmpPath);
+      await _downloadAsync(url, tmpPath, progressFunction);
       await Extract.extractAsync(tmpPath, outputPath);
       fs.removeSync(tmpPath);
     } else {

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -365,18 +365,32 @@ export async function _installExpoOnSimulatorAsync(url?: string) {
     total: 100,
     width: 40,
   });
-  const warningTimer = setTimeout(() => {
-    Logger.global.info(
-      'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
+
+  let warningTimer: NodeJS.Timeout;
+  const setWarningTimer = () => {
+    if (warningTimer) {
+      clearTimeout(warningTimer);
+    }
+    return setTimeout(
+      () =>
+        Logger.global.info(
+          'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
+        ),
+      INSTALL_WARNING_TIMEOUT
     );
-  }, INSTALL_WARNING_TIMEOUT);
+  };
+
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
+  warningTimer = setWarningTimer();
   let dir = await _downloadSimulatorAppAsync(url, progress => bar.tick(1, progress));
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
+
   Logger.global.info('Installing Expo client on iOS simulator');
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
+  warningTimer = setWarningTimer();
   let result = await _xcrunAsync(['simctl', 'install', 'booted', dir]);
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
+
   clearTimeout(warningTimer);
   return result;
 }

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -25,6 +25,8 @@ const SUGGESTED_XCODE_VERSION = `8.2.0`;
 const XCODE_NOT_INSTALLED_ERROR =
   'Simulator not installed. Please visit https://developer.apple.com/xcode/download/ to download Xcode and the iOS simulator. If you already have the latest version of Xcode installed, you may have to run the command `sudo xcode-select -s /Applications/Xcode.app`.';
 
+const INSTALL_WARNING_TIMEOUT = 30 * 1000;
+
 export function isPlatformSupported() {
   return process.platform === 'darwin';
 }
@@ -355,6 +357,11 @@ export async function _downloadSimulatorAppAsync(url?: string) {
 
 // url: Optional URL of Exponent.app tarball to download
 export async function _installExpoOnSimulatorAsync(url?: string) {
+  const warningTimer = setTimeout(() => {
+    Logger.global.info(
+      'This takes longer than expected, you can also download the clients from the website at https://expo.io/tools'
+    );
+  }, INSTALL_WARNING_TIMEOUT);
   Logger.global.info(`Downloading the latest version of Expo client app`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
   let dir = await _downloadSimulatorAppAsync(url);
@@ -363,6 +370,7 @@ export async function _installExpoOnSimulatorAsync(url?: string) {
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
   let result = await _xcrunAsync(['simctl', 'install', 'booted', dir]);
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
+  clearTimeout(warningTimer);
   return result;
 }
 

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -359,7 +359,7 @@ export async function _downloadSimulatorAppAsync(url?: string) {
 export async function _installExpoOnSimulatorAsync(url?: string) {
   const warningTimer = setTimeout(() => {
     Logger.global.info(
-      'This takes longer than expected, you can also download the clients from the website at https://expo.io/tools'
+      'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
     );
   }, INSTALL_WARNING_TIMEOUT);
   Logger.global.info(`Downloading the latest version of Expo client app`);

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -25,7 +25,7 @@ const SUGGESTED_XCODE_VERSION = `8.2.0`;
 const XCODE_NOT_INSTALLED_ERROR =
   'Simulator not installed. Please visit https://developer.apple.com/xcode/download/ to download Xcode and the iOS simulator. If you already have the latest version of Xcode installed, you may have to run the command `sudo xcode-select -s /Applications/Xcode.app`.';
 
-const INSTALL_WARNING_TIMEOUT = 30 * 1000;
+const INSTALL_WARNING_TIMEOUT = 60 * 1000;
 
 export function isPlatformSupported() {
   return process.platform === 'darwin';


### PR DESCRIPTION
Adds the workaround [described by Brent here](https://github.com/expo/expo-cli/issues/985#issuecomment-562909709).

- I have no clue if the current "30 seconds"-timeout is correct. Are there any metrics available on average install time? Or does anyone knows a better threshold?
- Alternative option was to use a non-awaiting `delayAsync`. But there is no cancel feature in js promises. Using timeouts works around that. If an exception is thrown, the timeout is also not triggered because the code is exiting.