### PR TITLE
fix(webpack-config): prevent secrets from being exposed

### DIFF
--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -18,9 +18,10 @@ export function createClientEnvironment(
   const __DEV__ = environment !== 'production';
 
   const ENV_VAR_REGEX = /^(EXPO_|REACT_NATIVE_|CI$)/i;
+  const SECRET_REGEX = /(PASSWORD|SECRET|TOKEN)/i;
 
   const processEnv = Object.keys(process.env)
-    .filter(key => ENV_VAR_REGEX.test(key))
+    .filter(key => ENV_VAR_REGEX.test(key) && !SECRET_REGEX.test(key))
     .reduce(
       (env, key) => {
         env[key] = JSON.stringify(process.env[key]);


### PR DESCRIPTION
Currently, all environment variables containing EXPO are exposed. However, if you are using a CI you might have some secrets and passwords defined that shouldn't be part of the build. This PR removes these environment variables explicitly.