### PR TITLE
Fix workflow extension support in webpack config

### DIFF
--- a/packages/webpack-config/src/loaders/createBabelLoader.ts
+++ b/packages/webpack-config/src/loaders/createBabelLoader.ts
@@ -23,9 +23,9 @@ const includeModulesThatContainPaths = [
 ];
 
 const excludedRootPaths = [
-  'node_modules',
-  'bower_components',
-  '.expo',
+  '/node_modules',
+  '/bower_components',
+  '/.expo/',
   // Prevent transpiling webpack generated files.
   '(webpack)',
 ];


### PR DESCRIPTION
- fixes critical error preventing `file.expo.js` files from being transpiled properly.

fix #1477