### PR TITLE
Adds missing dependency on package-manager

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -34,6 +34,7 @@
     "@expo/json-file": "^8.2.5",
     "@expo/ngrok": "2.4.3",
     "@expo/osascript": "^2.0.10",
+    "@expo/package-manager": "^0.0.5",
     "@expo/schemer": "^1.3.4",
     "@expo/spawn-async": "1.5.0",
     "@expo/webpack-config": "0.11.1",


### PR DESCRIPTION
`package-manager` is referenced in `xdl` here:
https://github.com/expo/expo-cli/blob/master/packages/xdl/src/Exp.ts#L14