### PR TITLE
refactor(expo-cli): localize publication dates in publish history

### DIFF
--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -1,14 +1,23 @@
-/**
- * @flow
- */
 import { readConfigJsonAsync } from '@expo/config';
 import { Api, ApiV2, FormData, Project, UserManager } from '@expo/xdl';
 
-import * as table from '../commands/utils/cli-table';
+import * as table from './utils/cli-table';
 
 const HORIZ_CELL_WIDTH_SMALL = 15;
 const HORIZ_CELL_WIDTH_BIG = 40;
 const VERSION = 2;
+
+type HistoryOptions = {
+  releaseChannel?: string;
+  count?: number;
+  platform?: 'android' | 'ios';
+  raw?: boolean;
+};
+
+type DetailOptions = {
+  publishId?: string;
+  raw?: boolean;
+};
 
 export default (program: any) => {
   program
@@ -26,7 +35,7 @@ export default (program: any) => {
     )
     .option('-p, --platform <ios|android>', 'Filter by platform, android or ios.')
     .option('-r, --raw', 'Produce some raw output.')
-    .asyncActionProjectDir(async (projectDir, options) => {
+    .asyncActionProjectDir(async (projectDir: string, options: HistoryOptions) => {
       if (options.count && (isNaN(options.count) || options.count < 1 || options.count > 100)) {
         throw new Error('-n must be a number between 1 and 100 inclusive');
       }
@@ -98,7 +107,7 @@ export default (program: any) => {
         ];
 
         // colWidths contains the cell size of each header
-        let colWidths = [];
+        let colWidths: number[] = [];
         let bigCells = new Set(['publicationId', 'channelId', 'publishedTime']);
         headers.forEach(header => {
           if (bigCells.has(header)) {
@@ -119,7 +128,7 @@ export default (program: any) => {
     .description('View the details of a published release.')
     .option('--publish-id <publish-id>', 'Publication id. (Required)')
     .option('-r, --raw', 'Produce some raw output.')
-    .asyncActionProjectDir(async (projectDir, options) => {
+    .asyncActionProjectDir(async (projectDir: string, options: DetailOptions) => {
       if (!options.publishId) {
         throw new Error('--publish-id must be specified.');
       }

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -1,5 +1,6 @@
 import { readConfigJsonAsync } from '@expo/config';
 import { Api, ApiV2, FormData, Project, UserManager } from '@expo/xdl';
+import dateFormat from 'dateformat';
 
 import * as table from './utils/cli-table';
 
@@ -17,6 +18,17 @@ type HistoryOptions = {
 type DetailOptions = {
   publishId?: string;
   raw?: boolean;
+};
+
+type Publication = {
+  fullName: string;
+  channel: string;
+  channelId: string;
+  publicationId: string;
+  appVersion: string;
+  sdkVersion: string;
+  publishedTime: string;
+  platform: 'android' | 'ios';
 };
 
 export default (program: any) => {
@@ -116,7 +128,11 @@ export default (program: any) => {
             colWidths.push(HORIZ_CELL_WIDTH_SMALL);
           }
         });
-        let tableString = table.printTableJsonArray(headers, result.queryResult, colWidths);
+        const resultRows = result.queryResult.map((publication: Publication) => ({
+          ...publication,
+          publishedTime: dateFormat(publication.publishedTime, 'ddd mmm dd yyyy HH:MM:ss Z'),
+        }));
+        let tableString = table.printTableJsonArray(headers, resultRows, colWidths);
         console.log(tableString);
       } else {
         throw new Error('No records found matching your query.');


### PR DESCRIPTION
This fixes #1384 and rewrites the `publish:history` and `publish:details` commands to typescript.

<details>
<summary>UTC timezone</summary>
<img width="1252" alt="Screenshot 2019-12-25 at 02 58 12" src="https://user-images.githubusercontent.com/1203991/71428673-82e86280-26c2-11ea-8f7e-a7c4cd0799e0.png">
</details>

<details>
<summary>Amsterdam timezone</summary>
<img width="1239" alt="Screenshot 2019-12-25 at 02 58 28" src="https://user-images.githubusercontent.com/1203991/71428687-9bf11380-26c2-11ea-9101-a1f1a24710a5.png">
</details>