### PR TITLE
feat(expo-cli): add menu for build type

### DIFF
--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -29,12 +29,7 @@ export default function(program: Command) {
       '--apple-id <login>',
       'Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable).'
     )
-    .option(
-      '-t --type <build>',
-      'Type of build: [archive|simulator].',
-      /^(archive|simulator)$/i,
-      'archive'
-    )
+    .option('-t --type <build>', 'Type of build: [archive|simulator].', 'archive')
     .option('--release-channel <channel-name>', 'Pull from specified release channel.', 'default')
     .option('--no-publish', 'Disable automatic publishing before building.')
     .option('--no-wait', 'Exit immediately after scheduling build.')
@@ -84,7 +79,7 @@ export default function(program: Command) {
     .option('--keystore-alias <alias>', 'Keystore Alias')
     .option('--generate-keystore', 'Generate Keystore if one does not exist')
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
-    .option('-t --type <build>', 'Type of build: [app-bundle|apk].', /^(app-bundle|apk)$/i, 'apk')
+    .option('-t --type <build>', 'Type of build: [app-bundle|apk].', 'apk')
     .description(
       'Build a standalone APK or App Bundle for your project, signed and ready for submission to the Google Play Store.'
     )

--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -29,7 +29,7 @@ export default function(program: Command) {
       '--apple-id <login>',
       'Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable).'
     )
-    .option('-t --type <build>', 'Type of build: [archive|simulator].', 'archive')
+    .option('-t --type <build>', 'Type of build: [archive|simulator].')
     .option('--release-channel <channel-name>', 'Pull from specified release channel.', 'default')
     .option('--no-publish', 'Disable automatic publishing before building.')
     .option('--no-wait', 'Exit immediately after scheduling build.')
@@ -79,7 +79,7 @@ export default function(program: Command) {
     .option('--keystore-alias <alias>', 'Keystore Alias')
     .option('--generate-keystore', 'Generate Keystore if one does not exist')
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
-    .option('-t --type <build>', 'Type of build: [app-bundle|apk].', 'apk')
+    .option('-t --type <build>', 'Type of build: [app-bundle|apk].')
     .description(
       'Build a standalone APK or App Bundle for your project, signed and ready for submission to the Google Play Store.'
     )

--- a/packages/expo-cli/src/commands/build/utils.ts
+++ b/packages/expo-cli/src/commands/build/utils.ts
@@ -4,7 +4,6 @@ import program from 'commander';
 
 import log from '../../log';
 import prompt from '../../prompt';
-import { AndroidOptions, IosOptions } from './BaseBuilder.types';
 
 export async function checkIfSdkIsSupported(
   sdkVersion: string,

--- a/packages/expo-cli/src/commands/build/utils.ts
+++ b/packages/expo-cli/src/commands/build/utils.ts
@@ -47,6 +47,10 @@ export async function askBuildType<T extends string>(
     }
   }
 
+  if (!typeFromFlag && program.nonInteractive) {
+    return allowedTypes[0];
+  }
+
   const { answer } = await prompt({
     type: 'list',
     name: 'answer',


### PR DESCRIPTION
Fixes #1377

This is a pretty simple setup for the menu Brent described in #1377. The `askBuildType` accepts both the type (from flag) and available build types with a description (plain object).

### What did you change?
1. Moved the `build:ios` type check to `askBuildType` method in `build/utils.js`
2. Added menu when build type is not defined
3. Implemented `askBuildType` in both `build:ios` and `build:android`
4. Removed the default values (in interactive mode, for non-interactive it uses the first default built type)
5. Added nonInteractive check for old behavior to avoid breaking changes in people's CI/CD

> By adding point 4, this change won't be a breaking change for non-internactive environments. Removing this is possible, but that would probably conflict with CI/CD systems where no type is defined.

### Default option value and validation
It might be better to remove the option regex. Right now, it uses this regex and prevents bad input. I noticed that this does not work as expected with default values. I added an example below, but basically this happens:

- `expo build:android --type app-bundle` -> `{ type: app-bundle }`
- `expo build:android --type polymer` -> `{ type: apk }`
- `expo build:ios` -> `{ type: archive }`

### Examples

<details>
<summary><code>expo build:android</code></summary>
<img src="https://user-images.githubusercontent.com/1203991/73128132-20d59280-3fcb-11ea-8d27-aabd7c6a90a6.png" alt="Android example" />
</details>

<details>
<summary><code>expo build:ios</code></summary>
<img src="https://user-images.githubusercontent.com/1203991/73128145-3b0f7080-3fcb-11ea-9b69-2ad696f5aa9c.png" alt="iOS example" />
</details>

<details>
<summary>Weird result I mentioned</summary>
<img src="https://user-images.githubusercontent.com/1203991/73128157-5b3f2f80-3fcb-11ea-8677-1afea7598244.png" alt="iOS example" />
</details>

