### PR TITLE
[expo-cli]  Add firebase web-config support

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -520,6 +520,14 @@ export type WebPlatformConfig = {
    * Configuration for PWA splash screens.
    */
   splash?: WebSplashScreen;
+  config?: {
+    /**
+     * [Firebase Configuration Object](https://support.google.com/firebase/answer/7015592) Firebase web configuration.
+     */
+    firebase?: {
+      [key: string]: any;
+    };
+  };
 };
 
 /**

--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -353,6 +353,13 @@ export function createEnvironmentConstants(appManifest: ExpoConfig, pwaManifestL
     android: undefined,
 
     // Use the PWA `manifest.json` as the native web manifest.
-    web,
+    web: {
+      ...web,
+
+      // Pass through config properties that are not stored in the
+      // PWA `manifest.json`, but still need to be accessible
+      // through `Constants.manifest`.
+      config: appManifest.web?.config,
+    },
   };
 }


### PR DESCRIPTION
This PR add support for putting the firebase web configuration in `app.json`. This is uses for auto-configuration of firebase on Web and to make Firebase Analytics possible on the standard Expo Client, through a pure JS Firebase Analytics tracker which requires the web-config `measurementId`.