### PR TITLE
[expo-cli] Refactor and test the upgrade command

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -221,8 +221,8 @@ function parseAndValidateRootConfig(
     );
   }
   return {
-    exp,
-    rootConfig: outputRootConfig,
+    exp: { ...exp },
+    rootConfig: { ...outputRootConfig },
   };
 }
 
@@ -273,7 +273,7 @@ export async function writeConfigJsonAsync(
 ): Promise<ProjectConfig> {
   const { configPath } = findConfigFile(projectRoot);
   let { exp, pkg, rootConfig } = await readConfigJsonAsync(projectRoot);
-  exp = { ...exp, ...options };
+  exp = { ...rootConfig.expo, ...options };
   rootConfig = { ...rootConfig, expo: exp };
 
   await JsonFile.writeAsync(configPath, rootConfig, { json5: false });

--- a/packages/expo-cli/__mocks__/fs.js
+++ b/packages/expo-cli/__mocks__/fs.js
@@ -1,0 +1,2 @@
+import { fs } from 'memfs';
+module.exports = fs;

--- a/packages/expo-cli/__mocks__/resolve-from.js
+++ b/packages/expo-cli/__mocks__/resolve-from.js
@@ -1,0 +1,21 @@
+module.exports = require(require.resolve('resolve-from'));
+
+module.exports.silent = (fromDirectory, request) => {
+  const fs = require('fs');
+  const path = require('path');
+
+  try {
+    fromDirectory = fs.realpathSync(fromDirectory);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      fromDirectory = path.resolve(fromDirectory);
+    } else {
+      return;
+    }
+  }
+
+  const outputPath = path.join(fromDirectory, 'node_modules', request);
+  if (fs.existsSync(outputPath)) {
+    return outputPath;
+  }
+};

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -19,6 +19,19 @@
     "test": "jest",
     "test:watch": "jest --watch"
   },
