### PR TITLE
make build calls api v2 by default

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -87,8 +87,9 @@ export default class BaseBuilder {
   async checkForBuildInProgress() {
     log('Checking if there is a build in progress...\n');
     let buildStatus;
-    if (process.env.EXPO_NEXT_API) {
-      buildStatus = await Project.getBuildStatusAsync(this.projectDir, {
+    if (process.env.EXPO_LEGACY_API === 'true') {
+      buildStatus = await Project.buildAsync(this.projectDir, {
+        mode: 'status',
         platform: this.platform(),
         current: true,
         releaseChannel: this.options.releaseChannel,
@@ -96,8 +97,7 @@ export default class BaseBuilder {
         sdkVersion: this.manifest.sdkVersion,
       } as any);
     } else {
-      buildStatus = await Project.buildAsync(this.projectDir, {
-        mode: 'status',
+      buildStatus = await Project.getBuildStatusAsync(this.projectDir, {
         platform: this.platform(),
         current: true,
         releaseChannel: this.options.releaseChannel,
@@ -114,15 +114,15 @@ export default class BaseBuilder {
     log('Fetching build history...\n');
 
     let buildStatus: Project.BuildStatusResult | Project.BuildCreatedResult;
-    if (process.env.EXPO_NEXT_API) {
-      buildStatus = await Project.getBuildStatusAsync(this.projectDir, {
+    if (process.env.EXPO_LEGACY_API === 'true') {
+      buildStatus = await Project.buildAsync(this.projectDir, {
+        mode: 'status',
         platform,
         current: false,
         releaseChannel: this.options.releaseChannel,
       });
     } else {
-      buildStatus = await Project.buildAsync(this.projectDir, {
-        mode: 'status',
+      buildStatus = await Project.getBuildStatusAsync(this.projectDir, {
         platform,
         current: false,
         releaseChannel: this.options.releaseChannel,
@@ -304,15 +304,15 @@ ${job.id}
     let spinner = ora().start();
     while (true) {
       let res;
-      if (process.env.EXPO_NEXT_API) {
-        res = await Project.getBuildStatusAsync(this.projectDir, {
-          current: false,
-          ...(publicUrl ? { publicUrl } : {}),
-        });
-      } else {
+      if (process.env.EXPO_LEGACY_API === 'true') {
         res = await Project.buildAsync(this.projectDir, {
           current: false,
           mode: 'status',
+          ...(publicUrl ? { publicUrl } : {}),
+        });
+      } else {
+        res = await Project.getBuildStatusAsync(this.projectDir, {
+          current: false,
           ...(publicUrl ? { publicUrl } : {}),
         });
       }
@@ -351,30 +351,7 @@ ${job.id}
     const bundleIdentifier = get(this.manifest, 'ios.bundleIdentifier');
 
     let result: any;
-    if (process.env.EXPO_NEXT_API) {
-      let opts: Record<string, any> = {
-        expIds,
-        platform,
-        releaseChannel: this.options.releaseChannel,
-        ...(publicUrl ? { publicUrl } : {}),
-      };
-
-      if (platform === PLATFORMS.IOS) {
-        opts = {
-          ...opts,
-          type: this.options.type,
-          bundleIdentifier,
-        };
-      } else if (platform === PLATFORMS.ANDROID) {
-        opts = {
-          ...opts,
-          type: this.options.type,
-        };
-      }
-
-      // call out to build api here with url
-      result = await Project.startBuildAsync(this.projectDir, opts);
-    } else {
+    if (process.env.EXPO_LEGACY_API === 'true') {
       let opts: Record<string, any> = {
         mode: 'create',
         expIds,
@@ -398,6 +375,29 @@ ${job.id}
 
       // call out to build api here with url
       result = await Project.buildAsync(this.projectDir, opts);
+    } else {
+      let opts: Record<string, any> = {
+        expIds,
+        platform,
+        releaseChannel: this.options.releaseChannel,
+        ...(publicUrl ? { publicUrl } : {}),
+      };
+
+      if (platform === PLATFORMS.IOS) {
+        opts = {
+          ...opts,
+          type: this.options.type,
+          bundleIdentifier,
+        };
+      } else if (platform === PLATFORMS.ANDROID) {
+        opts = {
+          ...opts,
+          type: this.options.type,
+        };
+      }
+
+      // call out to build api here with url
+      result = await Project.startBuildAsync(this.projectDir, opts);
     }
     const { id: buildId, priority, canPurchasePriorityBuilds } = result;
 

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -25,15 +25,15 @@ const logArtifactUrl = (platform: 'ios' | 'android') => async (
   }
 
   let res;
-  if (process.env.EXPO_NEXT_API) {
-    res = await Project.getBuildStatusAsync(projectDir, {
-      current: false,
-      ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
-    });
-  } else {
+  if (process.env.EXPO_LEGACY_API === 'true') {
     res = await Project.buildAsync(projectDir, {
       current: false,
       mode: 'status',
+      ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
+    });
+  } else {
+    res = await Project.getBuildStatusAsync(projectDir, {
+      current: false,
       ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
     });
   }


### PR DESCRIPTION
Note that calls for a builds status now have their own endpoint `build/status` and that this is a `post` instead of a `put`:
https://github.com/expo/expo-cli/blob/master/packages/xdl/src/Project.ts#L1533

Double checked on server side that this is what we want.

Sanity checked by running `expo build:android`. All calls going api v2 and build was successful.