### PR TITLE
[expo-cli] Updated unit test setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,11 @@
 module.exports = {
   root: true,
   extends: ['universe/node'],
+  overrides: [
+    {
+      files: ['**/__tests__/*'],
+    },
+  ],
   globals: {
     jasmine: false,
   },

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "@expo/babel-preset-cli/tsconfig.base",
-  "include": ["src/**/*.ts"],
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src"
-  }
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }

--- a/packages/expo-cli/gulpfile.js
+++ b/packages/expo-cli/gulpfile.js
@@ -16,10 +16,14 @@ const paths = {
   build: 'build',
 };
 
+const tsconfig = require('./tsconfig.json');
+const excluded = tsconfig.exclude.map(exclude => '!' + exclude);
+const sourcePaths = Object.values(paths.source).concat(excluded);
+
 const tasks = {
   babel() {
     return gulp
-      .src([paths.source.js, paths.source.ts])
+      .src(sourcePaths)
       .pipe(changed(paths.build))
       .pipe(plumber())
       .pipe(sourcemaps.init())
@@ -34,7 +38,7 @@ const tasks = {
   },
 
   watchBabel(done) {
-    gulp.watch([paths.source.js, paths.source.ts], tasks.babel);
+    gulp.watch(sourcePaths, tasks.babel);
     done();
   },
 };

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -369,14 +369,6 @@ async function getAppNamesAsync(
   return { displayName, name };
 }
 
-function stripDashes(s: string): string {
-  let ret = '';
-
-  for (let c of s) {
-    if (c !== ' ' && c !== '-') {
-      ret += c;
-    }
-  }
-
-  return ret;
+export function stripDashes(s: string): string {
+  return s.replace(/\s|-/g, '');
 }

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -324,6 +324,12 @@ if (Platform.OS === 'web') {
   log.newLine();
 }
 
+/**
+ * Returns a name that adheres to Xcode and Android naming conventions.
+ *
+ * - package name: https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
+ * @param projectRoot
+ */
 async function getAppNamesAsync(
   projectRoot: string
 ): Promise<{ displayName: string; name: string }> {

--- a/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
+++ b/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
@@ -1,0 +1,11 @@
+import { stripDashes } from '../Eject';
+
+describe('stripDashes', () => {
+  it(`removes spaces and dashes from a string`, () => {
+    expect(stripDashes(' My cool-app ')).toBe('Mycoolapp');
+    expect(stripDashes(' --- - ----- ')).toBe('');
+    expect(stripDashes('-----')).toBe('');
+    expect(stripDashes(' ')).toBe('');
+    expect(stripDashes(' \n-\n-')).toBe('');
+  });
+});

--- a/packages/expo-cli/tsconfig.json
+++ b/packages/expo-cli/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "@expo/babel-preset-cli/tsconfig.base",
-  "include": ["src/**/*.ts", "package.json"],
   "compilerOptions": {
     "outDir": "build",
     "resolveJsonModule": true
   },
+  "include": ["src/**/*.ts", "package.json"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "references": [
     { "path": "../xdl" }
   ]

--- a/packages/xdl/gulp/build-tasks.js
+++ b/packages/xdl/gulp/build-tasks.js
@@ -19,10 +19,14 @@ const paths = {
   caches: 'caches',
 };
 
+const tsconfig = require('../tsconfig.json');
+const excluded = tsconfig.exclude.map(exclude => '!' + exclude);
+const sourcePaths = Object.values(paths.source).concat(excluded);
+
 const tasks = {
   babel() {
     return gulp
-      .src([paths.source.js, paths.source.ts])
+      .src(sourcePaths)
       .pipe(changed(paths.build))
       .pipe(plumber())
       .pipe(
@@ -40,7 +44,7 @@ const tasks = {
   },
 
   watchBabel(done) {
-    gulp.watch([paths.source.js, paths.source.ts], tasks.babel);
+    gulp.watch(sourcePaths, tasks.babel);
     done();
   },
 

--- a/packages/xdl/tsconfig.json
+++ b/packages/xdl/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@expo/babel-preset-cli/tsconfig.base",
   "include": ["src/**/*.ts"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src"


### PR DESCRIPTION
- Added the ability to create TS unit tests in the src next to the files they test without copying the tests or mocks into the generated build folder.
- Applied this to both of the packages with incomplete TypeScript (expo-cli and xdl).
- Created a basic test for the Eject command utils.

## Test Plan

- test runs in `test-expo-cli`