### PR TITLE
Next.js PWA manifest support

### DIFF
--- a/packages/next-adapter/PWA.js
+++ b/packages/next-adapter/PWA.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+// To work with the iPhone X "notch" add `viewport-fit=cover` to the `viewport` meta tag.
+const DEFAULT_VIEWPORT =
+  'width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover';
+
+class PWA extends React.Component {
+  render() {
+    return [
+      this.props.themeColor && <meta name="theme-color" content={this.props.themeColor} />,
+      <meta name="viewport" content={this.props.viewport || DEFAULT_VIEWPORT} />,
+      <link rel="manifest" href={this.props.manifestPath || '/static/manifest.json'} />,
+    ];
+  }
+}
+
+export default PWA;

--- a/packages/next-adapter/package.json
+++ b/packages/next-adapter/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@expo/package-manager": "^0.0.2",
     "@expo/webpack-config": "^0.10.8",
+    "@pwa/manifest": "^1.1.0",
     "@types/next": "^8.0.6",
     "chalk": "^3.0.0",
     "commander": "^4.0.1",

--- a/packages/next-adapter/src/index.ts
+++ b/packages/next-adapter/src/index.ts
@@ -1,2 +1,3 @@
 export * from './Server';
 export { default as withExpo } from './withExpo';
+export { default as withExpoPWA } from './withExpoPWA';

