### PR TITLE
BREAKING CHANGE: drop Node.js 8 support

### DIFF
--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -5,9 +5,9 @@ var semver = require('semver');
 var version = process.versions.node;
 
 var supportedVersions = [
-  { range: '>=8.9.0 <9.0.0', name: 'Maintenance LTS' },
-  { range: '>=10.13.0 <11.0.0', name: 'Active LTS' },
-  { range: '>=12.0.0', name: 'Current Release' },
+  { range: semver.validRange('^10.13.0'), name: 'Active LTS' },
+  { range: semver.validRange('^12.0.0'), name: 'Active LTS' },
+  { range: semver.validRange('^13.0.0'), name: 'Current Release' },
 ];
 var isSupported = supportedVersions.some(function(supported) {
   return semver.satisfies(version, supported.range);

--- a/packages/expo-codemod/bin/expo-codemod.js
+++ b/packages/expo-codemod/bin/expo-codemod.js
@@ -2,7 +2,7 @@
 var semver = require('semver');
 var version = process.versions.node;
 
-if (semver.satisfies(version, '8.x.x || >=10.0.0')) {
+if (semver.satisfies(version, '^10.13.0 || ^12.0.0 || ^13.0.0')) {
   require('../build/cli.js')
     .runAsync(process.argv)
     .catch(error => {
@@ -10,5 +10,5 @@ if (semver.satisfies(version, '8.x.x || >=10.0.0')) {
       process.exit(1);
     });
 } else {
-  throw new Error('expo-codemod supports Node versions 8.x.x, 10.x.x and newer.');
+  throw new Error('expo-codemod supports Node versions ^10.13.0, ^12.0.0 and ^13.0.0.');
 }


### PR DESCRIPTION
Expo CLI supports Node.js current and LTS versions.
Node 8 reached end of life on December 31st 2019, so it is no longer supported.