### PR TITLE
Always show web in dev tools

### DIFF
--- a/packages/dev-tools/common/state.js
+++ b/packages/dev-tools/common/state.js
@@ -166,6 +166,62 @@ function updateLayout(client, id, input) {
   });
 }
 
+export const openBrowser = async props => {
+  const id = new Date().getTime();
+
+  // NOTE(jim): Breaks out of publishing modal.
+  props.dispatch({
+    type: 'UPDATE',
+    state: {
+      isPublishing: false,
+    },
+  });
+
+  props.dispatch({
+    type: 'ADD_TOAST',
+    toast: {
+      id,
+      name: 'info',
+      text: `Attempting to open the project in a web browser...`,
+    },
+  });
+
+  let hasError = false;
+  try {
+    let result = await props.client.mutate({
+      mutation: gql`
+        mutation OpenWeb {
+          openWeb {
+            error
+          }
+        }
+      `,
+      variables: {},
+    });
+    if (result.data.openWeb.error) {
+      hasError = true;
+    }
+  } catch (e) {
+    hasError = true;
+  }
+
+  if (!hasError) {
+    props.dispatch({
+      type: 'REMOVE_TOAST',
+      id,
+    });
+  } else {
+    props.dispatch({
+      type: 'ADD_TOAST',
+      toast: {
+        id,
+        name: 'error',
+        text: `Error opening for web. Check logs for details.`,
+      },
+    });
+  }
+};
+
 export const openSimulator = async (platform, props) => {
   const id = new Date().getTime();
   // NOTE(jim): Breaks out of publishing modal.

--- a/packages/dev-tools/components/ProjectManager.js
+++ b/packages/dev-tools/components/ProjectManager.js
@@ -178,6 +178,7 @@ class ProjectManager extends React.Component {
         onUpdateState={this.props.onUpdateState}
         onRecipientChange={this._handleRecipientChange}
         onSimulatorClickIOS={this.props.onSimulatorClickIOS}
+        onStartWebClick={this.props.onStartWebClick}
         onSimulatorClickAndroid={this.props.onSimulatorClickAndroid}
         onDeviceClickIOS={this._handleDeviceClickIOS}
         onDeviceClickAndroid={this._handleDeviceClickAndroid}

--- a/packages/dev-tools/components/ProjectManagerSidebarOptions.js
+++ b/packages/dev-tools/components/ProjectManagerSidebarOptions.js
@@ -137,23 +137,13 @@ export default class ProjectManagerSidebarOptions extends React.Component {
         <div className={STYLES_CONTENT_GROUP} onClick={this.props.onSimulatorClickAndroid}>
           <span className={STYLES_CONTENT_GROUP_LEFT}>Run on Android device/emulator</span>
         </div>
-
         <div className={STYLES_CONTENT_GROUP} onClick={this.props.onSimulatorClickIOS}>
           <span className={STYLES_CONTENT_GROUP_LEFT}>Run on iOS simulator</span>
         </div>
 
-        {this.props.processInfo.webAppUrl ? (
-          <a
-            className={STYLES_CONTENT_GROUP}
-            href={this.props.processInfo.webAppUrl}
-            target="_blank">
-            <span className={STYLES_CONTENT_GROUP_LEFT}>Run in the web browser</span>
-          </a>
-        ) : (
-          <div className={STYLES_CONTENT_GROUP} onClick={this.props.onStartWebClick}>
-            <span className={STYLES_CONTENT_GROUP_LEFT}>Start Expo Web</span>
-          </div>
-        )}
+        <a className={STYLES_CONTENT_GROUP} onClick={this.props.onStartWebClick}>
+          <span className={STYLES_CONTENT_GROUP_LEFT}>Run in web browser</span>
+        </a>
 
         <ContentGroup header={sendHeader} isActive={isSendFormVisible}>
           <InputWithButton
@@ -165,7 +155,6 @@ export default class ProjectManagerSidebarOptions extends React.Component {
             Send
           </InputWithButton>
         </ContentGroup>
-
         {this.props.user ? (
           <div className={STYLES_CONTENT_GROUP} onClick={this._handleShowPublishView}>
             <span className={STYLES_CONTENT_GROUP_LEFT}>Publish or republish project…</span>
@@ -174,7 +163,6 @@ export default class ProjectManagerSidebarOptions extends React.Component {
             </span>
           </div>
         ) : null}
-
         <div className={STYLES_URL_SECTION}>
           <SettingsControl
             onClick={this.props.onToggleProductionMode}

--- a/packages/dev-tools/components/ProjectManagerSidebarOptions.js
+++ b/packages/dev-tools/components/ProjectManagerSidebarOptions.js
@@ -147,9 +147,13 @@ export default class ProjectManagerSidebarOptions extends React.Component {
             className={STYLES_CONTENT_GROUP}
             href={this.props.processInfo.webAppUrl}
             target="_blank">
-            <span className={STYLES_CONTENT_GROUP_LEFT}>Run on web browser</span>
+            <span className={STYLES_CONTENT_GROUP_LEFT}>Run in the web browser</span>
           </a>
-        ) : null}
+        ) : (
+          <div className={STYLES_CONTENT_GROUP} onClick={this.props.onStartWebClick}>
+            <span className={STYLES_CONTENT_GROUP_LEFT}>Start Expo Web</span>
+          </div>
+        )}
 
         <ContentGroup header={sendHeader} isActive={isSendFormVisible}>
           <InputWithButton

--- a/packages/dev-tools/components/QRCode.js
+++ b/packages/dev-tools/components/QRCode.js
@@ -34,6 +34,7 @@ export default class QRCode extends React.Component {
     if (!this.props.url) return null;
     return (
       <div className={STYLES_CONTAINER}>
+        {/* TODO: size should be a number not a string */}
         <QRCodeReact renderAs="svg" size="100%" value={this.props.url} />
       </div>
     );

--- a/packages/dev-tools/pages/index.js
+++ b/packages/dev-tools/pages/index.js
@@ -181,7 +181,7 @@ class IndexPageContents extends React.Component {
   _handleChangeSectionCount = count => State.sectionCount({ count }, this.props);
   _handleUpdateState = options => State.update(options, this.props);
   _handleSimulatorClickIOS = () => State.openSimulator('IOS', this.props);
-  _handleStartWebClick = () => State.openSimulator('WEB', this.props);
+  _handleStartWebClick = () => State.openBrowser(this.props);
   _handleSimulatorClickAndroid = () => State.openSimulator('ANDROID', this.props);
   _handleHostTypeClick = hostType => State.setHostType({ hostType }, this.props);
   _handlePublishProject = options => State.publishProject(options, this.props);

--- a/packages/dev-tools/pages/index.js
+++ b/packages/dev-tools/pages/index.js
@@ -181,6 +181,7 @@ class IndexPageContents extends React.Component {
   _handleChangeSectionCount = count => State.sectionCount({ count }, this.props);
   _handleUpdateState = options => State.update(options, this.props);
   _handleSimulatorClickIOS = () => State.openSimulator('IOS', this.props);
+  _handleStartWebClick = () => State.openSimulator('WEB', this.props);
   _handleSimulatorClickAndroid = () => State.openSimulator('ANDROID', this.props);
   _handleHostTypeClick = hostType => State.setHostType({ hostType }, this.props);
   _handlePublishProject = options => State.publishProject(options, this.props);
@@ -425,6 +426,7 @@ class IndexPageContents extends React.Component {
           onToggleProductionMode={this._handleToggleProductionMode}
           onHostTypeClick={this._handleHostTypeClick}
           onSimulatorClickIOS={this._handleSimulatorClickIOS}
+          onStartWebClick={this._handleStartWebClick}
           onSimulatorClickAndroid={this._handleSimulatorClickAndroid}
           onSectionDrag={this._handleSectionDrag}
           onSectionDismiss={this._handleSectionDismiss}

--- a/packages/expo-cli/src/commands/start/TerminalUI.js
+++ b/packages/expo-cli/src/commands/start/TerminalUI.js
@@ -40,13 +40,12 @@ const printHelp = () => {
 
 const printUsage = async (projectDir, options = {}) => {
   const { dev } = await ProjectSettings.readAsync(projectDir);
-  const { exp } = await readConfigJsonAsync(projectDir);
   const openDevToolsAtStartup = await UserSettings.getAsync('openDevToolsAtStartup', true);
   const username = await UserManager.getCurrentUsernameAsync();
   const devMode = dev ? 'development' : 'production';
   const androidInfo = `${b`a`} to run on ${u`A`}ndroid device/emulator`;
   const iosInfo = process.platform === 'darwin' ? `${b`i`} to run on ${u`i`}OS simulator` : '';
-  const webInfo = exp.platforms.includes('web') ? `${b`w`} to run on ${u`w`}eb` : '';
+  const webInfo = `${b`w`} to run on ${u`w`}eb`;
   const platformInfo = [androidInfo, iosInfo, webInfo].filter(Boolean).join(', or ');
   log.nested(`
  \u203A Press ${platformInfo}.
@@ -81,6 +80,7 @@ export const printServerInfo = async (projectDir, options = {}) => {
   const wrapItem = wordwrap(4, process.stdout.columns || 80);
   const item = text => '  \u2022 ' + trimStart(wrapItem(text));
   const iosInfo = process.platform === 'darwin' ? `, or ${b('i')} for iOS simulator` : '';
+  const webInfo = `${b`w`} to run on ${u`w`}eb`;
   log.nested(wrap(u('To run the app with live reloading, choose one of:')));
   if (username) {
     log.nested(
@@ -92,7 +92,7 @@ export const printServerInfo = async (projectDir, options = {}) => {
     );
   }
   log.nested(item(`Scan the QR code above with the Expo app (Android) or the Camera app (iOS).`));
-  log.nested(item(`Press ${b`a`} for Android emulator${iosInfo}.`));
+  log.nested(item(`Press ${b`a`} for Android emulator${iosInfo}, or ${webInfo}.`));
   log.nested(item(`Press ${b`e`} to send a link to your phone with email.`));
   if (!username) {
     log.nested(item(`Press ${b`s`} to sign in and enable more options.`));


### PR DESCRIPTION
Now that web support is [approaching V1](https://github.com/expo/expo/issues/6782), we should make it always visible in the dev tools.

- add web to the Terminal UI all the time
- add ability to start Webpack from dev-tools page