### PR TITLE
[cli] fix spinner logging in auth

### DIFF
--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -43,7 +43,7 @@ export type AppleCtx = {
 
 export async function authenticate(options: Options = {}): Promise<AppleCtx> {
   const { appleId, appleIdPassword } = await _requestAppleIdCreds(options);
-  const spinner = ora(`Trying to authenticate with Apple Developer Portal...`).start();
+  log(`Authenticating to Apple Developer Portal...`); // use log instead of spinner in case we need to prompt user for 2fa
   try {
     const { teams, fastlaneSession } = await runAction(
       travelingFastlane.authenticate,
@@ -52,11 +52,11 @@ export async function authenticate(options: Options = {}): Promise<AppleCtx> {
         pipeStdout: true,
       }
     );
-    spinner.succeed('Authenticated with Apple Developer Portal successfully!');
+    log(chalk.green('Authenticated with Apple Developer Portal successfully!'));
     const team = await _chooseTeam(teams, options.teamId);
     return { appleId, appleIdPassword, team, fastlaneSession };
   } catch (err) {
-    spinner.fail('Authentication with Apple Developer Portal failed!');
+    log(chalk.green('Authentication with Apple Developer Portal failed!'));
     throw err;
   }
 }

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -56,7 +56,7 @@ export async function authenticate(options: Options = {}): Promise<AppleCtx> {
     const team = await _chooseTeam(teams, options.teamId);
     return { appleId, appleIdPassword, team, fastlaneSession };
   } catch (err) {
-    log(chalk.green('Authentication with Apple Developer Portal failed!'));
+    log(chalk.red('Authentication with Apple Developer Portal failed!'));
     throw err;
   }
 }


### PR DESCRIPTION
# why 
- change authentication logging from a spinner to a regular log - fastlane could ask for 2fa and if a spinner is going on at the same time, user input into the terminal becomes a mess

partially addresses https://github.com/expo/expo-cli/issues/1631