### PR TITLE
Add EXPO_WEB_BUILD_STRICT to enable warnings as errors in CI

### DIFF
--- a/packages/xdl/README.md
+++ b/packages/xdl/README.md
@@ -9,3 +9,20 @@ at https://github.com/expo/expo. Thanks!
 ## Building Watchman
 
 Configure with `./configure --disable-statedir --without-pcre` to use TMPDIR for the watchman state.
+
+## Environment Variables
+
+### EXPO_WEB_BUILD_STRICT
+
+All warnings will be treated as errors in CI.
+
+### EXPO_WEB_DEBUG
+
+When you have errors in the production build that aren't present in the development build you can use `EXPO_WEB_DEBUG=true expo start --no-dev` to debug those errors.
+
+- Prevent the production build from being minified.
+- Include file path info comments in the bundle.
+
+### EXPO_WEB_INFO
+
+Print a diagnostic report of the Webpack config.

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -239,8 +239,8 @@ export async function compileWebAppAsync(
         return reject(new Error(messages.errors.join('\n\n')));
       }
       if (
-        process.env.CI &&
-        (typeof process.env.CI !== 'string' || process.env.CI.toLowerCase() !== 'false') &&
+        getenv.boolish('EXPO_WEB_BUILD_STRICT', false) &&
+        getenv.boolish('CI', false) &&
         messages.warnings.length
       ) {
         ProjectUtils.logWarning(
@@ -248,7 +248,7 @@ export async function compileWebAppAsync(
           WEBPACK_LOG_TAG,
           withTag(
             chalk.yellow(
-              '\nTreating warnings as errors because process.env.CI = true.\n' +
+              '\nTreating warnings as errors because `process.env.CI = true` and `process.env.EXPO_WEB_BUILD_STRICT = true`. \n' +
                 'Most CI servers set it automatically.\n'
             )
           )


### PR DESCRIPTION
# Why

https://github.com/react-navigation/react-navigation/issues/6563

# How

- Disable throwing warnings as errors in CI by default
- Add `EXPO_WEB_BUILD_STRICT` env variable to enable throwing warnings as errors in CI. 

# Notes

- I'm somewhat reluctant to disable treating warnings as errors to circumvent meaningful error messages. 