### PR TITLE
fix(xdl): ping metro bundler when fetching current status

### DIFF
--- a/packages/expo-cli/e2e/__tests__/start-test.ts
+++ b/packages/expo-cli/e2e/__tests__/start-test.ts
@@ -17,16 +17,19 @@ beforeAll(async () => {
 });
 
 test('start --offline', async () => {
-  const promise = spawnAsync(EXPO_CLI, ['start', '--offline'], {
-    cwd: projectDir,
-  });
+  const promise = spawnAsync(EXPO_CLI, ['start', '--offline'], { cwd: projectDir });
   const cli = promise.child;
-  cli.stdout.pipe(process.stdout).on('data', data => {
-    if (/Your native app is running/.test(data.toString())) {
-      cli.kill('SIGINT');
-    }
-  });
+
   cli.stderr.pipe(process.stderr);
+  cli.stdout
+    .on('data', data => {
+      if (/Your native app is running/.test(data.toString())) {
+        cli.kill('SIGINT');
+      }
+    })
+    .pipe(process.stdout);
+
+  await promise;
 });
 
 test('start --offline with existing packager info', async () => {
@@ -41,12 +44,13 @@ test('start --offline with existing packager info', async () => {
   const cli = promise.child;
 
   cli.stderr.pipe(process.stderr);
-  cli.stdout.on('data', data => {
-    process.stdout.write(data);
-    if (/Your native app is running/.test(data.toString())) {
-      cli.kill('SIGINT');
-    }
-  });
+  cli.stdout
+    .on('data', data => {
+      if (/Your native app is running/.test(data.toString())) {
+        cli.kill('SIGINT');
+      }
+    })
+    .pipe(process.stdout);
 
   try {
     await promise;

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -23,6 +23,7 @@
     "testEnvironment": "node",
     "roots": [
       "__mocks__",
+      "e2e",
       "src"
     ],
     "moduleFileExtensions": [


### PR DESCRIPTION
Fixes #1677

This calls the Metro bundler's `/status` endpoint to determine if the project is running. It's performing a request, so that might slow the method down (with a current max time out of 2 seconds). But it provides a more accurate response about the current status. The code is [copied from `startReactNativeServerAsync`](https://github.com/expo/expo-cli/blob/a26baf39c19cefd016eb0acc0445c4a3cba16915/packages/xdl/src/Project.ts#L1925)

I did not check for the expo server, it [closes itself when you start it](https://github.com/expo/expo-cli/blob/master/packages/xdl/src/Project.ts#L1985). So that means it restarts every time you run `expo start`, right? And I think both `expo publish` and `expo build` doesn't require the Expo server to run.

Thanks for thinking along @quinlanj 😄 