### PR TITLE
refactor(cli) create ios push key selector

### DIFF
--- a/packages/expo-cli/src/credentials/api.ts
+++ b/packages/expo-cli/src/credentials/api.ts
@@ -130,6 +130,27 @@ export class IosApi {
       return record;
     });
   }
+  async getPushKey(
+    experienceName: string,
+    bundleIdentifier: string
+  ): Promise<IosPushCredentials | null> {
+    if (this.shouldRefetch) {
+      await this._fetchAllCredentials();
+    }
+    this._ensureAppCredentials(experienceName, bundleIdentifier);
+    const credIndex = findIndex(
+      this.credentials.appCredentials,
+      app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
+    );
+    const pushKeyId = this.credentials.appCredentials[credIndex].pushCredentialsId;
+    if (!pushKeyId) {
+      return null;
+    }
+    const pushKey = this.credentials.userCredentials.find(cred => cred.id === pushKeyId) as
+      | IosPushCredentials
+      | undefined;
+    return pushKey || null;
+  }
   async usePushKey(experienceName: string, bundleIdentifier: string, userCredentialsId: number) {
     await this.api.postAsync('credentials/ios/use/push', {
       experienceName,

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -99,7 +99,7 @@ export class SelectIosExperience implements IView {
       case 'remove-ios-dist':
         return new iosDistView.RemoveIosDist();
       case 'use-existing-push-ios':
-        return new iosPushView.UseExistingPushNotification();
+        return iosPushView.UseExistingPushNotification.withProjectContext(ctx);
       case 'use-existing-dist-ios':
         return iosDistView.UseExistingDistributionCert.withProjectContext(ctx);
       case 'remove-provisioning-profile':

--- a/packages/expo-cli/src/credentials/views/SetupIosPush.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosPush.ts
@@ -1,0 +1,48 @@
+import * as iosPushView from './IosPushCredentials';
+
+import { Context, IView } from '../context';
+
+export class SetupIosPush implements IView {
+  _experienceName: string;
+  _bundleIdentifier: string;
+
+  constructor(options: iosPushView.PushKeyOptions) {
+    const { experienceName, bundleIdentifier } = options;
+    this._experienceName = experienceName;
+    this._bundleIdentifier = bundleIdentifier;
+  }
+
+  async open(ctx: Context): Promise<IView | null> {
+    if (!ctx.user) {
+      throw new Error(`This workflow requires you to be logged in.`);
+    }
+
+    const configuredPushKey = await ctx.ios.getPushKey(
+      this._experienceName,
+      this._bundleIdentifier
+    );
+
+    if (!configuredPushKey) {
+      return new iosPushView.CreateOrReusePushKey({
+        experienceName: this._experienceName,
+        bundleIdentifier: this._bundleIdentifier,
+      });
+    }
+
+    if (!ctx.hasAppleCtx) {
+      throw new Error(`This workflow requires you to provide your Apple Credentials.`);
+    }
+
+    // check if valid
+    const isValid = await iosPushView.validatePushKey(ctx.appleCtx, configuredPushKey);
+
+    if (isValid) {
+      return null;
+    }
+
+    return new iosPushView.CreateOrReusePushKey({
+      experienceName: this._experienceName,
+      bundleIdentifier: this._bundleIdentifier,
+    });
+  }
+}


### PR DESCRIPTION
The iOS Push Key version of https://github.com/expo/expo-cli/pull/1381

# Tests
- [x] cred manager add/remove push key works still 
- [x] adhoc push key anon works
- [x] adhoc push key non anon works