### PR TITLE
[webpack-config] Add prop to disable offline support

### DIFF
--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -39,45 +39,44 @@ module.exports = async function(env, argv) {
 };
 ```
 
-### addons
+## Types
 
-For composing features into an existing Webpack config.
+### `Environment`
 
-```js
-import /* */ '@expo/webpack-config/addons';
-```
+The main options used to configure how `@expo/webpack-config` works.
 
-### env
+| name                        | type                                    | default     | description                                                                     |
+| --------------------------- | --------------------------------------- | ----------- | ------------------------------------------------------------------------------- |
+| `projectRoot`               | `string`                                | required    | Root of the Expo project.                                                       |
+| `https`                     | `boolean`                               | `false`     | Should the dev server use https protocol.                                       |
+| `offline`                   | `boolean`                               | `true`      | Passing `true` will disable offline support and skip adding a service worker.   |
+| `mode`                      | `Mode`                                  | required    | The Webpack mode to bundle the project in.                                      |
+| `platform`                  | [`ExpoPlatform`](#ExpoPlatform)         | required    | The target platform to bundle for. Only `web` and `electron` are supported.     |
+| `removeUnusedImportExports` | `boolean`                               | `false`     | Enables advanced tree-shaking with deep scope analysis.                         |
+| `pwa`                       | `boolean`                               | `true`      | Generate the PWA image assets in production mode.                               |
+| `report`                    | `Report`                                | `undefined` | Configure Webpack bundle reports. Using this adds significant time to rebuilds. |
+| `babel`                     | [`ExpoBabelOptions`](#ExpoBabelOptions) | `undefined` | Control how the default Babel loader is configured.                             |
 
-Getting the config, paths, mode, and various other settings in your environment.
+### `Environment` internal
 
-```js
-import /* */ '@expo/webpack-config/env';
-```
+| name        | type         | default     | description                                                        |
+| ----------- | ------------ | ----------- | ------------------------------------------------------------------ |
+| `config`    | `ExpoConfig` | `undefined` | The Expo project config, this should be read using `@expo/config`. |
+| `locations` | `FilePaths`  | `undefined` | Paths used to locate where things are.                             |
 
-### loaders
+### `ExpoPlatform`
 
-The module rules used to load various files.
+| type                                     | description                                                                 |
+| ---------------------------------------- | --------------------------------------------------------------------------- |
+| `'ios' | 'android' | 'web' | 'electron'` | The target platform to bundle for. Only `web` and `electron` are supported. |
 
-```js
-import /* */ '@expo/webpack-config/loaders';
-```
+### `ExpoBabelOptions`
 
-### plugins
+Control how the default Babel loader is configured.
 
-Custom versions of Webpack Plugins that are optimized for use with React Native.
-
-```js
-import /* */ '@expo/webpack-config/plugins';
-```
-
-### utils
-
-Tools for resolving fields, or searching and indexing loaders and plugins.
-
-```js
-import /* */ '@expo/webpack-config/utils';
-```
+| name                                   | type       | default     | description                                                               |
+| -------------------------------------- | ---------- | ----------- | ------------------------------------------------------------------------- |
+| `dangerouslyAddModulePathsToTranspile` | `string[]` | `undefined` | Add the names of node_modules that should be included transpilation step. |
 
 ## Guides
 
@@ -89,16 +88,19 @@ You may find that you want to include universal modules that aren't part of the 
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
 module.exports = async function(env, argv) {
-    const config = await createExpoWebpackConfigAsync({
-        ...env,
-        babel: {
-            dangerouslyAddModulePathsToTranspile: [
-                // Ensure that all packages starting with @evanbacon are transpiled.
-                '@evanbacon'
-            ]
-        }
-    }, argv);
-    return config;
+  const config = await createExpoWebpackConfigAsync(
+    {
+      ...env,
+      babel: {
+        dangerouslyAddModulePathsToTranspile: [
+          // Ensure that all packages starting with @evanbacon are transpiled.
+          '@evanbacon',
+        ],
+      },
+    },
+    argv
+  );
+  return config;
 };
 ```
 
