### PR TITLE
refactor(cli) check for deprecated push certs

### DIFF
--- a/packages/expo-cli/src/credentials/views/SetupIosPush.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosPush.ts
@@ -1,6 +1,10 @@
+import get from 'lodash/get';
+import { prompt } from 'inquirer';
 import * as iosPushView from './IosPushCredentials';
 
 import { Context, IView } from '../context';
+import { Question } from '../../prompt';
+import log from '../../log';
 
 export class SetupIosPush implements IView {
   _experienceName: string;
@@ -15,6 +19,29 @@ export class SetupIosPush implements IView {
   async open(ctx: Context): Promise<IView | null> {
     if (!ctx.user) {
       throw new Error(`This workflow requires you to be logged in.`);
+    }
+
+    // TODO: Remove this on Nov 2020 when Apple no longer accepts deprecated push certs
+    const appCredentials = await ctx.ios.getAppCredentials(
+      this._experienceName,
+      this._bundleIdentifier
+    );
+    const deprecatedPushId = get(appCredentials, 'credentials.pushId');
+    const deprecatedPushP12 = get(appCredentials, 'credentials.pushP12');
+    const deprecatedPushPassword = get(appCredentials, 'credentials.pushPassword');
+    if (deprecatedPushId && deprecatedPushP12 && deprecatedPushPassword) {
+      const confirmQuestion: Question = {
+        type: 'confirm',
+        name: 'confirm',
+        message: `We've detected legacy Push Certificates on file. Would you like to upgrade to the newer standard?`,
+        pageSize: Infinity,
+      };
+
+      const { confirm } = await prompt(confirmQuestion);
+      if (!confirm) {
+        log(`Using Deprecated Push Cert: ${deprecatedPushId} on file`);
+        return null;
+      }
     }
 
     const configuredPushKey = await ctx.ios.getPushKey(


### PR DESCRIPTION
skip setting up apns if users already have the deprecated push certs and dont want to upgrade