### PR TITLE
feat(expo-cli): make init simpler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-{{ checksum "/tmp/.executor_name" }}-{{ checksum "yarn.lock" }}
+            - yarn-{{ checksum "/tmp/.executor_name" }}-{{ checksum "yarn.lock" }}-v2
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
@@ -135,7 +135,7 @@ jobs:
             - expo-cli
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-{{ checksum "/tmp/.executor_name" }}-{{ checksum "yarn.lock" }}
+          key: yarn-{{ checksum "/tmp/.executor_name" }}-{{ checksum "yarn.lock" }}-v2
           paths:
             - ~/.cache/yarn
   test-dev-tools:

--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -21,7 +21,7 @@ test('init', async () => {
   const cwd = temporary.directory();
   const { stdout } = await runAsync(
     ['init', 'hello-world', '--template', 'blank', '--name', 'Hello'],
-    { cwd }
+    { cwd, env: { ...process.env, YARN_CACHE_FOLDER: path.join(cwd, 'yarn-cache') } }
   );
   expect(stdout).toMatch(`Your project is ready at ${cwd}`);
   const appJson = await JsonFile.readAsync(path.join(cwd, 'hello-world/app.json'));

--- a/packages/expo-cli/e2e/__tests__/start-test.ts
+++ b/packages/expo-cli/e2e/__tests__/start-test.ts
@@ -5,11 +5,14 @@ import temporary from 'tempy';
 
 import { EXPO_CLI, runAsync } from '../TestUtils';
 
-const projectDir = path.join(temporary.directory(), 'my-app');
+const tempDir = temporary.directory();
+const projectDir = path.join(tempDir, 'my-app');
 
 beforeAll(async () => {
   jest.setTimeout(60000);
-  await runAsync(['init', projectDir, '--template', 'blank', '--name', 'My App']);
+  await runAsync(['init', projectDir, '--template', 'blank', '--name', 'My App'], {
+    env: { ...process.env, YARN_CACHE_FOLDER: path.join(tempDir, 'yarn-cache') },
+  });
 });
 
 test('start --offline', async () => {


### PR DESCRIPTION
- Remove the inane `Use Yarn to install dependencies?` prompt: we now just print `Using Yarn to install packages. You can pass --npm to use npm instead.`
- Remove the complex `enquirer` app.json snippet prompt and only ask for project name and template.
  * `expo init` asks for a template and project name/folder
  * `expo init MyApp` only asks for a template
  * `expo init MyApp -t bare-minimum` doesn't ask any questions
  * `expo init --yes` (alias for `expo init . -t blank` (@EvanBacon's idea from #1044) also doesn't ask anything

Fixes https://github.com/expo/expo-cli/issues/1240.
