### PR TITLE
[expo-cli] fix an issue when team id is undefined

### DIFF
--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -63,12 +63,12 @@ async function _requestAppleIdCreds(options: Options): Promise<AppleCredentials>
   return _getAppleIdFromParams(options) || (await _promptForAppleId(options));
 }
 
-function _getAppleIdFromParams({ appleId }: Options): AppleCredentials | null {
-  const appleIdPassword = process.env.EXPO_APPLE_PASSWORD;
-  if (appleId && appleIdPassword) {
+function _getAppleIdFromParams({ appleId, appleIdPassword }: Options): AppleCredentials | null {
+  const passedAppleIdPassword = appleIdPassword || process.env.EXPO_APPLE_PASSWORD;
+  if (appleId && passedAppleIdPassword) {
     return {
       appleId,
-      appleIdPassword,
+      appleIdPassword: passedAppleIdPassword,
     };
   } else {
     return null;


### PR DESCRIPTION
Should fix https://github.com/expo/expo-cli/issues/1458

When a user uploaded app credentials on his own, we don't have his `appleId` stored in the database. I made a change so that when we detect this state we ask the user to select the proper team prior to uploading the app binary to App Store.