### PR TITLE
autofill expo-updates properties on `expo publish`

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -938,9 +938,9 @@ export async function publishAsync(
           'AndroidManifest.xml'
         );
         let androidManifestXmlFile = fs.readFileSync(androidManifestXmlPath, 'utf8');
-        let expoUpdateUrlRegex = /<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="[^"]*" \/>/;
-        let expoSdkVersionRegex = /<meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="[^"]*" \/>/;
-        let expoReleaseChannelRegex = /<meta-data android:name="expo.modules.updates.EXPO_RELEASE_CHANNEL" android:value="[^"]*" \/>/;
+        let expoUpdateUrlRegex = /<meta-data[^>]+"expo.modules.updates.EXPO_UPDATE_URL"[^>]+\/>/;
+        let expoSdkVersionRegex = /<meta-data[^>]+"expo.modules.updates.EXPO_SDK_VERSION"[^>]+\/>/;
+        let expoReleaseChannelRegex = /<meta-data[^>]+"expo.modules.updates.EXPO_RELEASE_CHANNEL"[^>]+\/>/;
 
         let expoUpdateUrlTag = `<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="${fullManifestUrl}" />`;
         let expoSdkVersionTag = `<meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="${exp.sdkVersion}" />`;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -932,12 +932,12 @@ export async function publishAsync(
           'AndroidManifest.xml'
         );
         let androidManifestXmlFile = fs.readFileSync(androidManifestXmlPath, 'utf8');
-        let expoAppUrlRegex = /<meta-data android:name="expo.modules.updates.EXPO_APP_URL" android:value="[^"]*" \/>/;
-        if (androidManifestXmlFile.search(expoAppUrlRegex) < 0) {
+        let expoUpdateUrlRegex = /<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="[^"]*" \/>/;
+        if (androidManifestXmlFile.search(expoUpdateUrlRegex) < 0) {
           // try to insert the meta-data tag if it isn't found
           await ExponentTools.regexFileAsync(
             /<activity\s+android:name=".MainActivity"/,
-            `<meta-data android:name="expo.modules.updates.EXPO_APP_URL" android:value="${fullManifestUrl}" />
+            `<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="${fullManifestUrl}" />
 
       <activity
         android:name=".MainActivity"`,
@@ -945,8 +945,8 @@ export async function publishAsync(
           );
         } else {
           await ExponentTools.regexFileAsync(
-            expoAppUrlRegex,
-            `<meta-data android:name="expo.modules.updates.EXPO_APP_URL" android:value="${fullManifestUrl}" />`,
+            expoUpdateUrlRegex,
+            `<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="${fullManifestUrl}" />`,
             androidManifestXmlPath
           );
         }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -868,12 +868,12 @@ export async function publishAsync(
           shellPlist.releaseChannel = options.releaseChannel;
           return shellPlist;
         });
-      } else if (fs.existsSync(path.join(supportingDirectory, 'expo-config.plist'))) {
-        // This is an app with expo-updates installed, set properties in expo-config.plist
-        await IosPlist.modifyAsync(supportingDirectory, 'expo-config', (configPlist: any) => {
-          configPlist.updateUrl = fullManifestUrl;
-          configPlist.releaseChannel = options.releaseChannel;
-          configPlist.sdkVersion = exp.sdkVersion;
+      } else if (fs.existsSync(path.join(supportingDirectory, 'Expo.plist'))) {
+        // This is an app with expo-updates installed, set properties in Expo.plist
+        await IosPlist.modifyAsync(supportingDirectory, 'Expo', (configPlist: any) => {
+          configPlist.EXUpdatesURL = fullManifestUrl;
+          configPlist.EXUpdatesReleaseChannel = options.releaseChannel;
+          configPlist.EXUpdatesSDKVersion = exp.sdkVersion;
           return configPlist;
         });
       }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -868,7 +868,8 @@ export async function publishAsync(
           shellPlist.releaseChannel = options.releaseChannel;
           return shellPlist;
         });
-      } else if (fs.existsSync(path.join(supportingDirectory, 'Expo.plist'))) {
+      }
+      if (fs.existsSync(path.join(supportingDirectory, 'Expo.plist'))) {
         // This is an app with expo-updates installed, set properties in Expo.plist
         await IosPlist.modifyAsync(supportingDirectory, 'Expo', (configPlist: any) => {
           configPlist.EXUpdatesURL = fullManifestUrl;
@@ -926,7 +927,8 @@ export async function publishAsync(
           `RELEASE_CHANNEL = "${options.releaseChannel}"`,
           constantsPath
         );
-      } else {
+      }
+      if (pkg.dependencies['expo-updates']) {
         // This is an app with expo-updates installed, so set the applicable meta-data properties in
         // AndroidManifest.xml
         let androidManifestXmlPath = path.join(

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -871,7 +871,7 @@ export async function publishAsync(
       } else if (fs.existsSync(path.join(supportingDirectory, 'expo-config.plist'))) {
         // This is an app with expo-updates installed, set properties in expo-config.plist
         await IosPlist.modifyAsync(supportingDirectory, 'expo-config', (configPlist: any) => {
-          configPlist.remoteUrl = fullManifestUrl;
+          configPlist.updateUrl = fullManifestUrl;
           configPlist.releaseChannel = options.releaseChannel;
           configPlist.sdkVersion = exp.sdkVersion;
           return configPlist;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -863,11 +863,13 @@ export async function publishAsync(
       const context = StandaloneContext.createUserContext(projectRoot, exp);
       const { supportingDirectory } = IosWorkspace.getPaths(context);
       if (fs.existsSync(path.join(supportingDirectory, 'EXShell.plist'))) {
+        // This is an ExpoKit app, set properties in EXShell.plist
         await IosPlist.modifyAsync(supportingDirectory, 'EXShell', (shellPlist: any) => {
           shellPlist.releaseChannel = options.releaseChannel;
           return shellPlist;
         });
       } else if (fs.existsSync(path.join(supportingDirectory, 'expo-config.plist'))) {
+        // This is an app with expo-updates installed, set properties in expo-config.plist
         await IosPlist.modifyAsync(supportingDirectory, 'expo-config', (configPlist: any) => {
           configPlist.remoteUrl = fullManifestUrl;
           configPlist.releaseChannel = options.releaseChannel;
@@ -900,6 +902,7 @@ export async function publishAsync(
         'AppConstants.java'
       );
       if (fs.existsSync(constantsPath)) {
+        // This is an ExpoKit app
         // We need to add EmbeddedResponse instances on Android to tell the runtime
         // that the shell app manifest and bundle is packaged.
         await ExponentTools.deleteLinesInFileAsync(
@@ -923,6 +926,8 @@ export async function publishAsync(
           constantsPath
         );
       } else {
+        // This is an app with expo-updates installed, so set the applicable meta-data properties in
+        // AndroidManifest.xml
         let androidManifestXmlPath = path.join(
           projectRoot,
           'android',


### PR DESCRIPTION
partial step of expo/expo#6517

In order to preserve the current functionality of ExpoKit updates in the new expo-updates unimodule, we want to set certain properties in the native iOS and Android projects when running `expo publish`. This PR adds that functionality for the properties defined in expo/expo#6625 and expo/expo#6787.