### PR TITLE
[webpack-config] Delete deprecated withUnimodules import

### DIFF
--- a/packages/webpack-config/withUnimodules.js
+++ b/packages/webpack-config/withUnimodules.js
@@ -1,5 +1,0 @@
-module.exports = require('./addons').withUnimodules;
-
-console.warn(
-  '`@expo/webpack-config/withUnimodules` is deprecated, please use `import { withUnimodules } from @expo/webpack-config/addons` instead.'
-);


### PR DESCRIPTION
Currently it's been deprecated for four months in beta.