### PR TITLE
fix typo options.mode -> mode

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -365,7 +365,7 @@ export async function getSlugAsync(
     ...options
   }: { mode?: 'production' | 'development'; [key: string]: any } = {}
 ): Promise<string> {
-  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode: options.mode });
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode });
   if (exp.slug) {
     return exp.slug;
   }


### PR DESCRIPTION
`expod ph` was broken:
<img width="952" alt="Screen Shot 2020-02-07 at 4 04 43 PM" src="https://user-images.githubusercontent.com/1220444/74074576-92e2aa00-49c3-11ea-8316-1df1e1d6fd3c.png">

Seems like `option.mode` was used before...  `mode` is defined by destructing now.