### PR TITLE
[cli] Better formatting of update message

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -399,7 +399,8 @@ async function checkCliVersionAsync() {
       boxen(
         chalk.green(`There is a new version of ${packageJSON.name} available (${latest}).
 You are currently using ${packageJSON.name} ${current}
-Install expo-cli globally using the package manager of your choice; for example: \`npm install -g ${packageJSON.name}\` to get the latest version`),
+Install expo-cli globally using the package manager of your choice;
+for example: \`npm install -g ${packageJSON.name}\` to get the latest version`),
         { borderColor: 'green', padding: 1 }
       )
     );
@@ -409,7 +410,7 @@ Install expo-cli globally using the package manager of your choice; for example:
     log.nestedWarn(
       boxen(
         chalk.red(
-          `This version of expo-cli is not supported anymore. 
+          `This version of expo-cli is not supported anymore.
 It's highly recommended to update to the newest version.
 
 The API endpoints used in this version of expo-cli might not exist,


### PR DESCRIPTION
# Why

The UI of the out of date message on the CLI is never properly formatted unless viewed on an huge display. This PR adds a return to make the message properly formatted on more screen sizes.

# Screenshots

## Before
<img width="844" alt="Screen Shot 2020-03-12 at 1 53 53 PM" src="https://user-images.githubusercontent.com/6455018/76551180-b2a93a00-6469-11ea-9f9b-7612e60c47f1.png">

## After
<img width="837" alt="Screen Shot 2020-03-12 at 1 57 04 PM" src="https://user-images.githubusercontent.com/6455018/76551219-b63cc100-6469-11ea-8d42-ec3f850cfe5c.png">
