### PR TITLE
@jkhales/add apiv2 option build

### DIFF
--- a/packages/expo-cli/src/commands/publish.js
+++ b/packages/expo-cli/src/commands/publish.js
@@ -63,13 +63,23 @@ export async function action(projectDir: string, options: Options = {}) {
     args: { sdkVersion },
   } = await Exp.getPublishInfoAsync(projectDir);
 
-  const buildStatus = await Project.buildAsync(projectDir, {
-    mode: 'status',
-    platform: 'all',
-    current: true,
-    releaseChannel: options.releaseChannel,
-    sdkVersion,
-  });
+  let buildStatus;
+  if (process.env.EXPO_NEXT_API) {
+    buildStatus = await Project.getBuildStatusAsync(projectDir, {
+      platform: 'all',
+      current: true,
+      releaseChannel: options.releaseChannel,
+      sdkVersion,
+    });
+  } else {
+    buildStatus = await Project.buildAsync(projectDir, {
+      mode: 'status',
+      platform: 'all',
+      current: true,
+      releaseChannel: options.releaseChannel,
+      sdkVersion,
+    });
+  }
 
   const { exp } = await readConfigJsonAsync(projectDir);
 

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -23,11 +23,20 @@ const logArtifactUrl = (platform: 'ios' | 'android') => async (
   if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
     throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
   }
-  const res = await Project.buildAsync(projectDir, {
-    current: false,
-    mode: 'status',
-    ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
-  });
+
+  let res;
+  if (process.env.EXPO_NEXT_API) {
+    res = await Project.getBuildStatusAsync(projectDir, {
+      current: false,
+      ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
+    });
+  } else {
+    res = await Project.buildAsync(projectDir, {
+      current: false,
+      mode: 'status',
+      ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
+    });
+  }
   const url = fp.compose(
     fp.get(['artifacts', 'url']),
     fp.head,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1557,6 +1557,13 @@ export async function buildAsync(
     sdkVersion?: string;
   } = {}
 ): Promise<BuildStatusResult | BuildCreatedResult> {
+  /**
+    This function corresponds to an apiv1 call and is deprecated.
+    Use 
+      * startBuildAsync
+      * getBuildStatusAsync
+    to call apiv2 instead.
+   */
   await UserManager.ensureLoggedInAsync();
   _assertValidProjectRoot(projectRoot);
 

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1967,7 +1967,6 @@ export async function startExpoServerAsync(projectRoot: string): Promise<void> {
     throw new Error(`Couldn't start project. Please fix the errors and restart the project.`);
   } // Serve the manifest.
   const manifestHandler = async (req: express.Request, res: express.Response) => {
-    console.log('MANIFEST HANDLER');
     try {
       // We intentionally don't `await`. We want to continue trying even
       // if there is a potential error in the package.json and don't want to slow

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1429,8 +1429,7 @@ type BuildCreatedResult = {
   hasUnlimitedPriorityBuilds: boolean;
 };
 
-function _validateManifest(options, exp, configName, configPrefix) {
-  // only run for 'create'
+function _validateManifest(options: any, exp: any, configName: any, configPrefix: any) {
   if (options.platform === 'ios' || options.platform === 'all') {
     if (!exp.ios || !exp.ios.bundleIdentifier) {
       throw new XDLError(
@@ -1451,7 +1450,7 @@ function _validateManifest(options, exp, configName, configPrefix) {
     }
   }
 }
-function _validateOptions(options) {
+function _validateOptions(options: any) {
   const schema = joi.object().keys({
     current: joi.boolean(),
     mode: joi.string(),
@@ -1470,7 +1469,7 @@ function _validateOptions(options) {
   }
 }
 
-async function _getExpAsync(projectRoot, options) {
+async function _getExpAsync(projectRoot: any, options: any) {
   const { exp, pkg, configName, configPrefix } = await getConfigAsync(projectRoot, options);
 
   if (!exp || !pkg) {
@@ -1491,7 +1490,7 @@ async function _getExpAsync(projectRoot, options) {
   return { exp, configName, configPrefix };
 }
 
-export async function buildStatusAsync(
+export async function getBuildStatusAsync(
   projectRoot: string,
   options: {
     current?: boolean;
@@ -1510,9 +1509,8 @@ export async function buildStatusAsync(
   _validateOptions(options);
   const { exp, configName, configPrefix } = await _getExpAsync(projectRoot, options);
 
-  const user = await UserManager.ensureLoggedInAsync();
   const api = ApiV2.clientForUser(user);
-  return await api.getAsync('build/status', { manifest: exp, options });
+  return await api.postAsync('build/status', { manifest: exp, options });
 }
 
 export async function startBuildAsync(

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1429,7 +1429,7 @@ type BuildCreatedResult = {
   hasUnlimitedPriorityBuilds: boolean;
 };
 
-function _validateManifest(options: any, exp: any, configName: any, configPrefix: any) {
+function _validateManifest(options: any, exp: any, configName: string, configPrefix: string) {
   if (options.platform === 'ios' || options.platform === 'all') {
     if (!exp.ios || !exp.ios.bundleIdentifier) {
       throw new XDLError(
@@ -1469,7 +1469,7 @@ function _validateOptions(options: any) {
   }
 }
 
-async function _getExpAsync(projectRoot: any, options: any) {
+async function _getExpAsync(projectRoot: string, options: any) {
   const { exp, pkg, configName, configPrefix } = await getConfigAsync(projectRoot, options);
 
   if (!exp || !pkg) {


### PR DESCRIPTION
# why
migrating off of apiv1. cli should still call apiv1 build by default, but can opt into apiv2 build.

# how 
refactored `Project.buildAsync` into `Project.buildStatusAsync` and `Project.startBuildAsync`.

# test
Set `EXPO_NEXT_API=true` and test against https://github.com/expo/universe/pull/3967