### PR TITLE
Remove preset-flow from expo-cli

### DIFF
--- a/packages/expo-cli/babel.config.js
+++ b/packages/expo-cli/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  presets: ['@expo/babel-preset-cli', '@babel/preset-flow'],
+  presets: ['@expo/babel-preset-cli'],
 };

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -58,7 +58,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
-    "@babel/preset-flow": "^7.0.0",
     "@expo/babel-preset-cli": "^0.2.5",
     "@types/ansi-regex": "^4.0.0",
     "@types/dateformat": "^3.0.0",

--- a/packages/webpack-config/babel.config.js
+++ b/packages/webpack-config/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   env: {
     test: {
-      presets: ['@expo/babel-preset-cli', '@babel/preset-flow'],
+      presets: ['@expo/babel-preset-cli'],
     },
   },
 };

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -71,7 +71,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
-    "@babel/preset-flow": "^7.0.0",
     "@expo/babel-preset-cli": "^0.2.5",
     "@types/copy-webpack-plugin": "^5.0.0",
     "@types/html-webpack-plugin": "^3.2.0",


### PR DESCRIPTION
- Moved from #1614
- Flow still exists in `expo-codemod->jscodeshift`

```sh
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "@babel/preset-flow@7.7.4"
info Reasons this module exists
   - "_project_#expo-codemod#jscodeshift" depends on it
   - Hoisted from "_project_#expo-codemod#jscodeshift#@babel#preset-flow"
info Disk size without dependencies: "20KB"
info Disk size with unique dependencies: "68KB"
info Disk size with transitive dependencies: "88KB"
info Number of shared dependencies: 2
✨  Done in 1.63s.
```