### PR TITLE
[config] remove mode from getConfig

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -63,7 +63,6 @@ function getConfigContext(
   return {
     pkg,
     context: {
-      mode: options.mode,
       projectRoot,
       configPath,
       config: configFromPkg,
@@ -76,11 +75,10 @@ function getConfigContext(
  * If a function is exported from the `app.config.js` then a partial config will be passed as an argument.
  * The partial config is composed from any existing app.json, and certain fields from the `package.json` like name and description.
  *
- * You should use the supplied `mode` option in an `app.config.js` instead of `process.env.NODE_ENV`
  *
  * **Example**
  * ```js
- * module.exports = function({ config, mode }) {
+ * module.exports = function({ config }) {
  *   // mutate the config before returning it.
  *   config.slug = 'new slug'
  *   return config;
@@ -94,14 +92,7 @@ function getConfigContext(
  * @param projectRoot the root folder containing all of your application code
  * @param options enforce criteria for a project config
  */
-export function getConfig(projectRoot: string, options: GetConfigOptions): ProjectConfig {
-  if (!['development', 'production'].includes(options.mode)) {
-    throw new ConfigError(
-      `Invalid mode "${options.mode}" was used to evaluate the project config.`,
-      'INVALID_MODE'
-    );
-  }
-
+export function getConfig(projectRoot: string, options: GetConfigOptions = {}): ProjectConfig {
   const { context, pkg } = getConfigContext(projectRoot, options);
 
   const config = findAndEvalConfig(context) ?? context.config;

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -931,17 +931,13 @@ export type ConfigErrorCode =
   | 'INVALID_MODE'
   | 'INVALID_CONFIG';
 
-export type ConfigMode = 'development' | 'production';
-
 export type ConfigContext = {
   projectRoot: string;
   configPath?: string;
   config: Partial<ExpoConfig>;
-  mode: ConfigMode;
 };
 
 export type GetConfigOptions = {
-  mode: ConfigMode;
   configPath?: string;
   skipSDKVersionRequirement?: boolean;
 };

--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -66,9 +66,9 @@ function sanitizePublicPath(publicPath: unknown): string {
 export function getConfigForPWA(
   projectRoot: string,
   getAbsolutePath: (...pathComponents: string[]) => string,
-  options: { templateIcon: string; mode: 'development' | 'production' }
+  options: { templateIcon: string }
 ) {
-  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode: options.mode });
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   return ensurePWAConfig(exp, getAbsolutePath, options);
 }
 

--- a/packages/config/src/__tests__/Config-test.js
+++ b/packages/config/src/__tests__/Config-test.js
@@ -99,19 +99,16 @@ describe('readConfigJson', () => {
     it(`will throw if the app.json is missing`, () => {
       expect(() => readConfigJson('/no-config')).toThrow(/does not contain a valid app\.json/);
       // No config is required for new method
-      expect(() => getConfig('/no-config', { mode: 'development' })).not.toThrow();
+      expect(() => getConfig('/no-config')).not.toThrow();
     });
 
     it(`will throw if the expo package is missing`, () => {
       expect(() => readConfigJson('/no-package', true)).toThrow(
         /Cannot determine which native SDK version your project uses/
       );
-      expect(() =>
-        getConfig('/no-package', { mode: 'development', skipSDKVersionRequirement: false })
-      ).toThrow(/Cannot determine which native SDK version your project uses/);
-    });
-    it(`will throw if an invalid mode is used to get the config`, () => {
-      expect(() => getConfig('/no-config', { mode: 'invalid' })).toThrow(/Invalid mode/);
+      expect(() => getConfig('/no-package', { skipSDKVersionRequirement: false })).toThrow(
+        /Cannot determine which native SDK version your project uses/
+      );
     });
   });
 });

--- a/packages/config/src/__tests__/ConfigParsing-test.js
+++ b/packages/config/src/__tests__/ConfigParsing-test.js
@@ -16,7 +16,6 @@ describe('getConfig', () => {
     xit('parses a ts config', () => {
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/ts');
       const { exp } = getConfig(projectRoot, {
-        mode: 'development',
         skipSDKVersionRequirement: true,
       });
       expect(exp.foo).toBe('bar');
@@ -26,12 +25,11 @@ describe('getConfig', () => {
       // ensure config is composed (package.json values still exist)
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/js');
       const { exp } = getConfig(projectRoot, {
-        mode: 'development',
         skipSDKVersionRequirement: true,
       });
       expect(exp.foo).toBe('bar');
-      // Ensure the config is passed the package.json values and mode
-      expect(exp.name).toBe('js-config-test+config+development');
+      // Ensure the config is passed the package.json values
+      expect(exp.name).toBe('js-config-test+config');
       // Ensures that the app.json is read and passed to the method
       expect(exp.slug).toBe('someslug+config');
     });
@@ -39,7 +37,6 @@ describe('getConfig', () => {
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/js');
       const configPath = path.resolve(projectRoot, 'with-default_app.config.js');
       const { exp } = getConfig(projectRoot, {
-        mode: 'development',
         skipSDKVersionRequirement: true,
         configPath,
       });
@@ -50,7 +47,6 @@ describe('getConfig', () => {
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/js');
       const configPath = path.resolve(projectRoot, 'export-json_app.config.js');
       const { exp } = getConfig(projectRoot, {
-        mode: 'development',
         skipSDKVersionRequirement: true,
         configPath,
       });
@@ -60,7 +56,6 @@ describe('getConfig', () => {
     xit('parses a yaml config', () => {
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/yaml');
       const { exp } = getConfig(projectRoot, {
-        mode: 'development',
         skipSDKVersionRequirement: true,
       });
       expect(exp.foo).toBe('bar');
@@ -68,7 +63,6 @@ describe('getConfig', () => {
     xit('parses a toml config', () => {
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/toml');
       const { exp } = getConfig(projectRoot, {
-        mode: 'development',
         skipSDKVersionRequirement: true,
       });
       expect(exp.foo).toBe('bar');
@@ -94,7 +88,6 @@ describe('getConfig', () => {
       setCustomConfigPath(fixtures.customLocationJson, customConfigPath);
 
       const { exp } = getConfig(projectRoot, {
-        mode: 'development',
         skipSDKVersionRequirement: true,
       });
       // Ensure the expo object is reduced out. See #1542.
@@ -113,7 +106,6 @@ describe('getConfig', () => {
       resetAllCustomFixtureLocations();
       // After the rest, read the root config and ensure it doesn't match the custom location config.
       const { exp: baseExp } = getConfig(projectRoot, {
-        mode: 'development',
         skipSDKVersionRequirement: true,
       });
       // name is read from the default config.

--- a/packages/config/src/__tests__/fixtures/language-support/js/app.config.js
+++ b/packages/config/src/__tests__/fixtures/language-support/js/app.config.js
@@ -1,6 +1,6 @@
-module.exports = function({ config, mode }) {
+module.exports = function({ config }) {
   config.foo = 'bar';
-  if (config.name) config.name += '+config+' + mode;
+  if (config.name) config.name += '+config';
   if (config.slug) config.slug += '+config';
   return config;
 };

--- a/packages/config/src/__tests__/getConfig-test.js
+++ b/packages/config/src/__tests__/getConfig-test.js
@@ -24,7 +24,6 @@ describe('findAndEvalConfig', () => {
   it(`throws a useful error for JS configs with a syntax error`, () => {
     expect(() =>
       findAndEvalConfig({
-        mode: 'development',
         projectRoot: join(__dirname, 'fixtures/behavior/syntax-error'),
         config: {},
       })

--- a/packages/config/src/paths/__tests__/paths-test.js
+++ b/packages/config/src/paths/__tests__/paths-test.js
@@ -23,7 +23,7 @@ describe('getEntryPointWithExtensions', () => {
       `The expected package.json path: /package.json does not exist`
     );
   });
-  it(`throws an error when an invalid mode is used`, () => {
+  xit(`throws an error when an invalid mode is used`, () => {
     expect(() => getEntryPointWithExtensions('/', [], [], null)).toThrow(
       `Invalid mode "null" was used to evaluate the project config`
     );

--- a/packages/config/src/paths/__tests__/paths-test.js
+++ b/packages/config/src/paths/__tests__/paths-test.js
@@ -23,11 +23,6 @@ describe('getEntryPointWithExtensions', () => {
       `The expected package.json path: /package.json does not exist`
     );
   });
-  xit(`throws an error when an invalid mode is used`, () => {
-    expect(() => getEntryPointWithExtensions('/', [], [], null)).toThrow(
-      `Invalid mode "null" was used to evaluate the project config`
-    );
-  });
 });
 
 // getAbsolutePathWithProjectRoot;

--- a/packages/config/src/paths/paths.ts
+++ b/packages/config/src/paths/paths.ts
@@ -6,7 +6,6 @@ import resolveFrom from 'resolve-from';
 import { getConfig } from '../Config';
 import { resolveModule } from '../Modules';
 import { getManagedExtensions } from './extensions';
-import { ConfigMode } from '../Config.types';
 
 // https://github.com/facebook/create-react-app/blob/9750738cce89a967cc71f28390daf5d4311b193c/packages/react-scripts/config/paths.js#L22
 export function ensureSlash(inputPath: string, needsSlash: boolean): string {
@@ -48,21 +47,19 @@ export function getAbsolutePathWithProjectRoot(
 export function getEntryPoint(
   projectRoot: string,
   entryFiles: string[],
-  platforms: string[],
-  mode: ConfigMode = 'development'
+  platforms: string[]
 ): string | null {
   const extensions = getManagedExtensions(platforms);
-  return getEntryPointWithExtensions(projectRoot, entryFiles, extensions, mode);
+  return getEntryPointWithExtensions(projectRoot, entryFiles, extensions);
 }
 
 // Used to resolve the main entry file for a project.
 export function getEntryPointWithExtensions(
   projectRoot: string,
   entryFiles: string[],
-  extensions: string[],
-  mode: ConfigMode = 'development'
+  extensions: string[]
 ): string {
-  const { exp, pkg } = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode });
+  const { exp, pkg } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
 
   // This will first look in the `app.json`s `expo.entryPoint` field for a potential main file.
   // We check the Expo config first in case you want your project to start differently with Expo then in a standalone environment.

--- a/packages/electron-adapter/src/Webpack.ts
+++ b/packages/electron-adapter/src/Webpack.ts
@@ -22,12 +22,10 @@ export function withExpoWebpack(
 
   const projectRoot = options.projectRoot || process.cwd();
 
-  const enforcedMode = config.mode === 'production' ? config.mode : 'development';
   const env: any = {
     platform: 'electron',
     projectRoot,
-    mode: enforcedMode,
-    locations: getPaths(projectRoot, enforcedMode),
+    locations: getPaths(projectRoot),
   };
   if (!config.plugins) config.plugins = [];
   if (!config.resolve) config.resolve = {};

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -52,7 +52,6 @@ export default function(program: Command) {
         }
         const { exp } = getConfig(projectDir, {
           skipSDKVersionRequirement: true,
-          mode: 'production',
         });
 
         if (exp) {

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -88,7 +88,6 @@ export async function action(projectDir: string = './', options: Options = { for
   // Doesn't matter if expo is installed or which mode is used.
   const { exp } = ConfigUtils.getConfig(projectDir, {
     skipSDKVersionRequirement: true,
-    mode: 'development',
   });
 
   const templateFolder = path.dirname(

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -31,7 +31,6 @@ const EXPO_APP_ENTRY = 'node_modules/expo/AppEntry.js';
 async function warnIfDependenciesRequireAdditionalSetupAsync(projectRoot: string): Promise<void> {
   // We just need the custom `nodeModulesPath` from the config.
   const { exp, pkg } = await ConfigUtils.getConfig(projectRoot, {
-    mode: 'production',
     skipSDKVersionRequirement: true,
   });
 

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -64,7 +64,7 @@ export default (program: any) => {
         if (exp.owner) {
           formData.append('owner', exp.owner);
         }
-        formData.append('slug', await Project.getSlugAsync(projectDir, options));
+        formData.append('slug', await Project.getSlugAsync(projectDir));
         formData.append('version', VERSION);
         if (options.releaseChannel) {
           formData.append('releaseChannel', options.releaseChannel);
@@ -83,7 +83,7 @@ export default (program: any) => {
         const api = ApiV2.clientForUser(user);
         result = await api.postAsync('publish/history', {
           owner: exp.owner,
-          slug: await Project.getSlugAsync(projectDir, options),
+          slug: await Project.getSlugAsync(projectDir),
           version: VERSION,
           releaseChannel: options.releaseChannel,
           count: options.count,
@@ -152,7 +152,7 @@ export default (program: any) => {
       // TODO(ville): handle the API result for not authenticated user instead of checking upfront
       const user = await UserManager.ensureLoggedInAsync();
       const { exp } = await readConfigJsonAsync(projectDir);
-      const slug = await Project.getSlugAsync(projectDir, options);
+      const slug = await Project.getSlugAsync(projectDir);
 
       let result: any;
       if (process.env.EXPO_LEGACY_API === 'true') {

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -33,7 +33,7 @@ export default function(program: Command) {
           let result = await api.postAsync('publish/set', {
             releaseChannel: options.releaseChannel,
             publishId: options.publishId,
-            slug: await Project.getSlugAsync(projectDir, options),
+            slug: await Project.getSlugAsync(projectDir),
           });
           let tableString = table.printTableJson(
             result.queryResult,
@@ -51,27 +51,27 @@ export default function(program: Command) {
     .alias('pr')
     .description('Rollback an update to a channel.')
     .option('--channel-id <channel-id>', 'The channel id to rollback in the channel. (Required)')
-    .asyncActionProjectDir(async (projectDir: string, options: { channelId?: string }): Promise<
-      void
-    > => {
-      if (!options.channelId) {
-        throw new Error('You must specify a channel id. You can find ids using publish:history.');
+    .asyncActionProjectDir(
+      async (projectDir: string, options: { channelId?: string }): Promise<void> => {
+        if (!options.channelId) {
+          throw new Error('You must specify a channel id. You can find ids using publish:history.');
+        }
+        const user = await UserManager.getCurrentUserAsync();
+        const api = ApiV2.clientForUser(user);
+        try {
+          let result = await api.postAsync('publish/rollback', {
+            channelId: options.channelId,
+            slug: await Project.getSlugAsync(projectDir),
+          });
+          let tableString = table.printTableJson(
+            result.queryResult,
+            'Channel Rollback Status ',
+            'SUCCESS'
+          );
+          console.log(tableString);
+        } catch (e) {
+          log.error(e);
+        }
       }
-      const user = await UserManager.getCurrentUserAsync();
-      const api = ApiV2.clientForUser(user);
-      try {
-        let result = await api.postAsync('publish/rollback', {
-          channelId: options.channelId,
-          slug: await Project.getSlugAsync(projectDir, options),
-        });
-        let tableString = table.printTableJson(
-          result.queryResult,
-          'Channel Rollback Status ',
-          'SUCCESS'
-        );
-        console.log(tableString);
-      } catch (e) {
-        log.error(e);
-      }
-    });
+    );
 }

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -304,10 +304,7 @@ export async function upgradeAsync(
   },
   options: Options
 ) {
-  let { exp, pkg } = await ConfigUtils.getConfig(projectRoot, {
-    skipSDKVersionRequirement: false,
-    mode: 'development',
-  });
+  let { exp, pkg } = await ConfigUtils.getConfig(projectRoot);
 
   if (await maybeBailOnGitStatusAsync()) return;
 
@@ -415,7 +412,7 @@ export async function upgradeAsync(
   } catch (_) {}
 
   // Evaluate project config (app.config.js)
-  const { exp: currentExp } = ConfigUtils.getConfig(projectRoot, { mode: 'development' });
+  const { exp: currentExp } = ConfigUtils.getConfig(projectRoot);
 
   if (
     !Versions.gteSdkVersion(currentExp, targetSdkVersionString) &&

--- a/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
+++ b/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
@@ -9,7 +9,6 @@ export async function getExpoSdkConfig(path: string) {
     const { projectRoot } = await findProjectRootAsync(path);
     const { exp } = ConfigUtils.getConfig(projectRoot, {
       skipSDKVersionRequirement: true,
-      mode: 'development',
     });
     return exp;
   } catch (error) {

--- a/packages/expo-optimize/src/assets.ts
+++ b/packages/expo-optimize/src/assets.ts
@@ -72,9 +72,8 @@ async function getAssetFilesAsync(
   projectDir: string,
   options: OptimizationOptions
 ): Promise<{ allFiles: string[]; selectedFiles: string[] }> {
-  const { exp } = await getConfig(projectDir, {
+  const { exp } = getConfig(projectDir, {
     skipSDKVersionRequirement: true,
-    mode: 'production',
   });
   const webOutputPath = await getWebOutputPath(exp);
   const { assetBundlePatterns } = exp;
@@ -188,7 +187,7 @@ export async function optimizeAsync(
       continue;
     }
 
-    if (!await isAvailableAsync()) {
+    if (!(await isAvailableAsync())) {
       console.log(
         chalk.bold.red(
           `\u203A Cannot optimize images without sharp-cli.\n\u203A Run this command again after successfully installing sharp with \`${chalk.magenta`npm install -g sharp-cli`}\``

--- a/packages/webpack-config/src/addons/withDevServer.ts
+++ b/packages/webpack-config/src/addons/withDevServer.ts
@@ -61,7 +61,7 @@ export function createDevServer(
   { allowedHost, proxy }: DevServerOptions = {}
 ): WebpackDevServerConfiguration {
   const { https = false } = env;
-  const locations = env.locations || getPaths(env.projectRoot, env.mode);
+  const locations = env.locations || getPaths(env.projectRoot);
   // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpackDevServer.config.js
   return {
     // Enable gzip compression of generated files.

--- a/packages/webpack-config/src/addons/withUnimodules.ts
+++ b/packages/webpack-config/src/addons/withUnimodules.ts
@@ -66,7 +66,7 @@ export default function withUnimodules(
   const config = argv.expoConfig || getConfig(environment);
 
   const mode = getMode(env);
-  const locations = env.locations || getPaths(environment.projectRoot, mode);
+  const locations = env.locations || getPaths(environment.projectRoot);
 
   const { build: buildConfig = {} } = config.web || {};
   const { babel: babelAppConfig = {} } = buildConfig;

--- a/packages/webpack-config/src/addons/withWorkbox.ts
+++ b/packages/webpack-config/src/addons/withWorkbox.ts
@@ -90,7 +90,7 @@ export default function withWorkbox(
     injectManifestOptions = {},
   } = options;
 
-  const locations = getPaths(projectRoot!, webpackConfig.mode);
+  const locations = getPaths(projectRoot!);
 
   webpackConfig.plugins.push(
     new CopyPlugin([

--- a/packages/webpack-config/src/env/__tests__/getConfig-test.js
+++ b/packages/webpack-config/src/env/__tests__/getConfig-test.js
@@ -5,8 +5,7 @@ import getConfig from '../getConfig';
 import { normalizePaths } from '../../utils';
 
 const projectRoot = path.resolve(__dirname, '../../../e2e/basic');
-const mode = 'development';
-const env = { projectRoot, mode };
+const env = { projectRoot };
 
 it(`has consistent defaults`, () => {
   const config = getConfig(env);

--- a/packages/webpack-config/src/env/getConfig.ts
+++ b/packages/webpack-config/src/env/getConfig.ts
@@ -1,8 +1,6 @@
 import { ExpoConfig, getConfigForPWA } from '@expo/config';
 
 import { Environment } from '../types';
-import { getConfigMode } from './getConfigMode';
-import getMode from './getMode';
 import { getPaths } from './paths';
 
 /**
@@ -11,19 +9,14 @@ import { getPaths } from './paths';
  * @param env Environment properties used for getting the Expo project config.
  * @category env
  */
-function getConfig(
-  env: Pick<Environment, 'projectRoot' | 'mode' | 'config' | 'locations'>
-): ExpoConfig {
+function getConfig(env: Pick<Environment, 'projectRoot' | 'config' | 'locations'>): ExpoConfig {
   if (env.config) {
     return env.config;
   }
-  const mode = getMode(env);
-  const configMode = getConfigMode(mode);
-  const locations = env.locations || getPaths(env.projectRoot, configMode);
+  const locations = env.locations || getPaths(env.projectRoot);
   // Fill all config values with PWA defaults
   return getConfigForPWA(env.projectRoot, locations.absolute, {
     templateIcon: locations.template.get('icon.png'),
-    mode: configMode,
   });
 }
 

--- a/packages/webpack-config/src/env/getConfigMode.ts
+++ b/packages/webpack-config/src/env/getConfigMode.ts
@@ -1,5 +1,0 @@
-import { ConfigMode } from '@expo/config';
-
-export function getConfigMode(mode: string): ConfigMode {
-  return mode === 'production' ? mode : 'development';
-}

--- a/packages/webpack-config/src/env/paths.ts
+++ b/packages/webpack-config/src/env/paths.ts
@@ -13,9 +13,8 @@ import url from 'url';
 
 import { Environment, FilePaths, Mode } from '../types';
 import getMode from './getMode';
-import { getConfigMode } from './getConfigMode';
 
-function parsePaths(projectRoot: string, mode: Mode, nativeAppManifest?: ExpoConfig): FilePaths {
+function parsePaths(projectRoot: string, nativeAppManifest?: ExpoConfig): FilePaths {
   const inputProjectRoot = projectRoot || getPossibleProjectRoot();
 
   function absolute(...pathComponents: string[]): string {
@@ -56,7 +55,7 @@ function parsePaths(projectRoot: string, mode: Mode, nativeAppManifest?: ExpoCon
     root: path.resolve(inputProjectRoot),
     appMain,
     modules: modulesPath,
-    servedPath: getServedPath(inputProjectRoot, mode),
+    servedPath: getServedPath(inputProjectRoot),
     template: {
       get: templatePath,
       folder: templatePath(),
@@ -87,13 +86,11 @@ function parsePaths(projectRoot: string, mode: Mode, nativeAppManifest?: ExpoCon
  * @param projectRoot
  * @category env
  */
-export function getPaths(projectRoot: string, mode?: string): FilePaths {
-  const configMode = getConfigMode(getMode({ mode }));
+export function getPaths(projectRoot: string): FilePaths {
   const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
-    mode: configMode,
   });
-  return parsePaths(projectRoot, configMode, exp);
+  return parsePaths(projectRoot, exp);
 }
 
 /**
@@ -102,14 +99,12 @@ export function getPaths(projectRoot: string, mode?: string): FilePaths {
  * @param projectRoot
  * @category env
  */
-export async function getPathsAsync(projectRoot: string, mode?: string): Promise<FilePaths> {
-  const configMode = getConfigMode(getMode({ mode }));
-
+export async function getPathsAsync(projectRoot: string): Promise<FilePaths> {
   let exp;
   try {
-    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode: configMode }).exp;
+    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp;
   } catch (error) {}
-  return parsePaths(projectRoot, configMode, exp);
+  return parsePaths(projectRoot, exp);
 }
 
 /**
@@ -118,12 +113,9 @@ export async function getPathsAsync(projectRoot: string, mode?: string): Promise
  * @param projectRoot
  * @category env
  */
-export function getServedPath(projectRoot: string, mode?: string): string {
-  const configMode = getConfigMode(getMode({ mode }));
-
+export function getServedPath(projectRoot: string): string {
   const { pkg } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
-    mode: configMode,
   });
   const envPublicUrl = process.env.WEB_PUBLIC_URL;
 
@@ -163,7 +155,7 @@ export function getPublicPaths(
 } {
   const parsedMode = getMode(env);
   if (parsedMode === 'production') {
-    const publicPath = getServedPath(env.projectRoot, parsedMode);
+    const publicPath = getServedPath(env.projectRoot);
     return {
       publicPath,
       publicUrl: publicPath.slice(0, -1),
@@ -179,12 +171,9 @@ export function getPublicPaths(
  * @param projectRoot
  * @category env
  */
-export function getProductionPath(projectRoot: string, mode?: string): string {
-  const configMode = getConfigMode(getMode({ mode }));
-
+export function getProductionPath(projectRoot: string): string {
   const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
-    mode: configMode,
   });
   return getAbsolutePathWithProjectRoot(projectRoot, getWebOutputPath(exp));
 }

--- a/packages/webpack-config/src/env/validate.ts
+++ b/packages/webpack-config/src/env/validate.ts
@@ -68,7 +68,7 @@ export function validateEnvironment(env: InputEnvironment): Environment {
   const filledEnv: any = environmentSchema.validateSync(env);
 
   if (!env.locations) {
-    filledEnv.locations = getPaths(env.projectRoot, env.mode);
+    filledEnv.locations = getPaths(env.projectRoot);
   }
 
   if (!env.config) {

--- a/packages/webpack-config/src/loaders/createAllLoaders.ts
+++ b/packages/webpack-config/src/loaders/createAllLoaders.ts
@@ -80,7 +80,7 @@ export default function createAllLoaders(
   // @ts-ignore
   env.config = env.config || getConfig(env);
   // @ts-ignore
-  env.locations = env.locations || getPaths(env.projectRoot, env.mode);
+  env.locations = env.locations || getPaths(env.projectRoot);
 
   const { root, includeModule, template } = env.locations;
 
@@ -110,7 +110,7 @@ export function getBabelLoaderRule(
   // @ts-ignore
   env.config = env.config || getConfig(env);
 
-  env.locations = env.locations || getPaths(env.projectRoot, env.mode);
+  env.locations = env.locations || getPaths(env.projectRoot);
 
   const { web: { build: { babel = {} } = {} } = {} } = env.config;
 

--- a/packages/webpack-config/src/loaders/createBabelLoader.ts
+++ b/packages/webpack-config/src/loaders/createBabelLoader.ts
@@ -86,7 +86,7 @@ export function createBabelLoaderFromEnvironment(
   env: Pick<Environment, 'babel' | 'locations' | 'projectRoot' | 'config' | 'mode' | 'platform'>
 ): Rule {
   const mode = getMode(env);
-  const locations = env.locations || getPaths(env.projectRoot, mode);
+  const locations = env.locations || getPaths(env.projectRoot);
   const appConfig = env.config || getConfig(env);
 
   const { build = {} } = appConfig.web;

--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -79,7 +79,7 @@ export default class DefinePlugin extends OriginalDefinePlugin {
     const mode = getMode(env);
     const { publicUrl } = getPublicPaths(env);
     const config = env.config || getConfig(env);
-    const locations = env.locations || getPaths(env.projectRoot, mode);
+    const locations = env.locations || getPaths(env.projectRoot);
     const productionManifestPath = locations.production.manifest;
     return new DefinePlugin({
       mode,

--- a/packages/webpack-config/src/plugins/ExpoHtmlWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoHtmlWebpackPlugin.ts
@@ -24,7 +24,7 @@ const DEFAULT_MINIFY = {
  */
 export default class HtmlWebpackPlugin extends OriginalHtmlWebpackPlugin {
   constructor(env: Environment) {
-    const locations = env.locations || getPaths(env.projectRoot, env.mode);
+    const locations = env.locations || getPaths(env.projectRoot);
     const config = getConfig(env);
     const isProduction = getMode(env) === 'production';
 

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -107,7 +107,7 @@ export default async function(
     // isProd
   );
 
-  const locations = env.locations || (await getPathsAsync(env.projectRoot, mode));
+  const locations = env.locations || (await getPathsAsync(env.projectRoot));
 
   const { publicPath, publicUrl } = getPublicPaths(env);
 

--- a/packages/webpack-pwa-manifest-plugin/src/__tests__/config-test.js
+++ b/packages/webpack-pwa-manifest-plugin/src/__tests__/config-test.js
@@ -6,7 +6,6 @@ it(`matches`, async () => {
   // Fill all config values with PWA defaults
   const config = getConfigForPWA(__dirname, (...props) => resolve(__dirname, ...props), {
     templateIcon: require.resolve('./icon.png'),
-    mode: 'development',
   });
 
   const manifest = createPWAManifestFromExpoConfig(config);

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -1,4 +1,4 @@
-import { readExpRcAsync } from '@expo/config';
+import { getConfig, readExpRcAsync } from '@expo/config';
 import spawnAsync from '@expo/spawn-async';
 import child_process from 'child_process';
 import chalk from 'chalk';
@@ -18,7 +18,6 @@ import * as UrlUtils from './UrlUtils';
 import UserSettings from './UserSettings';
 import * as Versions from './Versions';
 import { getUrlAsync as getWebpackUrlAsync } from './Webpack';
-import { getProjectConfigAsync } from './Config';
 
 let _lastUrl: string | null = null;
 const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
@@ -392,7 +391,7 @@ export async function openProjectAsync(
     await startAdbReverseAsync(projectRoot);
 
     let projectUrl = await UrlUtils.constructManifestUrlAsync(projectRoot);
-    const { exp } = await getProjectConfigAsync(projectRoot, {
+    const { exp } = getConfig(projectRoot, {
       skipSDKVersionRequirement: true,
     });
 
@@ -521,9 +520,7 @@ const splashScreenDPIConstraints = [
  * @since SDK33
  */
 export async function checkSplashScreenImages(projectDir: string): Promise<void> {
-  const { exp } = await getProjectConfigAsync(projectDir, {
-    skipSDKVersionRequirement: false,
-  });
+  const { exp } = getConfig(projectDir);
 
   // return before SDK33
   if (!Versions.gteSdkVersion(exp, '33.0.0')) {

--- a/packages/xdl/src/Config.ts
+++ b/packages/xdl/src/Config.ts
@@ -1,30 +1,6 @@
 import getenv from 'getenv';
 
-import { GetConfigOptions, ProjectConfig, getConfig } from '@expo/config';
 import * as Env from './Env';
-
-import * as ProjectSettings from './ProjectSettings';
-
-/**
- * Get the project config with mode defaulting to the ProjectSettings module.
- *
- * @param projectRoot
- * @param options if `mode` is not supplied it will be inferred from the ProjectSettings module.
- */
-export async function getProjectConfigAsync(
-  projectRoot: string,
-  options: Partial<GetConfigOptions> = {}
-): Promise<ProjectConfig> {
-  let { mode } = options;
-  if (!mode || !['development', 'production'].includes(mode)) {
-    const { dev } = await ProjectSettings.readAsync(projectRoot);
-    mode = dev ? 'development' : 'production';
-  }
-  return getConfig(projectRoot, {
-    ...options,
-    mode,
-  });
-}
 
 interface ApiConfig {
   scheme: string;

--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -1,4 +1,4 @@
-import { AppJSONConfig, BareAppConfig } from '@expo/config';
+import { AppJSONConfig, BareAppConfig, getConfig } from '@expo/config';
 
 import { getEntryPoint } from '@expo/config/paths';
 import fs from 'fs-extra';
@@ -22,7 +22,6 @@ import UserManager from './User';
 import * as UrlUtils from './UrlUtils';
 import UserSettings from './UserSettings';
 import * as ProjectSettings from './ProjectSettings';
-import { getProjectConfigAsync } from './Config';
 
 // TODO(ville): update when this has landed: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36598
 type ReadEntry = any;
@@ -267,7 +266,7 @@ export async function getPublishInfoAsync(root: string): Promise<PublishInfo> {
   let { username } = user;
 
   // Evaluate the project config and throw an error if the `sdkVersion` cannot be found.
-  const { exp } = await getProjectConfigAsync(root, { skipSDKVersionRequirement: false });
+  const { exp } = getConfig(root);
 
   const name = exp.slug;
   const { version, sdkVersion } = exp;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -45,7 +45,7 @@ import * as Analytics from './Analytics';
 import * as Android from './Android';
 import Api from './Api';
 import ApiV2 from './ApiV2';
-import Config, { getProjectConfigAsync } from './Config';
+import Config from './Config';
 import * as ExponentTools from './detach/ExponentTools';
 import StandaloneContext from './detach/StandaloneContext';
 import * as DevSession from './DevSession';
@@ -356,14 +356,8 @@ function _requireFromProject(modulePath: string, projectRoot: string, exp: ExpoC
 }
 
 // TODO: Move to @expo/config
-export async function getSlugAsync(
-  projectRoot: string,
-  {
-    mode = 'production',
-    ...options
-  }: { mode?: 'production' | 'development'; [key: string]: any } = {}
-): Promise<string> {
-  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, mode });
+export async function getSlugAsync(projectRoot: string): Promise<string> {
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   if (exp.slug) {
     return exp.slug;
   }
@@ -1006,7 +1000,7 @@ async function _getPublishExpConfigAsync(
   options.releaseChannel = options.releaseChannel || 'default'; // joi default not enforcing this :/
 
   // Verify that exp/app.json and package.json exist
-  const { exp, pkg } = await getProjectConfigAsync(projectRoot);
+  const { exp, pkg } = getConfig(projectRoot);
 
   if (exp.android && exp.android.config) {
     delete exp.android.config;
@@ -1407,11 +1401,11 @@ type GetExpConfigOptions = {
 
 async function getConfigAsync(
   projectRoot: string,
-  options: Pick<GetExpConfigOptions, 'publicUrl' | 'mode' | 'platform'> = {}
+  options: Pick<GetExpConfigOptions, 'publicUrl' | 'platform'> = {}
 ) {
   if (!options.publicUrl) {
     // get the manifest from the project directory
-    const { exp, pkg } = await getProjectConfigAsync(projectRoot, { mode: options.mode as any });
+    const { exp, pkg } = getConfig(projectRoot);
     const configName = configFilename(projectRoot);
     return {
       exp,
@@ -1784,7 +1778,7 @@ export async function startReactNativeServerAsync(
   await Watchman.addToPathAsync(); // Attempt to fix watchman if it's hanging
   await Watchman.unblockAndGetVersionAsync(projectRoot);
 
-  let { exp } = await getProjectConfigAsync(projectRoot);
+  let { exp } = getConfig(projectRoot);
 
   let packagerPort = await _getFreePortAsync(19001); // Create packager options
 
@@ -2011,10 +2005,7 @@ export async function startExpoServerAsync(projectRoot: string): Promise<void> {
       Doctor.validateWithNetworkAsync(projectRoot);
       // Get packager opts and then copy into bundleUrlPackagerOpts
       let packagerOpts = await ProjectSettings.readAsync(projectRoot);
-      let { exp: manifest } = getConfig(projectRoot, {
-        skipSDKVersionRequirement: false,
-        mode: packagerOpts.dev ? 'development' : 'production',
-      });
+      let { exp: manifest } = getConfig(projectRoot);
       let bundleUrlPackagerOpts = JSON.parse(JSON.stringify(packagerOpts));
       bundleUrlPackagerOpts.urlType = 'http';
       if (bundleUrlPackagerOpts.hostType === 'redirect') {
@@ -2393,7 +2384,7 @@ export async function startAsync(
     developerTool: Config.developerTool,
   });
 
-  let { exp } = await getProjectConfigAsync(projectRoot);
+  let { exp } = getConfig(projectRoot);
   if (options.webOnly) {
     await Webpack.restartAsync(projectRoot, options);
     DevSession.startSession(projectRoot, exp, 'web');

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -1,4 +1,5 @@
 import * as osascript from '@expo/osascript';
+import { getConfig } from '@expo/config';
 import spawnAsync from '@expo/spawn-async';
 import delayAsync from 'delay-async';
 import fs from 'fs-extra';
@@ -17,7 +18,6 @@ import UserSettings from './UserSettings';
 import * as Versions from './Versions';
 import { getUrlAsync as getWebpackUrlAsync } from './Webpack';
 import XDLError from './XDLError';
-import { getProjectConfigAsync } from './Config';
 
 let _lastUrl: string | null = null;
 
@@ -505,7 +505,7 @@ export async function openProjectAsync(
   let projectUrl = await UrlUtils.constructManifestUrlAsync(projectRoot, {
     hostType: 'localhost',
   });
-  const { exp } = await getProjectConfigAsync(projectRoot, {
+  const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
 

--- a/packages/xdl/src/Web.ts
+++ b/packages/xdl/src/Web.ts
@@ -1,12 +1,12 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import getenv from 'getenv';
+import { getConfig } from '@expo/config';
 import path from 'path';
 import openBrowser from 'react-dev-utils/openBrowser';
 import webpack from 'webpack';
 import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 
-import { getProjectConfigAsync } from './Config';
 import Logger from './Logger';
 import { LogTag, logWarning } from './project/ProjectUtils';
 import * as UrlUtils from './UrlUtils';
@@ -142,7 +142,7 @@ export async function openProjectAsync(
  * @param projectRoot
  */
 export async function onlySupportsWebAsync(projectRoot: string): Promise<boolean> {
-  const { exp } = await getProjectConfigAsync(projectRoot, {
+  const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
   if (Array.isArray(exp.platforms) && exp.platforms.length === 1) {

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -303,10 +303,9 @@ export async function bundleAsync(projectRoot: string, options?: BundlingOptions
   await bundleWebAppAsync(projectRoot, config);
 }
 
-export async function getProjectNameAsync(projectRoot: string, isDev: boolean): Promise<string> {
+export async function getProjectNameAsync(projectRoot: string): Promise<string> {
   const { exp } = ConfigUtils.getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
-    mode: isDev ? 'development' : 'production',
   });
   const { webName } = ConfigUtils.getNameFromConfig(exp);
   return webName;

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -128,7 +128,7 @@ export async function startAsync(
   const protocol = env.https ? 'https' : 'http';
   const urls = prepareUrls(protocol, '::', webpackServerPort);
   const useYarn = ConfigUtils.isUsingYarn(projectRoot);
-  const appName = await getProjectNameAsync(projectRoot, env.mode !== 'production');
+  const appName = await getProjectNameAsync(projectRoot);
   const nonInteractive = validateBoolOption(
     'nonInteractive',
     options.nonInteractive,

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -9,7 +9,7 @@ import glob from 'glob-promise';
 import uuid from 'uuid';
 import inquirer from 'inquirer';
 import spawnAsync from '@expo/spawn-async';
-import { findConfigFile } from '@expo/config';
+import { findConfigFile, getConfig } from '@expo/config';
 import isPlainObject from 'lodash/isPlainObject';
 
 import { isDirectory, regexFileAsync, rimrafDontThrow } from './ExponentTools';
@@ -29,7 +29,6 @@ import * as UrlUtils from '../UrlUtils';
 import * as Versions from '../Versions';
 import installPackagesAsync from './installPackagesAsync';
 import logger from './Logger';
-import { getProjectConfigAsync } from '../Config';
 
 async function yesnoAsync(message) {
   const { ok } = await inquirer.prompt([
@@ -68,7 +67,7 @@ async function _detachAsync(projectRoot, options) {
 
   let username = user.username;
   const { configName, configPath, configNamespace } = findConfigFile(projectRoot);
-  let { exp } = await getProjectConfigAsync(projectRoot, { skipSDKVersionRequirement: false });
+  let { exp } = getConfig(projectRoot);
   let experienceName = `@${username}/${exp.slug}`;
   let experienceUrl = `exp://exp.host/${experienceName}`;
 
@@ -354,7 +353,7 @@ async function _getIosExpoKitVersionThrowErrorAsync(iosProjectDirectory) {
 
 async function readNullableConfigJsonAsync(projectDir) {
   try {
-    return await getProjectConfigAsync(projectDir, { skipSDKVersionRequirement: false });
+    return getConfig(projectDir);
   } catch (_) {
     return null;
   }
@@ -395,7 +394,7 @@ async function prepareDetachedServiceContextIosAsync(projectDir, args) {
     path.join(context.data.expoSourcePath, '__internal__', 'keys.json')
   );
 
-  const { exp } = await getProjectConfigAsync(expoRootDir, { skipSDKVersionRequirement: true });
+  const { exp } = getConfig(expoRootDir, { skipSDKVersionRequirement: true });
 
   await IosPlist.modifyAsync(supportingDirectory, 'EXBuildConstants', constantsConfig => {
     // verify that we are actually in a service context and not a misconfigured project

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -3,6 +3,7 @@ import {
   PackageJSONConfig,
   configFilename,
   fileExistsAsync,
+  getConfig,
   getPackageJson,
   resolveModule,
 } from '@expo/config';
@@ -14,7 +15,7 @@ import _ from 'lodash';
 import path from 'path';
 import semver from 'semver';
 
-import Config, { getProjectConfigAsync } from '../Config';
+import Config from '../Config';
 import * as Versions from '../Versions';
 import * as Watchman from '../Watchman';
 import * as ExpSchema from './ExpSchema';
@@ -114,7 +115,7 @@ export async function validateWithSchemaFileAsync(
   projectRoot: string,
   schemaPath: string
 ): Promise<{ schemaErrorMessage: string | undefined; assetsErrorMessage: string | undefined }> {
-  let { exp } = await getProjectConfigAsync(projectRoot, { skipSDKVersionRequirement: false });
+  let { exp } = getConfig(projectRoot);
   let schema = JSON.parse(await fs.readFile(schemaPath, 'utf8'));
   return validateWithSchema(projectRoot, exp, schema.schema, 'exp.json', 'UNVERSIONED', true);
 }
@@ -171,7 +172,7 @@ async function _validateExpJsonAsync(
   allowNetwork: boolean
 ): Promise<number> {
   if (!exp || !pkg) {
-    // getProjectConfigAsync already logged an error
+    // getConfig already logged an error
     return FATAL;
   }
 
@@ -384,7 +385,7 @@ async function _validateReactNativeVersionAsync(
 
 async function _validateNodeModulesAsync(projectRoot: string): Promise<number> {
   // Just need `nodeModulesPath` so it doesn't matter if expo is installed or the sdkVersion is defined.
-  let { exp } = await getProjectConfigAsync(projectRoot, { skipSDKVersionRequirement: true });
+  let { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   let nodeModulesPath = projectRoot;
   if (exp.nodeModulesPath) {
     nodeModulesPath = path.resolve(projectRoot, exp.nodeModulesPath);
@@ -449,7 +450,7 @@ async function validateAsync(projectRoot: string, allowNetwork: boolean): Promis
 
   let exp, pkg;
   try {
-    const config = await getProjectConfigAsync(projectRoot, { skipSDKVersionRequirement: false });
+    const config = getConfig(projectRoot);
     exp = config.exp;
     pkg = config.pkg;
   } catch (e) {


### PR DESCRIPTION
# Why 

`getConfig` is currently used in a lot of different ways, not all of them correspond to a particular mode. 

# How

Remove the mode param from the `getConfig`'s options and context.

# Test Plan

All of the current tests for getConfig should continue to pass, the ones used for testing invalid modes will be removed.