### PR TITLE
[expo-cli] increase build wait timeout

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.js
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.js
@@ -305,7 +305,7 @@ ${job.id}
     }
   }
 
-  async wait(buildId, { timeout = 1200, interval = 30, publicUrl } = {}) {
+  async wait(buildId, { timeout = 3600, interval = 30, publicUrl } = {}) {
     log(`Waiting for build to complete. You can press Ctrl+C to exit.`);
     let spinner = ora().start();
     let time = new Date().getTime();


### PR DESCRIPTION
I increased the build wait timeout to 3600 sec (1 hour).

Related forums thread: https://forums.expo.io/t/expo-build-timeout/28887/4
