### PR TITLE
[xdl] Automatically start an emulator when no android device is connected

### DIFF
--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -325,10 +325,9 @@ async function attemptToStartEmulatorOrAssertAsync() {
   if (!(await _isDeviceAttachedAsync())) {
     // If no devices or emulators are attached we should attempt to open one.
     if (!(await maybeStartAnyEmulatorAsync())) {
-      // TODO(Bacon): Maybe add instructions for easily creating an emulator.
       const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
       throw new Error(
-        `No Android connected device found, and no emulators can be started automatically. Please connect a device or create an emulator, then follow the instructions here to enable USB debugging:\n${genymotionMessage}`
+        `No Android connected device found, and no emulators could be started automatically.\nPlease connect a device or create an emulator (https://docs.expo.io/versions/latest/workflow/android-studio-emulator).\nThen follow the instructions here to enable USB debugging:\n${genymotionMessage}`
       );
     }
   }

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -1,5 +1,6 @@
 import { readExpRcAsync } from '@expo/config';
 import spawnAsync from '@expo/spawn-async';
+import child_process from 'child_process';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import _ from 'lodash';
@@ -25,6 +26,91 @@ const CANT_START_ACTIVITY_ERROR = 'Activity not started, unable to resolve Inten
 
 const INSTALL_WARNING_TIMEOUT = 60 * 1000;
 
+const EMULATOR_MAX_WAIT_TIMEOUT = 30 * 1000;
+
+function whichEmulator(): string {
+  if (process.env.ANDROID_HOME) {
+    return `${process.env.ANDROID_HOME}/emulator/emulator`;
+  }
+  return 'emulator';
+}
+function whichADB(): string {
+  if (process.env.ANDROID_HOME) {
+    return `${process.env.ANDROID_HOME}/platform-tools/adb`;
+  }
+  return 'adb';
+}
+
+/**
+ * Returns a list of emulator names.
+ */
+async function getEmulatorsAsync(): Promise<string[]> {
+  try {
+    const { stdout } = await spawnAsync(whichEmulator(), ['-list-avds']);
+    return stdout.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function maybeStartEmulatorAsync(name: string): Promise<void> {
+  Logger.global.info(`\u203A Attempting to open emulator named: ${name}`);
+
+  // Start a process to open an emulator
+  const emulatorProcess = child_process.spawn(whichEmulator(), [`@${name}`], {
+    stdio: 'ignore',
+    detached: true,
+  });
+
+  emulatorProcess.unref();
+
+  return new Promise<void>((resolve, reject) => {
+    const waitTimer = setInterval(async () => {
+      if (await _isDeviceAttachedAsync()) {
+        stopWaiting();
+        resolve();
+      }
+    }, 1000);
+
+    // Reject command after timeout
+    const maxWait = setTimeout(() => {
+      const manualCommand = `${whichEmulator()} @${name}`;
+      stopWaitingAndReject(
+        `It took too long to start the Android emulator: ${name}. You can try starting the emulator manually from the terminal with: ${manualCommand}`
+      );
+    }, EMULATOR_MAX_WAIT_TIMEOUT);
+
+    const stopWaiting = () => {
+      clearTimeout(maxWait);
+      clearInterval(waitTimer);
+    };
+
+    const stopWaitingAndReject = (message: string) => {
+      stopWaiting();
+      reject(new Error(message));
+      clearInterval(waitTimer);
+    };
+
+    emulatorProcess.on('error', ({ message }) => stopWaitingAndReject(message));
+
+    emulatorProcess.on('exit', () => {
+      const manualCommand = `${whichEmulator()} @${name}`;
+      stopWaitingAndReject(
+        `The emulator (${name}) quit before it finished opening. You can try starting the emulator manually from the terminal with: ${manualCommand}`
+      );
+    });
+  });
+}
+
+async function maybeStartAnyEmulatorAsync(): Promise<boolean> {
+  const emulators = await getEmulatorsAsync();
+  if (emulators.length > 0) {
+    await maybeStartEmulatorAsync(emulators[0]);
+    return true;
+  }
+  return false;
+}
+
 export function isPlatformSupported(): boolean {
   return (
     process.platform === 'darwin' || process.platform === 'win32' || process.platform === 'linux'
@@ -33,9 +119,10 @@ export function isPlatformSupported(): boolean {
 
 export async function getAdbOutputAsync(args: string[]): Promise<string> {
   await Binaries.addToPathAsync('adb');
+  const adb = whichADB();
 
   try {
-    let result = await spawnAsync('adb', args);
+    let result = await spawnAsync(adb, args);
     return result.stdout;
   } catch (e) {
     let errorMessage = _.trim(e.stderr);
@@ -48,10 +135,15 @@ export async function getAdbOutputAsync(args: string[]): Promise<string> {
 
 // Device attached
 async function _isDeviceAttachedAsync() {
-  let devices = await getAdbOutputAsync(['devices']);
-  let lines = _.trim(devices).split(/\r?\n/);
-  // First line is "List of devices".
-  return lines.length > 1;
+  let output = await getAdbOutputAsync(['devices']);
+  const devices = output
+    .trim()
+    .split(/\r?\n/)
+    .reduce<string[]>((previous, line) => {
+      const [name, type] = line.split(/[ ,\t]+/).filter(Boolean);
+      return type === 'device' ? previous.concat(name) : previous;
+    }, []);
+  return devices.length > 0;
 }
 
 async function _isDeviceAuthorizedAsync() {
@@ -176,7 +268,7 @@ export async function uninstallExpoAsync() {
 
 export async function upgradeExpoAsync(url?: string): Promise<boolean> {
   try {
-    await assertDeviceReadyAsync();
+    await attemptToStartEmulatorOrAssertAsync();
 
     await uninstallExpoAsync();
     await installExpoAsync(url);
@@ -205,12 +297,6 @@ export async function upgradeExpoAsync(url?: string): Promise<boolean> {
 export async function assertDeviceReadyAsync() {
   const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
 
-  if (!(await _isDeviceAttachedAsync())) {
-    throw new Error(
-      `No Android device found. Please connect a device and follow the instructions here to enable USB debugging:\n${genymotionMessage}`
-    );
-  }
-
   if (!(await _isDeviceAuthorizedAsync())) {
     throw new Error(
       `This computer is not authorized to debug the device. Please follow the instructions here to enable USB debugging:\n${genymotionMessage}`
@@ -235,9 +321,23 @@ async function _openUrlAsync(url: string) {
   return output;
 }
 
+async function attemptToStartEmulatorOrAssertAsync() {
+  if (!(await _isDeviceAttachedAsync())) {
+    // If no devices or emulators are attached we should attempt to open one.
+    if (!(await maybeStartAnyEmulatorAsync())) {
+      // TODO(Bacon): Maybe add instructions for easily creating an emulator.
+      const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
+      throw new Error(
+        `No Android connected device found, and no emulators can be started automatically. Please connect a device or create an emulator, then follow the instructions here to enable USB debugging:\n${genymotionMessage}`
+      );
+    }
+  }
+  await assertDeviceReadyAsync();
+}
+
 async function openUrlAsync(url: string, isDetached: boolean = false): Promise<void> {
   try {
-    await assertDeviceReadyAsync();
+    await attemptToStartEmulatorOrAssertAsync();
 
     let installedExpo = false;
     if (!isDetached && !(await _isExpoInstalledAsync())) {


### PR DESCRIPTION
# Why

New users mostly don't know how to open an Emulator without opening Android Studio. Opening Android Studio can immediately kill your vibe so we should minimize reasons to do that.
Also `expo start --android` should work the same as `expo start --ios`.

# Test Plan

- `expo start --android` should open an emulator is no device is connected, then install the expo client and open the project.