### PR TITLE
[ts] Use require() to read package.json instead of import for TypeScript

### DIFF
--- a/packages/expo-cli/gulpfile.js
+++ b/packages/expo-cli/gulpfile.js
@@ -6,7 +6,7 @@ const changed = require('gulp-changed');
 const plumber = require('gulp-plumber');
 const sourcemaps = require('gulp-sourcemaps');
 
-const packageJSON = require('expo-cli/package.json');
+const packageJSON = require('../package.json');
 
 const paths = {
   source: {

--- a/packages/expo-cli/gulpfile.js
+++ b/packages/expo-cli/gulpfile.js
@@ -6,7 +6,7 @@ const changed = require('gulp-changed');
 const plumber = require('gulp-plumber');
 const sourcemaps = require('gulp-sourcemaps');
 
-const packageJSON = require('../package.json');
+const packageJSON = require('./package.json');
 
 const paths = {
   source: {

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -2,8 +2,7 @@ import { Command } from 'commander';
 // @ts-ignore
 import envinfo from 'envinfo';
 
-// @ts-ignore: expo-cli is not listed in its own dependencies
-import packageJSON from 'expo-cli/package.json';
+const packageJSON = require('../../package.json');
 
 async function action(options: never): Promise<void> {
   const info = await envinfo.run(

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -31,14 +31,16 @@ import {
 } from '@expo/xdl';
 import * as ConfigUtils from '@expo/config';
 
-// @ts-ignore: expo-cli is not listed in its own dependencies
-import packageJSON from 'expo-cli/package.json';
-
 import { loginOrRegisterIfLoggedOut } from './accounts';
 import log from './log';
 import update from './update';
 import urlOpts from './urlOpts';
 import { registerCommands } from './commands';
+
+// We use require() to exclude package.json from TypeScript's analysis since it lives outside the
+// src directory and would change the directory structure of the emitted files under the build
+// directory
+const packageJSON = require('../package.json');
 
 Api.setClientName(packageJSON.version);
 ApiV2.setClientName(packageJSON.version);

--- a/packages/expo-cli/src/update.ts
+++ b/packages/expo-cli/src/update.ts
@@ -1,7 +1,6 @@
 import { ModuleVersion } from '@expo/xdl';
 
-// @ts-ignore: expo-cli is not listed in its own dependencies
-import packageJSON from 'expo-cli/package.json';
+const packageJSON = require('../package.json');
 
 const ModuleVersionChecker = ModuleVersion.createModuleVersionChecker(
   packageJSON.name,

--- a/packages/expo-cli/tsconfig.json
+++ b/packages/expo-cli/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "build",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "package.json"],
+  "include": ["src/**/*.ts"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "references": [
     { "path": "../xdl" }

--- a/packages/expo-cli/tsconfig.json
+++ b/packages/expo-cli/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@expo/babel-preset-cli/tsconfig.base",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "build",
     "resolveJsonModule": true
   },


### PR DESCRIPTION
By default, Node does not allow for a package to import itself. This might work in scenarios such as a Yarn monorepo where all linked workspaces are linked under the root directory's `node_modules` folder so searching up the directory hierarchy leads to `<root>/node_modules/<workspace>`. This breaks in reality when a package is taken outside of the monorepo. This notably happens with expo-cli since it is most likely to be installed as a top-level program and not as a dependency.

If we import package.json, TypeScript thinks the package directory is the root directory and emits `build/{package.json,src}`. We don't want that -- we want package.json to be left alone and for the compiled contents of `src` to be emitted into `build`.

Test plan: `rm -fr build tsconfig.tsbuildinfo; yarn tsc` and check that `build` doesn't contain package.json. Start with `node bin/expo.js`. Run `yarn gulp --tasks` to make sure gulp can run.