### PR TITLE
[webpack-config] Fix source maps

### DIFF
--- a/packages/webpack-config/src/addons/withOptimizations.ts
+++ b/packages/webpack-config/src/addons/withOptimizations.ts
@@ -24,7 +24,7 @@ export default function withOptimizations(webpackConfig: AnyConfiguration): AnyC
   if (webpackConfig.mode !== 'production') {
     return webpackConfig;
   }
-  const shouldUseSourceMap = webpackConfig.devtool !== null;
+  const shouldUseSourceMap = typeof webpackConfig.devtool === 'string';
 
   const _isDebugMode = isDebugMode();
 

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -58,12 +58,14 @@ function getDevtool(
 
 function getOutput(locations: FilePaths, mode: Mode, publicPath: string): Output {
   const commonOutput: Output = {
-    sourceMapFilename: '[chunkhash].map',
     // We inferred the "public path" (such as / or /my-project) from homepage.
     // We use "/" in development.
     publicPath,
     // Build folder (default `web-build`)
     path: locations.production.folder,
+    // this defaults to 'window', but by setting it to 'this' then
+    // module chunks which are built will work in web workers as well.
+    globalObject: 'this',
   };
 
   if (mode === 'production') {
@@ -73,7 +75,7 @@ function getOutput(locations: FilePaths, mode: Mode, publicPath: string): Output
     // Point sourcemap entries to original disk location (format as URL on Windows)
     commonOutput.devtoolModuleFilenameTemplate = (
       info: webpack.DevtoolModuleFilenameTemplateInfo
-    ): string => locations.absolute(info.absoluteResourcePath).replace(/\\/g, '/');
+    ): string => path.relative(locations.root, info.absoluteResourcePath).replace(/\\/g, '/');
   } else {
     // Add comments that describe the file import/exports.
     // This will make it easier to debug.
@@ -276,7 +278,7 @@ export default async function(
             }
             return manifest;
           }, seed);
-          const entrypointFiles = entrypoints.main.filter(fileName => !fileName.endsWith('.map'));
+          const entrypointFiles = entrypoints.app.filter(fileName => !fileName.endsWith('.map'));
 
           return {
             files: manifestFiles,


### PR DESCRIPTION
- Source maps were being generated in the root build folder instead of the static/js folder
- Source maps were using absolute paths instead of relative paths (similar to the Iowa Caucus app lol)
- Source maps now dynamically download better -- harder to link them accidentally.
- Asset manifest was including source maps incorrectly, now the `asset-manifest.json` is split into two objects: `app`, and `entrypoints` (inspired by CRA, but with support for electron). 
- Added `GENERATE_SOURCEMAP` env variable for disabling source maps completely (this is for co-op with CRA users). 