### PR TITLE
fix(traveling-fastlane) cURL cURL's pem

### DIFF
--- a/packages/traveling-fastlane/Rakefile
+++ b/packages/traveling-fastlane/Rakefile
@@ -118,7 +118,7 @@ def create_package target
   sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz -C #{package_dir}/lib/ruby"
 
   # Hack to replace traveling ruby's expired ca-bundle.crt with cURL's most recent one
-  sh "wget #{CA_CERT_URL} -O #{package_dir}/lib/ruby/lib/ca-bundle.crt"
+  sh "curl -o #{package_dir}/lib/ruby/lib/ca-bundle.crt #{CA_CERT_URL}"
 
   for script in SCRIPTS do
     if script != 'funcs' && script != 'preload'

--- a/packages/traveling-fastlane/Rakefile
+++ b/packages/traveling-fastlane/Rakefile
@@ -6,6 +6,7 @@ VERSION = "1.11.3"
 TRAVELING_RUBY_VERSION = "20150715-2.2.2"
 JSON_VERSION = '1.8.2'
 UNF_VERSION = '0.0.6'
+CA_CERT_URL = 'https://curl.haxx.se/ca/cacert.pem' # from cURL
 
 # Be sure to add the name of a script here when you add it to actions
 SCRIPTS = [
@@ -115,6 +116,10 @@ def create_package target
   end
   sh "mkdir #{package_dir}/lib/ruby"
   sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz -C #{package_dir}/lib/ruby"
+
+  # Hack to replace traveling ruby's expired ca-bundle.crt with cURL's most recent one
+  sh "wget #{CA_CERT_URL} -O #{package_dir}/lib/ruby/lib/ca-bundle.crt"
+
   for script in SCRIPTS do
     if script != 'funcs' && script != 'preload'
       sh "cp wrappers/#{script}_wrapper.sh #{package_dir}/#{script}"


### PR DESCRIPTION
# Problem
Traveling ruby is a self-contained ruby with no dependencies. This means they also bundle their own ca certs. Unfortunately many of these certs are expired, causing https://github.com/expo/expo-cli/issues/1436

# Assumes
- we trust Mozilla and cURL

# How
- Mozilla has public Certificate Authorities (CA) available in its source tree: https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
- cURL parses this certdata.txt and extracts CA Root Certificates into PEM format, and makes it publicly available on their website
- Every time we release traveling fastlane, we replace `traveling-ruby`'s expired ca bundle with cURL's most up to date bundle.

# Test

- [x] ca bundle is not expired
```
$ openssl x509 -enddate -noout -in ca-bundle.crt 
notAfter=Jan 28 12:00:00 2028 GMT
```