### PR TITLE
remove link for netinfo

### DIFF
--- a/packages/webpack-config/src/env/alias.ts
+++ b/packages/webpack-config/src/env/alias.ts
@@ -7,7 +7,6 @@
 export const aliases = {
   // Alias direct react-native imports to react-native-web
   'react-native$': 'react-native-web',
-  '@react-native-community/netinfo': 'react-native-web/dist/exports/NetInfo',
   // Add polyfills for modules that react-native-web doesn't support
   // Depends on expo-asset
   'react-native/Libraries/Image/AssetSourceResolver$': 'expo-asset/build/AssetSourceResolver',


### PR DESCRIPTION
no longer exported as of RNW 0.12.0.

https://github.com/react-native-community/react-native-netinfo/tree/v5.5.0