### PR TITLE
[expo-cli] direct users to dashboard builds page

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.js
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.js
@@ -159,7 +159,7 @@ export default class BaseBuilder {
       return;
     }
 
-    this.logBuildStatuses(buildStatus);
+    await this.logBuildStatuses(buildStatus);
   }
 
   async checkStatusBeforeBuild(): Promise<void> {
@@ -185,11 +185,14 @@ Please see the docs (${chalk.underline(
     }
   }
 
-  logBuildStatuses(buildStatus: { jobs: Array<Object>, canPurchasePriorityBuilds: boolean }) {
+  async logBuildStatuses(buildStatus: { jobs: Array<Object>, canPurchasePriorityBuilds: boolean }) {
     log.raw();
     log('=================');
     log(' Builds Statuses ');
     log('=================\n');
+
+    const username = await UserManager.getCurrentUsernameAsync();
+
     buildStatus.jobs.forEach((job, i) => {
       let platform, packageExtension;
       if (job.platform === 'ios') {
@@ -200,7 +203,7 @@ Please see the docs (${chalk.underline(
         packageExtension = 'APK';
       }
 
-      log(`### ${i} | ${platform} | ${UrlUtils.constructBuildLogsUrl(job.id)} ###`);
+      log(`### ${i} | ${platform} | ${UrlUtils.constructBuildLogsUrl(job.id, username)} ###`);
 
       const hasPriorityBuilds =
         buildStatus.numberOfRemainingPriorityBuilds > 0 || buildStatus.hasUnlimitedPriorityBuilds;
@@ -419,10 +422,12 @@ ${job.id}
       );
     }
 
+    const username = await UserManager.getCurrentUsernameAsync();
+
     if (buildId) {
       log(
         `You can monitor the build at\n\n ${chalk.underline(
-          UrlUtils.constructBuildLogsUrl(buildId)
+          UrlUtils.constructBuildLogsUrl(buildId, username)
         )}\n`
       );
     }

--- a/packages/expo-cli/src/commands/build/BaseBuilder.js
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.js
@@ -191,7 +191,9 @@ Please see the docs (${chalk.underline(
     log(' Builds Statuses ');
     log('=================\n');
 
-    const username = await UserManager.getCurrentUsernameAsync();
+    const username = this.manifest.owner
+      ? this.manifest.owner
+      : await UserManager.getCurrentUsernameAsync();
 
     buildStatus.jobs.forEach((job, i) => {
       let platform, packageExtension;
@@ -422,7 +424,9 @@ ${job.id}
       );
     }
 
-    const username = await UserManager.getCurrentUsernameAsync();
+    const username = this.manifest.owner
+      ? this.manifest.owner
+      : await UserManager.getCurrentUsernameAsync();
 
     if (buildId) {
       log(

--- a/packages/expo-cli/src/commands/utils/url.ts
+++ b/packages/expo-cli/src/commands/utils/url.ts
@@ -8,7 +8,10 @@ export function getExpoDomainUrl(): string {
   }
 }
 
-export function constructBuildLogsUrl(buildId: string): string {
+export function constructBuildLogsUrl(buildId: string, username?: string): string {
+  if (username) {
+    return `${getExpoDomainUrl()}/dashboard/${username}/builds/${buildId}`;
+  }
   return `${getExpoDomainUrl()}/builds/${buildId}`;
 }
 


### PR DESCRIPTION
## Why

We shouldn't continue to reference the legacy /builds page now that the dashboard builds page has been out for a while and has proven to be stable.

## How

I updated the build page url generator function to return a dashboard link if a username is passed in. The output looks like what is shown below:
 
![Screen Shot 2019-12-18 at 2 28 27 PM](https://user-images.githubusercontent.com/12488826/71128715-ba2ab100-21a2-11ea-9a50-10e2505483d7.png)

---

Thanks for checking this out!

![smile_1](https://user-images.githubusercontent.com/12488826/71128868-15f53a00-21a3-11ea-9d55-773d44516df0.gif)

