### PR TITLE
Add ability to include modules to the babel loader

### DIFF
--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -20,6 +20,11 @@
 
 To learn more about how to use this Webpack config, check out the docs here: [Customizing the Webpack config][docs]
 
+### Contributing to the docs
+
+- [Documentation for the master branch][docs-latest]
+- [Documentation for the latest stable release][docs]
+
 ## API
 
 Running `expo customize:web` will generate this default config in your project.
@@ -74,10 +79,73 @@ Tools for resolving fields, or searching and indexing loaders and plugins.
 import /* */ '@expo/webpack-config/utils';
 ```
 
-### Contributing to the docs
+## Guides
 
-- [Documentation for the master branch][docs-latest]
-- [Documentation for the latest stable release][docs]
+### Include modules
+
+You may find that you want to include universal modules that aren't part of the default modules. You can do this by customizing the Webpack config:
+
+```ts
+const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+
+module.exports = async function(env, argv) {
+    const config = await createExpoWebpackConfigAsync({
+        ...env,
+        babel: {
+            dangerouslyAddModulePathsToTranspile: [
+                // Ensure that all packages starting with @evanbacon are transpiled.
+                '@evanbacon'
+            ]
+        }
+    }, argv);
+    return config;
+};
+```
+
+**`withUnimodules`**
+
+If you're adding support to some other Webpack config like in Storybook or Gatsby you can use the same process to include custom modules:
+
+```ts
+const { withUnimodules } = require('@expo/webpack-config/addons');
+
+module.exports = function() {
+  const someWebpackConfig = { /* Your custom Webpack config */ }
+
+  // Add Expo support...
+  const configWithExpo = withUnimodules(someWebpackConfig, {
+      projectRoot: __dirname,
+      babel: {
+          dangerouslyAddModulePathsToTranspile: [
+              // Ensure that all packages starting with @evanbacon are transpiled.
+              '@evanbacon'
+          ]
+      }
+  });
+
+  return configWithExpo;
+};
+```
+
+This method should be used instead of using the `expo.web.build.babel.include` field of the `app.json`.
+
+### Modify the babel loader
+
+If you want to modify the babel loader further, you can retrieve it using the helper method `getExpoBabelLoader` like this:
+
+```ts
+const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+const { getExpoBabelLoader } = require('@expo/webpack-config/utils');
+
+module.exports = async function(env, argv) {
+  const config = await createExpoWebpackConfigAsync(env, argv);
+  const loader = getExpoBabelLoader(config);
+  if (loader) {
+      // Modify the loader...
+  }
+  return config;
+};
+```
 
 ## License
 

--- a/packages/webpack-config/src/addons/withUnimodules.ts
+++ b/packages/webpack-config/src/addons/withUnimodules.ts
@@ -80,7 +80,10 @@ export default function withUnimodules(
     platform,
     babelProjectRoot,
     verbose: babelAppConfig.verbose,
-    include: babelAppConfig.include,
+    include: [
+      ...(babelAppConfig.include || []),
+      ...(env.babel?.dangerouslyAddModulePathsToTranspile || []),
+    ],
     use: babelAppConfig.use,
   });
 

--- a/packages/webpack-config/src/loaders/__tests__/createBabelLoader-test.js
+++ b/packages/webpack-config/src/loaders/__tests__/createBabelLoader-test.js
@@ -2,7 +2,7 @@
 import path from 'path';
 
 import { conditionMatchesFile, getRules } from '../../utils/search';
-import { getBabelLoaderRuleFromEnv } from '../createAllLoaders';
+import { getBabelLoaderRule } from '../createAllLoaders';
 
 const projectRoot = path.resolve(__dirname, '../../../tests/basic');
 
@@ -14,7 +14,7 @@ const env = {
 
 const rules = getRules({
   module: {
-    rules: [getBabelLoaderRuleFromEnv(env)],
+    rules: [getBabelLoaderRule(env)],
   },
 });
 for (const library of [

--- a/packages/webpack-config/src/loaders/createBabelLoader.ts
+++ b/packages/webpack-config/src/loaders/createBabelLoader.ts
@@ -82,7 +82,7 @@ function generateCacheIdentifier(projectRoot: string, version: string = '1'): st
  * @internal
  */
 export function createBabelLoaderFromEnvironment(
-  env: Pick<Environment, 'locations' | 'projectRoot' | 'config' | 'mode' | 'platform'>
+  env: Pick<Environment, 'babel' | 'locations' | 'projectRoot' | 'config' | 'mode' | 'platform'>
 ): Rule {
   const locations = env.locations || getPaths(env.projectRoot);
   const appConfig = env.config || getConfig(env);
@@ -96,7 +96,7 @@ export function createBabelLoaderFromEnvironment(
     platform: env.platform,
     babelProjectRoot: babel.root || locations.root,
     verbose: babel.verbose,
-    include: babel.include,
+    include: [...(babel.include || []), ...(env.babel?.dangerouslyAddModulePathsToTranspile || [])],
     use: babel.use,
   });
 }
@@ -197,6 +197,7 @@ export default function createBabelLoader({
         ...(customUseOptions || {}),
 
         caller: {
+          __dangerous_rule_id: 'expo-babel-loader',
           bundler: 'webpack',
           platform,
           mode,

--- a/packages/webpack-config/src/loaders/index.ts
+++ b/packages/webpack-config/src/loaders/index.ts
@@ -2,10 +2,8 @@ export {
   imageLoaderRule,
   fallbackLoaderRule,
   styleLoaderRule,
-  getBabelLoaderRuleFromEnv,
   getBabelLoaderRule,
   getHtmlLoaderRule,
-  getAllLoaderRules,
   default as createAllLoaders,
 } from './createAllLoaders';
 export { default as createBabelLoader } from './createBabelLoader';

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -30,6 +30,9 @@ export type InputEnvironment = {
     statsFilename: string;
     reportFilename: string;
   };
+  babel?: {
+    dangerouslyAddModulePathsToTranspile: string[];
+  };
 };
 
 export type Environment = {
@@ -44,6 +47,9 @@ export type Environment = {
   removeUnusedImportExports?: boolean;
   pwa?: boolean;
   report?: Report;
+  babel?: {
+    dangerouslyAddModulePathsToTranspile: string[];
+  };
 };
 
 export type Report = {

--- a/packages/webpack-config/src/utils/__tests__/search-test.js
+++ b/packages/webpack-config/src/utils/__tests__/search-test.js
@@ -7,6 +7,18 @@ import * as LoaderUtils from '../search';
 
 const projectRoot = path.resolve(__dirname, '../../../tests/basic');
 
+it(`getExpoBabelLoader gets the Expo babel loader`, async () => {
+  const config = await createWebpackConfigAsync({
+    projectRoot,
+    mode: 'development',
+    platform: 'web',
+  });
+
+  const loader = LoaderUtils.getExpoBabelLoader(config);
+  expect(loader).toBeDefined();
+  expect(loader.use.options.caller.__dangerous_rule_id).toBe('expo-babel-loader');
+});
+
 it(`getPluginsByName gets a known plugin`, async () => {
   const config = await createWebpackConfigAsync({
     projectRoot,

--- a/packages/webpack-config/src/utils/search.ts
+++ b/packages/webpack-config/src/utils/search.ts
@@ -7,6 +7,7 @@ import {
   Configuration,
   Entry,
   Plugin,
+  Rule,
   RuleSetCondition,
   RuleSetLoader,
   RuleSetRule,
@@ -79,6 +80,30 @@ export function getRulesAsItems(rules: RuleSetRule[]): RuleItem[] {
 export function getRules(config: AnyConfiguration): RuleItem[] {
   const { preLoaders = [], postLoaders = [], rules = [] } = config.module || {};
   return getRulesAsItems(getRulesFromRules([...preLoaders, ...postLoaders, ...rules]));
+}
+
+/**
+ * Get the babel-loader rule created by `@expo/webpack-config/loaders`
+ *
+ * @param config
+ * @category utils
+ */
+export function getExpoBabelLoader(config: AnyConfiguration): Rule | null {
+  const { preLoaders = [], postLoaders = [], rules = [] } = config.module || {};
+  const currentRules = getRulesAsItems(
+    getRulesFromRules([...preLoaders, ...postLoaders, ...rules])
+  );
+  for (const ruleItem of currentRules) {
+    const rule: any = ruleItem.rule;
+    if (
+      rule.use &&
+      typeof rule.use === 'object' &&
+      rule.use.options?.caller?.__dangerous_rule_id === 'expo-babel-loader'
+    ) {
+      return rule;
+    }
+  }
+  return null;
 }
 
 /**

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -112,7 +112,6 @@ export default async function(
   const { publicPath, publicUrl } = getPublicPaths(env);
 
   const { build: buildConfig = {} } = config.web || {};
-  const { babel: babelAppConfig = {} } = buildConfig;
 
   const devtool = getDevtool(
     { production: isProd, development: isDev },
@@ -120,8 +119,6 @@ export default async function(
       devtool: Options.Devtool;
     }
   );
-
-  const babelProjectRoot = babelAppConfig.root || locations.root;
 
   const appEntry: string[] = [];
 


### PR DESCRIPTION
A highly requested feature for including modules in a better way than through the `app.json`.