### PR TITLE
fix(webpack-config): register general service worker in development

### DIFF
--- a/packages/webpack-config/src/addons/withWorkbox.ts
+++ b/packages/webpack-config/src/addons/withWorkbox.ts
@@ -66,11 +66,6 @@ export default function withWorkbox(
   config: AnyConfiguration,
   options: OfflineOptions = {}
 ): AnyConfiguration {
-  // Do nothing in dev mode
-  if (config.mode !== 'production') {
-    return config;
-  }
-
   if (!config.plugins) config.plugins = [];
 
   const {
@@ -84,32 +79,8 @@ export default function withWorkbox(
   } = options;
 
   const locations = getPaths(projectRoot!);
-
-  const customManifestProps = {
-    navigateFallback: join(publicUrl, 'index.html'),
-  };
-
-  if (useServiceWorker) {
-    config.plugins.push(
-      new GenerateSW({
-        ...defaultGenerateSWOptions,
-        ...customManifestProps,
-        ...generateSWOptions,
-      })
-    );
-  } else {
-    const props = {
-      ...defaultInjectManifestOptions,
-      ...customManifestProps,
-      ...injectManifestOptions,
-    };
-
-    config.plugins.push(
-      // @ts-ignore: unused swSrc
-      new InjectManifest(props)
-    );
-  }
-
+  
+  // Always register general service worker
   const expoEntry = config.entry;
   config.entry = async () => {
     const entries = await resolveEntryAsync(expoEntry);
@@ -135,6 +106,36 @@ export default function withWorkbox(
     }
     return entries;
   };
+  
+  // ... but do not register Workbox in development
+  if (config.mode !== 'production') {
+    return config;
+  }
+
+  const customManifestProps = {
+    navigateFallback: join(publicUrl, 'index.html'),
+  };
+
+  if (useServiceWorker) {
+    config.plugins.push(
+      new GenerateSW({
+        ...defaultGenerateSWOptions,
+        ...customManifestProps,
+        ...generateSWOptions,
+      })
+    );
+  } else {
+    const props = {
+      ...defaultInjectManifestOptions,
+      ...customManifestProps,
+      ...injectManifestOptions,
+    };
+
+    config.plugins.push(
+      // @ts-ignore: unused swSrc
+      new InjectManifest(props)
+    );
+  }
 
   return config;
 }


### PR DESCRIPTION
Currently, no service worker is registered at all in development which makes it difficult to test service worker related functionality. This PR will always register the `expo-service-worker` but will still avoid Workbox in development.