### PR TITLE
[cli] better profile logging

### DIFF
--- a/packages/expo-cli/src/credentials/actions/list.ts
+++ b/packages/expo-cli/src/credentials/actions/list.ts
@@ -79,13 +79,10 @@ export function displayIosAppCredentials(appCredentials: IosAppCredentials) {
       appCredentials.bundleIdentifier
     }`
   );
-  if (
-    appCredentials.credentials.provisioningProfile &&
-    appCredentials.credentials.provisioningProfileId
-  ) {
+  if (appCredentials.credentials.provisioningProfile) {
     log(
       `    Provisioning profile (ID: ${chalk.green(
-        appCredentials.credentials.provisioningProfileId
+        appCredentials.credentials.provisioningProfileId || '---------'
       )})`
     );
   } else {


### PR DESCRIPTION
# why
- user uploaded provisioning profiles dont have ids, so when we display credentials, show `-----` (like we do with all our other uploaded creds) instead of saying `credential is missing`