### PR TITLE
[next-adapter] fix column style

### DIFF
--- a/packages/next-adapter/document.js
+++ b/packages/next-adapter/document.js
@@ -22,6 +22,7 @@ html, body, #__next {
 #__next {
   flex-shrink: 0;
   flex-basis: auto;
+  flex-direction: column;
   flex-grow: 1;
   display: flex;
   flex: 1;


### PR DESCRIPTION
For some reason the column direction is row by default in chrome when using Next.js. Fix this by ensuring the style is forced to column to match `react-native` and default expo for web functionality.