### PR TITLE
@jkhales/add apiv2 option credentials

### DIFF
--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -1,4 +1,9 @@
+import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
+import pick from 'lodash/pick';
+
 import { Platform, readConfigJsonAsync } from '@expo/config';
+import { ApiV2 } from '../xdl';
 
 import Api from '../Api';
 import UserManager from '../User';
@@ -47,65 +52,226 @@ export async function credentialsExistForPlatformAsync(
 
 export async function getEncryptedCredentialsForPlatformAsync(
   metadata: CredentialMetadata
-): Promise<Credentials | undefined> {
+): Promise<Credentials | undefined | null> {
   return fetchCredentials(metadata, false);
 }
 
 export async function getCredentialsForPlatform(
   metadata: CredentialMetadata
-): Promise<Credentials | undefined> {
+): Promise<Credentials | undefined | null> {
   return fetchCredentials(metadata, true);
 }
 
 async function fetchCredentials(
   { username, experienceName, bundleIdentifier, platform }: CredentialMetadata,
   decrypt: boolean
-): Promise<Credentials | undefined> {
+): Promise<Credentials | undefined | null> {
   // this doesn't hit our mac rpc channel, so it needs significantly less debugging
-  const { err, credentials } = await Api.callMethodAsync('getCredentials', [], 'post', {
-    username,
-    experienceName,
-    bundleIdentifier,
-    platform,
-    decrypt,
-  });
+  let credentials;
+  if (process.env.EXPO_NEXT_API) {
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
 
-  if (err) {
-    throw new Error('Error fetching credentials.');
+    if (platform === 'android') {
+      credentials = await api.getAsync(`credentials/android/keystore/${experienceName}`);
+      if (credentials['keystore']) {
+        credentials['keystore']['keystoreAlias'] = credentials['keystore']['keyAlias'];
+        delete credentials['keystore']['keyAlias'];
+      } else {
+        credentials = null;
+      }
+    } else if (platform === 'ios') {
+      const record = await api.getAsync(
+        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
+      );
+      if (record) {
+        credentials = {
+          ...record.pushCredentials,
+          ...record.distCredentials,
+          ...record.credentials,
+        };
+      } else {
+        credentials = {};
+      }
+    }
+  } else {
+    const response = await Api.callMethodAsync('getCredentials', [], 'post', {
+      username,
+      experienceName,
+      bundleIdentifier,
+      platform,
+      decrypt,
+    });
+
+    if (response.err) {
+      throw new Error('Error fetching credentials.');
+    }
+    credentials = response.credentials;
   }
-
   return credentials;
 }
 
 export async function updateCredentialsForPlatform(
   platform: string,
-  newCredentials: Credentials,
+  newCredentials: Credentials & { userCredentialsId: string },
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {
-  const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {
-    credentials: newCredentials,
-    userCredentialsIds,
-    platform,
-    ...metadata,
-  });
+  if (process.env.EXPO_NEXT_API) {
+    const { experienceName, bundleIdentifier } = metadata;
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    if (platform === 'android') {
+      const result = await api.putAsync(`credentials/android/keystore/${experienceName}`, {
+        credentials: newCredentials,
+      });
 
-  if (err || !credentials) {
-    throw new Error('Error updating credentials.');
+      if (!result) {
+        throw new Error('Error updating credentials.');
+      }
+    } else if (platform === 'ios') {
+      const { userCredentialsId: idFromCredentials, ...credentials } = newCredentials;
+      const userCredentialsIdOverride = idFromCredentials
+        ? [idFromCredentials]
+        : userCredentialsIds;
+
+      const currentCredentials = await api.getAsync(
+        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
+      );
+      const appleTeam = pick(credentials, ['teamId', 'teamName']);
+      const distCredentials = pick(credentials, [
+        'certP12',
+        'certPassword',
+        'certId',
+        'certPrivateSigningKey',
+        'distCertSerialNumber',
+      ]);
+      const pushCredentials = pick(credentials, ['apnsKeyId', 'apnsKeyP8']);
+      const appCredentials = pick(credentials, ['provisioningProfile', 'provisioningProfileId']);
+
+      if (!isEmpty(appCredentials)) {
+        await api.postAsync('credentials/ios/provisioningProfile/update', {
+          experienceName,
+          bundleIdentifier,
+          credentials: { ...appCredentials, ...appleTeam },
+        });
+      }
+
+      if (!isEmpty(pushCredentials)) {
+        const pushCredentialsId = get(currentCredentials, 'pushCredentialsId');
+        const { id: updatedId } = await api.putAsync(`credentials/ios/push/${pushCredentialsId}`, {
+          credentials: { ...pushCredentials, ...appleTeam },
+        });
+        if (!pushCredentialsId) {
+          await api.postAsync(`credentials/ios/use/push`, {
+            experienceName,
+            bundleIdentifier,
+            userCredentialsId: updatedId,
+          });
+        }
+      }
+
+      if (!isEmpty(distCredentials)) {
+        const distCredentialsId = get(currentCredentials, 'distCredentialsId');
+        const { id: updatedId } = await api.putAsync(`credentials/ios/dist/${distCredentialsId}`, {
+          credentials: { ...distCredentials, ...appleTeam },
+        });
+        if (!distCredentialsId) {
+          await api.postAsync(`credentials/ios/use/dist`, {
+            experienceName,
+            bundleIdentifier,
+            userCredentialsId: updatedId,
+          });
+        }
+      }
+
+      // reused credentials
+      for (const id of userCredentialsIdOverride) {
+        const record = await api.getAsync(`credentials/ios/userCredentials/${id}`, {
+          decrypt: false,
+        });
+        if (record && record.type === 'push-key') {
+          await api.postAsync(`credentials/ios/use/push`, {
+            experienceName,
+            bundleIdentifier,
+            userCredentialsId: id,
+          });
+        } else if (record && record.type === 'dist-cert') {
+          await api.postAsync(`credentials/ios/use/dist`, {
+            experienceName,
+            bundleIdentifier,
+            userCredentialsId: id,
+          });
+        }
+      }
+    }
+  } else {
+    const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {
+      credentials: newCredentials,
+      userCredentialsIds,
+      platform,
+      ...metadata,
+    });
+
+    if (err || !credentials) {
+      throw new Error('Error updating credentials.');
+    }
   }
 }
 
 export async function removeCredentialsForPlatform(
   platform: string,
-  metadata: CredentialMetadata
+  metadata: CredentialMetadata & { only: any }
 ): Promise<void> {
   // doesn't go through mac rpc, no request id needed
-  const { err } = await Api.callMethodAsync('deleteCredentials', [], 'post', {
-    platform,
-    ...metadata,
-  });
+  if (process.env.EXPO_NEXT_API) {
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    if (platform === 'android') {
+      console.log('deleting android credentials');
+      await api.deleteAsync(`credentials/android/keystore/${metadata.experienceName}`);
+    } else if (platform === 'ios') {
+      const { experienceName, bundleIdentifier, only } = metadata;
 
-  if (err) {
-    throw new Error('Error deleting credentials.');
+      if (only.appCredentials) {
+        only.provisioningProfile = true;
+        only.pushCert = true;
+        delete only.appCredentials;
+      }
+      const currentCredentials = await api.getAsync(
+        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
+      );
+      if (isEmpty(currentCredentials)) {
+        return;
+      }
+
+      if (only.provisioningProfile) {
+        await api.postAsync('credentials/ios/provisioningProfile/delete', {
+          experienceName,
+          bundleIdentifier,
+        });
+      }
+      if (only.pushCert) {
+        await api.postAsync('credentials/ios/pushCert/delete', {
+          experienceName,
+          bundleIdentifier,
+        });
+      }
+      if (only.pushKey && currentCredentials.pushCredentialsId) {
+        await api.deleteAsync(`credentials/ios/push/${currentCredentials.pushCredentialsId}`);
+      }
+      if (only.distributionCert && currentCredentials.distCredentialsId) {
+        await api.deleteAsync(`credentials/ios/dist/${currentCredentials.distCredentialsId}`);
+      }
+    }
+  } else {
+    const { err } = await Api.callMethodAsync('deleteCredentials', [], 'post', {
+      platform,
+      ...metadata,
+    });
+
+    if (err) {
+      throw new Error('Error deleting credentials.');
+    }
   }
 }

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -109,7 +109,7 @@ async function fetchCredentials(
 
 export async function updateCredentialsForPlatform(
   platform: 'android',
-  newCredentials: Credentials & { userCredentialsId: string },
+  newCredentials: Credentials,
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -220,50 +220,15 @@ export async function updateCredentialsForPlatform(
 }
 
 export async function removeCredentialsForPlatform(
-  platform: string,
-  metadata: CredentialMetadata & { only: any }
+  platform: 'android', // this is only used for android credential management now.
+  metadata: CredentialMetadata
 ): Promise<void> {
   // doesn't go through mac rpc, no request id needed
   if (process.env.EXPO_NEXT_API) {
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
-    if (platform === 'android') {
-      console.log('deleting android credentials');
-      await api.deleteAsync(`credentials/android/keystore/${metadata.experienceName}`);
-    } else if (platform === 'ios') {
-      const { experienceName, bundleIdentifier, only } = metadata;
-
-      if (only.appCredentials) {
-        only.provisioningProfile = true;
-        only.pushCert = true;
-        delete only.appCredentials;
-      }
-      const currentCredentials = await api.getAsync(
-        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
-      );
-      if (isEmpty(currentCredentials)) {
-        return;
-      }
-
-      if (only.provisioningProfile) {
-        await api.postAsync('credentials/ios/provisioningProfile/delete', {
-          experienceName,
-          bundleIdentifier,
-        });
-      }
-      if (only.pushCert) {
-        await api.postAsync('credentials/ios/pushCert/delete', {
-          experienceName,
-          bundleIdentifier,
-        });
-      }
-      if (only.pushKey && currentCredentials.pushCredentialsId) {
-        await api.deleteAsync(`credentials/ios/push/${currentCredentials.pushCredentialsId}`);
-      }
-      if (only.distributionCert && currentCredentials.distCredentialsId) {
-        await api.deleteAsync(`credentials/ios/dist/${currentCredentials.distCredentialsId}`);
-      }
-    }
+    console.log('deleting android credentials');
+    await api.deleteAsync(`credentials/android/keystore/${metadata.experienceName}`);
   } else {
     const { err } = await Api.callMethodAsync('deleteCredentials', [], 'post', {
       platform,

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -1,7 +1,3 @@
-import isEmpty from 'lodash/isEmpty';
-import get from 'lodash/get';
-import pick from 'lodash/pick';
-
 import { Platform, readConfigJsonAsync } from '@expo/config';
 import { ApiV2 } from '../xdl';
 
@@ -112,98 +108,21 @@ async function fetchCredentials(
 }
 
 export async function updateCredentialsForPlatform(
-  platform: string,
+  platform: 'android',
   newCredentials: Credentials & { userCredentialsId: string },
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {
   if (process.env.EXPO_NEXT_API) {
-    const { experienceName, bundleIdentifier } = metadata;
+    const { experienceName } = metadata;
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
-    if (platform === 'android') {
-      const result = await api.putAsync(`credentials/android/keystore/${experienceName}`, {
-        credentials: newCredentials,
-      });
+    const result = await api.putAsync(`credentials/android/keystore/${experienceName}`, {
+      credentials: newCredentials,
+    });
 
-      if (!result) {
-        throw new Error('Error updating credentials.');
-      }
-    } else if (platform === 'ios') {
-      const { userCredentialsId: idFromCredentials, ...credentials } = newCredentials;
-      const userCredentialsIdOverride = idFromCredentials
-        ? [idFromCredentials]
-        : userCredentialsIds;
-
-      const currentCredentials = await api.getAsync(
-        `credentials/ios/${experienceName}/${encodeURI(bundleIdentifier ?? '')}`
-      );
-      const appleTeam = pick(credentials, ['teamId', 'teamName']);
-      const distCredentials = pick(credentials, [
-        'certP12',
-        'certPassword',
-        'certId',
-        'certPrivateSigningKey',
-        'distCertSerialNumber',
-      ]);
-      const pushCredentials = pick(credentials, ['apnsKeyId', 'apnsKeyP8']);
-      const appCredentials = pick(credentials, ['provisioningProfile', 'provisioningProfileId']);
-
-      if (!isEmpty(appCredentials)) {
-        await api.postAsync('credentials/ios/provisioningProfile/update', {
-          experienceName,
-          bundleIdentifier,
-          credentials: { ...appCredentials, ...appleTeam },
-        });
-      }
-
-      if (!isEmpty(pushCredentials)) {
-        const pushCredentialsId = get(currentCredentials, 'pushCredentialsId');
-        const { id: updatedId } = await api.putAsync(`credentials/ios/push/${pushCredentialsId}`, {
-          credentials: { ...pushCredentials, ...appleTeam },
-        });
-        if (!pushCredentialsId) {
-          await api.postAsync(`credentials/ios/use/push`, {
-            experienceName,
-            bundleIdentifier,
-            userCredentialsId: updatedId,
-          });
-        }
-      }
-
-      if (!isEmpty(distCredentials)) {
-        const distCredentialsId = get(currentCredentials, 'distCredentialsId');
-        const { id: updatedId } = await api.putAsync(`credentials/ios/dist/${distCredentialsId}`, {
-          credentials: { ...distCredentials, ...appleTeam },
-        });
-        if (!distCredentialsId) {
-          await api.postAsync(`credentials/ios/use/dist`, {
-            experienceName,
-            bundleIdentifier,
-            userCredentialsId: updatedId,
-          });
-        }
-      }
-
-      // reused credentials
-      for (const id of userCredentialsIdOverride) {
-        const record = await api.getAsync(`credentials/ios/userCredentials/${id}`, {
-          decrypt: false,
-        });
-        if (record && record.type === 'push-key') {
-          await api.postAsync(`credentials/ios/use/push`, {
-            experienceName,
-            bundleIdentifier,
-            userCredentialsId: id,
-          });
-        } else if (record && record.type === 'dist-cert') {
-          await api.postAsync(`credentials/ios/use/dist`, {
-            experienceName,
-            bundleIdentifier,
-            userCredentialsId: id,
-          });
-        }
-      }
+    if (!result) {
+      throw new Error('Error updating credentials.');
     }
   } else {
     const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -146,7 +146,6 @@ export async function removeCredentialsForPlatform(
   if (process.env.EXPO_NEXT_API) {
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
-    console.log('deleting android credentials');
     await api.deleteAsync(`credentials/android/keystore/${metadata.experienceName}`);
   } else {
     const { err } = await Api.callMethodAsync('deleteCredentials', [], 'post', {

--- a/packages/xdl/src/credentials/IosCredentials.ts
+++ b/packages/xdl/src/credentials/IosCredentials.ts
@@ -34,15 +34,6 @@ export type CredObject = {
 
 export type CredsList = Array<CredObject>;
 
-export async function getExistingDistCerts(
-  username: string,
-  appleTeamId: string,
-  options: { provideFullCertificate?: boolean } = {}
-): Promise<CredsList> {
-  const distCerts = await getExistingUserCredentials(username, appleTeamId, 'dist-cert');
-  return formatDistCerts(distCerts, options);
-}
-
 export function formatDistCerts(distCerts: any, options: { provideFullCertificate?: boolean }) {
   return distCerts.map(({ usedByApps, userCredentialsId, certId, certP12, certPassword }: any) => {
     let serialNumber;
@@ -70,15 +61,6 @@ export function formatDistCerts(distCerts: any, options: { provideFullCertificat
   });
 }
 
-export async function getExistingPushKeys(
-  username: string,
-  appleTeamId: string,
-  options: { provideFullPushKey?: boolean } = {}
-): Promise<CredsList> {
-  const pushKeys = await getExistingUserCredentials(username, appleTeamId, 'push-key');
-  return formatPushKeys(pushKeys, options);
-}
-
 export function formatPushKeys(pushKeys: any, options: { provideFullPushKey?: boolean }) {
   return pushKeys.map(({ usedByApps, userCredentialsId, apnsKeyId, apnsKeyP8 }: any) => {
     let name = `Key ID: ${apnsKeyId}`;
@@ -95,45 +77,4 @@ export function formatPushKeys(pushKeys: any, options: { provideFullPushKey?: bo
       short: apnsKeyId,
     };
   });
-}
-
-async function getExistingUserCredentials(
-  username: string,
-  appleTeamId: string,
-  type: string
-): Promise<CredsList> {
-  let certs;
-  if (process.env.EXPO_NEXT_API) {
-    const user = await UserManager.ensureLoggedInAsync();
-    const api = ApiV2.clientForUser(user);
-    const { userCredentials, appCredentials } = await api.getAsync(`credentials/ios`);
-
-    certs = userCredentials
-      .filter((cred: any) => cred.type === type && cred.teamId === appleTeamId)
-      .map(({ id, ...cred }: any) => ({
-        ...cred,
-        userCredentialsId: id,
-        usedByApps: appCredentials
-          .filter((app: any) => app.pushCredentialsId === id || app.distCredentialsId === id)
-          .map(({ experienceName }: any) => experienceName)
-          .join(';'),
-      }));
-  } else {
-    const result = await Api.callMethodAsync('getExistingUserCredentials', [], 'post', {
-      username,
-      appleTeamId,
-      type,
-    });
-
-    if (result.err) {
-      throw new Error('Error getting existing distribution certificates.');
-    }
-    certs = result.certs;
-  }
-
-  return certs.map(({ usedByApps, userCredentialsId, ...rest }: any) => ({
-    usedByApps: usedByApps && usedByApps.split(';'),
-    userCredentialsId: String(userCredentialsId),
-    ...rest,
-  }));
 }


### PR DESCRIPTION
This was already approved here: https://github.com/expo/expo-cli/pull/1431
but github wouldn't let me reopen it.

Was able to remove some of the ios code and make some of the code "android only" due to @quinlanj recent work.

ran:
```
expo build:ios
expo build:android
expo build:ios --clear-credentials
expo build:android --clear-credentials
```