### PR TITLE
Increase max upload size of apiv2 to same as in apiv1

### DIFF
--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -15,8 +15,7 @@ import { Cacher } from './tools/FsCache';
 import UserManager from './User';
 import UserSettings from './UserSettings';
 import XDLError from './XDLError';
-
-const MAX_CONTENT_LENGTH = 100 /* MB */ * 1024 * 1024;
+import { MAX_CONTENT_LENGTH } from './ApiV2';
 
 const TIMER_DURATION = 30000;
 const TIMEOUT = 3600000;

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -10,6 +10,8 @@ import QueryString from 'querystring';
 import Config from './Config';
 import * as ConnectionStatus from './ConnectionStatus';
 
+export const MAX_CONTENT_LENGTH = 100 /* MB */ * 1024 * 1024;
+
 // These aren't constants because some commands switch between staging and prod
 function _rootBaseUrl() {
   return `${Config.api.scheme}://${Config.api.host}`;
@@ -192,7 +194,9 @@ export default class ApiV2Client {
       reqOptions.timeout = 1;
     }
 
-    reqOptions = merge({}, reqOptions, extraRequestOptions, uploadOptions);
+    reqOptions = merge({}, reqOptions, extraRequestOptions, uploadOptions, {
+      maxContentLength: MAX_CONTENT_LENGTH,
+    });
 
     let response;
     let result;


### PR DESCRIPTION
 # why
https://github.com/expo/expo-cli/issues/1647#issuecomment-598273532

# how
The default upload limit is 10, it was increased to 100 in api v1. This increases it in api v2 as well.

# test

Set the limit to 1 byte to repro the error.