### PR TITLE
fix(xdl): add new lines to client install timeout messages

### DIFF
--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -237,13 +237,12 @@ export async function installExpoAsync(url?: string) {
     if (warningTimer) {
       clearTimeout(warningTimer);
     }
-    return setTimeout(
-      () =>
-        Logger.global.info(
-          'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
-        ),
-      INSTALL_WARNING_TIMEOUT
-    );
+    return setTimeout(() => {
+      Logger.global.info('');
+      Logger.global.info(
+        'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
+      );
+    }, INSTALL_WARNING_TIMEOUT);
   };
 
   Logger.notifications.info({ code: NotificationCode.START_LOADING });

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -370,13 +370,12 @@ export async function _installExpoOnSimulatorAsync(url?: string) {
     if (warningTimer) {
       clearTimeout(warningTimer);
     }
-    return setTimeout(
-      () =>
-        Logger.global.info(
-          'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
-        ),
-      INSTALL_WARNING_TIMEOUT
-    );
+    return setTimeout(() => {
+      Logger.global.info('');
+      Logger.global.info(
+        'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
+      );
+    }, INSTALL_WARNING_TIMEOUT);
   };
 
   Logger.notifications.info({ code: NotificationCode.START_LOADING });


### PR DESCRIPTION
Fixes #1636

This breaks the message free from the progress bar, making it way more readable. Unfortunately, there is no `log.newLine` in the global logger, but this is the same approach to that 😄 