### PR TITLE
[xdl][Project] Support app.config.js

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -85,6 +85,7 @@
     "semver": "5.5.0",
     "serialize-error": "^5.0.0",
     "slugid": "1.1.0",
+    "slugify": "^1.3.6",
     "source-map-support": "0.4.18",
     "split": "1.0.1",
     "tar": "4.4.6",

--- a/packages/xdl/src/Config.ts
+++ b/packages/xdl/src/Config.ts
@@ -13,7 +13,7 @@ import * as ProjectSettings from './ProjectSettings';
  */
 export async function getProjectConfigAsync(
   projectRoot: string,
-  options: Partial<GetConfigOptions>
+  options: Partial<GetConfigOptions> = {}
 ): Promise<ProjectConfig> {
   let { mode } = options;
   if (!mode || !['development', 'production'].includes(mode)) {

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -291,9 +291,9 @@ async function _resolveManifestAssets(
 ) {
   try {
     // Asset fields that the user has set
-    const assetSchemas = (await ExpSchema.getAssetSchemasAsync(
-      manifest.sdkVersion
-    )).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
+    const assetSchemas = (
+      await ExpSchema.getAssetSchemasAsync(manifest.sdkVersion)
+    ).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
 
     // Get the URLs
     const urls = await Promise.all(
@@ -360,7 +360,7 @@ export async function getSlugAsync(
   projectRoot: string,
   {
     mode = 'production',
-    ...options,
+    ...options
   }: { mode?: 'production' | 'development'; [key: string]: any } = {}
 ): Promise<string> {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode: options.mode });
@@ -1872,7 +1872,7 @@ export async function startReactNativeServerAsync(
       ...process.env,
       REACT_NATIVE_APP_ROOT: projectRoot,
       ELECTRON_RUN_AS_NODE: '1',
-      ...nodePath ? { NODE_PATH: nodePath } : {},
+      ...(nodePath ? { NODE_PATH: nodePath } : {}),
     },
     silent: true,
   });

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -4,13 +4,11 @@ import {
   Platform,
   configFilename,
   getConfig,
-  projectHasModule,
-  readConfigJson,
-  readConfigJsonAsync,
   readExpRcAsync,
   resolveModule,
 } from '@expo/config';
 
+import slug from 'slugify';
 import { getManagedExtensions } from '@expo/config/paths';
 import JsonFile from '@expo/json-file';
 import ngrok from '@expo/ngrok';
@@ -47,7 +45,7 @@ import * as Analytics from './Analytics';
 import * as Android from './Android';
 import Api from './Api';
 import ApiV2 from './ApiV2';
-import Config from './Config';
+import Config, { getProjectConfigAsync } from './Config';
 import * as ExponentTools from './detach/ExponentTools';
 import StandaloneContext from './detach/StandaloneContext';
 import * as DevSession from './DevSession';
@@ -293,9 +291,9 @@ async function _resolveManifestAssets(
 ) {
   try {
     // Asset fields that the user has set
-    const assetSchemas = (
-      await ExpSchema.getAssetSchemasAsync(manifest.sdkVersion)
-    ).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
+    const assetSchemas = (await ExpSchema.getAssetSchemasAsync(
+      manifest.sdkVersion
+    )).filter((assetSchema: ExpSchema.AssetSchema) => get(manifest, assetSchema.fieldPath));
 
     // Get the URLs
     const urls = await Promise.all(
@@ -362,7 +360,7 @@ export async function getSlugAsync(
   projectRoot: string,
   {
     mode = 'production',
-    ...options
+    ...options,
   }: { mode?: 'production' | 'development'; [key: string]: any } = {}
 ): Promise<string> {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode: options.mode });
@@ -1008,7 +1006,7 @@ async function _getPublishExpConfigAsync(
   options.releaseChannel = options.releaseChannel || 'default'; // joi default not enforcing this :/
 
   // Verify that exp/app.json and package.json exist
-  const { exp, pkg } = await readConfigJsonAsync(projectRoot);
+  const { exp, pkg } = await getProjectConfigAsync(projectRoot);
 
   if (exp.android && exp.android.config) {
     delete exp.android.config;
@@ -1395,22 +1393,25 @@ async function uploadAssetsAsync(projectRoot: string, assets: Asset[]) {
   );
 }
 
+type GetExpConfigOptions = {
+  current?: boolean;
+  mode?: string;
+  platform?: 'android' | 'ios' | 'all';
+  expIds?: string[];
+  type?: string;
+  releaseChannel?: string;
+  bundleIdentifier?: string;
+  publicUrl?: string;
+  sdkVersion?: string;
+};
+
 async function getConfigAsync(
   projectRoot: string,
-  options: {
-    current?: boolean;
-    mode?: string;
-    platform?: 'android' | 'ios' | 'all';
-    expIds?: Array<string>;
-    type?: string;
-    releaseChannel?: string;
-    bundleIdentifier?: string;
-    publicUrl?: string;
-  } = {}
+  options: Pick<GetExpConfigOptions, 'publicUrl' | 'mode' | 'platform'> = {}
 ) {
   if (!options.publicUrl) {
     // get the manifest from the project directory
-    const { exp, pkg } = await readConfigJsonAsync(projectRoot);
+    const { exp, pkg } = await getProjectConfigAsync(projectRoot, { mode: options.mode as any });
     const configName = configFilename(projectRoot);
     return {
       exp,
@@ -1491,7 +1492,10 @@ function _validateOptions(options: any) {
   }
 }
 
-async function _getExpAsync(projectRoot: string, options: any) {
+async function _getExpAsync(
+  projectRoot: string,
+  options: Pick<GetExpConfigOptions, 'publicUrl' | 'mode' | 'platform'>
+) {
   const { exp, pkg, configName, configPrefix } = await getConfigAsync(projectRoot, options);
 
   if (!exp || !pkg) {
@@ -1506,30 +1510,24 @@ async function _getExpAsync(projectRoot: string, options: any) {
   if (!exp.version && 'version' in pkg && pkg.version) {
     exp.version = pkg.version;
   }
-  if (!exp.slug && 'name' in pkg && pkg.name) {
-    exp.slug = pkg.name;
+  if (!exp.name && 'name' in pkg && typeof pkg.name === 'string') {
+    exp.name = pkg.name;
+  }
+  if (!exp.slug && typeof exp.name === 'string') {
+    exp.slug = slug(exp.name.toLowerCase());
   }
   return { exp, configName, configPrefix };
 }
 
 export async function getBuildStatusAsync(
   projectRoot: string,
-  options: {
-    current?: boolean;
-    platform?: 'android' | 'ios' | 'all';
-    expIds?: Array<string>;
-    type?: string;
-    releaseChannel?: string;
-    bundleIdentifier?: string;
-    publicUrl?: string;
-    sdkVersion?: string;
-  } = {}
+  options: GetExpConfigOptions = {}
 ): Promise<BuildStatusResult> {
   const user = await UserManager.ensureLoggedInAsync();
 
   _assertValidProjectRoot(projectRoot);
   _validateOptions(options);
-  const { exp, configName, configPrefix } = await _getExpAsync(projectRoot, options);
+  const { exp } = await _getExpAsync(projectRoot, options);
 
   const api = ApiV2.clientForUser(user);
   return await api.postAsync('build/status', { manifest: exp, options });
@@ -1537,16 +1535,7 @@ export async function getBuildStatusAsync(
 
 export async function startBuildAsync(
   projectRoot: string,
-  options: {
-    current?: boolean;
-    platform?: 'android' | 'ios' | 'all';
-    expIds?: Array<string>;
-    type?: string;
-    releaseChannel?: string;
-    bundleIdentifier?: string;
-    publicUrl?: string;
-    sdkVersion?: string;
-  } = {}
+  options: GetExpConfigOptions = {}
 ): Promise<BuildCreatedResult> {
   const user = await UserManager.ensureLoggedInAsync();
 
@@ -1567,17 +1556,7 @@ export async function startBuildAsync(
 
 export async function buildAsync(
   projectRoot: string,
-  options: {
-    current?: boolean;
-    mode?: string;
-    platform?: 'android' | 'ios' | 'all';
-    expIds?: Array<string>;
-    type?: string;
-    releaseChannel?: string;
-    bundleIdentifier?: string;
-    publicUrl?: string;
-    sdkVersion?: string;
-  } = {}
+  options: GetExpConfigOptions = {}
 ): Promise<BuildStatusResult | BuildCreatedResult> {
   /**
     This function corresponds to an apiv1 call and is deprecated.
@@ -1805,7 +1784,7 @@ export async function startReactNativeServerAsync(
   await Watchman.addToPathAsync(); // Attempt to fix watchman if it's hanging
   await Watchman.unblockAndGetVersionAsync(projectRoot);
 
-  let { exp } = await readConfigJsonAsync(projectRoot);
+  let { exp } = await getProjectConfigAsync(projectRoot);
 
   let packagerPort = await _getFreePortAsync(19001); // Create packager options
 
@@ -1893,7 +1872,7 @@ export async function startReactNativeServerAsync(
       ...process.env,
       REACT_NATIVE_APP_ROOT: projectRoot,
       ELECTRON_RUN_AS_NODE: '1',
-      ...(nodePath ? { NODE_PATH: nodePath } : {}),
+      ...nodePath ? { NODE_PATH: nodePath } : {},
     },
     silent: true,
   });
@@ -2029,9 +2008,12 @@ export async function startExpoServerAsync(projectRoot: string): Promise<void> {
       // if there is a potential error in the package.json and don't want to slow
       // down the request
       Doctor.validateWithNetworkAsync(projectRoot);
-      let { exp: manifest } = readConfigJson(projectRoot);
       // Get packager opts and then copy into bundleUrlPackagerOpts
-      let packagerOpts = await ProjectSettings.getPackagerOptsAsync(projectRoot);
+      let packagerOpts = await ProjectSettings.readAsync(projectRoot);
+      let { exp: manifest } = getConfig(projectRoot, {
+        skipSDKVersionRequirement: false,
+        mode: packagerOpts.dev ? 'development' : 'production',
+      });
       let bundleUrlPackagerOpts = JSON.parse(JSON.stringify(packagerOpts));
       bundleUrlPackagerOpts.urlType = 'http';
       if (bundleUrlPackagerOpts.hostType === 'redirect') {
@@ -2410,7 +2392,7 @@ export async function startAsync(
     developerTool: Config.developerTool,
   });
 
-  let { exp } = await readConfigJsonAsync(projectRoot);
+  let { exp } = await getProjectConfigAsync(projectRoot);
   if (options.webOnly) {
     await Webpack.restartAsync(projectRoot, options);
     DevSession.startSession(projectRoot, exp, 'web');

--- a/packages/xdl/src/Versions.ts
+++ b/packages/xdl/src/Versions.ts
@@ -85,7 +85,10 @@ export async function releasedSdkVersionsAsync(): Promise<SDKVersions> {
   return pickBy(sdkVersions, (data, _sdkVersionString) => !!data.releaseNoteUrl);
 }
 
-export function gteSdkVersion(expJson: ExpoConfig, sdkVersion: string): boolean {
+export function gteSdkVersion(
+  expJson: Pick<ExpoConfig, 'sdkVersion'>,
+  sdkVersion: string
+): boolean {
   if (!expJson.sdkVersion) {
     return false;
   }
@@ -104,7 +107,10 @@ export function gteSdkVersion(expJson: ExpoConfig, sdkVersion: string): boolean 
   }
 }
 
-export function lteSdkVersion(expJson: ExpoConfig, sdkVersion: string): boolean {
+export function lteSdkVersion(
+  expJson: Pick<ExpoConfig, 'sdkVersion'>,
+  sdkVersion: string
+): boolean {
   if (!expJson.sdkVersion) {
     return false;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19028,7 +19028,7 @@ slugid@1.1.0:
   dependencies:
     uuid "^2.0.1"
 
-slugify@^1.0.2, slugify@^1.3.4:
+slugify@^1.0.2, slugify@^1.3.4, slugify@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.6.tgz#ba5fd6159b570fe4811d02ea9b1f4906677638c3"
   integrity sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ==


### PR DESCRIPTION
- _getExpAsync(): use slugify to transform config name from ThirdParty module
- Update types
- Remove unused variables
- Add support for app.config.js when starting a project on any platform
- Add support for app.config.js when getting build status, and starting a build.

## Notes

- I guess you can make config changes then refresh the client (⌘R) to see them.

# Test Plan

This effects:
- `expo start`
- `expo start:web`
- `expo publish`
- `expo url`

Each should be run with an `app.config.js` and `app.json`.

### Test Project

`app.json`
```json5
{
  "expo": {
    "version": "1.0.0"
    // ...
  }
}
```

`app.config.js`
```js
module.exports = function({ config, mode }) {
    return {
        ...config,
        name: "My Project - " + mode
    }
}
```

`App.js`
```js
import React from 'react';
import { Text } from 'react-native';
import Constants from 'expo-constants';

export default () => <Text>Data: {Constants.manifest.name}</Text>
```