--- a/packages/next-adapter/src/withExpoPWA.ts
+++ b/packages/next-adapter/src/withExpoPWA.ts
@@ -1,0 +1,94 @@
+import { ExpoConfig, getConfigForPWA } from '@expo/config';
+import {
+  getAbsolutePathWithProjectRoot,
+  getManagedExtensions,
+  getPossibleProjectRoot,
+} from '@expo/config/paths';
+import { AnyConfiguration } from '@expo/webpack-config/webpack/types';
+import { NextConfig } from 'next';
+// @ts-ignore: no types found
+import pwaManifest from '@pwa/manifest';
+
+function isObject(item: any): boolean {
+  return typeof item === 'object' && !Array.isArray(item) && item !== null;
+}
+
+function createPWAManifestFromExpoConfig(appJson: ExpoConfig): any {
+  if (!isObject(appJson)) {
+    throw new Error('app.json must be an object');
+  }
+
+  const { web = {} } = appJson;
+
+  const manifest: any = {
+    // PWA
+    background_color: web.backgroundColor,
+    description: web.description,
+    dir: web.dir,
+    display: web.display,
+    lang: web.lang,
+    name: web.name,
+    orientation: web.orientation,
+    scope: web.scope,
+    short_name: web.shortName,
+    start_url: web.startUrl || '/?utm_source=web_app_manifest',
+    theme_color: web.themeColor,
+    crossorigin: web.crossorigin,
+    // startupImages: web.startupImages,
+    // icons: web.icons,
+  };
+
+  if (Array.isArray(web.relatedApplications) && web.relatedApplications.length > 0) {
+    manifest.related_applications = web.relatedApplications;
+    manifest.prefer_related_applications = web.preferRelatedApplications;
+  }
+
+  return manifest;
+}
+
+export default function withExpoPWA(nextConfig: NextConfig = {}): NextConfig {
+  return {
+    ...nextConfig,
+    pageExtensions: getManagedExtensions(['web']),
+    webpack(config: AnyConfiguration, options: any): AnyConfiguration {
+      // Gather options
+      const { isServer, dev: isDev } = options;
+
+      const {
+        projectRoot = getPossibleProjectRoot(),
+        // Devs should use the app.json instead.
+        manifest = {},
+      } = nextConfig;
+
+      // Possibly generate PWA manifest from Expo config
+      if (!isDev) {
+        // Attempt to find the output path
+        const outputPath = `${isServer ? '../' : ''}static/`;
+
+        // Get a filled in Expo config
+        const expoConfig = getConfigForPWA(
+          projectRoot,
+          (...pathComponents) => getAbsolutePathWithProjectRoot(projectRoot, ...pathComponents),
+          {}
+        );
+
+        const writtenManifest = pwaManifest.sync({
+          // Convert the Expo config into a PWA manifest
+          ...createPWAManifestFromExpoConfig(expoConfig),
+          // Allow for overrides
+          ...manifest,
+        });
+
+        // Write manifest
+        pwaManifest.writeSync(outputPath, writtenManifest);
+      }
+
+      // Clean up...
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options);
+      }
+
+      return config;
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,6 +2449,23 @@
   resolved "https://registry.yarnpkg.com/@posthtml/esm/-/esm-1.0.0.tgz#09bcb28a02438dcee22ad1970ca1d85a000ae0cf"
   integrity sha512-dEVG+ITnvqKGa4v040tP+n8LOKOqr94qjLva7bE5pnfm2KHJwsKz69J4KMxgWLznbpBJzy8vQfCayEk3vLZnZQ==
 
+"@pwa/manifest@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@pwa/manifest/-/manifest-1.1.0.tgz#6129a2d440eef133149e81bfcd953206fe7ed371"
+  integrity sha512-0CB6oYKazRTJXqbefsBcqXLSpD/3obYrK+5Z39zhCfzESXyPRnAiCiXotUEO3VYM3GFbHzL5j+HR12dIlPIPgA==
+  dependencies:
+    ansi-styles "^3.1.0"
+    decamelize-keys "^1.1.0"
+    inquirer "^3.1.1"
+    is-css-color-hex "^0.2.0"
+    is-css-color-name "^0.1.3"
+    is-url-superb "^2.0.0"
+    load-json-file "^2.0.0"
+    object-assign "^4.1.1"
+    read-pkg-up "^2.0.0"
+    url-regex "^4.1.1"
+    write-json-file "^2.2.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -3731,7 +3748,7 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -6995,6 +7012,11 @@ crypto-random-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
+css-color-names@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.2.tgz#fba18e8cff86579572d749c146c47ee83f0ea955"
+  integrity sha1-+6GOjP+GV5Vy10nBRsR+6D8OqVU=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -7382,7 +7404,7 @@ decache@4.4.0:
   dependencies:
     callsite "^1.0.0"
 
-decamelize-keys@^1.0.0:
+decamelize-keys@^1.0.0, decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
   integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
@@ -8872,7 +8894,7 @@ extend@^3.0.0, extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^2.1.0:
+external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
   integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
@@ -11029,6 +11051,26 @@ inquirer@6.5.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+inquirer@^3.1.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
 inquirer@^6.2.0:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
@@ -11104,6 +11146,11 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+ip-regex@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-1.0.3.tgz#dc589076f659f419c222039a33316f1c7387effd"
+  integrity sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -11231,6 +11278,18 @@ is-color@^1.0.2:
     hsla-regex "^1.0.0"
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
+
+is-css-color-hex@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-css-color-hex/-/is-css-color-hex-0.2.0.tgz#350d96bbcec96dfc721bc4bacb30e956167df61d"
+  integrity sha1-NQ2Wu87JbfxyG8S6yzDpVhZ99h0=
+
+is-css-color-name@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/is-css-color-name/-/is-css-color-name-0.1.3.tgz#ea3b51bc901d8a243d32c9b7873d0680dbbef7f1"
+  integrity sha1-6jtRvJAdiiQ9Msm3hz0GgNu+9/E=
+  dependencies:
+    css-color-names "0.0.2"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -11584,6 +11643,13 @@ is-unc-path@^1.0.0:
   integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
   dependencies:
     unc-path-regex "^0.1.2"
+
+is-url-superb@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-2.0.0.tgz#b728a18cf692e4d16da6b94c7408a811db0d0492"
+  integrity sha1-tyihjPaS5NFtprlMdAioEdsNBJI=
+  dependencies:
+    url-regex "^3.0.0"
 
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
@@ -18193,6 +18259,18 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  integrity sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+  integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
+
 rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
@@ -19779,6 +19857,11 @@ tinycolor2@^1.4.1:
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
   integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
+tlds@^1.187.0:
+  version "1.207.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.207.0.tgz#459264e644cf63ddc0965fece3898913286b1afd"
+  integrity sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -20411,6 +20494,21 @@ url-parse@^1.4.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+url-regex@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-3.2.0.tgz#dbad1e0c9e29e105dd0b1f09f6862f7fdb482724"
+  integrity sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=
+  dependencies:
+    ip-regex "^1.0.1"
+
+url-regex@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-4.1.1.tgz#a5617b22e15e26dac57ce74c3f52088bcdfec995"
+  integrity sha512-ViSDgDPNKkrQHI81GLCjdDN+Rsk3tAW/uLXlBOJxtcHzWZjta58Z0APXhfXzS89YszsheMnEvXeDXsWUB53wwA==
+  dependencies:
+    ip-regex "^1.0.1"
+    tlds "^1.187.0"
 
 url@0.11.0, url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Create a plugin for generating a PWA manifest using the same logic as the default expo web flow. 

- [ ] Enable Android PWAs
- [ ] Enable iOS PWAs
- [ ] Enable Desktop PWAs 
- [ ] Account for deprecated static folder https://err.sh/zeit/next.js/static-dir-deprecated

- [ ] ~~Generate & Link icons~~ This needs to be documented well

## usage


`_document.js`
```jsx
import { getInitialProps } from '@expo/next-adapter/document';
import PWA from '@expo/next-adapter/PWA';
import Document, { Head, Main, NextScript } from 'next/document';
import React from 'react';

class CustomDocument extends Document {
  static getInitialProps = async props => {
    const result = await getInitialProps(props);
    return result;
  };

  render() {
    return (
      <html>
        <Head>
          <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
          {/* Must include the custom PWA tag to link the manifest */}
          <PWA />
        </Head>
        <body>
          <Main />
          <NextScript />
        </body>
      </html>
    );
  }
}

export default CustomDocument;
```

`next.config.js`
```js
const { withExpo, withExpoPWA } = require('@expo/next-adapter')
const withPlugins = require('next-compose-plugins')

module.exports = withPlugins(
  [
    [withExpo, { projectRoot: __dirname }],
    [withExpoPWA, { projectRoot: __dirname, manifest: { /* overrides */ } }]
  ],
  {
  }
)
```

## Related

- Pending #1686