### PR TITLE
Added proper TypeScript support for Webpack Config

### DIFF
--- a/packages/babel-preset-cli/ts-declarations/pnp-webpack-plugin/index.d.ts
+++ b/packages/babel-preset-cli/ts-declarations/pnp-webpack-plugin/index.d.ts
@@ -1,4 +1,5 @@
 declare module 'pnp-webpack-plugin' {
   function apply(resolver: any /* EnhancedResolve.Resolver */): void;
   function moduleLoader(module: NodeModule): any;
+  function forkTsCheckerOptions(config: any): any;
 }

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -56,7 +56,7 @@
     "is-wsl": "^2.0.0",
     "mini-css-extract-plugin": "^0.5.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
-    "pnp-webpack-plugin": "^1.2.1",
+    "pnp-webpack-plugin": "^1.5.0",
     "postcss-safe-parser": "^4.0.1",
     "progress-bar-webpack-plugin": "^1.12.1",
     "react-dev-utils": "9.0.3",

--- a/packages/webpack-config/src/addons/index.ts
+++ b/packages/webpack-config/src/addons/index.ts
@@ -7,3 +7,4 @@ export { default as withAlias } from './withAlias';
 export { default as withDevServer } from './withDevServer';
 export { default as withNodeMocks } from './withNodeMocks';
 export { default as withEntry } from './withEntry';
+export { default as withTypeScriptAsync } from './withTypeScriptAsync';

--- a/packages/webpack-config/src/addons/withTypeScriptAsync.ts
+++ b/packages/webpack-config/src/addons/withTypeScriptAsync.ts
@@ -33,9 +33,10 @@ export default async function withTypeScriptAsync(
 
   const isTypeScriptEnabled = Boolean(typeScriptPath && (await fileExistsAsync(tsConfigPath)));
 
-  if (config.resolve?.extensions) {
+  if (!isTypeScriptEnabled && config.resolve?.extensions) {
     config.resolve.extensions = config.resolve.extensions.filter(extension => {
-      return isTypeScriptEnabled || !extension.includes('.ts');
+      // filter out ts and tsx extensions, including .web.ts
+      return !extension.endsWith('.ts') && !extension.endsWith('.tsx');
     });
   }
 

--- a/packages/webpack-config/src/addons/withTypeScriptAsync.ts
+++ b/packages/webpack-config/src/addons/withTypeScriptAsync.ts
@@ -1,0 +1,78 @@
+import { fileExistsAsync, resolveModule } from '@expo/config';
+import { getPossibleProjectRoot } from '@expo/config/paths';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+import PnpWebpackPlugin from 'pnp-webpack-plugin';
+
+import { getAbsolute, getConfig } from '../env';
+import { AnyConfiguration, InputEnvironment } from '../types';
+
+/**
+ * Enable or disable TypeScript in the Webpack config that's provided.
+ * - Disabling will filter out any TypeScript extensions.
+ * - Enabling will add fork TS checker to the plugins.
+ *
+ * @param config input webpack config to modify and return.
+ * @param env environment used to configure the input config.
+ */
+export default async function withTypeScriptAsync(
+  config: AnyConfiguration,
+  env: Pick<InputEnvironment, 'config' | 'locations' | 'projectRoot'> = {}
+): Promise<AnyConfiguration> {
+  const isDev = config.mode !== 'production';
+
+  env.projectRoot = env.projectRoot || getPossibleProjectRoot();
+  // @ts-ignore
+  env.config = env.config || getConfig(env);
+
+  let typeScriptPath: string | null = null;
+  try {
+    typeScriptPath = resolveModule('typescript', env.projectRoot, env.config!);
+  } catch (_) {}
+
+  const tsConfigPath = getAbsolute(env.projectRoot, 'tsconfig.json');
+
+  const isTypeScriptEnabled = Boolean(typeScriptPath && (await fileExistsAsync(tsConfigPath)));
+
+  if (config.resolve?.extensions) {
+    config.resolve.extensions = config.resolve.extensions.filter(extension => {
+      return isTypeScriptEnabled || !extension.includes('.ts');
+    });
+  }
+
+  if (!isTypeScriptEnabled) {
+    return config;
+  }
+
+  if (!config.plugins) config.plugins = [];
+
+  config.plugins.push(
+    new ForkTsCheckerWebpackPlugin(
+      PnpWebpackPlugin.forkTsCheckerOptions({
+        async: isDev,
+        typescript: typeScriptPath,
+        useTypescriptIncrementalApi: true,
+        checkSyntacticErrors: true,
+
+        tsconfig: tsConfigPath,
+        reportFiles: [
+          '**',
+          '!**/__tests__/**',
+          '!**/?(*.)(spec|test).*',
+          // Add support for CRA projects
+          '!**/src/setupProxy.*',
+          '!**/src/setupTests.*',
+        ],
+
+        compilerOptions: {
+          isolatedModules: true,
+          noEmit: true,
+        },
+        // Disable the formatter in production like CRA
+        formatter: isDev ? 'codeframe' : undefined,
+        silent: true,
+      })
+    )
+  );
+
+  return config;
+}

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -30,6 +30,7 @@ import {
   withNodeMocks,
   withOptimizations,
   withReporting,
+  withTypeScriptAsync,
 } from './addons';
 
 import { Arguments, DevConfiguration, Environment, FilePaths, Mode } from './types';
@@ -311,8 +312,11 @@ export default async function(
     webpackConfig = withCompression(withOptimizations(webpackConfig), env);
   }
 
-  return withDevServer(withReporting(withNodeMocks(withAlias(webpackConfig)), env), env, {
-    allowedHost: argv.allowedHost,
-    proxy: argv.proxy,
-  });
+  return withTypeScriptAsync(
+    withDevServer(withReporting(withNodeMocks(withAlias(webpackConfig)), env), env, {
+      allowedHost: argv.allowedHost,
+      proxy: argv.proxy,
+    }),
+    env
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16069,7 +16069,7 @@ pngjs@3.4.0, pngjs@^3.0.0, pngjs@^3.3.3:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
 
-pnp-webpack-plugin@^1.2.1:
+pnp-webpack-plugin@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.5.0.tgz#62a1cd3068f46d564bb33c56eb250e4d586676eb"
   integrity sha512-jd9olUr9D7do+RN8Wspzhpxhgp1n6Vd0NtQ4SFkmIACZoEL1nkyAdW9Ygrinjec0vgDcWjscFQQ1gDW8rsfKTg==


### PR DESCRIPTION
- Ensure TS checker is added when tsconfig is present. 
- Remove support for TS extensions when a tsconfig isn't present -- this will help debugging TypeScript setup.