### PR TITLE
fix(webpack-config): remove compressed versions from manifest

### DIFF
--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -260,6 +260,10 @@ export default async function(
       new ManifestPlugin({
         fileName: 'asset-manifest.json',
         publicPath,
+        filter = ({ path }) => {
+          // Remove compressed versions
+          return !path.endsWith('.gz')
+        },
       }),
 
       deepScopeAnalysisEnabled && new WebpackDeepScopeAnalysisPlugin(),

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -261,8 +261,8 @@ export default async function(
         fileName: 'asset-manifest.json',
         publicPath,
         filter = ({ path }) => {
-          // Remove compressed versions
-          return !path.endsWith('.gz')
+          // Remove compressed versions and service workers
+          return !(path.endsWith('.gz') || path.endsWith('worker.js'))
         },
       }),
 


### PR DESCRIPTION
Currently, even the compressed versions of all files are included in the manifest which causes the files to be downloaded twice by the service worker. This fix will remove them from the manifest.