### PR TITLE
feat: generate hermes bytecode bundle when exporting

### DIFF
--- a/packages/xdl/src/Hermes.ts
+++ b/packages/xdl/src/Hermes.ts
@@ -46,7 +46,7 @@ export async function tryGenerateBytecode(
 export async function getBytecodeVersion(projectRoot: string) {
   const binPath = await getBinForPlatform(projectRoot);
   if (!binPath) {
-    throw new Error('Hermes binnary not found');
+    throw new Error('Hermes binary not found');
   }
   const { stdout } = await spawn(binPath, ['--version'], { stdio: 'pipe' });
   const match = stdout.match(/HBC bytecode version: (\d+)/);

--- a/packages/xdl/src/Hermes.ts
+++ b/packages/xdl/src/Hermes.ts
@@ -1,0 +1,58 @@
+import path from 'path';
+import fs from 'fs-extra';
+
+import spawn from '@expo/spawn-async';
+
+const binPaths: Record<string, string> = {
+  win32: 'win64-bin/hermes.exe',
+  linux: 'linux64-bin/hermes',
+  darwin: 'osx-bin/hermes',
+};
+
+async function getBinForPlatform(projectRoot: string): Promise<string | null> {
+  const binPath = binPaths[process.platform];
+  if (!binPath) {
+    throw new Error(`Unsupported platform ${process.platform}`);
+  }
+
+  const expoHermesPath = path.join(projectRoot, 'node_modules/@expo/hermes-engine', binPath);
+  if (await fs.pathExists(expoHermesPath)) {
+    return expoHermesPath;
+  }
+
+  const hermesEnginePath = path.join(projectRoot, 'node_modules/hermes-engine', binPath);
+  if (await fs.pathExists(hermesEnginePath)) {
+    return hermesEnginePath;
+  }
+  return null;
+}
+
+export async function tryGenerateBytecode(
+  projectRoot: string,
+  jsBundlePath: string,
+  outputPath: string,
+  flags: string[] = []
+) {
+  const hermesFlags = ['-O', ...flags];
+  const binPath = await getBinForPlatform(projectRoot);
+  if (!binPath) {
+    return;
+  }
+  await spawn(binPath, ['-emit-binary', '-out', outputPath, jsBundlePath, ...hermesFlags], {
+    stdio: 'pipe',
+  });
+}
+
+export async function getBytecodeVersion(projectRoot: string) {
+  const binPath = await getBinForPlatform(projectRoot);
+  if (!binPath) {
+    throw new Error('Hermes binnary not found');
+  }
+  const { stdout } = await spawn(binPath, ['--version'], { stdio: 'pipe' });
+  const match = stdout.match(/HBC bytecode version: (\d+)/);
+  const version = match?.[1];
+  if (!version) {
+    throw new Error('Unable to detect bytecode version');
+  }
+  return parseInt(version, 10);
+}


### PR DESCRIPTION
Generates Hermes bytecode when using `expo export` only if there is `hermes-engine` or `@expo/hermes-engine` package in `node_modules`.

Info about bytecode in manifest looks like this
```
  "bytecode": {
    "url": "https://test.test/bundles/android-7b8597e8ffb18adf0358382ccd2edbc9.hbc",
    "version": 62
  },
```