### PR TITLE
Remove default description, name, and primary color from web config

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -348,7 +348,7 @@ export type WebPlatformConfig = {
   themeColor?: Color;
   /**
    * Provides a general description of what the pinned website does.
-   * @fallback 'expo.description', "'A Neat Expo App'"
+   * @fallback 'expo.description'
    * @pwa description
    */
   description?: string;

--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -13,7 +13,6 @@ const DEFAULT_ROOT_ID = `root`;
 const DEFAULT_BUILD_PATH = `web-build`;
 const DEFAULT_LANGUAGE_ISO_CODE = `en`;
 const DEFAULT_NO_JS_MESSAGE = `Oh no! It looks like JavaScript is not enabled in your browser.`;
-const DEFAULT_NAME = 'Expo App';
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_START_URL = '.';
 const DEFAULT_DISPLAY = 'standalone';
@@ -79,7 +78,7 @@ export function getNameFromConfig(exp: ExpoConfig = {}): { appName: string; webN
   const { web = {} } = appManifest;
 
   // rn-cli apps use a displayName value as well.
-  const appName = exp.displayName || appManifest.displayName || appManifest.name || DEFAULT_NAME;
+  const appName = exp.displayName || appManifest.displayName || appManifest.name;
   const webName = web.name || appName;
 
   return {

--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -1,7 +1,7 @@
 import JsonFile from '@expo/json-file';
 
 import { readConfigJson } from './Config';
-import { AppJSONConfig, ExpoConfig, WebPlatformConfig, WebSplashScreen } from './Config.types';
+import { AppJSONConfig, ExpoConfig } from './Config.types';
 
 const APP_JSON_FILE_NAME = 'app.json';
 
@@ -14,8 +14,6 @@ const DEFAULT_BUILD_PATH = `web-build`;
 const DEFAULT_LANGUAGE_ISO_CODE = `en`;
 const DEFAULT_NO_JS_MESSAGE = `Oh no! It looks like JavaScript is not enabled in your browser.`;
 const DEFAULT_NAME = 'Expo App';
-const DEFAULT_THEME_COLOR = '#4630EB';
-const DEFAULT_DESCRIPTION = 'A Neat Expo App';
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_START_URL = '.';
 const DEFAULT_DISPLAY = 'standalone';
@@ -110,8 +108,8 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
   const rootId = webBuild.rootId || DEFAULT_ROOT_ID;
   const buildOutputPath = getWebOutputPath(appJSON);
   const publicPath = sanitizePublicPath(webManifest.publicPath);
-  const primaryColor = appManifest.primaryColor || DEFAULT_THEME_COLOR;
-  const description = appManifest.description || DEFAULT_DESCRIPTION;
+  const primaryColor = appManifest.primaryColor;
+  const description = appManifest.description;
   // The theme_color sets the color of the tool bar, and may be reflected in the app's preview in task switchers.
   const webThemeColor = webManifest.themeColor || primaryColor;
   const dir = webManifest.dir || DEFAULT_LANG_DIR;

--- a/packages/webpack-config/src/env/__tests__/__snapshots__/getConfig-test.js.snap
+++ b/packages/webpack-config/src/env/__tests__/__snapshots__/getConfig-test.js.snap
@@ -18,7 +18,7 @@ Object {
     "android",
     "web",
   ],
-  "primaryColor": "#4630EB",
+  "primaryColor": undefined,
   "privacy": "public",
   "sdkVersion": "33.0.0",
   "slug": "basic",
@@ -89,7 +89,7 @@ Object {
         "supportsTablet": true,
       },
     ],
-    "themeColor": "#4630EB",
+    "themeColor": undefined,
   },
 }
 `;

--- a/packages/webpack-config/tests/basic/package.json
+++ b/packages/webpack-config/tests/basic/package.json
@@ -1,5 +1,6 @@
 {
   "name": "webpack-config-basic-test",
+  "description": "A Neat Expo App",
   "version": "1.0.0",
   "main": "./index",
   "scripts": {

--- a/packages/webpack-config/tests/nextjs/package.json
+++ b/packages/webpack-config/tests/nextjs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "webpack-config-nextjs-test",
+  "description": "A Neat Expo App",
   "scripts": {
     "start": "next dev",
     "android": "expo start --android",

--- a/packages/webpack-pwa-manifest-plugin/src/__tests__/__snapshots__/config-test.js.snap
+++ b/packages/webpack-pwa-manifest-plugin/src/__tests__/__snapshots__/config-test.js.snap
@@ -4,7 +4,6 @@ exports[`matches 1`] = `
 Object {
   "background_color": "#ffffff",
   "crossorigin": undefined,
-  "description": "A Neat Expo App",
   "dir": "auto",
   "display": "standalone",
   "icons": Array [


### PR DESCRIPTION
fix #1171 

- color and description aren't needed to make a PWA run
- name will be validated elsewhere