### PR TITLE
[webpack-config] Add support for web workers by default

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -68,6 +68,7 @@
     "webpack-deep-scope-plugin": "1.6.0",
     "webpack-manifest-plugin": "^2.0.4",
     "workbox-webpack-plugin": "^3.6.3",
+    "worker-loader": "^2.0.0",
     "yup": "^0.27.0"
   },
   "devDependencies": {

--- a/packages/webpack-config/src/loaders/createAllLoaders.ts
+++ b/packages/webpack-config/src/loaders/createAllLoaders.ts
@@ -5,6 +5,7 @@ import { Environment, FilePaths, Mode } from '../types';
 import { getConfig, getMode, getPaths } from '../env';
 import createBabelLoader from './createBabelLoader';
 import createFontLoader from './createFontLoader';
+import createWorkerLoader from './createWorkerLoader';
 
 // This is needed for webpack to import static images in JavaScript files.
 // "url" loader works like "file" loader except that it embeds assets
@@ -111,6 +112,7 @@ export function getAllLoaderRules(
     getHtmlLoaderRule(template.folder),
     imageLoaderRule,
     getBabelLoaderRule(root, config, mode, platform),
+    createWorkerLoader(),
     createFontLoader(root, includeModule),
     styleLoaderRule,
     // This needs to be the last loader

--- a/packages/webpack-config/src/loaders/createWorkerLoader.ts
+++ b/packages/webpack-config/src/loaders/createWorkerLoader.ts
@@ -1,0 +1,6 @@
+import { Rule } from 'webpack';
+
+export default (): Rule => ({
+  test: /\.worker\.(js|mjs|jsx|ts|tsx)$/,
+  use: { loader: require.resolve('worker-loader') },
+});

--- a/packages/webpack-config/src/loaders/createWorkerLoader.ts
+++ b/packages/webpack-config/src/loaders/createWorkerLoader.ts
@@ -1,6 +1,7 @@
 import { Rule } from 'webpack';
 
 export default (): Rule => ({
-  test: /\.worker\.(js|mjs|jsx|ts|tsx)$/,
+  // Cannot exclude any node modules yet but in the future we should just target a select few.
+  test: /\.worker\.(js|mjs|ts)$/,
   use: { loader: require.resolve('worker-loader') },
 });

--- a/packages/webpack-config/src/loaders/index.ts
+++ b/packages/webpack-config/src/loaders/index.ts
@@ -11,3 +11,4 @@ export {
 export { default as createBabelLoader } from './createBabelLoader';
 export * from './createBabelLoader';
 export { default as createFontLoader } from './createFontLoader';
+export { default as createWorkerLoader } from './createWorkerLoader';

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -113,10 +113,9 @@ export default async function(
   const { build: buildConfig = {} } = config.web || {};
   const { babel: babelAppConfig = {} } = buildConfig;
 
-  const devtool = getDevtool(
-    { production: isProd, development: isDev },
-    buildConfig as { devtool: Options.Devtool }
-  );
+  const devtool = getDevtool({ production: isProd, development: isDev }, buildConfig as {
+    devtool: Options.Devtool;
+  });
 
   const babelProjectRoot = babelAppConfig.root || locations.root;
 
@@ -302,10 +301,12 @@ export default async function(
 
   if (isProd) {
     webpackConfig = withCompression(withOptimizations(webpackConfig), env);
+  } else {
+    webpackConfig = withDevServer(webpackConfig, env, {
+      allowedHost: argv.allowedHost,
+      proxy: argv.proxy,
+    });
   }
 
-  return withDevServer(withReporting(withNodeMocks(withAlias(webpackConfig)), env), env, {
-    allowedHost: argv.allowedHost,
-    proxy: argv.proxy,
-  });
+  return withReporting(withNodeMocks(withAlias(webpackConfig)), env);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13416,7 +13416,7 @@ loader-utils@1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@1.2.3, loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -18294,7 +18294,7 @@ sax@>=0.6.0, sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-schema-utils@^0.4.2, schema-utils@^0.4.3:
+schema-utils@^0.4.0, schema-utils@^0.4.2, schema-utils@^0.4.3:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
@@ -21306,6 +21306,14 @@ worker-farm@^1.5.2, worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
+
+worker-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
+  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+  dependencies:
+    loader-utils "^1.0.0"
+    schema-utils "^0.4.0"
 
 worker-rpc@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Add support for workers now that we want to use workers in `expo-camera` https://github.com/expo/expo/pull/4166

Any file with the `.worker.js`, `.worker.ts`, `.worker.mjs` extension will be treated as a worker.
