### PR TITLE
@jkhales/add apiv2 option credentials

### DIFF
--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -236,7 +236,7 @@ export async function removeCredentialsForPlatform(
         throw new Error('Error deleting credentials.');
       }
     } else if (platform === 'ios') {
-      const { only } = metadata;
+      const { experienceName, bundleIdentifier, only } = metadata;
 
       if (only.appCredentials) {
         only.provisioningProfile = true;
@@ -244,7 +244,7 @@ export async function removeCredentialsForPlatform(
         delete only.appCredentials;
       }
       const currentCredentials = await api.getAsync(
-        `credentials/ios/${metadata.experienceName}/${encodeURI(metadata.bundleIdentifier ?? '')}`
+        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
       );
       if (isEmpty(currentCredentials)) {
         return;
@@ -252,14 +252,14 @@ export async function removeCredentialsForPlatform(
 
       if (only.provisioningProfile) {
         await api.postAsync('credentials/ios/provisioningProfile/delete', {
-          experienceName: metadata.experienceName,
-          bundleIdentifier: metadata.bundleIdentifier,
+          experienceName,
+          bundleIdentifier,
         });
       }
       if (only.pushCert) {
         await api.postAsync('credentials/ios/pushCert/delete', {
-          experienceName: metadata.experienceName,
-          bundleIdentifier: metadata.bundleIdentifier,
+          experienceName,
+          bundleIdentifier,
         });
       }
       if (only.pushKey && currentCredentials.pushCredentialsId) {

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -189,7 +189,9 @@ export async function updateCredentialsForPlatform(
 
       // reused credentials
       for (const id of userCredentialsIdOverride) {
-        const record = await api.get(`credentials/ios/userCredentials/${id}`, { decrypt: false });
+        const record = await api.getAsync(`credentials/ios/userCredentials/${id}`, {
+          decrypt: false,
+        });
         if (record && record.type === 'push-key') {
           await api.postAsync(`credentials/ios/use/push`, {
             experienceName,

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -86,11 +86,9 @@ async function fetchCredentials(
       if (record) {
         const { pushCredentials, distCredentials, credentials } = record;
         return {
-          credentials: {
-            ...pushCredentials,
-            ...distCredentials,
-            ...credentials,
-          },
+          ...pushCredentials,
+          ...distCredentials,
+          ...credentials,
         };
       } else {
         return {};

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -1,4 +1,5 @@
 import { Platform, readConfigJsonAsync } from '@expo/config';
+import { ApiV2 } from '../xdl';
 
 import Api from '../Api';
 import UserManager from '../User';
@@ -46,33 +47,49 @@ export async function credentialsExistForPlatformAsync(
 
 export async function getEncryptedCredentialsForPlatformAsync(
   metadata: CredentialMetadata
-): Promise<Credentials | undefined> {
+): Promise<Credentials | undefined | null> {
   return fetchCredentials(metadata, false);
 }
 
 export async function getCredentialsForPlatform(
   metadata: CredentialMetadata
-): Promise<Credentials | undefined> {
+): Promise<Credentials | undefined | null> {
   return fetchCredentials(metadata, true);
 }
 
 async function fetchCredentials(
   { username, experienceName, bundleIdentifier, platform }: CredentialMetadata,
   decrypt: boolean
-): Promise<Credentials | undefined> {
+): Promise<Credentials | undefined | null> {
   // this doesn't hit our mac rpc channel, so it needs significantly less debugging
-  const { err, credentials } = await Api.callMethodAsync('getCredentials', [], 'post', {
-    username,
-    experienceName,
-    bundleIdentifier,
-    platform,
-    decrypt,
-  });
+  console.log('fetchCredentials', { username, experienceName, bundleIdentifier, platform });
+  let credentials;
+  if (process.env.EXPO_NEXT_API) {
+    //TODO-JJ make this work for ios as well
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    credentials = await api.getAsync(`credentials/${platform}/keystore/${experienceName}`);
+    console.log({ credentials });
+    if (credentials['keystore']) {
+      credentials['keystore']['keystoreAlias'] = credentials['keystore']['keyAlias'];
+      delete credentials['keystore']['keyAlias'];
+    } else {
+      return null;
+    }
+  } else {
+    const response = await Api.callMethodAsync('getCredentials', [], 'post', {
+      username,
+      experienceName,
+      bundleIdentifier,
+      platform,
+      decrypt,
+    });
 
-  if (err) {
-    throw new Error('Error fetching credentials.');
+    if (response.err) {
+      throw new Error('Error fetching credentials.');
+    }
+    credentials = response.credentials;
   }
-
   return credentials;
 }
 
@@ -82,15 +99,41 @@ export async function updateCredentialsForPlatform(
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {
-  const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {
-    credentials: newCredentials,
-    userCredentialsIds,
+  console.log('updateCredentialsForPlatform', {
     platform,
-    ...metadata,
+    newCredentials,
+    userCredentialsIds,
+    metadata,
   });
 
-  if (err || !credentials) {
-    throw new Error('Error updating credentials.');
+  if (process.env.EXPO_NEXT_API) {
+    //TODO-JJ make this work for ios as well
+    console.log('API V2 updateCredentialsForPlatform');
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    const result = await api.putAsync(
+      `credentials/${platform}/keystore/${metadata.experienceName}`,
+      {
+        credentials: newCredentials,
+      }
+    );
+
+    console.log('API V2 creds result:', result);
+    if (!result) {
+      throw new Error('Error updating credentials.');
+    }
+  } else {
+    const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {
+      credentials: newCredentials,
+      userCredentialsIds,
+      platform,
+      ...metadata,
+    });
+
+    console.log({ err, credentials });
+    if (err || !credentials) {
+      throw new Error('Error updating credentials.');
+    }
   }
 }
 
@@ -99,12 +142,31 @@ export async function removeCredentialsForPlatform(
   metadata: CredentialMetadata
 ): Promise<void> {
   // doesn't go through mac rpc, no request id needed
-  const { err } = await Api.callMethodAsync('deleteCredentials', [], 'post', {
-    platform,
-    ...metadata,
-  });
+  console.log('deleteCredentials');
+  console.log({ platform, metadata });
 
-  if (err) {
-    throw new Error('Error deleting credentials.');
+  if (process.env.EXPO_NEXT_API) {
+    //TODO-JJ make this work for ios as well
+    console.log('API V2 Delete CredentialsForPlatform');
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    const result = await api.deleteAsync(
+      `credentials/${platform}/keystore/${metadata.experienceName}`
+    );
+
+    console.log('API V2 creds result:', result);
+    if (!result) {
+      throw new Error('Error deleting credentials.');
+    }
+  } else {
+    const { err } = await Api.callMethodAsync('deleteCredentials', [], 'post', {
+      platform,
+      ...metadata,
+    });
+
+    console.log({ err });
+    if (err) {
+      throw new Error('Error deleting credentials.');
+    }
   }
 }

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -227,13 +227,8 @@ export async function removeCredentialsForPlatform(
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
     if (platform === 'android') {
-      const result = await api.deleteAsync(
-        `credentials/android/keystore/${metadata.experienceName}`
-      );
-
-      if (!result) {
-        throw new Error('Error deleting credentials.');
-      }
+      console.log('deleting android credentials');
+      await api.deleteAsync(`credentials/android/keystore/${metadata.experienceName}`);
     } else if (platform === 'ios') {
       const { experienceName, bundleIdentifier, only } = metadata;
 

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -201,7 +201,7 @@ export async function updateCredentialsForPlatform(
       // reused credentials
       for (const id of userCredentialsIdOverride) {
         //const record = await IosCredentials.getUserCredentials(id, userId, false);
-        const record = await api.get(`/credentials/ios/record/${id}`, { decrypt: false });
+        const record = await api.get(`/credentials/ios/userCredentials/${id}`, { decrypt: false });
         if (record && record.type === 'push-key') {
           //await IosCredentials.usePushKey({ experienceName, bundleIdentifier }, id, userId);
           await api.postAsync(`credentials/ios/use/push`, {

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -171,7 +171,7 @@ export async function updateCredentialsForPlatform(
 
       if (!isEmpty(pushCredentials)) {
         const pushCredentialsId = get(currentCredentials, 'pushCredentialsId');
-        const updatedId = await api.putAsync(`credentials/ios/push/${pushCredentialsId}`, {
+        const { id: updatedId } = await api.putAsync(`credentials/ios/push/${pushCredentialsId}`, {
           credentials: { ...pushCredentials, ...appleTeam },
         });
         if (!pushCredentialsId) {
@@ -186,7 +186,7 @@ export async function updateCredentialsForPlatform(
       if (!isEmpty(distCredentials)) {
         const distCredentialsId = get(currentCredentials, 'distCredentialsId');
         //const updatedId = await IosCredentials.updateDistCert(
-        const updatedId = await api.putAsync(`credentials/ios/dist/${distCredentialsId}`, {
+        const { id: updatedId } = await api.putAsync(`credentials/ios/dist/${distCredentialsId}`, {
           credentials: { ...distCredentials, ...appleTeam },
         });
         if (!distCredentialsId) {

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -72,26 +72,25 @@ async function fetchCredentials(
     const api = ApiV2.clientForUser(user);
 
     if (platform === 'android') {
-      credentials = await api.getAsync(`credentials/${platform}/keystore/${experienceName}`);
+      credentials = await api.getAsync(`credentials/android/keystore/${experienceName}`);
       if (credentials['keystore']) {
         credentials['keystore']['keystoreAlias'] = credentials['keystore']['keyAlias'];
         delete credentials['keystore']['keyAlias'];
       } else {
-        return null;
+        credentials = null;
       }
     } else if (platform === 'ios') {
       const record = await api.getAsync(
-        `credentials/${platform}/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
+        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
       );
       if (record) {
-        const { pushCredentials, distCredentials, credentials } = record;
-        return {
-          ...pushCredentials,
-          ...distCredentials,
-          ...credentials,
+        credentials = {
+          ...record.pushCredentials,
+          ...record.distCredentials,
+          ...record.credentials,
         };
       } else {
-        return {};
+        credentials = {};
       }
     }
   } else {
@@ -122,7 +121,7 @@ export async function updateCredentialsForPlatform(
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
     if (platform === 'android') {
-      const result = await api.putAsync(`credentials/${platform}/keystore/${experienceName}`, {
+      const result = await api.putAsync(`credentials/android/keystore/${experienceName}`, {
         credentials: newCredentials,
       });
 

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -81,7 +81,7 @@ async function fetchCredentials(
       }
     } else if (platform === 'ios') {
       const record = await api.getAsync(
-        `credentials/${platform}/${experienceName}/${encodeURI(bundleIdentifier)}`
+        `credentials/${platform}/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
       );
       if (record) {
         const { pushCredentials, distCredentials, credentials } = record;
@@ -138,7 +138,7 @@ export async function updateCredentialsForPlatform(
         : userCredentialsIds;
 
       const currentCredentials = await api.getAsync(
-        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier)}`
+        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
       );
       const appleTeam = pick(credentials, ['teamId', 'teamName']);
       const distCredentials = pick(credentials, [
@@ -244,7 +244,7 @@ export async function removeCredentialsForPlatform(
         delete only.appCredentials;
       }
       const currentCredentials = await api.getAsync(
-        `credentials/ios/${metadata.experienceName}/${encodeURI(metadata.bundleIdentifier)}`
+        `credentials/ios/${metadata.experienceName}/${encodeURI(metadata.bundleIdentifier ?? '')}`
       );
       if (isEmpty(currentCredentials)) {
         return;

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -113,7 +113,7 @@ async function fetchCredentials(
 
 export async function updateCredentialsForPlatform(
   platform: string,
-  newCredentials: Credentials,
+  newCredentials: Credentials & { userCredentialsId: string },
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {
@@ -221,7 +221,7 @@ export async function updateCredentialsForPlatform(
 
 export async function removeCredentialsForPlatform(
   platform: string,
-  metadata: CredentialMetadata
+  metadata: CredentialMetadata & { only: any }
 ): Promise<void> {
   // doesn't go through mac rpc, no request id needed
   if (process.env.EXPO_NEXT_API) {

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -119,17 +119,8 @@ export async function updateCredentialsForPlatform(
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {
-  console.log('updateCredentialsForPlatform', {
-    platform,
-    newCredentials,
-    userCredentialsIds,
-    metadata,
-  });
-
   if (process.env.EXPO_NEXT_API) {
     const { experienceName, bundleIdentifier } = metadata;
-    //TODO-JJ make this work for ios as well
-    console.log('API V2 updateCredentialsForPlatform');
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
     if (platform === 'android') {
@@ -137,7 +128,6 @@ export async function updateCredentialsForPlatform(
         credentials: newCredentials,
       });
 
-      console.log('API V2 creds result:', result);
       if (!result) {
         throw new Error('Error updating credentials.');
       }
@@ -185,7 +175,6 @@ export async function updateCredentialsForPlatform(
 
       if (!isEmpty(distCredentials)) {
         const distCredentialsId = get(currentCredentials, 'distCredentialsId');
-        //const updatedId = await IosCredentials.updateDistCert(
         const { id: updatedId } = await api.putAsync(`credentials/ios/dist/${distCredentialsId}`, {
           credentials: { ...distCredentials, ...appleTeam },
         });
@@ -200,17 +189,14 @@ export async function updateCredentialsForPlatform(
 
       // reused credentials
       for (const id of userCredentialsIdOverride) {
-        //const record = await IosCredentials.getUserCredentials(id, userId, false);
         const record = await api.get(`credentials/ios/userCredentials/${id}`, { decrypt: false });
         if (record && record.type === 'push-key') {
-          //await IosCredentials.usePushKey({ experienceName, bundleIdentifier }, id, userId);
           await api.postAsync(`credentials/ios/use/push`, {
             experienceName,
             bundleIdentifier,
             userCredentialsId: id,
           });
         } else if (record && record.type === 'dist-cert') {
-          //await IosCredentials.useDistCert({ experienceName, bundleIdentifier }, id, userId);
           await api.postAsync(`credentials/ios/use/dist`, {
             experienceName,
             bundleIdentifier,
@@ -227,7 +213,6 @@ export async function updateCredentialsForPlatform(
       ...metadata,
     });
 
-    console.log({ err, credentials });
     if (err || !credentials) {
       throw new Error('Error updating credentials.');
     }
@@ -239,11 +224,7 @@ export async function removeCredentialsForPlatform(
   metadata: CredentialMetadata
 ): Promise<void> {
   // doesn't go through mac rpc, no request id needed
-  console.log('deleteCredentials');
-  console.log({ platform, metadata });
-
   if (process.env.EXPO_NEXT_API) {
-    console.log('API V2 Delete CredentialsForPlatform');
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
     if (platform === 'android') {
@@ -251,7 +232,6 @@ export async function removeCredentialsForPlatform(
         `credentials/android/keystore/${metadata.experienceName}`
       );
 
-      console.log('API V2 creds result:', result);
       if (!result) {
         throw new Error('Error deleting credentials.');
       }
@@ -295,7 +275,6 @@ export async function removeCredentialsForPlatform(
       ...metadata,
     });
 
-    console.log({ err });
     if (err) {
       throw new Error('Error deleting credentials.');
     }

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -201,7 +201,7 @@ export async function updateCredentialsForPlatform(
       // reused credentials
       for (const id of userCredentialsIdOverride) {
         //const record = await IosCredentials.getUserCredentials(id, userId, false);
-        const record = await api.get(`/credentials/ios/userCredentials/${id}`, { decrypt: false });
+        const record = await api.get(`credentials/ios/userCredentials/${id}`, { decrypt: false });
         if (record && record.type === 'push-key') {
           //await IosCredentials.usePushKey({ experienceName, bundleIdentifier }, id, userId);
           await api.postAsync(`credentials/ios/use/push`, {
@@ -271,22 +271,22 @@ export async function removeCredentialsForPlatform(
       }
 
       if (only.provisioningProfile) {
-        await api.postAsync('/credentials/ios/provisioningProfile/delete', {
+        await api.postAsync('credentials/ios/provisioningProfile/delete', {
           experienceName: metadata.experienceName,
           bundleIdentifier: metadata.bundleIdentifier,
         });
       }
       if (only.pushCert) {
-        await api.postAsync('/credentials/ios/pushCert/delete', {
+        await api.postAsync('credentials/ios/pushCert/delete', {
           experienceName: metadata.experienceName,
           bundleIdentifier: metadata.bundleIdentifier,
         });
       }
       if (only.pushKey && currentCredentials.pushCredentialsId) {
-        await api.delAsync(`/credentials/ios/push/${currentCredentials.pushCredentialsId}`);
+        await api.deleteAsync(`credentials/ios/push/${currentCredentials.pushCredentialsId}`);
       }
       if (only.distributionCert && currentCredentials.distCredentialsId) {
-        await api.delAsync(`/credentials/ios/dist/${currentCredentials.distCredentialsId}`);
+        await api.deleteAsync(`credentials/ios/dist/${currentCredentials.distCredentialsId}`);
       }
     }
   } else {

--- a/packages/xdl/src/credentials/IosCredentials.ts
+++ b/packages/xdl/src/credentials/IosCredentials.ts
@@ -1,5 +1,7 @@
 import Api from '../Api';
 import { findP12CertSerialNumber } from '../detach/PKCS12Utils';
+import UserManager from '../User';
+import { ApiV2 } from '../xdl';
 
 export type Credentials = {
   appleId?: string;
@@ -95,19 +97,38 @@ async function getExistingUserCredentials(
   appleTeamId: string,
   type: string
 ): Promise<CredsList> {
-  const { err, certs } = await Api.callMethodAsync('getExistingUserCredentials', [], 'post', {
-    username,
-    appleTeamId,
-    type,
-  });
+  let certs;
+  if (process.env.EXPO_NEXT_API) {
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    const { userCredentials, appCredentials } = await api.getAsync(`credentials/ios`);
 
-  if (err) {
-    throw new Error('Error getting existing distribution certificates.');
+    certs = userCredentials
+      .filter(cred => cred.type === type && cred.teamId === appleTeamId)
+      .map(({ id, ...cred }) => ({
+        ...cred,
+        userCredentialsId: id,
+        usedByApps: appCredentials
+          .filter(app => app.pushCredentialsId === id || app.distCredentialsId === id)
+          .map(({ experienceName }) => experienceName)
+          .join(';'),
+      }));
   } else {
-    return certs.map(({ usedByApps, userCredentialsId, ...rest }: any) => ({
-      usedByApps: usedByApps && usedByApps.split(';'),
-      userCredentialsId: String(userCredentialsId),
-      ...rest,
-    }));
+    const result = await Api.callMethodAsync('getExistingUserCredentials', [], 'post', {
+      username,
+      appleTeamId,
+      type,
+    });
+
+    if (result.err) {
+      throw new Error('Error getting existing distribution certificates.');
+    }
+    certs = result.certs;
   }
+
+  return certs.map(({ usedByApps, userCredentialsId, ...rest }: any) => ({
+    usedByApps: usedByApps && usedByApps.split(';'),
+    userCredentialsId: String(userCredentialsId),
+    ...rest,
+  }));
 }

--- a/packages/xdl/src/credentials/IosCredentials.ts
+++ b/packages/xdl/src/credentials/IosCredentials.ts
@@ -104,13 +104,13 @@ async function getExistingUserCredentials(
     const { userCredentials, appCredentials } = await api.getAsync(`credentials/ios`);
 
     certs = userCredentials
-      .filter(cred => cred.type === type && cred.teamId === appleTeamId)
-      .map(({ id, ...cred }) => ({
+      .filter((cred: any) => cred.type === type && cred.teamId === appleTeamId)
+      .map(({ id, ...cred }: any) => ({
         ...cred,
         userCredentialsId: id,
         usedByApps: appCredentials
-          .filter(app => app.pushCredentialsId === id || app.distCredentialsId === id)
-          .map(({ experienceName }) => experienceName)
+          .filter((app: any) => app.pushCredentialsId === id || app.distCredentialsId === id)
+          .map(({ experienceName }: any) => experienceName)
           .join(';'),
       }));
   } else {


### PR DESCRIPTION
 # why

Move credential calls used by `expo build:*` to api v2.

 # how

api v1 has a single big call, apiv2 instead exposes each bit.
So the idea is basically to just bring the server side code from here: 
https://github.com/expo/universe/blob/master/server/www/src/api/credentials.js

into the cli client, replacing calls to models with calls to apiv2.

 # testing

ran 

`expo build:ios`
`expo build:android`
`expo build:ios --clear-credentials`
`expo build:android --clear-credentials`
`expo build:ios --clear-dist-cert`
`expo build:ios --clear-push-key`
`expo build:ios --clear-push-cert`
`expo build:ios --clear-provisioning-profile`
`expo build:ios --clear-credentials -r`
`expo build:ios --clear-dist-cert -r`
`expo build:ios --clear-push-key -r`
`expo build:ios --clear-push-cert -r`
`expo build:ios --clear-provisioning-profile -r`
