### PR TITLE
fix(dev-tools): fix an EventEmitter memory leak

### DIFF
--- a/packages/dev-tools/server/asynciterators/mergeAsyncIterators.js
+++ b/packages/dev-tools/server/asynciterators/mergeAsyncIterators.js
@@ -19,6 +19,30 @@ export default function mergeAsyncIterators(...iterators: Array<AsyncIterator>) 
       };
     },
 
+    async return() {
+      for (const iterator of iterators) {
+        if (iterator.return) {
+          await iterator.return();
+        }
+      }
+      return {
+        done: true,
+        value: undefined,
+      };
+    },
+
+    async throw(error) {
+      for (const iterator of iterators) {
+        if (iterator.throw) {
+          await iterator.throw(error);
+        }
+      }
+      return {
+        done: true,
+        value: undefined,
+      };
+    },
+
     [$$asyncIterator]() {
       return this;
     },

--- a/packages/dev-tools/server/graphql/GraphQLSchema.js
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.js
@@ -641,6 +641,7 @@ const resolvers = {
         const issueIterator = context.getIssueIterator();
         const messageIterator = context.getMessageIterator(parsedCursor);
         const iterator = mergeAsyncIterators(issueIterator, messageIterator);
+
         return {
           async next() {
             const result = await iterator.next();
@@ -653,6 +654,14 @@ const resolvers = {
               },
               done,
             };
+          },
+
+          return() {
+            return iterator.return();
+          },
+
+          throw(error) {
+            return iterator.throw(error);
           },
 
           [$$asyncIterator]() {


### PR DESCRIPTION
Fix a memory leak resulting in warnings like this to be generated by Node:
```
(node:14054) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 ADDED listeners added to [Issues]. Use emitter.setMaxListeners() to increase limit
(node:14054) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 UPDATED listeners added to [Issues]. Use emitter.setMaxListeners() to increase limit
(node:14054) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 DELETED listeners added to [Issues]. Use emitter.setMaxListeners() to increase limit
```

To reproduce the bug I refreshed the browser tab with Dev Tools in it 10+ times. After this, the  warning shown above was printed in the terminal.

The underlying cause was that each time the browser subscribed to the logs, `addListener` was called in `eventEmitterToAsyncIterator`, but the corresponding `removeListener` was never called.

There was code wrapping async iterators in the Dev Tools server, which did not implement the `return()` and `throw()` methods of the async iterator. For this reason, whenever a client disconnected, the async iterator was not cleaned up.