### PR TITLE
[cli] better provisioning profile validation

### DIFF
--- a/packages/expo-cli/src/appleApi/provisioningProfile.ts
+++ b/packages/expo-cli/src/appleApi/provisioningProfile.ts
@@ -1,5 +1,4 @@
 import ora from 'ora';
-import plist, { PlistObject } from '@expo/plist';
 import { IosCodeSigning } from '@expo/xdl';
 import { runAction, travelingFastlane } from './fastlane';
 import { AppleCtx } from './authenticate';
@@ -111,12 +110,5 @@ export class ProvisioningProfileManager {
     ];
     await runAction(travelingFastlane.manageProvisioningProfiles, args);
     spinner.succeed();
-  }
-
-  static isExpired(base64EncodedProfile: string): boolean {
-    const buffer = Buffer.from(base64EncodedProfile, 'base64');
-    const profile = buffer.toString('utf-8');
-    const profilePlist = plist.parse(profile) as PlistObject;
-    return new Date(profilePlist['ExpirationDate'] as string) <= new Date();
   }
 }

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -170,7 +170,8 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
         ctx,
         appCredentials,
         this.options.teamId!,
-        provisioningProfileFromParams
+        provisioningProfileFromParams,
+        distributionCert
       );
     } else {
       await runCredentialsManager(

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -350,12 +350,12 @@ export async function validateProfileWithoutApple(
   const profile = buffer.toString('utf-8');
   const profilePlist = plist.parse(profile) as PlistObject;
 
-  const distCertFingerprint = await PKCS12Utils.getP12CertFingerprint(
-    distCert.certP12,
-    distCert.certPassword
-  );
-
   try {
+    const distCertFingerprint = await PKCS12Utils.getP12CertFingerprint(
+      distCert.certP12,
+      distCert.certPassword
+    );
+
     IosCodeSigning.validateProvisioningProfile(profilePlist, {
       distCertFingerprint,
       bundleIdentifier,

--- a/packages/xdl/src/xdl.ts
+++ b/packages/xdl/src/xdl.ts
@@ -60,6 +60,8 @@ import NotificationCode from './NotificationCode';
 
 import PackagerLogsStream, { LogRecord, LogUpdater } from './logs/PackagerLogsStream';
 
+import * as PKCS12Utils from './detach/PKCS12Utils';
+
 import * as Project from './Project';
 
 import * as ProjectSettings from './ProjectSettings';
@@ -144,6 +146,7 @@ export { ModuleVersion };
 export { Modules };
 export { NotificationCode };
 export { PackagerLogsStream, LogRecord, LogUpdater };
+export { PKCS12Utils };
 export { Project };
 export { ProjectSettings };
 export { ProjectUtils };


### PR DESCRIPTION
# Why
Have better validation for provisioning profiles, especially if:
- the profile was uploaded by a user 
- there is no access to apple

# Tests
- [x] Upload provisioning profile with Dist Cert A, then run `expo build:ios` with Dist Cert B. Expect to detect that uploaded profile is not compatible and recover. 

