### PR TITLE
fix: prompt before overwriting credential files

### DIFF
--- a/packages/expo-cli/src/commands/fetch/android.ts
+++ b/packages/expo-cli/src/commands/fetch/android.ts
@@ -8,7 +8,7 @@ import { Context } from '../../credentials';
 
 import log from '../../log';
 
-async function maybeRenameExistingFile(projectDir, filename) {
+async function maybeRenameExistingFile(projectDir: string, filename: string) {
   let desiredFilePath = path.resolve(projectDir, filename);
 
   if (await fs.pathExists(desiredFilePath)) {


### PR DESCRIPTION
Using the `expo fetch:android:*` commands, users can overwrite previously downloaded keystores, so we should prompt them to rename the new file, or confirm the overwrite

Defaults to overwrite in `non-interactive` mode