### PR TITLE
fix resolve_itc_team_id Error: undefined method `[]' for nil:NilClass

### DIFF
--- a/packages/traveling-fastlane/actions/resolve_itc_team_id.rb
+++ b/packages/traveling-fastlane/actions/resolve_itc_team_id.rb
@@ -5,6 +5,8 @@ require 'spaceship'
 require 'pilot'
 require 'funcs'
 require 'json'
+require "i18n"
+I18n.available_locales = [:en]
 
 $result = nil
 
@@ -14,7 +16,7 @@ captured_stderr = with_captured_stderr{
     developer_team = portal_client.teams.find { |team| team['teamId'] == ENV['FASTLANE_TEAM_ID'] }
 
     Spaceship::Tunes.login(ENV['FASTLANE_USER'], ENV['FASTLANE_PASSWORD'])
-    itunes_team = Spaceship::Tunes.client.teams.find { |team| team['contentProvider']['name'].start_with? developer_team['name']  }
+    itunes_team = Spaceship::Tunes.client.teams.find { |team| I18n.transliterate(team['contentProvider']['name']).start_with? I18n.transliterate(developer_team['name'])  }
 
     itc_team_id = itunes_team['contentProvider']['contentProviderId'].to_s
 


### PR DESCRIPTION
When the developer_team name is accented (when it contains "é" or "è" for instance), we face this curious situation :
- Spaceship::Tunes.client.teams have unaccented developer_team name ("é" became "e")
- Spaceship::Portal.teams still have accented developer_team names
=> that's why comparing both names failed and itunes_team is nil, raising the "undefined method `[]' for nil:NilClass" error

With the use of I18n.transliterate we get rid of any accent related issues.

NB : this issue may come from the fact that when the developer_team name is accented its display is not consistent on apple websites :
- on appstoreconnect.apple.com it is unaccented ("é" => "e")
- on developer.apple.com it is still accented