@@ -110,17 +112,19 @@ If you're adding support to some other Webpack config like in Storybook or Gatsb
 const { withUnimodules } = require('@expo/webpack-config/addons');
 
 module.exports = function() {
-  const someWebpackConfig = { /* Your custom Webpack config */ }
+  const someWebpackConfig = {
+    /* Your custom Webpack config */
+  };
 
   // Add Expo support...
   const configWithExpo = withUnimodules(someWebpackConfig, {
-      projectRoot: __dirname,
-      babel: {
-          dangerouslyAddModulePathsToTranspile: [
-              // Ensure that all packages starting with @evanbacon are transpiled.
-              '@evanbacon'
-          ]
-      }
+    projectRoot: __dirname,
+    babel: {
+      dangerouslyAddModulePathsToTranspile: [
+        // Ensure that all packages starting with @evanbacon are transpiled.
+        '@evanbacon',
+      ],
+    },
   });
 
   return configWithExpo;
@@ -141,10 +145,235 @@ module.exports = async function(env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
   const loader = getExpoBabelLoader(config);
   if (loader) {
-      // Modify the loader...
+    // Modify the loader...
   }
   return config;
 };
+```
+
+## Exports
+
+### addons
+
+For adding features to an existing Webpack config.
+
+#### `withUnimodules`
+
+```js
+import { withUnimodules } from '@expo/webpack-config/addons';
+```
+
+Wrap your existing webpack config with support for Unimodules (Expo web). ex: **Storybook** `({ config }) => withUnimodules(config)`
+
+**params**
+
+- `webpackConfig: AnyConfiguration = {}` Optional existing Webpack config to modify.
+- `env: InputEnvironment = {}` Optional [`Environment`][#environment] options for configuring what features the Webpack config supports.
+- `argv: Arguments = {}`
+
+#### `withWorkbox`
+
+Add offline support with Workbox (`workbox-webpack-plugin`).
+
+```js
+import { withWorkbox } from '@expo/webpack-config/addons';
+```
+
+#### `withOptimizations`
+
+```js
+import { withOptimizations } from '@expo/webpack-config/addons';
+```
+
+#### `withReporting`
+
+```js
+import { withReporting } from '@expo/webpack-config/addons';
+```
+
+#### `withCompression`
+
+```js
+import { withCompression } from '@expo/webpack-config/addons';
+```
+
+#### `withAlias`
+
+Add aliases for React Native web.
+
+```js
+import { withAlias } from '@expo/webpack-config/addons';
+```
+
+#### `withDevServer`
+
+```js
+import { withDevServer } from '@expo/webpack-config/addons';
+```
+
+#### `withNodeMocks`
+
+```js
+import { withNodeMocks } from '@expo/webpack-config/addons';
+```
+
+#### `withEntry`
+
+```js
+import { withEntry } from '@expo/webpack-config/addons';
+```
+
+#### `withTypeScriptAsync`
+
+```js
+import { withTypeScriptAsync } from '@expo/webpack-config/addons';
+```
+
+### env
+
+Getting the config, paths, mode, and various other settings in your environment.
+
+#### `getConfig`
+
+```js
+import { getConfig } from '@expo/webpack-config/env';
+```
+
+#### `getMode`
+
+```js
+import { getMode } from '@expo/webpack-config/env';
+```
+
+#### `validateEnvironment`
+
+```js
+import { validateEnvironment } from '@expo/webpack-config/env';
+```
+
+#### `aliases`
+
+```js
+import { aliases } from '@expo/webpack-config/env';
+```
+
+#### `getPaths`
+
+```js
+import { getPaths } from '@expo/webpack-config/env';
+```
+
+#### `getPathsAsync`
+
+```js
+import { getPathsAsync } from '@expo/webpack-config/env';
+```
+
+#### `getServedPath`
+
+```js
+import { getServedPath } from '@expo/webpack-config/env';
+```
+
+#### `getPublicPaths`
+
+```js
+import { getPublicPaths } from '@expo/webpack-config/env';
+```
+
+#### `getProductionPath`
+
+```js
+import { getProductionPath } from '@expo/webpack-config/env';
+```
+
+#### `getAbsolute`
+
+```js
+import { getAbsolute } from '@expo/webpack-config/env';
+```
+
+#### `getModuleFileExtensions`
+
+```js
+import { getModuleFileExtensions } from '@expo/webpack-config/env';
+```
+
+### loaders
+
+The module rules used to load various files.
+
+#### `imageLoaderRule`
+
+```js
+import { imageLoaderRule } from '@expo/webpack-config/loaders';
+```
+
+This is needed for webpack to import static images in JavaScript files.
+"url" loader works like "file" loader except that it embeds assets smaller than specified limit in bytes as data URLs to avoid requests.
+A missing `test` is equivalent to a match.
+
+#### `fallbackLoaderRule`
+
+```js
+import { fallbackLoaderRule } from '@expo/webpack-config/loaders';
+```
+
+"file" loader makes sure those assets get served by WebpackDevServer.
+When you `import` an asset, you get its (virtual) filename.
+In production, they would get copied to the `build` folder.
+This loader doesn't use a "test" so it will catch all modules
+that fall through the other loaders.
+
+#### `styleLoaderRule`
+
+```js
+import { styleLoaderRule } from '@expo/webpack-config/loaders';
+```
+
+Default CSS loader.
+
+### plugins
+
+```js
+import /* */ '@expo/webpack-config/plugins';
+```
+
+Custom versions of Webpack Plugins that are optimized for use with React Native.
+
+#### `ExpoDefinePlugin`
+
+```js
+import { ExpoDefinePlugin } from '@expo/webpack-config/plugins';
+```
+
+Required for `expo-constants` https://docs.expo.io/versions/latest/sdk/constants/.
+This surfaces the `app.json` (config) as an environment variable which is then parsed by `expo-constants`.
+
+#### `ExpoHtmlWebpackPlugin`
+
+```js
+import { ExpoHtmlWebpackPlugin } from '@expo/webpack-config/plugins';
+```
+
+Generates an `index.html` file with the <script> injected.
+
+#### `ExpoInterpolateHtmlPlugin`
+
+```js
+import { ExpoInterpolateHtmlPlugin } from '@expo/webpack-config/plugins';
+```
+
+Add variables to the `index.html`.
+
+### utils
+
+Tools for resolving fields, or searching and indexing loaders and plugins.
+
+#### `resolveEntryAsync`
+
+```js
+import { resolveEntryAsync } from '@expo/webpack-config/utils';
 ```
 
 ## License

--- a/packages/webpack-config/src/env/validate.ts
+++ b/packages/webpack-config/src/env/validate.ts
@@ -14,6 +14,7 @@ const environmentSchema = yup.object({
   polyfill: yup.boolean().notRequired(),
   removeUnusedImportExports: yup.boolean().default(false),
   pwa: yup.boolean().notRequired(),
+  offline: yup.boolean().notRequired(),
   projectRoot: yup.string().required(),
   mode: yup
     .mixed<'production' | 'development' | 'none'>()

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -29,5 +29,8 @@ export default async function createWebpackConfigAsync(
 
   const publicUrl = workbox.publicUrl || getPublicPaths(environment).publicUrl;
 
+  if (environment.offline === false) {
+    return config;
+  }
   return withWorkbox(config, { projectRoot: environment.projectRoot, ...workbox, publicUrl });
 }

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -25,12 +25,10 @@ export default async function createWebpackConfigAsync(
     console.warn('environment.info is deprecated');
   }
 
-  const { workbox = {} } = argv;
-
-  const publicUrl = workbox.publicUrl || getPublicPaths(environment).publicUrl;
-
   if (environment.offline === false) {
     return config;
   }
+  const { workbox = {} } = argv;
+  const publicUrl = workbox.publicUrl || getPublicPaths(environment).publicUrl;
   return withWorkbox(config, { projectRoot: environment.projectRoot, ...workbox, publicUrl });
 }

--- a/packages/webpack-config/src/loaders/createAllLoaders.ts
+++ b/packages/webpack-config/src/loaders/createAllLoaders.ts
@@ -1,9 +1,8 @@
+import { getPossibleProjectRoot } from '@expo/config/paths';
 import { Rule } from 'webpack';
 
-import { ExpoConfig } from '@expo/config';
-import { getPossibleProjectRoot } from '@expo/config/paths';
-import { Environment, FilePaths, Mode } from '../types';
-import { getConfig, getMode, getPaths } from '../env';
+import { getConfig, getPaths } from '../env';
+import { Environment } from '../types';
 import createBabelLoader from './createBabelLoader';
 import createFontLoader from './createFontLoader';
 import createWorkerLoader from './createWorkerLoader';
@@ -59,6 +58,8 @@ export const fallbackLoaderRule: Rule = {
 };
 
 /**
+ * Default CSS loader.
+ *
  * @category loaders
  */
 export const styleLoaderRule: Rule = {
@@ -96,11 +97,10 @@ export default function createAllLoaders(
 }
 
 /**
+ * Creates a Rule for loading application code and packages that work with the Expo ecosystem.
+ * This method attempts to emulate how Metro loads ES modules in the `node_modules` folder.
  *
- * @param projectRoot
- * @param param1
- * @param mode
- * @param platform
+ * @param env partial Environment object.
  * @category loaders
  */
 export function getBabelLoaderRule(
@@ -114,6 +114,7 @@ export function getBabelLoaderRule(
 
   const { web: { build: { babel = {} } = {} } = {} } = env.config;
 
+  // TODO: deprecate app.json method in favor of env.babel
   const { root, verbose, include = [], use } = babel;
 
   const babelProjectRoot = root || env.projectRoot;

--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -67,7 +67,7 @@ export function createClientEnvironment(
 }
 
 /**
- * Required for `expo-constants` https://docs.expo.io/versions/latest/sdk/constants/
+ * Required for `expo-constants` https://docs.expo.io/versions/latest/sdk/constants/.
  * This surfaces the `app.json` (config) as an environment variable which is then parsed by `expo-constants`.
  * @category plugins
  */

--- a/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
@@ -15,7 +15,7 @@ export function createNoJSComponent(message: string): string {
 }
 
 /**
- * Add variables to the `index.html`
+ * Add variables to the `index.html`.
  *
  * @category plugins
  */

--- a/packages/webpack-config/src/plugins/ExpoProgressBarPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoProgressBarPlugin.ts
@@ -7,6 +7,7 @@ import { ProgressPlugin } from 'webpack';
  * but with TypeScript support.
  *
  * @category plugins
+ * @internal
  */
 export default class ExpoProgressBarPlugin extends ProgressPlugin {
   constructor() {

--- a/packages/webpack-config/src/plugins/index.ts
+++ b/packages/webpack-config/src/plugins/index.ts
@@ -1,4 +1,4 @@
 export { default as ExpoDefinePlugin } from './ExpoDefinePlugin';
-export { default as ExpoProgressBarPlugin } from './ExpoProgressBarPlugin';
 export { default as ExpoHtmlWebpackPlugin } from './ExpoHtmlWebpackPlugin';
 export { default as ExpoInterpolateHtmlPlugin } from './ExpoInterpolateHtmlPlugin';
+export { default as ExpoProgressBarPlugin } from './ExpoProgressBarPlugin';

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -11,6 +11,8 @@ export interface DevConfiguration extends WebpackConfiguration {
 
 export type AnyConfiguration = DevConfiguration | WebpackConfiguration;
 
+type AnyObject = { [key: string]: any };
+
 export type InputEnvironment = {
   projectRoot?: string;
   platform?: 'ios' | 'android' | 'web' | 'electron';
@@ -18,12 +20,13 @@ export type InputEnvironment = {
   https?: boolean;
   production?: boolean;
   development?: boolean;
-  config?: { [key: string]: any };
+  config?: AnyObject;
   locations?: FilePaths;
   polyfill?: boolean;
   mode?: Mode;
   removeUnusedImportExports?: boolean;
   pwa?: boolean;
+  offline?: boolean;
   report?: {
     verbose: boolean;
     path: string;
@@ -36,21 +39,89 @@ export type InputEnvironment = {
 };
 
 export type Environment = {
+  /**
+   * Should the dev server use https protocol.
+   *
+   * @default false
+   */
   https: boolean;
+  /**
+   * The Expo project config, this should be read using `@expo/config`.
+   *
+   * @default undefined
+   */
   config: { [key: string]: any };
+  /**
+   * Paths used to locate where things are.
+   */
   locations: FilePaths;
+  /**
+   * Root of the Expo project.
+   */
   projectRoot: string;
-  polyfill?: boolean;
+  /**
+   * Passing `true` will disable offline support and skip adding a service worker.
+   *
+   * @default true
+   */
+  offline?: boolean;
+  /**
+   * The Webpack mode to bundle the project in.
+   */
   mode: Mode;
-  platform: 'ios' | 'android' | 'web' | 'electron';
+  /**
+   * The target platform to bundle for. Currently only `web` and `electron` are supported.
+   */
+  platform: ExpoPlatform;
+  /**
+   * Enables advanced tree-shaking with deep scope analysis.
+   *
+   * @default false
+   */
   removeUnusedImportExports?: boolean;
+  /**
+   * Generate the PWA image assets in production mode.
+   *
+   * @default true
+   */
   pwa?: boolean;
+  /**
+   * Configure Webpack bundle reports.
+   * Using this adds time to rebuilds, you should only use it in production mode.
+   *
+   * Passing an empty object defaults to `true`.
+   */
   report?: Report;
-  babel?: {
-    dangerouslyAddModulePathsToTranspile: string[];
-  };
+  /**
+   * Control how the default Babel loader is configured.
+   */
+  babel?: ExpoBabelOptions;
+  /**
+   * Includes all Babel polyfills.
+   *
+   * @deprecated
+   */
+  polyfill?: boolean;
 };
 
+/**
+ * The target platform to bundle for. Currently only `web` and `electron` are supported.
+ */
+export type ExpoPlatform = 'ios' | 'android' | 'web' | 'electron';
+
+/**
+ * Control how the default Babel loader is configured.
+ */
+export type ExpoBabelOptions = {
+  /**
+   * Add the names of node_modules that should be included transpilation step.
+   */
+  dangerouslyAddModulePathsToTranspile: string[];
+};
+
+/**
+ * Configure Webpack bundle reports.
+ */
 export type Report = {
   verbose: boolean;
   path: string;

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -162,6 +162,38 @@ export default async function(
     generatePWAImageAssets = env.pwa;
   }
 
+  const filesToCopy = [
+    {
+      from: locations.template.folder,
+      to: locations.production.folder,
+      // We generate new versions of these based on the templates
+      ignore: [
+        'expo-service-worker.js',
+        'favicon.ico',
+        'serve.json',
+        'index.html',
+        'icon.png',
+        // We copy this over in `withWorkbox` as it must be part of the Webpack `entry` and have templates replaced.
+        'register-service-worker.js',
+      ],
+    },
+    {
+      from: locations.template.serveJson,
+      to: locations.production.serveJson,
+    },
+    {
+      from: locations.template.favicon,
+      to: locations.production.favicon,
+    },
+  ];
+
+  if (env.offline !== false) {
+    filesToCopy.push({
+      from: locations.template.serviceWorker,
+      to: locations.production.serviceWorker,
+    });
+  }
+
   let webpackConfig: DevConfiguration = {
     mode,
     entry: {
@@ -183,35 +215,7 @@ export default async function(
           verbose: false,
         }),
       // Copy the template files over
-      isProd &&
-        new CopyWebpackPlugin([
-          {
-            from: locations.template.folder,
-            to: locations.production.folder,
-            // We generate new versions of these based on the templates
-            ignore: [
-              'expo-service-worker.js',
-              'favicon.ico',
-              'serve.json',
-              'index.html',
-              'icon.png',
-              // We copy this over in `withWorkbox` as it must be part of the Webpack `entry` and have templates replaced.
-              'register-service-worker.js',
-            ],
-          },
-          {
-            from: locations.template.serveJson,
-            to: locations.production.serveJson,
-          },
-          {
-            from: locations.template.favicon,
-            to: locations.production.favicon,
-          },
-          {
-            from: locations.template.serviceWorker,
-            to: locations.production.serviceWorker,
-          },
-        ]),
+      isProd && new CopyWebpackPlugin(filesToCopy),
 
       // Generate the `index.html`
       new ExpoHtmlWebpackPlugin(env),


### PR DESCRIPTION

- Added ability to disable offline mode:

```js
const createExpoWebpackConfigAsync = require('@expo/webpack-config');

module.exports = async function(env, argv) {
  const config = await createExpoWebpackConfigAsync({ ...env,  offline: false }, argv);
  return config;
};
```

- Updated docs