+  "jest": {
+    "testEnvironment": "node",
+    "roots": [
+      "__mocks__",
+      "src"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "ts",
+      "json"
+    ],
+    "resetModules": false
+  },
   "bin": {
     "expo": "./bin/expo.js",
     "expo-cli": "./bin/expo.js"

--- a/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
@@ -1,0 +1,316 @@
+import { vol } from 'memfs';
+
+import {
+  getDependenciesFromBundledNativeModules,
+  maybeFormatSdkVersion,
+  upgradeAsync,
+} from '../upgrade';
+
+jest.mock('fs');
+jest.mock('resolve-from');
+
+describe('maybeFormatSdkVersion', () => {
+  it(`returns null`, () => {
+    expect(maybeFormatSdkVersion(null)).toBe(null);
+  });
+  it(`returns formatted version`, () => {
+    expect(maybeFormatSdkVersion('2')).toBe('2.0.0');
+    expect(maybeFormatSdkVersion('2.4')).toBe('2.4.0');
+    expect(maybeFormatSdkVersion('2.0.0')).toBe('2.0.0');
+  });
+});
+
+describe('getDependenciesFromBundledNativeModules', () => {
+  const originalWarn = console.warn;
+  beforeEach(() => {
+    console.warn = jest.fn();
+  });
+  afterAll(() => {
+    console.warn = originalWarn;
+  });
+
+  it(`warns when the target SDK versions aren't provided`, () => {
+    console.warn = jest.fn();
+    getDependenciesFromBundledNativeModules({
+      projectDependencies: {},
+      bundledNativeModules: {},
+      sdkVersion: '3.0.0',
+      workflow: 'bare',
+      targetSdkVersion: null,
+    });
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  describe('priority', () => {
+    const projectDependencies = { 'jest-expo': '1.0.0' };
+    const bundledNativeModules = { 'jest-expo': '2.0.0' };
+    const sdkVersion = '3.0.0';
+    const targetSdkVersion = {
+      expoReactNativeTag: 'mock-expoReactNativeTag',
+      facebookReactVersion: 'mock-facebookReactVersion',
+      facebookReactNativeVersion: 'mock-facebookReactNativeVersion',
+      relatedPackages: {
+        'jest-expo': '4.0.0',
+      },
+    };
+
+    it(`upgrades jest-expo to bundledNativeModules when sdkVersion and targetSdkVersion aren't defined`, () => {
+      const deps = getDependenciesFromBundledNativeModules({
+        projectDependencies,
+        bundledNativeModules,
+        workflow: 'bare',
+        targetSdkVersion: null,
+      });
+      expect(deps['jest-expo']).toBe('2.0.0');
+    });
+
+    it(`upgrades jest-expo to sdkVersion when targetSdkVersion is undefined`, () => {
+      const deps = getDependenciesFromBundledNativeModules({
+        projectDependencies,
+        bundledNativeModules,
+        sdkVersion,
+        workflow: 'bare',
+        targetSdkVersion: null,
+      });
+      expect(deps['jest-expo']).toBe('^3.0.0');
+    });
+
+    it(`upgrades jest-expo to targetSdkVersion.relatedPackages when everything is defined`, () => {
+      const deps = getDependenciesFromBundledNativeModules({
+        projectDependencies,
+        bundledNativeModules,
+        sdkVersion,
+        workflow: 'bare',
+        targetSdkVersion,
+      });
+      expect(deps['jest-expo']).toBe('4.0.0');
+    });
+  });
+
+  describe('react-native', () => {
+    const projectDependencies = { 'react-native': '1.0.0' };
+    const bundledNativeModules = { 'react-native': '2.0.0' };
+    const sdkVersion = '3.0.0';
+    const targetSdkVersion = {
+      expoReactNativeTag: 'mock-expoReactNativeTag',
+      facebookReactVersion: 'mock-facebookReactVersion',
+      facebookReactNativeVersion: 'mock-facebookReactNativeVersion',
+      relatedPackages: {},
+    };
+
+    for (const workflow of ['bare', 'managed']) {
+      it(`upgrades react-native to expo fork when expokit is installed, in ${workflow} workflow`, () => {
+        const deps = getDependenciesFromBundledNativeModules({
+          projectDependencies: { ...projectDependencies, expokit: 'mock-expokit' },
+          bundledNativeModules,
+          sdkVersion,
+          workflow: workflow as any,
+          targetSdkVersion,
+        });
+        expect(deps['react-native']).toBe(
+          'https://github.com/expo/react-native/archive/mock-expoReactNativeTag.tar.gz'
+        );
+      });
+    }
+
+    it(`upgrades react-native to fb version in bare workflow`, () => {
+      const deps = getDependenciesFromBundledNativeModules({
+        projectDependencies: { ...projectDependencies },
+        bundledNativeModules,
+        sdkVersion,
+        workflow: 'bare',
+        targetSdkVersion,
+      });
+      expect(deps['react-native']).toBe('mock-facebookReactNativeVersion');
+    });
+  });
+
+  it(`doesn't add a package if it's not already installed`, () => {
+    // Test that react-dom isn't added to a project that doesn't already have react-dom
+    const targetSdkVersion = {
+      expoReactNativeTag: 'mock-expoReactNativeTag',
+      facebookReactVersion: 'mock-facebookReactVersion',
+      facebookReactNativeVersion: 'mock-facebookReactNativeVersion',
+      relatedPackages: { 'react-dom': 'mock-react-dom-related' },
+    };
+
+    const deps = getDependenciesFromBundledNativeModules({
+      projectDependencies: { react: 'mock-react' },
+      bundledNativeModules: { 'react-dom': 'mock-react-dom' },
+      sdkVersion: '100.0.0',
+      workflow: 'bare',
+      targetSdkVersion,
+    });
+    expect('react-dom' in deps).toBe(false);
+  });
+});
+
+describe('upgradeAsync', () => {
+  const originalWarn = console.warn;
+  const originalLog = console.log;
+  beforeEach(() => {
+    console.warn = jest.fn();
+    console.log = jest.fn();
+  });
+  afterAll(() => {
+    console.warn = originalWarn;
+    console.log = originalLog;
+  });
+
+  beforeEach(() => {
+    jest.mock('commander', () => {
+      return {
+        nonInteractive: true,
+      };
+    });
+    jest.mock('@expo/package-manager', () => {
+      return {
+        createForProject() {
+          return {
+            addAsync: jest.fn(),
+            addDevAsync: jest.fn(),
+          };
+        },
+      };
+    });
+    jest.mock('@expo/xdl', () => {
+      const pkg = jest.requireActual('@expo/xdl');
+      return {
+        ...pkg,
+        Project: {
+          ...pkg.Project,
+          startReactNativeServerAsync: jest.fn(),
+          stopReactNativeServerAsync: jest.fn(),
+        },
+      };
+    });
+    jest.mock('@expo/config', () => {
+      const config = jest.requireActual('@expo/config');
+      return {
+        ...config,
+        resolveModule: (name, projectRoot) => {
+          return {
+            'expo/bundledNativeModules.json': `${projectRoot}/node_modules/expo/bundledNativeModules.json`,
+          }[name];
+        },
+        writeConfigJsonAsync: jest.fn((...props) => {
+          return config.writeConfigJsonAsync(...props);
+        }),
+      };
+    });
+  });
+
+  afterEach(() => {
+    jest.unmock('commander');
+    jest.unmock('@expo/package-manager');
+    jest.unmock('@expo/config');
+    jest.unmock('@expo/xdl');
+  });
+
+  beforeAll(() => {
+    const packageJson = JSON.stringify(
+      {
+        name: 'testing123',
+        version: '0.1.0',
+        description: 'fake description',
+        main: 'index.js',
+      },
+      null,
+      2
+    );
+
+    const appJson = {
+      name: 'testing 123',
+      version: '0.1.0',
+      slug: 'testing-123',
+      sdkVersion: '33.0.0',
+    };
+
+    const expoPackageJson = JSON.stringify({
+      name: 'expo',
+      version: '35.0.0',
+    });
+
+    vol.fromJSON({
+      '/from-app-json-UNVERSIONED/package.json': packageJson,
+      '/from-app-json-UNVERSIONED/app.json': JSON.stringify({
+        expo: { ...appJson, sdkVersion: 'UNVERSIONED' },
+      }),
+      '/from-app-json-UNVERSIONED/app.config.js': `module.exports=({config}) => ({ ...config, sdkVersion: '34.0.0' })`,
+      '/from-app-json-UNVERSIONED/node_modules/expo/package.json': expoPackageJson,
+      '/from-app-json-UNVERSIONED/node_modules/expo/bundledNativeModules.json': JSON.stringify({}),
+
+      '/from-app-json/package.json': packageJson,
+      '/from-app-json/app.json': JSON.stringify({ expo: { ...appJson } }),
+      '/from-app-json/app.config.js': `module.exports=({config}) => ({ ...config, sdkVersion: '34.0.0' })`,
+      '/from-app-json/node_modules/expo/package.json': expoPackageJson,
+      '/from-app-json/node_modules/expo/bundledNativeModules.json': JSON.stringify({}),
+
+      '/from-app-config-js/package.json': packageJson,
+      '/from-app-config-js/app.json': JSON.stringify({
+        expo: { ...appJson, sdkVersion: undefined },
+      }),
+      '/from-app-config-js/app.config.js': `module.exports=({config}) => ({ ...config, sdkVersion: '34.0.0' })`,
+      '/from-app-config-js/node_modules/expo/package.json': expoPackageJson,
+      '/from-app-config-js/node_modules/expo/bundledNativeModules.json': JSON.stringify({}),
+
+      '/from-expo-package/package.json': packageJson,
+      '/from-expo-package/app.json': JSON.stringify({
+        expo: { ...appJson, sdkVersion: undefined },
+      }),
+      '/from-expo-package/app.config.js': `module.exports=({config}) => ({ ...config })`,
+      '/from-expo-package/node_modules/expo/package.json': expoPackageJson,
+      '/from-expo-package/node_modules/expo/bundledNativeModules.json': JSON.stringify({}),
+    });
+  });
+  afterAll(() => {
+    vol.reset();
+  });
+
+  // Ensure we delete the app.json sdkVersion if it's defined
+  it(`delete the app.json sdkVersion if it's defined`, async () => {
+    require('@expo/config').writeConfigJsonAsync = jest.fn((...props) => {
+      return jest.requireActual('@expo/config').writeConfigJsonAsync(...props);
+    });
+    const projectRoot = '/from-app-json';
+    await upgradeAsync(
+      { projectRoot, workflow: 'bare', requestedSdkVersion: null },
+      { yarn: true }
+    );
+    expect(require('@expo/config').writeConfigJsonAsync).toBeCalledTimes(1);
+    expect(require('@expo/config').writeConfigJsonAsync).toHaveBeenLastCalledWith(projectRoot, {
+      sdkVersion: undefined,
+    });
+
+    const { exp, rootConfig: json } = await require('@expo/config').readConfigJsonAsync(
+      projectRoot
+    );
+    expect(json.expo.sdkVersion).not.toBeDefined();
+    // Uses expo package version
+    expect(exp.sdkVersion).toBe('35.0.0');
+  }, 5000);
+
+  // Important to ensure that we don't modify the app.json extraneously
+  it(`skips modifying the app.json if the app.json doesn't define an sdkVersion`, async () => {
+    require('@expo/config').writeConfigJsonAsync = jest.fn();
+    const projectRoot = '/from-app-config-js';
+    await upgradeAsync(
+      { projectRoot, workflow: 'bare', requestedSdkVersion: null },
+      { yarn: true }
+    );
+    expect(require('@expo/config').writeConfigJsonAsync).toBeCalledTimes(0);
+  }, 5000);
+
+  // Ensure we skip modifying an unversioned app.json
+  // Skip for now because upgrade doesn't support UNVERSIONED
+  xit(`skips modifying the app.json if the version is UNVERSIONED`, async () => {
+    require('@expo/config').writeConfigJsonAsync = jest.fn();
+    const projectRoot = '/from-app-json-UNVERSIONED';
+    await upgradeAsync(
+      { projectRoot, workflow: 'bare', requestedSdkVersion: null },
+      { yarn: true }
+    );
+    expect(require('@expo/config').writeConfigJsonAsync).toBeCalledTimes(0);
+  }, 5000);
+});

--- a/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
@@ -13,6 +13,9 @@ describe('maybeFormatSdkVersion', () => {
   it(`returns null`, () => {
     expect(maybeFormatSdkVersion(null)).toBe(null);
   });
+  it(`supports UNVERSIONED`, () => {
+    expect(maybeFormatSdkVersion('UNVERSIONED')).toBe('UNVERSIONED');
+  });
   it(`returns formatted version`, () => {
     expect(maybeFormatSdkVersion('2')).toBe('2.0.0');
     expect(maybeFormatSdkVersion('2.4')).toBe('2.4.0');

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -1,24 +1,32 @@
-import { Command } from 'commander';
-import { Android, Project, Simulator, Versions } from '@expo/xdl';
-import JsonFile from '@expo/json-file';
 import * as ConfigUtils from '@expo/config';
-import chalk from 'chalk';
-import semver from 'semver';
-import _ from 'lodash';
-
+import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
-import CommandError from '../CommandError';
-import prompt from '../prompt';
+import { Android, Project, Simulator, Versions } from '@expo/xdl';
+import chalk from 'chalk';
+import program, { Command } from 'commander';
+import _ from 'lodash';
+import semver from 'semver';
+
 import log from '../log';
+import prompt from '../prompt';
 import { findProjectRootAsync, validateGitStatusAsync } from './utils/ProjectUtils';
+
+type DependencyList = Record<string, string>;
 
 type Options = {
   npm?: boolean;
   yarn?: boolean;
 };
 
-function maybeFormatSdkVersion(sdkVersionString: string | null) {
-  if (typeof sdkVersionString !== 'string') {
+export type ExpoWorkflow = 'managed' | 'bare';
+
+export type TargetSDKVersion = Pick<
+  Versions.SDKVersion,
+  'expoReactNativeTag' | 'facebookReactVersion' | 'facebookReactNativeVersion' | 'relatedPackages'
+>;
+
+export function maybeFormatSdkVersion(sdkVersionString: string | null): string | null {
+  if (typeof sdkVersionString !== 'string' || sdkVersionString === 'UNVERSIONED') {
     return sdkVersionString;
   }
 
@@ -26,37 +34,60 @@ function maybeFormatSdkVersion(sdkVersionString: string | null) {
   return semver.valid(semver.coerce(sdkVersionString) || '');
 }
 
-type DependencyList = { [key: string]: string };
-
 /**
  * Produce a list of dependencies used by the project that need to be updated
  */
-async function getUpdatedDependenciesAsync(
+export async function getUpdatedDependenciesAsync(
   projectRoot: string,
-  workflow: 'managed' | 'bare',
-  targetSdkVersion: {
-    expoReactNativeTag: string;
-    facebookReactVersion?: string;
-    facebookReactNativeVersion: string;
-    relatedPackages?: { [name: string]: string };
-  } | null
+  workflow: ExpoWorkflow,
+  targetSdkVersion: TargetSDKVersion | null
 ): Promise<DependencyList> {
-  let result: DependencyList = {};
-
   // Get the updated version for any bundled modules
-  let { exp, pkg } = await ConfigUtils.readConfigJsonAsync(projectRoot);
-  let bundledNativeModules = (await JsonFile.readAsync(
+  const { exp, pkg } = await ConfigUtils.readConfigJsonAsync(projectRoot);
+  const bundledNativeModules = (await JsonFile.readAsync(
     ConfigUtils.resolveModule('expo/bundledNativeModules.json', projectRoot, exp)
   )) as DependencyList;
 
   // Smoosh regular and dev dependencies together for now
-  let dependencies = { ...pkg.dependencies, ...pkg.devDependencies };
+  const projectDependencies = { ...pkg.dependencies, ...pkg.devDependencies };
+
+  return getDependenciesFromBundledNativeModules({
+    projectDependencies,
+    bundledNativeModules,
+    sdkVersion: exp.sdkVersion,
+    workflow,
+    targetSdkVersion,
+  });
+}
+
+export type UpgradeDependenciesOptions = {
+  projectDependencies: DependencyList;
+  bundledNativeModules: DependencyList;
+  sdkVersion?: string;
+  workflow: ExpoWorkflow;
+  targetSdkVersion: TargetSDKVersion | null;
+};
+
+export function getDependenciesFromBundledNativeModules({
+  projectDependencies,
+  bundledNativeModules,
+  sdkVersion,
+  workflow,
+  targetSdkVersion,
+}: UpgradeDependenciesOptions): DependencyList {
+  const result: DependencyList = {};
 
   Object.keys(bundledNativeModules).forEach(name => {
-    if (dependencies[name]) {
+    if (projectDependencies[name]) {
       result[name] = bundledNativeModules[name];
     }
   });
+
+  // If sdkVersion is known and jest-expo is used, then upgrade to the current sdk version
+  // jest-expo is versioned with expo because jest-expo mocks out the native SDKs used it expo.
+  if (sdkVersion && projectDependencies['jest-expo']) {
+    result['jest-expo'] = `^${sdkVersion}`;
+  }
 
   if (!targetSdkVersion) {
     log.warn(
@@ -65,12 +96,8 @@ async function getUpdatedDependenciesAsync(
     return result;
   }
 
-  if (dependencies['jest-expo']) {
-    result['jest-expo'] = `^${exp.sdkVersion}`;
-  }
-
   // Get the supported react/react-native/react-dom versions and other related packages
-  if (workflow === 'managed' || dependencies['expokit']) {
+  if (workflow === 'managed' || projectDependencies['expokit']) {
     result[
       'react-native'
     ] = `https://github.com/expo/react-native/archive/${targetSdkVersion.expoReactNativeTag}.tar.gz`;
@@ -83,7 +110,7 @@ async function getUpdatedDependenciesAsync(
     result['react'] = targetSdkVersion.facebookReactVersion;
 
     // react-dom version is always the same as the react version
-    if (dependencies['react-dom']) {
+    if (projectDependencies['react-dom']) {
       result['react-dom'] = targetSdkVersion.facebookReactVersion;
     }
   }
@@ -91,7 +118,7 @@ async function getUpdatedDependenciesAsync(
   // Update any related packages
   if (targetSdkVersion.relatedPackages) {
     Object.keys(targetSdkVersion.relatedPackages).forEach(name => {
-      if (dependencies[name]) {
+      if (projectDependencies[name]) {
         result[name] = targetSdkVersion.relatedPackages![name];
       }
     });
@@ -100,57 +127,64 @@ async function getUpdatedDependenciesAsync(
   return result;
 }
 
-async function upgradeAsync(requestedSdkVersion: string | null, options: Options) {
-  let { projectRoot, workflow } = await findProjectRootAsync(process.cwd());
-  let { exp, pkg } = await ConfigUtils.readConfigJsonAsync(projectRoot);
-  let isGitStatusClean = await validateGitStatusAsync();
+async function maybeBailOnGitStatusAsync(): Promise<boolean> {
+  const isGitStatusClean = await validateGitStatusAsync();
   log.newLine();
 
   // Give people a chance to bail out if git working tree is dirty
   if (!isGitStatusClean) {
-    let answer = await prompt({
+    if (program.nonInteractive) {
+      log.warn(
+        `Git status is dirty but the command will continue because nonInteractive is enabled.`
+      );
+      return false;
+    }
+
+    const answer = await prompt({
       type: 'confirm',
       name: 'ignoreDirtyGit',
       message: `Would you like to proceed?`,
     });
 
     if (!answer.ignoreDirtyGit) {
-      return;
+      return true;
     }
 
     log.newLine();
   }
+  return false;
+}
 
+async function maybeBailOnUnsafeFunctionalityAsync(
+  exp: Pick<ConfigUtils.ExpoConfig, 'sdkVersion'>
+): Promise<boolean> {
   // Give people a chance to bail out if they're updating from a super old version because YMMV
   if (!Versions.gteSdkVersion(exp, '33.0.0')) {
-    let answer = await prompt({
+    if (program.nonInteractive) {
+      log.warn(
+        `This command works best on SDK 33 and higher. Because the command is running in nonInteractive mode it'll continue regardless.`
+      );
+      return true;
+    }
+
+    const answer = await prompt({
       type: 'confirm',
       name: 'attemptOldUpdate',
       message: `This command works best on SDK 33 and higher. We can try updating for you, but you will likely need to follow up with the instructions from https://docs.expo.io/versions/latest/workflow/upgrading-expo-sdk-walkthrough/. Continue anyways?`,
     });
 
     if (!answer.attemptOldUpdate) {
-      return;
+      return true;
     }
 
     log.newLine();
   }
+  return false;
+}
 
-  // Can't upgrade if we don't have a SDK version (tapping on head meme)
-  if (!exp.sdkVersion) {
-    if (workflow === 'bare') {
-      log.error(
-        'This command only works for bare workflow projects that also have the expo package installed and sdkVersion configured in app.json.'
-      );
-      throw new CommandError('SDK_VERSION_REQUIRED_FOR_UPGRADE_COMMAND_IN_BARE');
-    } else {
-      log.error('No sdkVersion field is present in app.json, cannot upgrade project.');
-      throw new CommandError('SDK_VERSION_REQUIRED_FOR_UPGRADE_COMMAND_IN_MANAGED');
-    }
-  }
-
+async function stopExpoServerAsync(projectRoot: string): Promise<void> {
   // Can't upgrade if Expo is running
-  let status = await Project.currentStatus(projectRoot);
+  const status = await Project.currentStatus(projectRoot);
   if (status === 'running') {
     await Project.stopAsync(projectRoot);
     log(
@@ -160,8 +194,128 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
     );
     log.addNewLineIfNone();
   }
+}
 
-  let currentSdkVersionString = exp.sdkVersion;
+async function shouldBailWhenUsingLatest(
+  currentSdkVersionString: string,
+  targetSdkVersionString: string
+): Promise<boolean> {
+  // Maybe bail out early if people are trying to update to the current version
+  if (targetSdkVersionString === currentSdkVersionString) {
+    if (program.nonInteractive) {
+      log.warn(
+        `You are already using the latest SDK version but the command will continue because nonInteractive is enabled.`
+      );
+      return false;
+    }
+    const answer = await prompt({
+      type: 'confirm',
+      name: 'attemptUpdateAgain',
+      message: `You are already using the latest SDK version. Do you want to run the update anyways? This may be useful to ensure that all of your packages are set to the correct version.`,
+    });
+
+    if (!answer.attemptUpdateAgain) {
+      log('Follow the Expo blog at https://blog.expo.io for new release information!');
+      return true;
+    }
+  }
+  return false;
+}
+
+async function shouldUpgradeSimulatorAsync(): Promise<boolean> {
+  // Check if we can, and probably should, upgrade the (ios) simulator
+  if (Simulator.isPlatformSupported()) {
+    if (program.nonInteractive) {
+      log.warn(`Skipping attempt to upgrade the client app on iOS simulator.`);
+      return false;
+    }
+
+    let answer = await prompt({
+      type: 'confirm',
+      name: 'upgradeSimulator',
+      message:
+        'You might have to upgrade your iOS simulator. Before you can do that, you have to run the simulator. Do you want to upgrade it now?',
+      default: false,
+    });
+
+    return answer.upgradeSimulator;
+  }
+  return false;
+}
+
+async function maybeUpgradeSimulatorAsync() {
+  // Check if we can, and probably should, upgrade the (ios) simulator
+  if (Simulator.isPlatformSupported()) {
+    if (await shouldUpgradeSimulatorAsync()) {
+      let result = await Simulator.upgradeExpoAsync();
+      if (!result) {
+        log.error(
+          "The upgrade of your simulator didn't go as planned. You might have to reinstall it manually with expo client:install:ios."
+        );
+      }
+    }
+    log.newLine();
+  }
+}
+
+async function shouldUpgradeEmulatorAsync(): Promise<boolean> {
+  // Check if we can, and probably should, upgrade the android client
+  if (Android.isPlatformSupported()) {
+    if (program.nonInteractive) {
+      log.warn(`Skipping attempt to upgrade the client app on the Android emulator.`);
+      return false;
+    }
+
+    const answer = await prompt({
+      type: 'confirm',
+      name: 'upgradeAndroid',
+      message:
+        'You might have to upgrade your Android client. Before you can do that, you have to run the emulator, or plug a device in. Do you want to upgrade it now?',
+      default: false,
+    });
+
+    return answer.upgradeAndroid;
+  }
+  return false;
+}
+
+async function maybeUpgradeEmulatorAsync() {
+  // Check if we can, and probably should, upgrade the android client
+  if (await shouldUpgradeEmulatorAsync()) {
+    const result = await Android.upgradeExpoAsync();
+    if (!result) {
+      log.error(
+        "The upgrade of your Android client didn't go as planned. You might have to reinstall it manually with expo client:install:android."
+      );
+    }
+    log.newLine();
+  }
+}
+
+export async function upgradeAsync(
+  {
+    requestedSdkVersion,
+    projectRoot,
+    workflow,
+  }: {
+    requestedSdkVersion: string | null;
+    projectRoot: string;
+    workflow: ExpoWorkflow;
+  },
+  options: Options
+) {
+  let { exp, pkg } = await ConfigUtils.getConfig(projectRoot, {
+    skipSDKVersionRequirement: false,
+    mode: 'development',
+  });
+
+  if (await maybeBailOnGitStatusAsync()) return;
+
+  if (await maybeBailOnUnsafeFunctionalityAsync(exp)) return;
+
+  await stopExpoServerAsync(projectRoot);
+
+  let currentSdkVersionString = exp.sdkVersion!;
   let sdkVersions = await Versions.releasedSdkVersionsAsync();
   let latestSdkVersion = await Versions.newestReleasedSdkVersionAsync();
   let latestSdkVersionString = latestSdkVersion.version;
@@ -170,22 +324,12 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
   let targetSdkVersion = sdkVersions[targetSdkVersionString];
 
   // Maybe bail out early if people are trying to update to the current version
-  if (targetSdkVersionString === currentSdkVersionString) {
-    let answer = await prompt({
-      type: 'confirm',
-      name: 'attemptUpdateAgain',
-      message: `You are already using the latest SDK version. Do you want to run the update anyways? This may be useful to ensure that all of your packages are set to the correct version.`,
-    });
-
-    if (!answer.attemptUpdateAgain) {
-      log('Follow the Expo blog at https://blog.expo.io for new release information!');
-      return;
-    }
-  }
+  if (await shouldBailWhenUsingLatest(currentSdkVersionString, targetSdkVersionString)) return;
 
   if (
     targetSdkVersionString === latestSdkVersionString &&
-    currentSdkVersionString !== targetSdkVersionString
+    currentSdkVersionString !== targetSdkVersionString &&
+    !program.nonInteractive
   ) {
     let answer = await prompt({
       type: 'confirm',
@@ -217,64 +361,36 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
       log.newLine();
     }
   } else if (!targetSdkVersion) {
-    // If they provide an apparently unsupported sdk version then let people try
-    // anyways, maybe we want to use this for testing alpha versions or
-    // something...
-    let answer = await prompt({
-      type: 'confirm',
-      name: 'attemptUnknownUpdate',
-      message: `You provided the target SDK version value of ${targetSdkVersionString} which does not seem to exist. But hey, I'm just a program, what do I know. Do you want to try to upgrade to it anyways?`,
-    });
+    if (program.nonInteractive) {
+      log.warn(
+        `You provided the target SDK version value of ${targetSdkVersionString} which does not seem to exist. Upgrading anyways because the command is running in nonInteractive mode.`
+      );
+    } else {
+      // If they provide an apparently unsupported sdk version then let people try
+      // anyways, maybe we want to use this for testing alpha versions or
+      // something...
+      let answer = await prompt({
+        type: 'confirm',
+        name: 'attemptUnknownUpdate',
+        message: `You provided the target SDK version value of ${targetSdkVersionString} which does not seem to exist. But hey, I'm just a program, what do I know. Do you want to try to upgrade to it anyways?`,
+      });
 
-    if (!answer.attemptUnknownUpdate) {
-      return;
+      if (!answer.attemptUnknownUpdate) {
+        return;
+      }
     }
   }
 
   const platforms = exp.platforms || [];
 
   // Check if we can, and probably should, upgrade the (ios) simulator
-  if (Simulator.isPlatformSupported() && platforms.includes('ios')) {
-    let answer = await prompt({
-      type: 'confirm',
-      name: 'upgradeSimulator',
-      message:
-        'You might have to upgrade your iOS simulator. Before you can do that, you have to run the simulator. Do you want to upgrade it now?',
-      default: false,
-    });
-
-    if (answer.upgradeSimulator) {
-      let result = await Simulator.upgradeExpoAsync();
-      if (!result) {
-        log.error(
-          "The upgrade of your simulator didn't go as planned. You might have to reinstall it manually with expo client:install:ios."
-        );
-      }
-    }
-
-    log.newLine();
+  if (platforms.includes('ios')) {
+    await maybeUpgradeSimulatorAsync();
   }
 
   // Check if we can, and probably should, upgrade the android client
-  if (Android.isPlatformSupported() && platforms.includes('android')) {
-    let answer = await prompt({
-      type: 'confirm',
-      name: 'upgradeAndroid',
-      message:
-        'You might have to upgrade your Android client. Before you can do that, you have to run the emulator, or plug a device in. Do you want to upgrade it now?',
-      default: false,
-    });
-
-    if (answer.upgradeAndroid) {
-      let result = await Android.upgradeExpoAsync();
-      if (!result) {
-        log.error(
-          "The upgrade of your Android client didn't go as planned. You might have to reinstall it manually with expo client:install:android."
-        );
-      }
-    }
-
-    log.newLine();
+  if (platforms.includes('android')) {
+    await maybeUpgradeEmulatorAsync();
   }
 
   let packageManager = PackageManager.createForProject(projectRoot, {
@@ -288,9 +404,28 @@ async function upgradeAsync(requestedSdkVersion: string | null, options: Options
   log.addNewLineIfNone();
   await packageManager.addAsync(`expo@^${targetSdkVersionString}`);
 
-  log.addNewLineIfNone();
-  log(chalk.underline.bold('Updating sdkVersion in app.json...'));
-  await ConfigUtils.writeConfigJsonAsync(projectRoot, { sdkVersion: targetSdkVersionString });
+  // Remove sdkVersion from app.json
+  try {
+    const { rootConfig } = await ConfigUtils.readConfigJsonAsync(projectRoot);
+    if (rootConfig.expo.sdkVersion && rootConfig.expo.sdkVersion !== 'UNVERSIONED') {
+      log.addNewLineIfNone();
+      log(chalk.underline.bold('Removing deprecated sdkVersion property from the app.json...'));
+      await ConfigUtils.writeConfigJsonAsync(projectRoot, { sdkVersion: undefined });
+    }
+  } catch (_) {}
+
+  // Evaluate project config (app.config.js)
+  const { exp: currentExp } = ConfigUtils.getConfig(projectRoot, { mode: 'development' });
+
+  if (
+    !Versions.gteSdkVersion(currentExp, targetSdkVersionString) &&
+    currentExp.sdkVersion !== 'UNVERSIONED'
+  ) {
+    log.addNewLineIfNone();
+    log(
+      chalk.underline.bold("Please manually delete the sdkVersion in your project's app.config...")
+    );
+  }
 
   log(chalk.bold.underline('Updating packages to compatible versions (where known)...'));
   log.addNewLineIfNone();
@@ -413,5 +548,16 @@ export default function(program: Command) {
     .option('--npm', 'Use npm to install dependencies. (default when package-lock.json exists)')
     .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
     .description('Upgrades your project dependencies and app.json and to the given SDK version')
-    .asyncAction(upgradeAsync);
+    .asyncAction(async (requestedSdkVersion: string | null, options: Options) => {
+      const { projectRoot, workflow } = await findProjectRootAsync(process.cwd());
+
+      await upgradeAsync(
+        {
+          requestedSdkVersion,
+          projectRoot,
+          workflow,
+        },
+        options
+      );
+    });
 }

--- a/packages/expo-cli/src/prompt.ts
+++ b/packages/expo-cli/src/prompt.ts
@@ -1,5 +1,4 @@
 import program from 'commander';
-import get from 'lodash/get';
 import inquirer, { ChoiceType, Question } from 'inquirer';
 
 import CommandError from './CommandError';


### PR DESCRIPTION
- Add unit tests to `expo upgrade` command
- Add support for nonInteractive mode in upgrade command
- Fix bug where raw config was being mutated
- Change config writing in upgrade command to only run when the `app.json` is present