### PR TITLE
[config][paths] add mode to paths methods

### DIFF
--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -1,6 +1,6 @@
 import JsonFile from '@expo/json-file';
 
-import { getConfig, readConfigJson } from './Config';
+import { getConfig } from './Config';
 import { AppJSONConfig, ExpoConfig } from './Config.types';
 
 const APP_JSON_FILE_NAME = 'app.json';

--- a/packages/config/src/paths/__tests__/paths-test.js
+++ b/packages/config/src/paths/__tests__/paths-test.js
@@ -1,4 +1,4 @@
-import { ensureSlash } from '../paths';
+import { ensureSlash, getEntryPointWithExtensions } from '../paths';
 
 // TODO: Bacon: Add test for resolving entry point
 // TODO: Bacon: Add test for custom config paths
@@ -13,5 +13,22 @@ describe('ensureSlash', () => {
     expect(ensureSlash('/', false)).toBe('');
   });
 });
+
+describe('getEntryPointWithExtensions', () => {
+  // Allow legacy versions to continue to use the getEntry without the last argument 'mode'
+  it(`doesn't throw when mode isn't defined`, () => {
+    // Test that it throws the error after the config error.
+    // This error is thrown because the mock FS isn't implemented.
+    expect(() => getEntryPointWithExtensions('/', [], [])).toThrow(
+      `The expected package.json path: /package.json does not exist`
+    );
+  });
+  it(`throws an error when an invalid mode is used`, () => {
+    expect(() => getEntryPointWithExtensions('/', [], [], null)).toThrow(
+      `Invalid mode "null" was used to evaluate the project config`
+    );
+  });
+});
+
 // getAbsolutePathWithProjectRoot;
 // getEntryPoint;

--- a/packages/config/src/paths/paths.ts
+++ b/packages/config/src/paths/paths.ts
@@ -3,9 +3,10 @@ import path from 'path';
 import findWorkspaceRoot from 'find-yarn-workspace-root';
 
 import resolveFrom from 'resolve-from';
-import { readConfigJson } from '../Config';
+import { getConfig } from '../Config';
 import { resolveModule } from '../Modules';
 import { getManagedExtensions } from './extensions';
+import { ConfigMode } from '../Config.types';
 
 // https://github.com/facebook/create-react-app/blob/9750738cce89a967cc71f28390daf5d4311b193c/packages/react-scripts/config/paths.js#L22
 export function ensureSlash(inputPath: string, needsSlash: boolean): string {
@@ -47,19 +48,21 @@ export function getAbsolutePathWithProjectRoot(
 export function getEntryPoint(
   projectRoot: string,
   entryFiles: string[],
-  platforms: string[]
+  platforms: string[],
+  mode: ConfigMode = 'development'
 ): string | null {
   const extensions = getManagedExtensions(platforms);
-  return getEntryPointWithExtensions(projectRoot, entryFiles, extensions);
+  return getEntryPointWithExtensions(projectRoot, entryFiles, extensions, mode);
 }
 
 // Used to resolve the main entry file for a project.
 export function getEntryPointWithExtensions(
   projectRoot: string,
   entryFiles: string[],
-  extensions: string[]
+  extensions: string[],
+  mode: ConfigMode = 'development'
 ): string {
-  const { exp, pkg } = readConfigJson(projectRoot, true, true);
+  const { exp, pkg } = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode });
 
   // This will first look in the `app.json`s `expo.entryPoint` field for a potential main file.
   // We check the Expo config first in case you want your project to start differently with Expo then in a standalone environment.


### PR DESCRIPTION
- migrate paths to support `app.config.js`
- moved from #1581