### PR TITLE
[cli] better worded prompt

### DIFF
--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -92,7 +92,7 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
       {
         type: 'confirm',
         name: 'confirm',
-        message: `Do you have access to the Apple Account that owns the app with the bundle identifier ${bundleIdentifier}?`,
+        message: `Do you have access to the Apple Account that will be used for submitting this app to the App Store?`,
       },
     ]);
     if (confirm) {

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -92,7 +92,7 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
       {
         type: 'confirm',
         name: 'confirm',
-        message: `Do you have access to the Apple Account that will be used for submitting this app to the App Store?`,
+        message: `Do you have access to the Apple account that will be used for submitting this app to the App Store?`,
       },
     ]);
     if (confirm) {


### PR DESCRIPTION
make cli prompt more clear - original question can be kind of confusing because it implies that an app with the bundle id already exists on the store. 