### PR TITLE
fix(build): multiply build timeout by 10

### DIFF
--- a/packages/expo-cli/src/commands/build-native/utils.ts
+++ b/packages/expo-cli/src/commands/build-native/utils.ts
@@ -11,7 +11,7 @@ import { BuildInfo } from './Builder';
 async function waitForBuildEnd(
   client: TurtleApi,
   buildId: string,
-  { timeoutSec = 1800, intervalSec = 30 } = {}
+  { timeoutSec = 18000, intervalSec = 30 } = {}
 ) {
   log('Waiting for build to complete. You can press Ctrl+C to exit.');
   const spinner = ora().start();


### PR DESCRIPTION
Fix: https://expo.canny.io/feature-requests/p/increase-default-build-timeout-and-permit-its-configuration 
https://forums.expo.io/t/expo-build-timeout/28887
https://stackoverflow.com/questions/59539215/how-to-increase-the-expo-build-time-out

It can be tested with:

```bash
npm i --save-dev @yeutech-lab/expo-cli@3.11.3-fix-1405.2
expo-fix-1405 build
```

