### PR TITLE
[expo-cli] fixes an issue when upload:ios fails with 'You must provid…

### DIFF
--- a/packages/expo-cli/src/commands/upload.js
+++ b/packages/expo-cli/src/commands/upload.js
@@ -29,6 +29,7 @@ export default program => {
     'appleId',
     'appleIdPassword',
     'appName',
+    'companyName',
     'sku',
     'language',
     'publicUrl',
@@ -54,6 +55,10 @@ export default program => {
     .option(
       '--app-name <app-name>',
       `the name of your app as it will appear on the App Store, this can't be longer than 30 characters (default: expo.name from app.json)`
+    )
+    .option(
+      '--company-name <company-name>',
+      'the name of your company, needed only for the first upload of any app to App Store'
     )
     .option(
       '--sku <sku>',

--- a/packages/expo-cli/src/commands/upload/utils.ts
+++ b/packages/expo-cli/src/commands/upload/utils.ts
@@ -30,7 +30,14 @@ export async function runFastlaneAsync(
     appleIdPassword,
     appleTeamId,
     itcTeamId,
-  }: { appleId?: string; appleIdPassword?: string; appleTeamId?: string; itcTeamId?: string },
+    companyName,
+  }: {
+    appleId?: string;
+    appleIdPassword?: string;
+    appleTeamId?: string;
+    itcTeamId?: string;
+    companyName?: string;
+  },
   pipeToLogger = false
 ): Promise<{ [key: string]: any }> {
   const pipeToLoggerOptions: any = pipeToLogger
@@ -45,6 +52,7 @@ export async function runFastlaneAsync(
           FASTLANE_DONT_STORE_PASSWORD: '1',
           FASTLANE_TEAM_ID: appleTeamId,
           ...(itcTeamId && { FASTLANE_ITC_TEAM_ID: itcTeamId }),
+          ...(companyName && { PRODUCE_COMPANY_NAME: companyName }),
         }
       : {};
 


### PR DESCRIPTION
…e a company name to use on the App Store' error

Fixes https://github.com/expo/expo-cli/issues/1066
If a user hasn't uploaded any app to App Store prior to using `expo upload:ios`, he doesn't get a meaningful error message about what he should do. I added detecting this kind of error and a way to pass the company name to the `expo upload:ios` command.