### PR TITLE
migrate publish commands to default to api v2

### DIFF
--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -57,17 +57,7 @@ export default (program: any) => {
       const { exp } = await readConfigJsonAsync(projectDir);
 
       let result: any;
-      if (process.env.EXPO_NEXT_API) {
-        const api = ApiV2.clientForUser(user);
-        result = await api.postAsync('publish/history', {
-          owner: exp.owner,
-          slug: await Project.getSlugAsync(projectDir, options),
-          version: VERSION,
-          releaseChannel: options.releaseChannel,
-          count: options.count,
-          platform: options.platform,
-        });
-      } else {
+      if (process.env.EXPO_LEGACY_API === 'true') {
         // TODO(ville): move request from multipart/form-data to JSON once supported by the endpoint.
         let formData = new FormData();
         formData.append('queryType', 'history');
@@ -88,6 +78,16 @@ export default (program: any) => {
 
         result = await Api.callMethodAsync('publishInfo', [], 'post', null, {
           formData,
+        });
+      } else {
+        const api = ApiV2.clientForUser(user);
+        result = await api.postAsync('publish/history', {
+          owner: exp.owner,
+          slug: await Project.getSlugAsync(projectDir, options),
+          version: VERSION,
+          releaseChannel: options.releaseChannel,
+          count: options.count,
+          platform: options.platform,
         });
       }
 
@@ -155,14 +155,7 @@ export default (program: any) => {
       const slug = await Project.getSlugAsync(projectDir, options);
 
       let result: any;
-      if (process.env.EXPO_NEXT_API) {
-        const api = ApiV2.clientForUser(user);
-        result = await api.postAsync('publish/details', {
-          owner: exp.owner,
-          publishId: options.publishId,
-          slug,
-        });
-      } else {
+      if (process.env.EXPO_LEGACY_API === 'true') {
         let formData = new FormData();
         formData.append('queryType', 'details');
 
@@ -174,6 +167,13 @@ export default (program: any) => {
 
         result = await Api.callMethodAsync('publishInfo', null, 'post', null, {
           formData,
+        });
+      } else {
+        const api = ApiV2.clientForUser(user);
+        result = await api.postAsync('publish/details', {
+          owner: exp.owner,
+          publishId: options.publishId,
+          slug,
         });
       }
 

--- a/packages/expo-cli/src/commands/publish.js
+++ b/packages/expo-cli/src/commands/publish.js
@@ -64,16 +64,16 @@ export async function action(projectDir: string, options: Options = {}) {
   } = await Exp.getPublishInfoAsync(projectDir);
 
   let buildStatus;
-  if (process.env.EXPO_NEXT_API) {
-    buildStatus = await Project.getBuildStatusAsync(projectDir, {
+  if (process.env.EXPO_LEGACY_API === 'true') {
+    buildStatus = await Project.buildAsync(projectDir, {
+      mode: 'status',
       platform: 'all',
       current: true,
       releaseChannel: options.releaseChannel,
       sdkVersion,
     });
   } else {
-    buildStatus = await Project.buildAsync(projectDir, {
-      mode: 'status',
+    buildStatus = await Project.getBuildStatusAsync(projectDir, {
       platform: 'all',
       current: true,
       releaseChannel: options.releaseChannel,


### PR DESCRIPTION
Checked commands:

```
export EXPO_LOCAL=1

expod p
EXPO_LEGACY_API=true expod p
expod ph
EXPO_LEGACY_API=true expod ph
expod pd
EXPO_LEGACY_API=true expod pd

```

Work and call the appropriate endpoints.