### PR TITLE
fix: offline mode should default to localhost

### DIFF
--- a/packages/expo-cli/src/commands/start.js
+++ b/packages/expo-cli/src/commands/start.js
@@ -7,15 +7,7 @@ import path from 'path';
 import * as ConfigUtils from '@expo/config';
 import { DevToolsServer } from '@expo/dev-tools';
 import JsonFile from '@expo/json-file';
-import {
-  ConnectionStatus,
-  Project,
-  ProjectSettings,
-  UrlUtils,
-  UserSettings,
-  Versions,
-  Web,
-} from '@expo/xdl';
+import { Project, ProjectSettings, UrlUtils, UserSettings, Versions, Web } from '@expo/xdl';
 import chalk from 'chalk';
 import openBrowser from 'react-dev-utils/openBrowser';
 import intersection from 'lodash/intersection';
@@ -58,10 +50,6 @@ function parseStartOptions(projectDir: string, options: Object): Object {
 
   if (options.maxWorkers) {
     startOpts.maxWorkers = options.maxWorkers;
-  }
-
-  if (options.offline) {
-    ConnectionStatus.setIsOffline(true);
   }
 
   return startOpts;

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -1,7 +1,7 @@
 import indentString from 'indent-string';
 import qrcodeTerminal from 'qrcode-terminal';
 
-import { Android, ProjectSettings, Simulator, Webpack } from '@expo/xdl';
+import { Android, ConnectionStatus, ProjectSettings, Simulator, Webpack } from '@expo/xdl';
 import { Command } from 'commander';
 
 import CommandError from './CommandError';
@@ -33,6 +33,13 @@ async function optsAsync(projectDir: string, options: any) {
     );
   }
 
+  opts.hostType = 'lan';
+
+  if (options.offline) {
+    ConnectionStatus.setIsOffline(true);
+    opts.hostType = 'localhost';
+  }
+
   if (options.host) {
     opts.hostType = options.host;
   } else if (options.tunnel) {
@@ -41,8 +48,6 @@ async function optsAsync(projectDir: string, options: any) {
     opts.hostType = 'lan';
   } else if (options.localhost) {
     opts.hostType = 'localhost';
-  } else {
-    opts.hostType = 'lan';
   }
 
   await ProjectSettings.setAsync(projectDir, opts);


### PR DESCRIPTION
fixes https://github.com/expo/expo-cli/issues/1307

moved `setIsOffline` logic to urlOpts, so that it's also used by the other `allowOffline` commands (`ios`, `android`, and `send`)

I'm not sure what the use case of it would be, but seemed right to still allow people to use another host type if they want to