### PR TITLE
Migrate all imports of package.json to use node resolution

### DIFF
--- a/packages/config/jest.config.js
+++ b/packages/config/jest.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   rootDir: path.resolve(__dirname),
-  displayName: require('./package.json').name,
+  displayName: require('@expo/config/package.json').name,
   testRegex: '/__tests__/.*(test|spec)\\.(j|t)sx?$',
   moduleNameMapper: {
     '^jest/(.*)': path.join(__dirname, '../../jest/$1'),

--- a/packages/expo-cli/gulpfile.js
+++ b/packages/expo-cli/gulpfile.js
@@ -6,7 +6,7 @@ const changed = require('gulp-changed');
 const plumber = require('gulp-plumber');
 const sourcemaps = require('gulp-sourcemaps');
 
-const packageJSON = require('./package.json');
+const packageJSON = require('expo-cli/package.json');
 
 const paths = {
   source: {

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -1,7 +1,9 @@
 import { Command } from 'commander';
 // @ts-ignore
 import envinfo from 'envinfo';
-import { version } from '../../package.json';
+
+// @ts-ignore: expo-cli is not listed in its own dependencies
+import packageJSON from 'expo-cli/package.json';
 
 async function action(options: never): Promise<void> {
   const info = await envinfo.run(
@@ -13,7 +15,7 @@ async function action(options: never): Promise<void> {
       npmGlobalPackages: ['expo-cli'],
     },
     {
-      title: `Expo CLI ${version} environment info`,
+      title: `Expo CLI ${packageJSON.version} environment info`,
     }
   );
   console.log(info);

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -31,11 +31,13 @@ import {
 } from '@expo/xdl';
 import * as ConfigUtils from '@expo/config';
 
+// @ts-ignore: expo-cli is not listed in its own dependencies
+import packageJSON from 'expo-cli/package.json';
+
 import { loginOrRegisterIfLoggedOut } from './accounts';
 import log from './log';
 import update from './update';
 import urlOpts from './urlOpts';
-import packageJSON from '../package.json';
 import { registerCommands } from './commands';
 
 Api.setClientName(packageJSON.version);

--- a/packages/expo-cli/src/update.ts
+++ b/packages/expo-cli/src/update.ts
@@ -1,6 +1,7 @@
 import { ModuleVersion } from '@expo/xdl';
 
-import packageJSON from '../package.json';
+// @ts-ignore: expo-cli is not listed in its own dependencies
+import packageJSON from 'expo-cli/package.json';
 
 const ModuleVersionChecker = ModuleVersion.createModuleVersionChecker(
   packageJSON.name,

--- a/packages/expo-codemod/jest.config.js
+++ b/packages/expo-codemod/jest.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   rootDir: path.resolve(__dirname, 'src'),
-  displayName: require('./package.json').name,
+  displayName: require('expo-codemod/package.json').name,
   testRegex: '/__(tests|testfixtures)__/.*(test|spec)\\.(j|t)sx?$',
   moduleNameMapper: {
     '^jest/(.*)': path.join(__dirname, '../../jest/$1'),

--- a/packages/expo-optimize/src/index.ts
+++ b/packages/expo-optimize/src/index.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { resolve } from 'path';
-// @ts-ignore: expo-cli is not listed in its own dependencies
+// @ts-ignore: expo-optimize is not listed in its own dependencies
 import packageJSON from 'expo-optimize/package.json';
 
 import { isProjectOptimized as isProjectOptimizedAsync, optimizeAsync } from './assets';

--- a/packages/expo-optimize/src/index.ts
+++ b/packages/expo-optimize/src/index.ts
@@ -2,16 +2,16 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { resolve } from 'path';
+// @ts-ignore: expo-cli is not listed in its own dependencies
+import packageJSON from 'expo-optimize/package.json';
 
 import { isProjectOptimized as isProjectOptimizedAsync, optimizeAsync } from './assets';
 import shouldUpdate from './update';
 
 let projectDirectory: string = '';
 
-const packageJson = () => require('../package.json');
-
-const program = new Command(packageJson().name)
-  .version(packageJson().version)
+const program = new Command(packageJSON.name)
+  .version(packageJSON.version)
   .arguments('<project-directory>')
   .usage(`${chalk.green('<project-directory>')} [options]`)
   .description('Compress the assets in your Expo project')

--- a/packages/expo-optimize/src/update.ts
+++ b/packages/expo-optimize/src/update.ts
@@ -12,7 +12,7 @@ function shouldUseYarn() {
 }
 
 export default async function shouldUpdate() {
-  const packageJson = () => require('../package.json');
+  const packageJson = () => require('expo-optimize/package.json');
 
   const update = checkForUpdate(packageJson()).catch(() => null);
 

--- a/packages/image-utils/src/sharp.ts
+++ b/packages/image-utils/src/sharp.ts
@@ -139,7 +139,9 @@ async function findSharpBinAsync(): Promise<string> {
   if (_sharpBin) {
     return _sharpBin;
   }
-  const requiredCliVersion = require('../package.json').peerDependencies['sharp-cli'];
+  const requiredCliVersion = require('@expo/image-utils/package.json').peerDependencies[
+    'sharp-cli'
+  ];
   try {
     const sharpCliPackage = require('sharp-cli/package.json');
     const libVipsVersion = require('sharp').versions.vips;

--- a/packages/json-file/jest.config.js
+++ b/packages/json-file/jest.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   rootDir: path.resolve(__dirname),
-  displayName: require('./package.json').name,
+  displayName: require('@expo/json-file/package.json').name,
   testRegex: '/__tests__/.*(test|spec)\\.(j|t)sx?$',
   moduleNameMapper: {
     '^jest/(.*)': path.join(__dirname, '../../jest/$1'),

--- a/packages/package-manager/jest.config.js
+++ b/packages/package-manager/jest.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   rootDir: path.resolve(__dirname),
-  displayName: require('./package.json').name,
+  displayName: require('@expo/package-manager/package.json').name,
   testRegex: '/__tests__/.*(test|spec)\\.(j|t)sx?$',
   moduleNameMapper: {
     '^jest/(.*)': path.join(__dirname, '../../jest/$1'),

--- a/packages/schemer/jest.config.js
+++ b/packages/schemer/jest.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   rootDir: path.resolve(__dirname),
-  displayName: require('./package.json').name,
+  displayName: require('@expo/schemer/package.json').name,
   testRegex: '/__tests__/.*(test|spec)\\.(j|t)sx?$',
   moduleNameMapper: {
     '^jest/(.*)': path.join(__dirname, '../../jest/$1'),

--- a/packages/webpack-config/jest/unit-test-config.js
+++ b/packages/webpack-config/jest/unit-test-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   rootDir: path.resolve(__dirname, '..'),
   roots: ['src'],
-  displayName: require('../package.json').name,
+  displayName: require('@expo/webpack-config/package.json').name,
   testRegex: '/__(tests|testfixtures)__/.*(test|spec)\\.(j|t)sx?$',
   moduleNameMapper: {
     '^jest/(.*)': path.join(__dirname, '../../../jest/$1'),

--- a/packages/webpack-pwa-manifest-plugin/jest.config.js
+++ b/packages/webpack-pwa-manifest-plugin/jest.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  displayName: require('./package.json').name,
+  displayName: require('@expo/webpack-pwa-manifest-plugin/package.json').name,
   testRegex: '/__tests__/.*(test|spec)\\.(j|t)sx?$',
   moduleNameMapper: {
     '^jest/(.*)': path.join(__dirname, '../../jest/$1'),

--- a/packages/xdl/gulp/build-tasks.js
+++ b/packages/xdl/gulp/build-tasks.js
@@ -8,7 +8,7 @@ const request = require('request');
 const sourcemaps = require('gulp-sourcemaps');
 const rimraf = require('rimraf');
 
-const packageJson = require('../package.json');
+const packageJson = require('@expo/xdl/package.json');
 
 const paths = {
   source: {

--- a/packages/xdl/jest/unit-test-config.js
+++ b/packages/xdl/jest/unit-test-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   rootDir: path.resolve(__dirname, '..'),
   roots: ['__mocks__', 'src'],
-  displayName: require('../package.json').name,
+  displayName: require('@expo/xdl/package.json').name,
   testRegex: '/__(tests|testfixtures)__/.*(test|spec)\\.(j|t)sx?$',
   moduleNameMapper: {
     '^jest/(.*)': path.join(__dirname, '../../../jest/$1'),

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2098,7 +2098,7 @@ export async function startExpoServerAsync(projectRoot: string): Promise<void> {
       const hostInfo = {
         host: hostUUID,
         server: 'xdl',
-        serverVersion: require('../package.json').version,
+        serverVersion: require('@expo/xdl/package.json').version,
         serverDriver: Config.developerTool,
         serverOS: os.platform(),
         serverOSVersion: os.release(),

--- a/packages/xdl/src/__tests__/tools/FsCache-test.js
+++ b/packages/xdl/src/__tests__/tools/FsCache-test.js
@@ -35,7 +35,7 @@ describe('Cacher', () => {
   });
 
   xit('works with a bootstrap file', async () => {
-    const expected = JSON.parse(await fs.readFile(path.join(__dirname, '../../../package.json')));
+    const expected = JSON.parse(await fs.readFile(path.join(__dirname, '@expo/xdl/package.json')));
 
     const failCacher = new Cacher(
       () => {
@@ -43,7 +43,7 @@ describe('Cacher', () => {
       },
       'bootstrap',
       1000,
-      path.join(__dirname, '../../../package.json')
+      path.join(__dirname, '@expo/xdl/package.json')
     );
 
     // since we don't mock the fs here (.cache is transient), need to make sure it's empty


### PR DESCRIPTION
# Why

TypeScript will attempt to bundle the `package.json` when it's imported relatively which breaks the bundle. This approach prevents that.

- Moved from #1614 