### PR TITLE
[webpack-config] Fix register service worker

### DIFF
--- a/packages/webpack-config/src/addons/withCompression.ts
+++ b/packages/webpack-config/src/addons/withCompression.ts
@@ -11,7 +11,7 @@ import { enableWithPropertyOrConfig, overrideWithPropertyOrConfig } from '../uti
  * @internal
  */
 export const DEFAULT_GZIP_OPTIONS = {
-  test: /\.(js|css)$/,
+  test: /static\/.*\.(js|css)$/,
   filename: '[path].gz[query]',
   algorithm: 'gzip',
   threshold: 1024,

--- a/packages/webpack-config/src/addons/withWorkbox.ts
+++ b/packages/webpack-config/src/addons/withWorkbox.ts
@@ -1,4 +1,6 @@
-import { ensureDirSync, readFileSync, writeFileSync } from 'fs-extra';
+import { ensureSlash } from '@expo/config/paths';
+import CopyPlugin from 'copy-webpack-plugin';
+import { ensureDirSync, writeFileSync } from 'fs-extra';
 import { join } from 'path';
 import {
   GenerateSW,
@@ -7,11 +9,9 @@ import {
   InjectManifestOptions,
 } from 'workbox-webpack-plugin';
 
-import CopyPlugin from 'copy-webpack-plugin';
-import { ensureSlash } from '@expo/config/paths';
+import { getPaths } from '../env';
 import { AnyConfiguration } from '../types';
 import { resolveEntryAsync } from '../utils';
-import { getPaths } from '../env';
 
 /**
  * @internal

--- a/packages/webpack-config/src/addons/withWorkbox.ts
+++ b/packages/webpack-config/src/addons/withWorkbox.ts
@@ -7,6 +7,7 @@ import {
   InjectManifestOptions,
 } from 'workbox-webpack-plugin';
 
+import CopyPlugin from 'copy-webpack-plugin';
 import { ensureSlash } from '@expo/config/paths';
 import { AnyConfiguration } from '../types';
 import { resolveEntryAsync } from '../utils';
@@ -90,25 +91,29 @@ export default function withWorkbox(
 
   const locations = getPaths(projectRoot!, webpackConfig.mode);
 
+  webpackConfig.plugins.push(
+    new CopyPlugin([
+      {
+        from: locations.template.registerServiceWorker,
+        to: locations.production.registerServiceWorker,
+        transform(content) {
+          return content
+            .toString()
+            .replace('SW_PUBLIC_URL', publicUrl)
+            .replace('SW_PUBLIC_SCOPE', ensureSlash(scope || publicUrl, true));
+        },
+      },
+    ])
+  );
+
   // Always register general service worker
   const expoEntry = webpackConfig.entry;
   webpackConfig.entry = async () => {
     const entries = await resolveEntryAsync(expoEntry);
     const swPath = join(locations.production.registerServiceWorker);
     if (entries.app && !entries.app.includes(swPath) && autoRegister) {
-      let content = readFileSync(require.resolve(locations.template.registerServiceWorker), 'utf8');
-      if (content) {
-        content = content
-          .replace('SW_PUBLIC_URL', publicUrl)
-          .replace('SW_PUBLIC_SCOPE', ensureSlash(scope || publicUrl, true));
-        ensureDirSync(locations.production.folder);
-      } else {
-        content = `
-        console.warn("failed to load service-worker in @expo/webpack-config -> withWorkbox. This can be due to the environment the project was built in. Please try again with a globally installed instance of expo-cli. If you continue to run into problems open an issue in https://github.com/expo/expo-cli")
-        `;
-      }
-      writeFileSync(swPath, content, 'utf8');
-
+      ensureDirSync(locations.production.folder);
+      writeFileSync(swPath, '// noop', 'utf8');
       if (!Array.isArray(entries.app)) {
         entries.app = [entries.app];
       }


### PR DESCRIPTION

When rebuilding your project `register-service-worker.js` was created before the clean plugin deleted the web-build folder. This lead to issues where the `web-build/register-service-worker.js` was not included. 

- Target compression to the static folder
- fixes issue created in https://github.com/expo/expo-cli/pull/1457