### PR TITLE
Extract Android standalone app config to @expo/config and apply on eject

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "yarn run bootstrap && lerna run watch --parallel --ignore @expo/dev-tools --ignore expo-optimize --ignore @expo/next-adapter --ignore @expo/electron-adapter",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1",
     "lint": "eslint . --ext js,ts",
-    "test-coverage": "jest --coverage && codecov"
+    "test-coverage": "jest -i --coverage && codecov"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "yarn run bootstrap && lerna run watch --parallel --ignore @expo/dev-tools --ignore expo-optimize --ignore @expo/next-adapter --ignore @expo/electron-adapter",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1",
     "lint": "eslint . --ext js,ts",
-    "test-coverage": "jest -i --coverage && codecov"
+    "test-coverage": "jest --coverage && codecov"
   },
   "husky": {
     "hooks": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -9,7 +9,7 @@
     "prepare": "yarn run clean && yarn build",
     "clean": "rm -rf build ./tsconfig.tsbuildinfo",
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest -i"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -9,7 +9,7 @@
     "prepare": "yarn run clean && yarn build",
     "clean": "rm -rf build ./tsconfig.tsbuildinfo",
     "lint": "eslint .",
-    "test": "jest -i"
+    "test": "jest"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -125,6 +125,12 @@ export type AndroidPlatformConfig = {
   versionCode?: number;
 
   /**
+   * The background color for your app, behind any of your React views. This is also known as the root view background color. This value should be a 6 character long hex color string, eg: '#000000'. Default is white — '#ffffff'.
+   * Overrides the top-level `backgroundColor` key if it is present.
+   */
+  backgroundColor?: string;
+
+  /**
    * Local path or remote url to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` key. We recommend that you use a 1024x1024 png file (transparency is recommended for the Google Play Store). This icon will appear on the home screen and within the Expo app.
    */
   icon?: Icon;
@@ -147,6 +153,12 @@ export type AndroidPlatformConfig = {
    * [Firebase Configuration File](https://support.google.com/firebase/answer/7015592) google-services.json file for configuring Firebase.
    */
   googleServicesFile?: string;
+
+  /**
+   * Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.
+   * @fallback light
+   */
+  userInterfaceStyle?: 'light' | 'dark' | 'automatic';
 
   config?: {
     /**
@@ -185,6 +197,15 @@ export type AndroidPlatformConfig = {
      * [Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID.
      */
     googleMobileAdsAppId?: string;
+    /**
+     *  A boolean indicating whether to initialize Google App Measurement and begin sending
+     *  user-level event data to Google immediately when the app starts. The default in Expo
+     *  (Client and in standalone apps) is `false`.
+     *
+     *  Sets the opposite of the given value to the following tag in AndroidManifest.xml:
+     *  https://developers.google.com/admob/android/eu-consent#delay_app_measurement_optional
+     */
+    googleMobileAdsAutoInit: boolean;
     /**
      * [Google Sign-In Android SDK](https://developers.google.com/identity/sign-in/android/start-integrating) keys for your standalone app.
      */
@@ -250,7 +271,7 @@ export type AndroidPlatformConfig = {
         ]
       }]
      */
-  intentFilters?: IntentFilter | IntentFilter[];
+  intentFilters?: IntentFilter[];
 };
 
 // tslint:disable-next-line:max-line-length
@@ -561,6 +582,13 @@ export type IosPlatformConfig = {
    * @pattern ^[A-Za-z0-9\\.]+$
    */
   buildNumber?: string;
+
+  /**
+   * The background color for your app, behind any of your React views. This is also known as the root view background color. This value should be a 6 character long hex color string, eg: '#000000'. Default is white — '#ffffff'.
+   * Overrides the top-level `backgroundColor` key if it is present.
+   */
+  backgroundColor?: string;
+
   /**
    * Local path or remote URL to an image to use for your app's icon on iOS. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency. Expo will generate the other required sizes. This icon will appear on the home screen and within the Expo app.
    */
@@ -698,6 +726,10 @@ export type ExpoConfig = {
    */
   slug?: string;
   /**
+   * The background color for your app, behind any of your React views. This is also known as the root view background color. This value should be a 6 character long hex color string, eg: '#000000'. Default is white — '#ffffff'.
+   */
+  backgroundColor?: string;
+  /**
    * The username of the account under which this app is published. If not specified, the app is published as the currently signed-in user.
    */
   owner?: string;
@@ -784,7 +816,7 @@ export type ExpoConfig = {
     /**
      * Determines whether to show or hide the bottom navigation bar. When set to `false`, both the navigation bar and the status bar are hidden by enabling full-screen mode, as recommended by the Android documentation.
      */
-    visible?: boolean;
+    visible?: 'leanback' | 'immersive' | 'sticky-immersive';
     /**
      * Configure the navigation bar icons to have a light or dark color. Supported on Android Oreo and newer.
      */

--- a/packages/config/src/android/AdaptiveIcon.ts
+++ b/packages/config/src/android/AdaptiveIcon.ts
@@ -1,0 +1,19 @@
+import { ExpoConfig } from '../Config.types';
+import { addWarningAndroid } from '../WarningAggregator';
+
+export function getAdaptiveIcon(config: ExpoConfig) {
+  // TODO: add support for applying adaptive icon config
+  return config.android?.adaptiveIcon?.foregroundImage ?? null;
+}
+
+export async function setAdaptiveIconAsync(config: ExpoConfig, projectRoot: string) {
+  let icon = getAdaptiveIcon(config);
+  if (!icon) {
+    return;
+  }
+
+  addWarningAndroid(
+    'android.adaptiveIcon',
+    'This is the image that your app uses on your home screen, you will need to configure it manually.'
+  );
+}

--- a/packages/config/src/android/Branch.ts
+++ b/packages/config/src/android/Branch.ts
@@ -1,0 +1,53 @@
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+export function getBranchApiKey(config: ExpoConfig) {
+  return config.android?.config?.branch?.apiKey ?? null;
+}
+
+export async function setBranchApiKey(config: ExpoConfig, projectDirectory: string) {
+  const apiKey = getBranchApiKey(config);
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+
+  if (!apiKey || !manifestPath) {
+    return false;
+  }
+
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+  let mainApplication = androidManifestJson.manifest.application.filter(
+    (e: any) => e['$']['android:name'] === '.MainApplication'
+  )[0];
+
+  let existingBranchApiKeyItem;
+  const newBranchApiKeyItem = {
+    $: {
+      'android:name': 'io.branch.sdk.BranchKey',
+      'android:value': apiKey,
+    },
+  };
+  if (mainApplication.hasOwnProperty('meta-data')) {
+    existingBranchApiKeyItem = mainApplication['meta-data'].filter(
+      (e: any) => e['$']['android:name'] === 'io.branch.sdk.BranchKey'
+    );
+    if (existingBranchApiKeyItem.length) {
+      existingBranchApiKeyItem[0]['$']['android:value'] = apiKey;
+    } else {
+      mainApplication['meta-data'].push(newBranchApiKeyItem);
+    }
+  } else {
+    mainApplication['meta-data'] = [newBranchApiKeyItem];
+  }
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android Branch API key. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/Branch.ts
+++ b/packages/config/src/android/Branch.ts
@@ -1,24 +1,18 @@
 import { ExpoConfig } from '../Config.types';
-import {
-  getProjectAndroidManifestPathAsync,
-  readAndroidManifestAsync,
-  writeAndroidManifestAsync,
-} from './Manifest';
+import { Document } from './Manifest';
 
 export function getBranchApiKey(config: ExpoConfig) {
   return config.android?.config?.branch?.apiKey ?? null;
 }
 
-export async function setBranchApiKey(config: ExpoConfig, projectDirectory: string) {
+export async function setBranchApiKey(config: ExpoConfig, manifestDocument: Document) {
   const apiKey = getBranchApiKey(config);
-  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
 
-  if (!apiKey || !manifestPath) {
-    return false;
+  if (!apiKey) {
+    return manifestDocument;
   }
 
-  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
-  let mainApplication = androidManifestJson.manifest.application.filter(
+  let mainApplication = manifestDocument.manifest.application.filter(
     (e: any) => e['$']['android:name'] === '.MainApplication'
   )[0];
 
@@ -42,12 +36,5 @@ export async function setBranchApiKey(config: ExpoConfig, projectDirectory: stri
     mainApplication['meta-data'] = [newBranchApiKeyItem];
   }
 
-  try {
-    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
-  } catch (e) {
-    throw new Error(
-      `Error setting Android Branch API key. Cannot write new AndroidManifest.xml to ${manifestPath}.`
-    );
-  }
-  return true;
+  return manifestDocument;
 }

--- a/packages/config/src/android/Colors.ts
+++ b/packages/config/src/android/Colors.ts
@@ -1,0 +1,57 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { Builder, Parser } from 'xml2js';
+import { Document } from './Manifest';
+import { XMLItem } from './Styles';
+
+const BASE_STYLES_XML = `<?xml version="1.0" encoding="utf-8"?><resources></resources>`;
+
+export async function getProjectColorsXMLPathAsync(projectDir: string): Promise<string | null> {
+  try {
+    const shellPath = path.join(projectDir, 'android');
+    if ((await fs.stat(shellPath)).isDirectory()) {
+      const colorsPath = path.join(shellPath, 'app/src/main/res/values/colors.xml');
+      await fs.ensureFile(colorsPath);
+      return colorsPath;
+    }
+  } catch (error) {
+    throw new Error('No android directory found in your project.');
+  }
+
+  return null;
+}
+
+export async function readColorsXMLAsync(colorsPath: string): Promise<Document> {
+  const contents = await fs.readFile(colorsPath, { encoding: 'utf8', flag: 'r' });
+  const parser = new Parser();
+  const manifest = parser.parseStringPromise(contents || BASE_STYLES_XML);
+  return manifest;
+}
+
+export async function writeColorsXMLAsync(colorsPath: string, colorsContent: any): Promise<void> {
+  const colorsXml = new Builder().buildObject(colorsContent);
+  await fs.ensureDir(path.dirname(colorsPath));
+  await fs.writeFile(colorsPath, colorsXml);
+}
+
+export function setColorItem(itemToAdd: XMLItem[], colorFileContentsJSON: Document) {
+  if (colorFileContentsJSON.resources.color) {
+    let colorNameExists = colorFileContentsJSON.resources.color.filter(
+      (e: XMLItem) => e['$'].name === itemToAdd[0]['$'].name
+    )[0];
+    if (colorNameExists) {
+      colorNameExists['_'] = itemToAdd[0]['_'];
+    } else {
+      colorFileContentsJSON.resources.color = colorFileContentsJSON.resources.color.concat(
+        itemToAdd
+      );
+    }
+  } else {
+    if (typeof colorFileContentsJSON.resources === 'string') {
+      //file was empty and JSON is `{resources : ''}`
+      colorFileContentsJSON.resources = {};
+    }
+    colorFileContentsJSON.resources.color = itemToAdd;
+  }
+  return colorFileContentsJSON;
+}

--- a/packages/config/src/android/Facebook.ts
+++ b/packages/config/src/android/Facebook.ts
@@ -1,0 +1,151 @@
+import { Parser } from 'xml2js';
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+const facebookSchemeActivity = (scheme: string) => `
+<activity
+    android:name="com.facebook.CustomTabActivity"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="${scheme}" />
+    </intent-filter>
+</activity>
+`;
+
+export function getFacebookScheme(config: ExpoConfig) {
+  return config.facebookScheme ?? null;
+}
+
+export function getFacebookAppId(config: ExpoConfig) {
+  return config.facebookAppId ?? null;
+}
+
+export function getFacebookDisplayName(config: ExpoConfig) {
+  return config.facebookDisplayName ?? null;
+}
+export function getFacebookAutoInitEnabled(config: ExpoConfig) {
+  return config.hasOwnProperty('facebookAutoInitEnabled') ? config.facebookAutoInitEnabled : null;
+}
+
+export function getFacebookAutoLogAppEvents(config: ExpoConfig) {
+  return config.hasOwnProperty('facebookAutoLogAppEventsEnabled')
+    ? config.facebookAutoLogAppEventsEnabled
+    : null;
+}
+
+export function getFacebookAdvertiserIDCollection(config: ExpoConfig) {
+  return config.hasOwnProperty('facebookAdvertiserIDCollectionEnabled')
+    ? config.facebookAdvertiserIDCollectionEnabled
+    : null;
+}
+
+export async function setFacebookConfig(config: ExpoConfig, projectDirectory: string) {
+  const scheme = getFacebookScheme(config);
+  const appId = getFacebookAppId(config);
+  const displayName = getFacebookDisplayName(config);
+  const autoInitEnabled = getFacebookAutoInitEnabled(config);
+  const autoLogAppEvents = getFacebookAutoLogAppEvents(config);
+  const advertiserIdCollection = getFacebookAdvertiserIDCollection(config);
+
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+  if (!manifestPath) {
+    return false;
+  }
+
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+  let mainApplication = androidManifestJson.manifest.application.filter(
+    (e: any) => e['$']['android:name'] === '.MainApplication'
+  )[0];
+
+  if (scheme) {
+    const facebookSchemeActivityXML = facebookSchemeActivity(scheme);
+    const parser = new Parser();
+    const facebookSchemeActivityJSON = await parser.parseStringPromise(facebookSchemeActivityXML);
+
+    if (mainApplication.hasOwnProperty('activity')) {
+      mainApplication['activity'] = mainApplication['activity'].concat(
+        facebookSchemeActivityJSON['activity']
+      );
+    } else {
+      mainApplication['activity'] = facebookSchemeActivityJSON['activity'];
+    }
+  }
+  if (appId) {
+    mainApplication = addMetaDataItemToMainApplication(
+      mainApplication,
+      'com.facebook.sdk.ApplicationId',
+      appId
+    );
+  }
+  if (displayName) {
+    mainApplication = addMetaDataItemToMainApplication(
+      mainApplication,
+      'com.facebook.sdk.ApplicationName',
+      displayName
+    );
+  }
+  if (autoInitEnabled !== null) {
+    mainApplication = addMetaDataItemToMainApplication(
+      mainApplication,
+      'com.facebook.sdk.AutoInitEnabled',
+      autoInitEnabled
+    );
+  }
+  if (autoLogAppEvents !== null) {
+    mainApplication = addMetaDataItemToMainApplication(
+      mainApplication,
+      'com.facebook.sdk.AutoLogAppEventsEnabled',
+      autoLogAppEvents
+    );
+  }
+  if (advertiserIdCollection !== null) {
+    mainApplication = addMetaDataItemToMainApplication(
+      mainApplication,
+      'com.facebook.sdk.AdvertiserIDCollectionEnabled',
+      advertiserIdCollection
+    );
+  }
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android Google Maps API key. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}
+
+function addMetaDataItemToMainApplication(
+  mainApplication: any,
+  itemName: string,
+  itemValue: string
+) {
+  let existingMetaDataItem;
+  const newItem = {
+    $: {
+      'android:name': itemName,
+      'android:value': itemValue,
+    },
+  };
+  if (mainApplication.hasOwnProperty('meta-data')) {
+    existingMetaDataItem = mainApplication['meta-data'].filter(
+      (e: any) => e['$']['android:name'] === itemName
+    );
+    if (existingMetaDataItem.length) {
+      existingMetaDataItem[0]['$']['android:value'] = itemValue;
+    } else {
+      mainApplication['meta-data'].push(newItem);
+    }
+  } else {
+    mainApplication['meta-data'] = [newItem];
+  }
+  return mainApplication;
+}

--- a/packages/config/src/android/GoogleMapsApiKey.ts
+++ b/packages/config/src/android/GoogleMapsApiKey.ts
@@ -1,24 +1,14 @@
 import { ExpoConfig } from '../Config.types';
-import {
-  getProjectAndroidManifestPathAsync,
-  readAndroidManifestAsync,
-  writeAndroidManifestAsync,
-} from './Manifest';
+import { Document } from './Manifest';
 
 export function getGoogleMapsApiKey(config: ExpoConfig) {
   return config.android?.config?.googleMaps?.apiKey ?? null;
 }
 
-export async function setGoogleMapsApiKey(config: ExpoConfig, projectDirectory: string) {
+export async function setGoogleMapsApiKey(config: ExpoConfig, manifestDocument: Document) {
   const apiKey = getGoogleMapsApiKey(config);
-  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
 
-  if (!apiKey || !manifestPath) {
-    return false;
-  }
-
-  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
-  let mainApplication = androidManifestJson.manifest.application.filter(
+  let mainApplication = manifestDocument.manifest.application.filter(
     (e: any) => e['$']['android:name'] === '.MainApplication'
   )[0];
 
@@ -65,12 +55,5 @@ export async function setGoogleMapsApiKey(config: ExpoConfig, projectDirectory: 
     mainApplication['uses-library'] = [newUsesLibraryItem];
   }
 
-  try {
-    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
-  } catch (e) {
-    throw new Error(
-      `Error setting Android Google Maps API key. Cannot write new AndroidManifest.xml to ${manifestPath}.`
-    );
-  }
-  return true;
+  return manifestDocument;
 }

--- a/packages/config/src/android/GoogleMapsApiKey.ts
+++ b/packages/config/src/android/GoogleMapsApiKey.ts
@@ -1,0 +1,76 @@
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+export function getGoogleMapsApiKey(config: ExpoConfig) {
+  return config.android?.config?.googleMaps?.apiKey ?? null;
+}
+
+export async function setGoogleMapsApiKey(config: ExpoConfig, projectDirectory: string) {
+  const apiKey = getGoogleMapsApiKey(config);
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+
+  if (!apiKey || !manifestPath) {
+    return false;
+  }
+
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+  let mainApplication = androidManifestJson.manifest.application.filter(
+    (e: any) => e['$']['android:name'] === '.MainApplication'
+  )[0];
+
+  // add meta-data item
+  let existingMetaDataItem;
+  const metaDataItem = {
+    $: {
+      'android:name': 'com.google.android.geo.API_KEY',
+      'android:value': apiKey,
+    },
+  };
+  if (mainApplication.hasOwnProperty('meta-data')) {
+    existingMetaDataItem = mainApplication['meta-data'].filter(
+      (e: any) => e['$']['android:name'] === 'com.google.android.geo.API_KEY'
+    );
+    if (existingMetaDataItem.length) {
+      existingMetaDataItem[0]['$']['android:value'] = apiKey;
+    } else {
+      mainApplication['meta-data'].push(metaDataItem);
+    }
+  } else {
+    mainApplication['meta-data'] = [metaDataItem];
+  }
+
+  // add uses-library item
+  let existingUsesLibraryItem;
+  const newUsesLibraryItem = {
+    $: {
+      'android:name': 'org.apache.http.legacy',
+      'android:required': 'false',
+    },
+  };
+
+  if (mainApplication.hasOwnProperty('uses-library')) {
+    existingUsesLibraryItem = mainApplication['uses-library'].filter(
+      (e: any) => e['$']['android:name'] === 'org.apache.http.legacy'
+    );
+    if (existingUsesLibraryItem.length) {
+      existingUsesLibraryItem[0]['$']['android:required'] = 'false';
+    } else {
+      mainApplication['uses-library'].push(newUsesLibraryItem);
+    }
+  } else {
+    mainApplication['uses-library'] = [newUsesLibraryItem];
+  }
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android Google Maps API key. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/GoogleMobileAds.ts
+++ b/packages/config/src/android/GoogleMobileAds.ts
@@ -1,0 +1,81 @@
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+export function getGoogleMobileAdsAppId(config: ExpoConfig) {
+  return config.android?.config?.googleMobileAdsAppId ?? null;
+}
+
+export function getGoogleMobileAdsAutoInit(config: ExpoConfig) {
+  return config.android?.config?.googleMobileAdsAutoInit ?? false;
+}
+
+export async function setGoogleMobileAdsConfig(config: ExpoConfig, projectDirectory: string) {
+  const appId = getGoogleMobileAdsAppId(config);
+  const autoInit = getGoogleMobileAdsAutoInit(config);
+
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+
+  if (!appId || !manifestPath) {
+    return false;
+  }
+
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+  let mainApplication = androidManifestJson.manifest.application.filter(
+    (e: any) => e['$']['android:name'] === '.MainApplication'
+  )[0];
+
+  // add application ID
+  let existingApplicationId;
+  const newApplicationId = {
+    $: {
+      'android:name': 'com.google.android.gms.ads.APPLICATION_ID',
+      'android:value': appId,
+    },
+  };
+  if (mainApplication.hasOwnProperty('meta-data')) {
+    existingApplicationId = mainApplication['meta-data'].filter(
+      (e: any) => e['$']['android:name'] === 'com.google.android.gms.ads.APPLICATION_ID'
+    );
+    if (existingApplicationId.length) {
+      existingApplicationId[0]['$']['android:value'] = appId;
+    } else {
+      mainApplication['meta-data'].push(newApplicationId);
+    }
+  } else {
+    mainApplication['meta-data'] = [newApplicationId];
+  }
+
+  // add delay auto init
+  let existingDelayAutoInit;
+  const newDelayAutoInit = {
+    $: {
+      'android:name': 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT',
+      'android:value': !autoInit,
+    },
+  };
+  if (mainApplication.hasOwnProperty('meta-data')) {
+    existingDelayAutoInit = mainApplication['meta-data'].filter(
+      (e: any) => e['$']['android:name'] === 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT'
+    );
+    if (existingDelayAutoInit.length) {
+      existingDelayAutoInit[0]['$']['android:value'] = !autoInit;
+    } else {
+      mainApplication['meta-data'].push(newDelayAutoInit);
+    }
+  } else {
+    mainApplication['meta-data'] = [newDelayAutoInit];
+  }
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android Google Mobile Ads config. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/GoogleMobileAds.ts
+++ b/packages/config/src/android/GoogleMobileAds.ts
@@ -1,9 +1,5 @@
 import { ExpoConfig } from '../Config.types';
-import {
-  getProjectAndroidManifestPathAsync,
-  readAndroidManifestAsync,
-  writeAndroidManifestAsync,
-} from './Manifest';
+import { Document } from './Manifest';
 
 export function getGoogleMobileAdsAppId(config: ExpoConfig) {
   return config.android?.config?.googleMobileAdsAppId ?? null;
@@ -13,18 +9,11 @@ export function getGoogleMobileAdsAutoInit(config: ExpoConfig) {
   return config.android?.config?.googleMobileAdsAutoInit ?? false;
 }
 
-export async function setGoogleMobileAdsConfig(config: ExpoConfig, projectDirectory: string) {
+export async function setGoogleMobileAdsConfig(config: ExpoConfig, manifestDocument: Document) {
   const appId = getGoogleMobileAdsAppId(config);
   const autoInit = getGoogleMobileAdsAutoInit(config);
 
-  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
-
-  if (!appId || !manifestPath) {
-    return false;
-  }
-
-  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
-  let mainApplication = androidManifestJson.manifest.application.filter(
+  let mainApplication = manifestDocument.manifest.application.filter(
     (e: any) => e['$']['android:name'] === '.MainApplication'
   )[0];
 
@@ -70,12 +59,5 @@ export async function setGoogleMobileAdsConfig(config: ExpoConfig, projectDirect
     mainApplication['meta-data'] = [newDelayAutoInit];
   }
 
-  try {
-    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
-  } catch (e) {
-    throw new Error(
-      `Error setting Android Google Mobile Ads config. Cannot write new AndroidManifest.xml to ${manifestPath}.`
-    );
-  }
-  return true;
+  return manifestDocument;
 }

--- a/packages/config/src/android/GoogleServices.ts
+++ b/packages/config/src/android/GoogleServices.ts
@@ -1,0 +1,32 @@
+import fs from 'fs-extra';
+import { resolve } from 'path';
+import { ExpoConfig } from '../Config.types';
+
+const DEFAULT_TARGET_PATH = './android/app/google-services.json';
+
+export function getGoogleServicesFilePath(config: ExpoConfig) {
+  return config.android?.googleServicesFile ?? null;
+}
+
+export async function setGoogleServicesFile(
+  config: ExpoConfig,
+  projectDirectory: string,
+  targetPath: string = DEFAULT_TARGET_PATH
+) {
+  let partialSourcePath = getGoogleServicesFilePath(config);
+  if (!partialSourcePath) {
+    return false;
+  }
+
+  const completeSourcePath = resolve(projectDirectory, partialSourcePath);
+  const destinationPath = resolve(projectDirectory, targetPath);
+
+  try {
+    await fs.copy(completeSourcePath, destinationPath);
+  } catch (e) {
+    throw new Error(
+      `Cannot copy google-services.json from ${completeSourcePath} to ${destinationPath}. Please make sure the source and destination paths exist.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/Icon.ts
+++ b/packages/config/src/android/Icon.ts
@@ -1,0 +1,24 @@
+import { ExpoConfig } from '../Config.types';
+import { addWarningAndroid } from '../WarningAggregator';
+
+export function getIcon(config: ExpoConfig) {
+  // Until we add support applying icon config we just test if the user has configured the icon
+  // so we can warn
+  if (config.icon || config.android?.icon) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+export async function setIconAsync(config: ExpoConfig, projectRoot: string) {
+  let icon = getIcon(config);
+  if (!icon) {
+    return;
+  }
+
+  addWarningAndroid(
+    'icon',
+    'This is the image that your app uses on your home screen, you will need to configure it manually.'
+  );
+}

--- a/packages/config/src/android/IntentFilters.ts
+++ b/packages/config/src/android/IntentFilters.ts
@@ -1,0 +1,92 @@
+import _ from 'lodash';
+import { Parser } from 'xml2js';
+
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+// TODO: make it so intent filters aren't written again if you run the command again
+
+export function getIntentFilters(config: ExpoConfig) {
+  return config.android?.intentFilters ?? [];
+}
+
+export async function setAndroidIntentFilters(config: ExpoConfig, projectDirectory: string) {
+  const intentFilters = getIntentFilters(config);
+  if (!intentFilters.length) {
+    return false;
+  }
+
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+  if (!manifestPath) {
+    return false;
+  }
+
+  let intentFiltersXML = renderIntentFilters(intentFilters).join('');
+  const parser = new Parser();
+  const intentFiltersJSON = await parser.parseStringPromise(intentFiltersXML);
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+
+  let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+    (e: any) => e['$']['android:name'] === '.MainActivity'
+  );
+
+  mainActivity[0]['intent-filter'] = mainActivity[0]['intent-filter'].concat(
+    intentFiltersJSON['intent-filter']
+  );
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android intent filters. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}
+
+export default function renderIntentFilters(intentFilters: any) {
+  // returns an array of <intent-filter> tags:
+  // [
+  //   `<intent-filter>
+  //     <data android:scheme="exp"/>
+  //     <data android:scheme="exps"/>
+  //
+  //     <action android:name="android.intent.action.VIEW"/>
+  //
+  //     <category android:name="android.intent.category.DEFAULT"/>
+  //     <category android:name="android.intent.category.BROWSABLE"/>
+  //   </intent-filter>`,
+  //   ...
+  // ]
+  return intentFilters.map((intentFilter: any) => {
+    const autoVerify = intentFilter.autoVerify ? ' android:autoVerify="true"' : '';
+
+    return `<intent-filter${autoVerify}>
+      ${renderIntentFilterData(intentFilter.data)}
+      <action android:name="android.intent.action.${intentFilter.action}"/>
+      ${renderIntentFilterCategory(intentFilter.category)}
+    </intent-filter>`;
+  });
+}
+
+function renderIntentFilterDatumEntries(datum: any) {
+  return _.toPairs(datum)
+    .map(entry => `android:${entry[0]}="${entry[1]}"`)
+    .join(' ');
+}
+
+function renderIntentFilterData(data: any) {
+  return (Array.isArray(data) ? data : [data])
+    .map(datum => `<data ${renderIntentFilterDatumEntries(datum)}/>`)
+    .join('\n');
+}
+
+function renderIntentFilterCategory(category: any) {
+  return (Array.isArray(category) ? category : [category])
+    .map(cat => `<category android:name="android.intent.category.${cat}"/>`)
+    .join('\n');
+}

--- a/packages/config/src/android/Manifest.ts
+++ b/packages/config/src/android/Manifest.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 const USES_PERMISSION = 'uses-permission';
 
-type Document = { [key: string]: any };
+export type Document = { [key: string]: any };
 
 export function removePermissions(doc: Document, permissionNames?: string[]) {
   const targetNames = permissionNames ? permissionNames.map(ensurePermissionNameFormat) : null;
@@ -162,7 +162,7 @@ export async function getProjectAndroidManifestPathAsync(
   return null;
 }
 
-export async function readAsync(manifestPath: string): Promise<Document> {
+export async function readAndroidManifestAsync(manifestPath: string): Promise<Document> {
   const contents = await fs.readFile(manifestPath, { encoding: 'utf8', flag: 'r' });
   const parser = new Parser();
   const manifest = parser.parseStringPromise(contents);
@@ -178,7 +178,7 @@ export async function persistAndroidPermissionsAsync(
   if (!manifestPath) {
     return false;
   }
-  const manifest = await readAsync(manifestPath);
+  const manifest = await readAndroidManifestAsync(manifestPath);
   removePermissions(manifest);
   const results = ensurePermissions(manifest, permissions);
   if (Object.values(results).reduce((prev, current) => prev && current, true) === false) {

--- a/packages/config/src/android/NavigationBar.ts
+++ b/packages/config/src/android/NavigationBar.ts
@@ -1,0 +1,76 @@
+import {
+  XMLItem,
+  getProjectStylesXMLPathAsync,
+  readStylesXMLAsync,
+  setStylesItem,
+  writeStylesXMLAsync,
+} from './Styles';
+import {
+  getProjectColorsXMLPathAsync,
+  readColorsXMLAsync,
+  setColorItem,
+  writeColorsXMLAsync,
+} from './Colors';
+import { ExpoConfig } from '../Config.types';
+
+const NAVIGATION_BAR_COLOR = 'navigationBarColor';
+const WINDOW_LIGHT_NAVIGATION_BAR = 'android:windowLightNavigationBar';
+
+export function getNavigationBarImmersiveMode(config: ExpoConfig) {
+  return config.androidNavigationBar?.visible || null;
+}
+
+export function getNavigationBarColor(config: ExpoConfig) {
+  return config.androidNavigationBar?.backgroundColor || null;
+}
+
+export function getNavigationBarStyle(config: ExpoConfig) {
+  return config.androidNavigationBar?.barStyle || 'light-content';
+}
+
+export async function setNavigationBarConfig(config: ExpoConfig, projectDirectory: string) {
+  const immersiveMode = getNavigationBarImmersiveMode(config);
+  const hexString = getNavigationBarColor(config);
+  const barStyle = getNavigationBarStyle(config);
+
+  const stylesPath = await getProjectStylesXMLPathAsync(projectDirectory);
+  const colorsPath = await getProjectColorsXMLPathAsync(projectDirectory);
+  if (!colorsPath || !stylesPath) {
+    return false;
+  }
+
+  let stylesJSON = await readStylesXMLAsync(stylesPath);
+  let colorsJSON = await readColorsXMLAsync(colorsPath);
+
+  if (immersiveMode) {
+    // Immersive mode needs to be set programatically
+    console.log(
+      'Hiding the Android navigation bar must be done programatically. Please see the Android documentation: https://developer.android.com/training/system-ui/immersive'
+    );
+  }
+  if (hexString) {
+    let colorItemToAdd: XMLItem[] = [{ _: hexString, $: { name: NAVIGATION_BAR_COLOR } }];
+    colorsJSON = setColorItem(colorItemToAdd, colorsJSON);
+
+    let styleItemToAdd: XMLItem[] = [
+      { _: `@color/${NAVIGATION_BAR_COLOR}`, $: { name: `android:${NAVIGATION_BAR_COLOR}` } },
+    ];
+    stylesJSON = setStylesItem(styleItemToAdd, stylesJSON);
+  }
+  if (barStyle === 'dark-content') {
+    let navigationBarStyleItem: XMLItem[] = [
+      { _: 'true', $: { name: WINDOW_LIGHT_NAVIGATION_BAR } },
+    ];
+    stylesJSON = setStylesItem(navigationBarStyleItem, stylesJSON);
+  }
+
+  try {
+    await writeColorsXMLAsync(colorsPath, colorsJSON);
+    await writeStylesXMLAsync(stylesPath, stylesJSON);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android navigation bar color. Cannot write colors.xml to ${colorsPath}, or styles.xml to ${stylesPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/NavigationBar.ts
+++ b/packages/config/src/android/NavigationBar.ts
@@ -12,6 +12,7 @@ import {
   writeColorsXMLAsync,
 } from './Colors';
 import { ExpoConfig } from '../Config.types';
+import { addWarningAndroid } from '../WarningAggregator';
 
 const NAVIGATION_BAR_COLOR = 'navigationBarColor';
 const WINDOW_LIGHT_NAVIGATION_BAR = 'android:windowLightNavigationBar';
@@ -44,8 +45,9 @@ export async function setNavigationBarConfig(config: ExpoConfig, projectDirector
 
   if (immersiveMode) {
     // Immersive mode needs to be set programatically
-    console.log(
-      'Hiding the Android navigation bar must be done programatically. Please see the Android documentation: https://developer.android.com/training/system-ui/immersive'
+    addWarningAndroid(
+      'androidNavigationBar.visible',
+      'Hiding the navigation bar must be done programmatically. Refer to the Android documentation - https://developer.android.com/training/system-ui/immersive - for instructions.'
     );
   }
   if (hexString) {

--- a/packages/config/src/android/Orientation.ts
+++ b/packages/config/src/android/Orientation.ts
@@ -1,9 +1,5 @@
 import { ExpoConfig } from '../Config.types';
-import {
-  getProjectAndroidManifestPathAsync,
-  readAndroidManifestAsync,
-  writeAndroidManifestAsync,
-} from './Manifest';
+import { Document } from './Manifest';
 
 export const SCREEN_ORIENTATION_ATTRIBUTE = 'android:screenOrientation';
 
@@ -11,29 +7,16 @@ export function getOrientation(config: ExpoConfig) {
   return typeof config.orientation === 'string' ? config.orientation : null;
 }
 
-export async function setAndroidOrientation(config: ExpoConfig, projectDirectory: string) {
+export async function setAndroidOrientation(config: ExpoConfig, manifestDocument: Document) {
   const orientation = getOrientation(config);
   if (!orientation) {
-    return false;
+    return manifestDocument;
   }
 
-  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
-  if (!manifestPath) {
-    return false;
-  }
-
-  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
-  let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+  let mainActivity = manifestDocument.manifest.application[0].activity.filter(
     (e: any) => e['$']['android:name'] === '.MainActivity'
   );
   mainActivity[0]['$'][SCREEN_ORIENTATION_ATTRIBUTE] = orientation;
 
-  try {
-    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
-  } catch (e) {
-    throw new Error(
-      `Error setting Android orientation. Cannot write new AndroidManifest.xml to ${manifestPath}.`
-    );
-  }
-  return true;
+  return manifestDocument;
 }

--- a/packages/config/src/android/Orientation.ts
+++ b/packages/config/src/android/Orientation.ts
@@ -1,0 +1,39 @@
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+export const SCREEN_ORIENTATION_ATTRIBUTE = 'android:screenOrientation';
+
+export function getOrientation(config: ExpoConfig) {
+  return typeof config.orientation === 'string' ? config.orientation : null;
+}
+
+export async function setAndroidOrientation(config: ExpoConfig, projectDirectory: string) {
+  const orientation = getOrientation(config);
+  if (!orientation) {
+    return false;
+  }
+
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+  if (!manifestPath) {
+    return false;
+  }
+
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+  let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+    (e: any) => e['$']['android:name'] === '.MainActivity'
+  );
+  mainActivity[0]['$'][SCREEN_ORIENTATION_ATTRIBUTE] = orientation;
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android orientation. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/Package.ts
+++ b/packages/config/src/android/Package.ts
@@ -1,9 +1,5 @@
 import { ExpoConfig } from '../Config.types';
-import {
-  getProjectAndroidManifestPathAsync,
-  readAndroidManifestAsync,
-  writeAndroidManifestAsync,
-} from './Manifest';
+import { Document } from './Manifest';
 
 export function getPackage(config: ExpoConfig) {
   if (config.android && config.android.package) {
@@ -23,22 +19,10 @@ export function setPackageInBuildGradle(config: ExpoConfig, buildGradle: string)
   return buildGradle.replace(pattern, `applicationId '${packageName}'`);
 }
 
-export async function setPackageInAndroidManifest(config: ExpoConfig, projectDirectory: string) {
+export async function setPackageInAndroidManifest(config: ExpoConfig, manifestDocument: Document) {
   let packageName = getPackage(config);
-  let manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
-  if (!packageName || !manifestPath) {
-    return false;
-  }
 
-  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
-  androidManifestJson['manifest']['$']['package'] = packageName;
+  manifestDocument['manifest']['$']['package'] = packageName;
 
-  try {
-    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
-  } catch (e) {
-    throw new Error(
-      `Error setting Android package. Cannot write new AndroidManifest.xml to ${manifestPath}.`
-    );
-  }
-  return true;
+  return manifestDocument;
 }

--- a/packages/config/src/android/Package.ts
+++ b/packages/config/src/android/Package.ts
@@ -1,0 +1,39 @@
+import { ExpoConfig } from '../Config.types';
+
+const DEFAULT_PACKAGE_NAME = 'com.helloworld';
+
+export function getPackage(config: ExpoConfig) {
+  if (config.android && config.android.package) {
+    return config.android.package;
+  }
+
+  return null;
+}
+
+export function setPackageInBuildGradle(
+  config: ExpoConfig,
+  buildGradle: string,
+  packageNameToReplace = DEFAULT_PACKAGE_NAME
+) {
+  let packageName = getPackage(config);
+  if (packageName === null) {
+    return buildGradle;
+  }
+
+  let pattern = new RegExp(`applicationId ['"]${packageNameToReplace}['"]`);
+  return buildGradle.replace(pattern, `applicationId '${packageName}'`);
+}
+
+export function setPackageInAndroidManifest(
+  config: ExpoConfig,
+  androidManifest: string,
+  packageNameToReplace = DEFAULT_PACKAGE_NAME
+) {
+  let packageName = getPackage(config);
+  if (packageName === null) {
+    return androidManifest;
+  }
+
+  let pattern = new RegExp(`package="${packageNameToReplace}"`);
+  return androidManifest.replace(pattern, `package="${packageName}"`);
+}

--- a/packages/config/src/android/Permissions.ts
+++ b/packages/config/src/android/Permissions.ts
@@ -1,0 +1,114 @@
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+type XMLPermission = { $: { 'android:name': string } };
+
+export const requiredPermissions = [
+  'android.permission.INTERNET',
+  'android.permission.ACCESS_NETWORK_STATE',
+  'android.permission.SYSTEM_ALERT_WINDOW',
+  'android.permission.WAKE_LOCK',
+  'com.google.android.c2dm.permission.RECEIVE',
+];
+export const allPermissions = [
+  ...requiredPermissions,
+  'android.permission.ACCESS_WIFI_STATE',
+  'android.permission.ACCESS_COARSE_LOCATION',
+  'android.permission.ACCESS_FINE_LOCATION',
+  'android.permission.CAMERA',
+  'android.permission.MANAGE_DOCUMENTS',
+  'android.permission.READ_CONTACTS',
+  'android.permission.WRITE_CONTACTS',
+  'android.permission.READ_CALENDAR',
+  'android.permission.WRITE_CALENDAR',
+  'android.permission.READ_EXTERNAL_STORAGE',
+  'android.permission.READ_INTERNAL_STORAGE',
+  'android.permission.READ_PHONE_STATE',
+  'android.permission.RECORD_AUDIO',
+  'android.permission.USE_FINGERPRINT',
+  'android.permission.VIBRATE',
+  'android.permission.WRITE_EXTERNAL_STORAGE',
+  'android.permission.READ_SMS',
+  'com.anddoes.launcher.permission.UPDATE_COUNT',
+  'com.android.launcher.permission.INSTALL_SHORTCUT',
+  'com.google.android.gms.permission.ACTIVITY_RECOGNITION',
+  'com.google.android.providers.gsf.permission.READ_GSERVICES',
+  'com.htc.launcher.permission.READ_SETTINGS',
+  'com.htc.launcher.permission.UPDATE_SHORTCUT',
+  'com.majeur.launcher.permission.UPDATE_BADGE',
+  'com.sec.android.provider.badge.permission.READ',
+  'com.sec.android.provider.badge.permission.WRITE',
+  'com.sonyericsson.home.permission.BROADCAST_BADGE',
+];
+
+function prefixAndroidPermissionsIfNecessary(permissions: string[]): string[] {
+  return permissions.map(permission => {
+    if (!permission.includes('.')) {
+      return `android.permission.${permission}`;
+    }
+    return permission;
+  });
+}
+
+export function getAndroidPermissions(config: ExpoConfig): string[] {
+  return config.android?.permissions ?? [];
+}
+
+export async function setAndroidPermissions(config: ExpoConfig, projectDirectory: string) {
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+  if (!manifestPath) {
+    return false;
+  }
+
+  const permissions = getAndroidPermissions(config);
+  let permissionsToAdd = [];
+  if (permissions === null) {
+    // Use all Expo permissions
+    permissionsToAdd = allPermissions;
+  } else {
+    // Use minimum required, plus any specified in permissions array
+    const providedPermissions = prefixAndroidPermissionsIfNecessary(permissions);
+    permissionsToAdd = [...providedPermissions, ...requiredPermissions];
+  }
+
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+  let manifestPermissions: XMLPermission[] = [];
+  if (!androidManifestJson.manifest.hasOwnProperty('uses-permission')) {
+    androidManifestJson.manifest['uses-permission'] = [];
+  }
+  manifestPermissions = androidManifestJson.manifest['uses-permission'];
+
+  permissionsToAdd.forEach(permission => {
+    if (!isPermissionAlreadyRequested(permission, manifestPermissions)) {
+      addPermissionToManifest(permission, manifestPermissions);
+    }
+  });
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android permissions. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}
+
+export function isPermissionAlreadyRequested(
+  permission: string,
+  manifestPermissions: XMLPermission[]
+): boolean {
+  const hasPermission = manifestPermissions.filter(
+    (e: any) => e['$']['android:name'] === permission
+  );
+  return hasPermission.length > 0;
+}
+
+export function addPermissionToManifest(permission: string, manifestPermissions: XMLPermission[]) {
+  manifestPermissions.push({ $: { 'android:name': permission } });
+  return manifestPermissions;
+}

--- a/packages/config/src/android/PrimaryColor.ts
+++ b/packages/config/src/android/PrimaryColor.ts
@@ -49,7 +49,7 @@ export async function setPrimaryColor(config: ExpoConfig, projectDirectory: stri
     await writeStylesXMLAsync(stylesPath, stylesJSON);
   } catch (e) {
     throw new Error(
-      `Error setting Android primary color. Cannot write new AndroidManifest.xml to ${stylesPath}.`
+      `Error setting Android primary color. Cannot write new styles.xml to ${stylesPath}.`
     );
   }
   return true;

--- a/packages/config/src/android/PrimaryColor.ts
+++ b/packages/config/src/android/PrimaryColor.ts
@@ -1,0 +1,56 @@
+import { ExpoConfig } from '../Config.types';
+import {
+  XMLItem,
+  getProjectStylesXMLPathAsync,
+  readStylesXMLAsync,
+  setStylesItem,
+  writeStylesXMLAsync,
+} from './Styles';
+import {
+  getProjectColorsXMLPathAsync,
+  readColorsXMLAsync,
+  setColorItem,
+  writeColorsXMLAsync,
+} from './Colors';
+
+const COLOR_PRIMARY_KEY = 'colorPrimary';
+const DEFAULT_PRIMARY_COLOR = '#023c69';
+
+export function getPrimaryColor(config: ExpoConfig) {
+  return config.primaryColor ?? DEFAULT_PRIMARY_COLOR;
+}
+
+export async function setPrimaryColor(config: ExpoConfig, projectDirectory: string) {
+  let hexString = getPrimaryColor(config);
+
+  const stylesPath = await getProjectStylesXMLPathAsync(projectDirectory);
+  const colorsPath = await getProjectColorsXMLPathAsync(projectDirectory);
+  if (!colorsPath || !stylesPath) {
+    return false;
+  }
+
+  let stylesJSON = await readStylesXMLAsync(stylesPath);
+  let colorsJSON = await readColorsXMLAsync(colorsPath);
+
+  let colorItemToAdd: XMLItem[] = [{ _: '', $: { name: '' } }];
+  let styleItemToAdd: XMLItem[] = [{ _: '', $: { name: '' } }];
+
+  colorItemToAdd[0]._ = hexString;
+  colorItemToAdd[0].$.name = COLOR_PRIMARY_KEY;
+
+  styleItemToAdd[0]._ = `@color/${COLOR_PRIMARY_KEY}`;
+  styleItemToAdd[0].$.name = COLOR_PRIMARY_KEY;
+
+  colorsJSON = setColorItem(colorItemToAdd, colorsJSON);
+  stylesJSON = setStylesItem(styleItemToAdd, stylesJSON);
+
+  try {
+    await writeColorsXMLAsync(colorsPath, colorsJSON);
+    await writeStylesXMLAsync(stylesPath, stylesJSON);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android primary color. Cannot write new AndroidManifest.xml to ${stylesPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/RootViewBackgroundColor.ts
+++ b/packages/config/src/android/RootViewBackgroundColor.ts
@@ -59,7 +59,7 @@ export async function setRootViewBackgroundColor(config: ExpoConfig, projectDire
     await writeStylesXMLAsync(stylesPath, stylesJSON);
   } catch (e) {
     throw new Error(
-      `Error setting Android root view background color. Cannot write new AndroidManifest.xml to ${stylesPath}.`
+      `Error setting Android root view background color. Cannot write new styles.xml to ${stylesPath}.`
     );
   }
   return true;

--- a/packages/config/src/android/RootViewBackgroundColor.ts
+++ b/packages/config/src/android/RootViewBackgroundColor.ts
@@ -1,0 +1,66 @@
+import { ExpoConfig } from '../Config.types';
+import {
+  XMLItem,
+  getProjectStylesXMLPathAsync,
+  readStylesXMLAsync,
+  setStylesItem,
+  writeStylesXMLAsync,
+} from './Styles';
+import {
+  getProjectColorsXMLPathAsync,
+  readColorsXMLAsync,
+  setColorItem,
+  writeColorsXMLAsync,
+} from './Colors';
+
+const ANDROID_WINDOW_BACKGROUND = 'android:windowBackground';
+const WINDOW_BACKGROUND_COLOR = 'activityBackground';
+
+export function getRootViewBackgroundColor(config: ExpoConfig) {
+  if (config.android && config.android.backgroundColor) {
+    return config.android.backgroundColor;
+  }
+  if (config.backgroundColor) {
+    return config.backgroundColor;
+  }
+
+  return null;
+}
+
+export async function setRootViewBackgroundColor(config: ExpoConfig, projectDirectory: string) {
+  let hexString = getRootViewBackgroundColor(config);
+  if (!hexString) {
+    return false;
+  }
+
+  const stylesPath = await getProjectStylesXMLPathAsync(projectDirectory);
+  const colorsPath = await getProjectColorsXMLPathAsync(projectDirectory);
+  if (!colorsPath || !stylesPath) {
+    return false;
+  }
+
+  let stylesJSON = await readStylesXMLAsync(stylesPath);
+  let colorsJSON = await readColorsXMLAsync(colorsPath);
+
+  let colorItemToAdd: XMLItem[] = [{ _: '', $: { name: '' } }];
+  let styleItemToAdd: XMLItem[] = [{ _: '', $: { name: '' } }];
+
+  colorItemToAdd[0]._ = hexString;
+  colorItemToAdd[0].$.name = WINDOW_BACKGROUND_COLOR;
+
+  styleItemToAdd[0]._ = `@color/${WINDOW_BACKGROUND_COLOR}`;
+  styleItemToAdd[0].$.name = ANDROID_WINDOW_BACKGROUND;
+
+  colorsJSON = setColorItem(colorItemToAdd, colorsJSON);
+  stylesJSON = setStylesItem(styleItemToAdd, stylesJSON);
+
+  try {
+    await writeColorsXMLAsync(colorsPath, colorsJSON);
+    await writeStylesXMLAsync(stylesPath, stylesJSON);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android root view background color. Cannot write new AndroidManifest.xml to ${stylesPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/Scheme.ts
+++ b/packages/config/src/android/Scheme.ts
@@ -1,28 +1,18 @@
 import { Parser } from 'xml2js';
 import { ExpoConfig } from '../Config.types';
-import {
-  getProjectAndroidManifestPathAsync,
-  readAndroidManifestAsync,
-  writeAndroidManifestAsync,
-} from './Manifest';
+import { Document } from './Manifest';
 
 export function getScheme(config: ExpoConfig) {
   return typeof config.scheme === 'string' ? config.scheme : null;
 }
 
-export async function setScheme(config: ExpoConfig, projectDirectory: string) {
+export async function setScheme(config: ExpoConfig, manifestDocument: Document) {
   let scheme = getScheme(config);
   if (!scheme) {
     return false;
   }
 
-  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
-  if (!manifestPath) {
-    return false;
-  }
-
-  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
-  let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+  let mainActivity = manifestDocument.manifest.application[0].activity.filter(
     (e: any) => e['$']['android:name'] === '.MainActivity'
   );
 
@@ -45,12 +35,5 @@ export async function setScheme(config: ExpoConfig, projectDirectory: string) {
     mainActivity[0]['intent-filter'] = intentFiltersJSON['intent-filter'];
   }
 
-  try {
-    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
-  } catch (e) {
-    throw new Error(
-      `Error setting Android orientation. Cannot write new AndroidManifest.xml to ${manifestPath}.`
-    );
-  }
-  return true;
+  return manifestDocument;
 }

--- a/packages/config/src/android/Scheme.ts
+++ b/packages/config/src/android/Scheme.ts
@@ -1,0 +1,56 @@
+import { Parser } from 'xml2js';
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+export function getScheme(config: ExpoConfig) {
+  return typeof config.scheme === 'string' ? config.scheme : null;
+}
+
+export async function setScheme(config: ExpoConfig, projectDirectory: string) {
+  let scheme = getScheme(config);
+  if (!scheme) {
+    return false;
+  }
+
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+  if (!manifestPath) {
+    return false;
+  }
+
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+  let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+    (e: any) => e['$']['android:name'] === '.MainActivity'
+  );
+
+  const schemeTag = `<data android:scheme="${scheme}"/>`;
+  const intentFiltersXML = `
+  <intent-filter>
+    ${schemeTag}
+    <action android:name="android.intent.action.VIEW"/>
+    <category android:name="android.intent.category.DEFAULT"/>
+    <category android:name="android.intent.category.BROWSABLE"/>
+  </intent-filter>`;
+  const parser = new Parser();
+  const intentFiltersJSON = await parser.parseStringPromise(intentFiltersXML);
+
+  if (mainActivity[0].hasOwnProperty('intent-filter')) {
+    mainActivity[0]['intent-filter'] = mainActivity[0]['intent-filter'].concat(
+      intentFiltersJSON['intent-filter']
+    );
+  } else {
+    mainActivity[0]['intent-filter'] = intentFiltersJSON['intent-filter'];
+  }
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android orientation. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/SplashScreen.ts
+++ b/packages/config/src/android/SplashScreen.ts
@@ -1,0 +1,24 @@
+import { ExpoConfig } from '../Config.types';
+import { addWarningAndroid } from '../WarningAggregator';
+
+export function getSplashScreen(config: ExpoConfig) {
+  // Until we add support applying icon config we just test if the user has configured the icon
+  // so we can warn
+  if (config.splash?.image || config.android?.splash?.mdpi) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
+  let splash = getSplashScreen(config);
+  if (!splash) {
+    return;
+  }
+
+  addWarningAndroid(
+    'splash',
+    'This is the image that your app uses on the loading screen, you will need to configure it manually.'
+  );
+}

--- a/packages/config/src/android/StatusBar.ts
+++ b/packages/config/src/android/StatusBar.ts
@@ -25,7 +25,7 @@ export function getStatusBarStyle(config: ExpoConfig) {
   return config.androidStatusBar?.barStyle || 'light-content';
 }
 
-export async function setStatusBarColor(config: ExpoConfig, projectDirectory: string) {
+export async function setStatusBarConfig(config: ExpoConfig, projectDirectory: string) {
   let hexString = getStatusBarColor(config);
   let statusBarStyle = getStatusBarStyle(config);
 

--- a/packages/config/src/android/StatusBar.ts
+++ b/packages/config/src/android/StatusBar.ts
@@ -1,0 +1,72 @@
+import {
+  XMLItem,
+  getProjectStylesXMLPathAsync,
+  readStylesXMLAsync,
+  setStylesItem,
+  writeStylesXMLAsync,
+} from './Styles';
+import {
+  getProjectColorsXMLPathAsync,
+  readColorsXMLAsync,
+  setColorItem,
+  writeColorsXMLAsync,
+} from './Colors';
+import { ExpoConfig } from '../Config.types';
+
+const COLOR_PRIMARY_DARK_KEY = 'colorPrimaryDark';
+const WINDOW_TRANSLUCENT_STATUS = 'android:windowTranslucentStatus';
+const WINDOW_LIGHT_STATUS_BAR = 'android:windowLightStatusBar';
+
+export function getStatusBarColor(config: ExpoConfig) {
+  return config.androidStatusBar?.backgroundColor || 'translucent';
+}
+
+export function getStatusBarStyle(config: ExpoConfig) {
+  return config.androidStatusBar?.barStyle || 'light-content';
+}
+
+export async function setStatusBarColor(config: ExpoConfig, projectDirectory: string) {
+  let hexString = getStatusBarColor(config);
+  let statusBarStyle = getStatusBarStyle(config);
+
+  const stylesPath = await getProjectStylesXMLPathAsync(projectDirectory);
+  const colorsPath = await getProjectColorsXMLPathAsync(projectDirectory);
+  if (!colorsPath || !stylesPath) {
+    return false;
+  }
+
+  let stylesJSON = await readStylesXMLAsync(stylesPath);
+  let colorsJSON = await readColorsXMLAsync(colorsPath);
+
+  let styleItemToAdd: XMLItem[] = [{ _: '', $: { name: '' } }];
+  if (hexString === 'translucent') {
+    // translucent status bar set in theme
+    styleItemToAdd[0]._ = 'true';
+    styleItemToAdd[0].$.name = WINDOW_TRANSLUCENT_STATUS;
+  } else {
+    // Need to add a color key to colors.xml to use in styles.xml
+    let colorItemToAdd: XMLItem[] = [{ _: hexString, $: { name: COLOR_PRIMARY_DARK_KEY } }];
+    colorsJSON = setColorItem(colorItemToAdd, colorsJSON);
+
+    styleItemToAdd[0]._ = `@color/${COLOR_PRIMARY_DARK_KEY}`;
+    styleItemToAdd[0].$.name = COLOR_PRIMARY_DARK_KEY;
+  }
+
+  // Default is light-content, don't need to do anything to set it
+  if (statusBarStyle === 'dark-content') {
+    let statusBarStyleItem: XMLItem[] = [{ _: 'true', $: { name: WINDOW_LIGHT_STATUS_BAR } }];
+    stylesJSON = setStylesItem(statusBarStyleItem, stylesJSON);
+  }
+
+  stylesJSON = setStylesItem(styleItemToAdd, stylesJSON);
+
+  try {
+    await writeColorsXMLAsync(colorsPath, colorsJSON);
+    await writeStylesXMLAsync(stylesPath, stylesJSON);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android status bar config. Cannot write colors.xml to ${colorsPath}, or styles.xml to ${stylesPath}.`
+    );
+  }
+  return true;
+}

--- a/packages/config/src/android/Styles.ts
+++ b/packages/config/src/android/Styles.ts
@@ -1,0 +1,58 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { Builder, Parser } from 'xml2js';
+import { Document } from './Manifest';
+
+export type XMLItem = {
+  _: string;
+  $: { name: string };
+};
+
+export async function getProjectStylesXMLPathAsync(projectDir: string): Promise<string | null> {
+  try {
+    const shellPath = path.join(projectDir, 'android');
+    if ((await fs.stat(shellPath)).isDirectory()) {
+      const stylesPath = path.join(shellPath, 'app/src/main/res/values/styles.xml');
+      await fs.ensureFile(stylesPath);
+      return stylesPath;
+    }
+  } catch (error) {
+    throw new Error(`Could not create android/app/src/main/res/values/styles.xml`);
+  }
+
+  return null;
+}
+
+export async function readStylesXMLAsync(stylesPath: string): Promise<Document> {
+  const contents = await fs.readFile(stylesPath, { encoding: 'utf8', flag: 'r' });
+  const parser = new Parser();
+  const manifest = parser.parseStringPromise(contents);
+  return manifest;
+}
+
+export async function writeStylesXMLAsync(stylesPath: string, stylesContent: any): Promise<void> {
+  const stylesXml = new Builder().buildObject(stylesContent);
+  await fs.ensureDir(path.dirname(stylesPath));
+  await fs.writeFile(stylesPath, stylesXml);
+}
+
+export function setStylesItem(itemToAdd: XMLItem[], styleFileContentsJSON: Document) {
+  let appTheme = styleFileContentsJSON.resources.style.filter(
+    (e: any) => e['$']['name'] === 'AppTheme'
+  )[0];
+  if (appTheme.item) {
+    let existingItem = appTheme.item.filter(
+      (item: XMLItem) => item['$'].name === itemToAdd[0].$.name
+    )[0];
+
+    // Don't want to 2 of the same item, so if one exists, we overwrite it
+    if (existingItem) {
+      existingItem['_'] = itemToAdd[0]['_'];
+    } else {
+      appTheme.item = appTheme.item.concat(itemToAdd);
+    }
+  } else {
+    appTheme.item = itemToAdd;
+  }
+  return styleFileContentsJSON;
+}

--- a/packages/config/src/android/UserInterfaceStyle.ts
+++ b/packages/config/src/android/UserInterfaceStyle.ts
@@ -1,9 +1,5 @@
 import { ExpoConfig } from '../Config.types';
-import {
-  getProjectAndroidManifestPathAsync,
-  readAndroidManifestAsync,
-  writeAndroidManifestAsync,
-} from './Manifest';
+import { Document } from './Manifest';
 
 export const CONFIG_CHANGES_ATTRIBUTE = 'android:configChanges';
 
@@ -25,32 +21,19 @@ export function getUserInterfaceStyle(config: ExpoConfig): string {
   return result ?? null;
 }
 
-export async function setUiModeAndroidManifest(config: ExpoConfig, projectDirectory: string) {
+export async function setUiModeAndroidManifest(config: ExpoConfig, manifestDocument: Document) {
   let userInterfaceStyle = getUserInterfaceStyle(config);
   if (!userInterfaceStyle) {
-    return false;
+    return manifestDocument;
   }
 
-  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
-  if (!manifestPath) {
-    return false;
-  }
-
-  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
-  let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+  let mainActivity = manifestDocument.manifest.application[0].activity.filter(
     (e: any) => e['$']['android:name'] === '.MainActivity'
   );
   mainActivity[0]['$'][CONFIG_CHANGES_ATTRIBUTE] =
     'keyboard|keyboardHidden|orientation|screenSize|uiMode';
 
-  try {
-    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
-  } catch (e) {
-    throw new Error(
-      `Error setting Android user interface style. Cannot write new AndroidManifest.xml to ${manifestPath}.`
-    );
-  }
-  return true;
+  return manifestDocument;
 }
 
 export function addOnConfigurationChangedMainActivity(

--- a/packages/config/src/android/UserInterfaceStyle.ts
+++ b/packages/config/src/android/UserInterfaceStyle.ts
@@ -1,0 +1,68 @@
+import { ExpoConfig } from '../Config.types';
+import {
+  getProjectAndroidManifestPathAsync,
+  readAndroidManifestAsync,
+  writeAndroidManifestAsync,
+} from './Manifest';
+
+export const CONFIG_CHANGES_ATTRIBUTE = 'android:configChanges';
+
+export const ON_CONFIGURATION_CHANGED = `
+public class MainActivity extends ReactActivity {
+
+    // Added automatically by Expo Config
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        Intent intent = new Intent("onConfigurationChanged");
+        intent.putExtra("newConfig", newConfig);
+        sendBroadcast(intent);
+    }
+`;
+
+export function getUserInterfaceStyle(config: ExpoConfig): string {
+  let result = config.android?.userInterfaceStyle ?? config.userInterfaceStyle;
+  return result ?? null;
+}
+
+export async function setUiModeAndroidManifest(config: ExpoConfig, projectDirectory: string) {
+  let userInterfaceStyle = getUserInterfaceStyle(config);
+  if (!userInterfaceStyle) {
+    return false;
+  }
+
+  const manifestPath = await getProjectAndroidManifestPathAsync(projectDirectory);
+  if (!manifestPath) {
+    return false;
+  }
+
+  let androidManifestJson = await readAndroidManifestAsync(manifestPath);
+  let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+    (e: any) => e['$']['android:name'] === '.MainActivity'
+  );
+  mainActivity[0]['$'][CONFIG_CHANGES_ATTRIBUTE] =
+    'keyboard|keyboardHidden|orientation|screenSize|uiMode';
+
+  try {
+    await writeAndroidManifestAsync(manifestPath, androidManifestJson);
+  } catch (e) {
+    throw new Error(
+      `Error setting Android user interface style. Cannot write new AndroidManifest.xml to ${manifestPath}.`
+    );
+  }
+  return true;
+}
+
+export function addOnConfigurationChangedMainActivity(
+  config: ExpoConfig,
+  MainActivity: string
+): string {
+  let userInterfaceStyle = getUserInterfaceStyle(config);
+  if (!userInterfaceStyle) {
+    return MainActivity;
+  }
+
+  // Cruzan: this is not ideal, but I'm not sure of a better way to handle writing to MainActivity.java
+  let pattern = new RegExp(`public class MainActivity extends ReactActivity {`);
+  return MainActivity.replace(pattern, ON_CONFIGURATION_CHANGED);
+}

--- a/packages/config/src/android/UserInterfaceStyle.ts
+++ b/packages/config/src/android/UserInterfaceStyle.ts
@@ -46,6 +46,9 @@ export function addOnConfigurationChangedMainActivity(
   }
 
   // Cruzan: this is not ideal, but I'm not sure of a better way to handle writing to MainActivity.java
+  if (MainActivity.match(`onConfigurationChanged`)?.length) {
+    return MainActivity;
+  }
   let pattern = new RegExp(`public class MainActivity extends ReactActivity {`);
   return MainActivity.replace(pattern, ON_CONFIGURATION_CHANGED);
 }

--- a/packages/config/src/android/Version.ts
+++ b/packages/config/src/android/Version.ts
@@ -1,0 +1,40 @@
+import { ExpoConfig } from '../Config.types';
+
+const DEFAULT_VERSION_NAME = '1.0';
+const DEFAULT_VERSION_CODE = '1';
+
+export function getVersionName(config: ExpoConfig) {
+  return config.version ? config.version : null;
+}
+
+export function setVersionName(
+  config: ExpoConfig,
+  buildGradle: string,
+  versionToReplace = DEFAULT_VERSION_NAME
+) {
+  let versionName = getVersionName(config);
+  if (versionName === null) {
+    return buildGradle;
+  }
+
+  let pattern = new RegExp(`versionName "${versionToReplace}"`);
+  return buildGradle.replace(pattern, `versionName "${versionName}"`);
+}
+
+export function getVersionCode(config: ExpoConfig) {
+  return config.android && config.android.versionCode ? config.android.versionCode : null;
+}
+
+export function setVersionCode(
+  config: ExpoConfig,
+  buildGradle: string,
+  versionCodeToReplace = DEFAULT_VERSION_CODE
+) {
+  let versionCode = getVersionCode(config);
+  if (versionCode === null) {
+    return buildGradle;
+  }
+
+  let pattern = new RegExp(`versionCode ${versionCodeToReplace}`);
+  return buildGradle.replace(pattern, `versionCode ${versionCode}`);
+}

--- a/packages/config/src/android/__tests__/Branch-test.js
+++ b/packages/config/src/android/__tests__/Branch-test.js
@@ -1,0 +1,53 @@
+import { dirname, resolve } from 'path';
+import fs from 'fs-extra';
+import { getBranchApiKey, setBranchApiKey } from '../Branch';
+import { readAndroidManifestAsync } from '../Manifest';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android branch test', () => {
+  it(`returns null if no android branch api key is provided`, () => {
+    expect(getBranchApiKey({ android: { config: {} } })).toBe(null);
+  });
+
+  it(`returns apikey if android branch api key is provided`, () => {
+    expect(getBranchApiKey({ android: { config: { branch: { apiKey: 'MY-API-KEY' } } } })).toBe(
+      'MY-API-KEY'
+    );
+  });
+
+  describe('sets branch api key in AndroidManifest.xml if given', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(appManifestPath));
+      await fs.copyFile(sampleManifestPath, appManifestPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it('add branch api key', async () => {
+      expect(
+        await setBranchApiKey(
+          { android: { config: { branch: { apiKey: 'MY-API-KEY' } } } },
+          projectDirectory
+        )
+      ).toBe(true);
+
+      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      let mainApplication = androidManifestJson.manifest.application.filter(
+        e => e['$']['android:name'] === '.MainApplication'
+      )[0];
+
+      let apiKeyItem = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'io.branch.sdk.BranchKey'
+      );
+      expect(apiKeyItem).toHaveLength(1);
+      expect(apiKeyItem[0]['$']['android:value']).toMatch('MY-API-KEY');
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/Branch-test.js
+++ b/packages/config/src/android/__tests__/Branch-test.js
@@ -18,7 +18,6 @@ describe('Android branch test', () => {
   });
 
   describe('sets branch api key in AndroidManifest.xml if given', () => {
-    const projectDirectory = resolve(fixturesPath, 'tmp/');
     const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
 
     beforeAll(async () => {
@@ -31,14 +30,11 @@ describe('Android branch test', () => {
     });
 
     it('add branch api key', async () => {
-      expect(
-        await setBranchApiKey(
-          { android: { config: { branch: { apiKey: 'MY-API-KEY' } } } },
-          projectDirectory
-        )
-      ).toBe(true);
-
       let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await setBranchApiKey(
+        { android: { config: { branch: { apiKey: 'MY-API-KEY' } } } },
+        androidManifestJson
+      );
       let mainApplication = androidManifestJson.manifest.application.filter(
         e => e['$']['android:name'] === '.MainApplication'
       )[0];

--- a/packages/config/src/android/__tests__/Facebook-test.js
+++ b/packages/config/src/android/__tests__/Facebook-test.js
@@ -1,0 +1,109 @@
+import { dirname, resolve } from 'path';
+import fs from 'fs-extra';
+import {
+  getFacebookAdvertiserIDCollection,
+  getFacebookAppId,
+  getFacebookAutoInitEnabled,
+  getFacebookAutoLogAppEvents,
+  getFacebookDisplayName,
+  getFacebookScheme,
+  setFacebookConfig,
+} from '../Facebook';
+import { readAndroidManifestAsync } from '../Manifest';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android facebook config', () => {
+  it(`returns null from all getters if no value provided`, () => {
+    expect(getFacebookScheme({})).toBe(null);
+    expect(getFacebookAppId({})).toBe(null);
+    expect(getFacebookDisplayName({})).toBe(null);
+    expect(getFacebookAutoLogAppEvents({})).toBe(null);
+    expect(getFacebookAutoInitEnabled({})).toBe(null);
+    expect(getFacebookAdvertiserIDCollection({})).toBe(null);
+  });
+
+  it(`returns correct value from all getters if value provided`, () => {
+    expect(getFacebookScheme({ facebookScheme: 'myscheme' })).toMatch('myscheme');
+    expect(getFacebookAppId({ facebookAppId: 'my-app-id' })).toMatch('my-app-id');
+    expect(getFacebookDisplayName({ facebookDisplayName: 'my-display-name' })).toMatch(
+      'my-display-name'
+    );
+    expect(getFacebookAutoLogAppEvents({ facebookAutoLogAppEventsEnabled: false })).toBe(false);
+    expect(getFacebookAutoInitEnabled({ facebookAutoInitEnabled: true })).toBe(true);
+    expect(
+      getFacebookAdvertiserIDCollection({ facebookAdvertiserIDCollectionEnabled: false })
+    ).toBe(false);
+  });
+
+  describe('write Facebook config to androidmanifest.xml correctly', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(appManifestPath));
+      await fs.copyFile(sampleManifestPath, appManifestPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it('adds scheme, appid, display name, autolog events, auto init, advertiser id collection', async () => {
+      const facebookConfig = {
+        facebookScheme: 'myscheme',
+        facebookAppId: 'my-app-id',
+        facebookDisplayName: 'my-display-name',
+        facebookAutoLogAppEventsEnabled: 'false',
+        facebookAutoInitEnabled: 'true',
+        facebookAdvertiserIDCollectionEnabled: 'false',
+      };
+      expect(await setFacebookConfig(facebookConfig, projectDirectory)).toBe(true);
+
+      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      let mainApplication = androidManifestJson.manifest.application.filter(
+        e => e['$']['android:name'] === '.MainApplication'
+      )[0];
+      let facebookActivity = mainApplication['activity'].filter(
+        e => e['$']['android:name'] === 'com.facebook.CustomTabActivity'
+      );
+      expect(facebookActivity).toHaveLength(1);
+      let applicationId = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'com.facebook.sdk.ApplicationId'
+      );
+      expect(applicationId).toHaveLength(1);
+      expect(applicationId[0]['$']['android:value']).toMatch(facebookConfig.facebookAppId);
+
+      let displayName = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'com.facebook.sdk.ApplicationName'
+      );
+      expect(displayName).toHaveLength(1);
+      expect(displayName[0]['$']['android:value']).toMatch(facebookConfig.facebookDisplayName);
+
+      let autoLogAppEventsEnabled = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'com.facebook.sdk.AutoLogAppEventsEnabled'
+      );
+      expect(autoLogAppEventsEnabled).toHaveLength(1);
+      expect(autoLogAppEventsEnabled[0]['$']['android:value']).toMatch(
+        facebookConfig.facebookAutoLogAppEventsEnabled
+      );
+
+      let advertiserIDCollectionEnabled = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'com.facebook.sdk.AdvertiserIDCollectionEnabled'
+      );
+      expect(advertiserIDCollectionEnabled).toHaveLength(1);
+      expect(advertiserIDCollectionEnabled[0]['$']['android:value']).toMatch(
+        facebookConfig.facebookAdvertiserIDCollectionEnabled
+      );
+
+      let autoInitEnabled = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'com.facebook.sdk.AutoInitEnabled'
+      );
+      expect(autoInitEnabled).toHaveLength(1);
+      expect(autoInitEnabled[0]['$']['android:value']).toMatch(
+        facebookConfig.facebookAutoInitEnabled
+      );
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/Facebook-test.js
+++ b/packages/config/src/android/__tests__/Facebook-test.js
@@ -38,7 +38,6 @@ describe('Android facebook config', () => {
   });
 
   describe('write Facebook config to androidmanifest.xml correctly', () => {
-    const projectDirectory = resolve(fixturesPath, 'tmp/');
     const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
 
     beforeAll(async () => {
@@ -51,6 +50,7 @@ describe('Android facebook config', () => {
     });
 
     it('adds scheme, appid, display name, autolog events, auto init, advertiser id collection', async () => {
+      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
       const facebookConfig = {
         facebookScheme: 'myscheme',
         facebookAppId: 'my-app-id',
@@ -59,9 +59,7 @@ describe('Android facebook config', () => {
         facebookAutoInitEnabled: 'true',
         facebookAdvertiserIDCollectionEnabled: 'false',
       };
-      expect(await setFacebookConfig(facebookConfig, projectDirectory)).toBe(true);
-
-      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await setFacebookConfig(facebookConfig, androidManifestJson);
       let mainApplication = androidManifestJson.manifest.application.filter(
         e => e['$']['android:name'] === '.MainApplication'
       )[0];

--- a/packages/config/src/android/__tests__/GoogleMapsApiKey-test.js
+++ b/packages/config/src/android/__tests__/GoogleMapsApiKey-test.js
@@ -18,7 +18,6 @@ describe('Android google maps api key', () => {
   });
 
   describe('sets google maps key in AndroidManifest.xml if given', () => {
-    const projectDirectory = resolve(fixturesPath, 'tmp/');
     const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
 
     beforeAll(async () => {
@@ -31,14 +30,12 @@ describe('Android google maps api key', () => {
     });
 
     it('add google maps key', async () => {
-      expect(
-        await setGoogleMapsApiKey(
-          { android: { config: { googleMaps: { apiKey: 'MY-API-KEY' } } } },
-          projectDirectory
-        )
-      ).toBe(true);
-
       let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await setGoogleMapsApiKey(
+        { android: { config: { googleMaps: { apiKey: 'MY-API-KEY' } } } },
+        androidManifestJson
+      );
+
       let mainApplication = androidManifestJson.manifest.application.filter(
         e => e['$']['android:name'] === '.MainApplication'
       )[0];

--- a/packages/config/src/android/__tests__/GoogleMapsApiKey-test.js
+++ b/packages/config/src/android/__tests__/GoogleMapsApiKey-test.js
@@ -1,5 +1,4 @@
-import { dirname, resolve } from 'path';
-import fs from 'fs-extra';
+import { resolve } from 'path';
 import { getGoogleMapsApiKey, setGoogleMapsApiKey } from '../GoogleMapsApiKey';
 import { readAndroidManifestAsync } from '../Manifest';
 
@@ -17,40 +16,27 @@ describe('Android google maps api key', () => {
     ).toBe('MY-API-KEY');
   });
 
-  describe('sets google maps key in AndroidManifest.xml if given', () => {
-    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+  it('add google maps key to androidmanifest.xml', async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifestJson = await setGoogleMapsApiKey(
+      { android: { config: { googleMaps: { apiKey: 'MY-API-KEY' } } } },
+      androidManifestJson
+    );
 
-    beforeAll(async () => {
-      await fs.ensureDir(dirname(appManifestPath));
-      await fs.copyFile(sampleManifestPath, appManifestPath);
-    });
+    let mainApplication = androidManifestJson.manifest.application.filter(
+      e => e['$']['android:name'] === '.MainApplication'
+    )[0];
 
-    afterAll(async () => {
-      await fs.remove(resolve(fixturesPath, 'tmp/'));
-    });
+    let apiKeyItem = mainApplication['meta-data'].filter(
+      e => e['$']['android:name'] === 'com.google.android.geo.API_KEY'
+    );
+    expect(apiKeyItem).toHaveLength(1);
+    expect(apiKeyItem[0]['$']['android:value']).toMatch('MY-API-KEY');
 
-    it('add google maps key', async () => {
-      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
-      androidManifestJson = await setGoogleMapsApiKey(
-        { android: { config: { googleMaps: { apiKey: 'MY-API-KEY' } } } },
-        androidManifestJson
-      );
-
-      let mainApplication = androidManifestJson.manifest.application.filter(
-        e => e['$']['android:name'] === '.MainApplication'
-      )[0];
-
-      let apiKeyItem = mainApplication['meta-data'].filter(
-        e => e['$']['android:name'] === 'com.google.android.geo.API_KEY'
-      );
-      expect(apiKeyItem).toHaveLength(1);
-      expect(apiKeyItem[0]['$']['android:value']).toMatch('MY-API-KEY');
-
-      let usesLibraryItem = mainApplication['uses-library'].filter(
-        e => e['$']['android:name'] === 'org.apache.http.legacy'
-      );
-      expect(usesLibraryItem).toHaveLength(1);
-      expect(usesLibraryItem[0]['$']['android:required']).toMatch('false');
-    });
+    let usesLibraryItem = mainApplication['uses-library'].filter(
+      e => e['$']['android:name'] === 'org.apache.http.legacy'
+    );
+    expect(usesLibraryItem).toHaveLength(1);
+    expect(usesLibraryItem[0]['$']['android:required']).toMatch('false');
   });
 });

--- a/packages/config/src/android/__tests__/GoogleMapsApiKey-test.js
+++ b/packages/config/src/android/__tests__/GoogleMapsApiKey-test.js
@@ -1,0 +1,59 @@
+import { dirname, resolve } from 'path';
+import fs from 'fs-extra';
+import { getGoogleMapsApiKey, setGoogleMapsApiKey } from '../GoogleMapsApiKey';
+import { readAndroidManifestAsync } from '../Manifest';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android google maps api key', () => {
+  it(`returns null if no android google maps api key is provided`, () => {
+    expect(getGoogleMapsApiKey({ android: { config: { googleMaps: {} } } })).toBe(null);
+  });
+
+  it(`returns apikey if android google maps api key is provided`, () => {
+    expect(
+      getGoogleMapsApiKey({ android: { config: { googleMaps: { apiKey: 'MY-API-KEY' } } } })
+    ).toBe('MY-API-KEY');
+  });
+
+  describe('sets google maps key in AndroidManifest.xml if given', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(appManifestPath));
+      await fs.copyFile(sampleManifestPath, appManifestPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it('add google maps key', async () => {
+      expect(
+        await setGoogleMapsApiKey(
+          { android: { config: { googleMaps: { apiKey: 'MY-API-KEY' } } } },
+          projectDirectory
+        )
+      ).toBe(true);
+
+      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      let mainApplication = androidManifestJson.manifest.application.filter(
+        e => e['$']['android:name'] === '.MainApplication'
+      )[0];
+
+      let apiKeyItem = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'com.google.android.geo.API_KEY'
+      );
+      expect(apiKeyItem).toHaveLength(1);
+      expect(apiKeyItem[0]['$']['android:value']).toMatch('MY-API-KEY');
+
+      let usesLibraryItem = mainApplication['uses-library'].filter(
+        e => e['$']['android:name'] === 'org.apache.http.legacy'
+      );
+      expect(usesLibraryItem).toHaveLength(1);
+      expect(usesLibraryItem[0]['$']['android:required']).toMatch('false');
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/GoogleMobileAds-test.js
+++ b/packages/config/src/android/__tests__/GoogleMobileAds-test.js
@@ -1,0 +1,71 @@
+import { dirname, resolve } from 'path';
+import fs from 'fs-extra';
+import {
+  getGoogleMobileAdsAppId,
+  getGoogleMobileAdsAutoInit,
+  setGoogleMobileAdsConfig,
+} from '../GoogleMobileAds';
+import { readAndroidManifestAsync } from '../Manifest';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android permissions', () => {
+  it(`returns falsey for both if no android google mobileads config is provided`, () => {
+    expect(getGoogleMobileAdsAppId({ android: { config: {} } })).toBe(null);
+    expect(getGoogleMobileAdsAutoInit({ android: { config: {} } })).toBe(false);
+  });
+
+  it(`returns value if android google mobile ads config is provided`, () => {
+    expect(
+      getGoogleMobileAdsAppId({ android: { config: { googleMobileAdsAppId: 'MY-API-KEY' } } })
+    ).toMatch('MY-API-KEY');
+    expect(
+      getGoogleMobileAdsAutoInit({ android: { config: { googleMobileAdsAutoInit: true } } })
+    ).toBe(true);
+  });
+
+  describe('sets google maps key in AndroidManifest.xml if given', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(appManifestPath));
+      await fs.copyFile(sampleManifestPath, appManifestPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it('add google mobile ads app config', async () => {
+      expect(
+        await setGoogleMobileAdsConfig(
+          {
+            android: {
+              config: { googleMobileAdsAppId: 'MY-API-KEY', googleMobileAdsAutoInit: false },
+            },
+          },
+          projectDirectory
+        )
+      ).toBe(true);
+
+      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      let mainApplication = androidManifestJson.manifest.application.filter(
+        e => e['$']['android:name'] === '.MainApplication'
+      )[0];
+
+      let apiKeyItem = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'com.google.android.gms.ads.APPLICATION_ID'
+      );
+      expect(apiKeyItem).toHaveLength(1);
+      expect(apiKeyItem[0]['$']['android:value']).toMatch('MY-API-KEY');
+
+      let usesLibraryItem = mainApplication['meta-data'].filter(
+        e => e['$']['android:name'] === 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT'
+      );
+      expect(usesLibraryItem).toHaveLength(1);
+      expect(usesLibraryItem[0]['$']['android:value']).toMatch('true');
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/GoogleMobileAds-test.js
+++ b/packages/config/src/android/__tests__/GoogleMobileAds-test.js
@@ -1,5 +1,4 @@
-import { dirname, resolve } from 'path';
-import fs from 'fs-extra';
+import { resolve } from 'path';
 import {
   getGoogleMobileAdsAppId,
   getGoogleMobileAdsAutoInit,
@@ -25,45 +24,31 @@ describe('Android permissions', () => {
     ).toBe(true);
   });
 
-  describe('sets google maps key in AndroidManifest.xml if given', () => {
-    const projectDirectory = resolve(fixturesPath, 'tmp/');
-    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
-
-    beforeAll(async () => {
-      await fs.ensureDir(dirname(appManifestPath));
-      await fs.copyFile(sampleManifestPath, appManifestPath);
-    });
-
-    afterAll(async () => {
-      await fs.remove(resolve(fixturesPath, 'tmp/'));
-    });
-
-    it('add google mobile ads app config', async () => {
-      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
-      androidManifestJson = await setGoogleMobileAdsConfig(
-        {
-          android: {
-            config: { googleMobileAdsAppId: 'MY-API-KEY', googleMobileAdsAutoInit: false },
-          },
+  it('add google mobile ads app config to androidmanifest.xml', async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifestJson = await setGoogleMobileAdsConfig(
+      {
+        android: {
+          config: { googleMobileAdsAppId: 'MY-API-KEY', googleMobileAdsAutoInit: false },
         },
-        androidManifestJson
-      );
+      },
+      androidManifestJson
+    );
 
-      let mainApplication = androidManifestJson.manifest.application.filter(
-        e => e['$']['android:name'] === '.MainApplication'
-      )[0];
+    let mainApplication = androidManifestJson.manifest.application.filter(
+      e => e['$']['android:name'] === '.MainApplication'
+    )[0];
 
-      let apiKeyItem = mainApplication['meta-data'].filter(
-        e => e['$']['android:name'] === 'com.google.android.gms.ads.APPLICATION_ID'
-      );
-      expect(apiKeyItem).toHaveLength(1);
-      expect(apiKeyItem[0]['$']['android:value']).toMatch('MY-API-KEY');
+    let apiKeyItem = mainApplication['meta-data'].filter(
+      e => e['$']['android:name'] === 'com.google.android.gms.ads.APPLICATION_ID'
+    );
+    expect(apiKeyItem).toHaveLength(1);
+    expect(apiKeyItem[0]['$']['android:value']).toMatch('MY-API-KEY');
 
-      let usesLibraryItem = mainApplication['meta-data'].filter(
-        e => e['$']['android:name'] === 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT'
-      );
-      expect(usesLibraryItem).toHaveLength(1);
-      expect(usesLibraryItem[0]['$']['android:value']).toBe(true);
-    });
+    let usesLibraryItem = mainApplication['meta-data'].filter(
+      e => e['$']['android:name'] === 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT'
+    );
+    expect(usesLibraryItem).toHaveLength(1);
+    expect(usesLibraryItem[0]['$']['android:value']).toBe(true);
   });
 });

--- a/packages/config/src/android/__tests__/GoogleMobileAds-test.js
+++ b/packages/config/src/android/__tests__/GoogleMobileAds-test.js
@@ -39,18 +39,16 @@ describe('Android permissions', () => {
     });
 
     it('add google mobile ads app config', async () => {
-      expect(
-        await setGoogleMobileAdsConfig(
-          {
-            android: {
-              config: { googleMobileAdsAppId: 'MY-API-KEY', googleMobileAdsAutoInit: false },
-            },
-          },
-          projectDirectory
-        )
-      ).toBe(true);
-
       let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await setGoogleMobileAdsConfig(
+        {
+          android: {
+            config: { googleMobileAdsAppId: 'MY-API-KEY', googleMobileAdsAutoInit: false },
+          },
+        },
+        androidManifestJson
+      );
+
       let mainApplication = androidManifestJson.manifest.application.filter(
         e => e['$']['android:name'] === '.MainApplication'
       )[0];
@@ -65,7 +63,7 @@ describe('Android permissions', () => {
         e => e['$']['android:name'] === 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT'
       );
       expect(usesLibraryItem).toHaveLength(1);
-      expect(usesLibraryItem[0]['$']['android:value']).toMatch('true');
+      expect(usesLibraryItem[0]['$']['android:value']).toBe(true);
     });
   });
 });

--- a/packages/config/src/android/__tests__/GoogleServices-test.js
+++ b/packages/config/src/android/__tests__/GoogleServices-test.js
@@ -1,16 +1,12 @@
 import fs from 'fs-extra';
-import { dirname, resolve } from 'path';
+import { resolve } from 'path';
 import { getGoogleServicesFilePath, setGoogleServicesFile } from '../GoogleServices';
 
+jest.mock('fs-extra');
 const fixturesPath = resolve(__dirname, 'fixtures');
 
 describe('google services file', () => {
-  beforeEach(async () => {
-    await fs.remove(resolve(fixturesPath, 'android/app'));
-    await fs.remove(resolve(fixturesPath, 'not/'));
-  });
   afterAll(async () => {
-    await fs.remove(resolve(fixturesPath, 'android/app'));
     await fs.remove(resolve(fixturesPath, 'not/'));
   });
 
@@ -32,8 +28,6 @@ describe('google services file', () => {
   });
 
   it(`copies google services file to android/app`, async () => {
-    const projectRoot = fixturesPath;
-
     expect(
       await setGoogleServicesFile(
         {
@@ -41,17 +35,17 @@ describe('google services file', () => {
             googleServicesFile: './google-services.json',
           },
         },
-        projectRoot
+        fixturesPath
       )
     ).toBe(true);
 
-    await expect(
-      fs.pathExists(resolve(fixturesPath, 'android/app/google-services.json'))
-    ).resolves.toBeTruthy();
+    expect(fs.copy).toHaveBeenCalledWith(
+      resolve(fixturesPath, 'google-services.json'),
+      resolve(fixturesPath, 'android/app/google-services.json')
+    );
   });
 
   it(`copies google services file to custom target path`, async () => {
-    const projectRoot = fixturesPath;
     const customTargetPath = './not/sure/why/youd/do/this/google-services.json';
     expect(
       await setGoogleServicesFile(
@@ -60,11 +54,14 @@ describe('google services file', () => {
             googleServicesFile: './google-services.json',
           },
         },
-        projectRoot,
+        fixturesPath,
         customTargetPath
       )
     ).toBe(true);
 
-    await expect(fs.pathExists(resolve(fixturesPath, customTargetPath))).resolves.toBeTruthy();
+    expect(fs.copy).toHaveBeenCalledWith(
+      resolve(fixturesPath, 'google-services.json'),
+      resolve(fixturesPath, customTargetPath)
+    );
   });
 });

--- a/packages/config/src/android/__tests__/GoogleServices-test.js
+++ b/packages/config/src/android/__tests__/GoogleServices-test.js
@@ -1,0 +1,70 @@
+import fs from 'fs-extra';
+import { dirname, resolve } from 'path';
+import { getGoogleServicesFilePath, setGoogleServicesFile } from '../GoogleServices';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+
+describe('google services file', () => {
+  beforeEach(async () => {
+    await fs.remove(resolve(fixturesPath, 'android/app'));
+    await fs.remove(resolve(fixturesPath, 'not/'));
+  });
+  afterAll(async () => {
+    await fs.remove(resolve(fixturesPath, 'android/app'));
+    await fs.remove(resolve(fixturesPath, 'not/'));
+  });
+
+  it(`returns null if no googleServicesFile is provided`, () => {
+    expect(getGoogleServicesFilePath({}, fixturesPath)).toBe(null);
+  });
+
+  it(`returns googleServicesFile path if provided`, () => {
+    expect(
+      getGoogleServicesFilePath(
+        {
+          android: {
+            googleServicesFile: 'path/to/google-services.json',
+          },
+        },
+        fixturesPath
+      )
+    ).toBe('path/to/google-services.json');
+  });
+
+  it(`copies google services file to android/app`, async () => {
+    const projectRoot = fixturesPath;
+
+    expect(
+      await setGoogleServicesFile(
+        {
+          android: {
+            googleServicesFile: './google-services.json',
+          },
+        },
+        projectRoot
+      )
+    ).toBe(true);
+
+    await expect(
+      fs.pathExists(resolve(fixturesPath, 'android/app/google-services.json'))
+    ).resolves.toBeTruthy();
+  });
+
+  it(`copies google services file to custom target path`, async () => {
+    const projectRoot = fixturesPath;
+    const customTargetPath = './not/sure/why/youd/do/this/google-services.json';
+    expect(
+      await setGoogleServicesFile(
+        {
+          android: {
+            googleServicesFile: './google-services.json',
+          },
+        },
+        projectRoot,
+        customTargetPath
+      )
+    ).toBe(true);
+
+    await expect(fs.pathExists(resolve(fixturesPath, customTargetPath))).resolves.toBeTruthy();
+  });
+});

--- a/packages/config/src/android/__tests__/IntentFilters-test.js
+++ b/packages/config/src/android/__tests__/IntentFilters-test.js
@@ -1,0 +1,76 @@
+import fs from 'fs-extra';
+import { dirname, resolve } from 'path';
+import { readAndroidManifestAsync } from '../Manifest';
+import { getIntentFilters, setAndroidIntentFilters } from '../IntentFilters';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android intent filters', () => {
+  const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+  const projectDirectory = resolve(fixturesPath, 'tmp/');
+
+  beforeAll(async () => {
+    await fs.ensureDir(dirname(appManifestPath));
+    await fs.copyFile(sampleManifestPath, appManifestPath);
+  });
+
+  afterAll(async () => {
+    await fs.remove(resolve(fixturesPath, 'tmp/'));
+  });
+
+  it(`returns empty array if no intent filters are provided`, () => {
+    expect(getIntentFilters({})).toEqual([]);
+  });
+
+  it(`returns false if bad project directory`, async () => {
+    expect(
+      await setAndroidIntentFilters(
+        {
+          android: {
+            intentFilters: [
+              {
+                action: 'VIEW',
+                data: {
+                  scheme: 'https',
+                  host: '*.myapp.io',
+                },
+                category: ['BROWSABLE', 'DEFAULT'],
+              },
+            ],
+          },
+        },
+        'bad/directory/'
+      )
+    ).toBe(false);
+  });
+
+  it(`writes intent filter to android manifest`, async () => {
+    expect(
+      await setAndroidIntentFilters(
+        {
+          android: {
+            intentFilters: [
+              {
+                action: 'VIEW',
+                data: {
+                  scheme: 'https',
+                  host: '*.myapp.io',
+                },
+                category: ['BROWSABLE', 'DEFAULT'],
+              },
+            ],
+          },
+        },
+        projectDirectory
+      )
+    ).toBe(true);
+
+    let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+    expect(
+      androidManifestJson.manifest.application[0].activity.filter(
+        e => e['$']['android:name'] === '.MainActivity'
+      )[0]['intent-filter']
+    ).toHaveLength(2);
+  });
+});

--- a/packages/config/src/android/__tests__/IntentFilters-test.js
+++ b/packages/config/src/android/__tests__/IntentFilters-test.js
@@ -8,7 +8,6 @@ const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.x
 
 describe('Android intent filters', () => {
   const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
-  const projectDirectory = resolve(fixturesPath, 'tmp/');
 
   beforeAll(async () => {
     await fs.ensureDir(dirname(appManifestPath));
@@ -23,50 +22,26 @@ describe('Android intent filters', () => {
     expect(getIntentFilters({})).toEqual([]);
   });
 
-  it(`returns false if bad project directory`, async () => {
-    expect(
-      await setAndroidIntentFilters(
-        {
-          android: {
-            intentFilters: [
-              {
-                action: 'VIEW',
-                data: {
-                  scheme: 'https',
-                  host: '*.myapp.io',
-                },
-                category: ['BROWSABLE', 'DEFAULT'],
-              },
-            ],
-          },
-        },
-        'bad/directory/'
-      )
-    ).toBe(false);
-  });
-
   it(`writes intent filter to android manifest`, async () => {
-    expect(
-      await setAndroidIntentFilters(
-        {
-          android: {
-            intentFilters: [
-              {
-                action: 'VIEW',
-                data: {
-                  scheme: 'https',
-                  host: '*.myapp.io',
-                },
-                category: ['BROWSABLE', 'DEFAULT'],
-              },
-            ],
-          },
-        },
-        projectDirectory
-      )
-    ).toBe(true);
-
     let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+    androidManifestJson = await setAndroidIntentFilters(
+      {
+        android: {
+          intentFilters: [
+            {
+              action: 'VIEW',
+              data: {
+                scheme: 'https',
+                host: '*.myapp.io',
+              },
+              category: ['BROWSABLE', 'DEFAULT'],
+            },
+          ],
+        },
+      },
+      androidManifestJson
+    );
+
     expect(
       androidManifestJson.manifest.application[0].activity.filter(
         e => e['$']['android:name'] === '.MainActivity'

--- a/packages/config/src/android/__tests__/IntentFilters-test.js
+++ b/packages/config/src/android/__tests__/IntentFilters-test.js
@@ -1,5 +1,4 @@
-import fs from 'fs-extra';
-import { dirname, resolve } from 'path';
+import { resolve } from 'path';
 import { readAndroidManifestAsync } from '../Manifest';
 import { getIntentFilters, setAndroidIntentFilters } from '../IntentFilters';
 
@@ -7,23 +6,57 @@ const fixturesPath = resolve(__dirname, 'fixtures');
 const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
 
 describe('Android intent filters', () => {
-  const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
-
-  beforeAll(async () => {
-    await fs.ensureDir(dirname(appManifestPath));
-    await fs.copyFile(sampleManifestPath, appManifestPath);
-  });
-
-  afterAll(async () => {
-    await fs.remove(resolve(fixturesPath, 'tmp/'));
-  });
-
   it(`returns empty array if no intent filters are provided`, () => {
     expect(getIntentFilters({})).toEqual([]);
   });
 
   it(`writes intent filter to android manifest`, async () => {
-    let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifestJson = await setAndroidIntentFilters(
+      {
+        android: {
+          intentFilters: [
+            {
+              action: 'VIEW',
+              data: {
+                scheme: 'https',
+                host: '*.myapp.io',
+              },
+              category: ['BROWSABLE', 'DEFAULT'],
+            },
+          ],
+        },
+      },
+      androidManifestJson
+    );
+
+    expect(
+      androidManifestJson.manifest.application[0].activity.filter(
+        e => e['$']['android:name'] === '.MainActivity'
+      )[0]['intent-filter']
+    ).toHaveLength(2);
+  });
+
+  xit(`does not duplicate android intent filters`, async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifestJson = await setAndroidIntentFilters(
+      {
+        android: {
+          intentFilters: [
+            {
+              action: 'VIEW',
+              data: {
+                scheme: 'https',
+                host: '*.myapp.io',
+              },
+              category: ['BROWSABLE', 'DEFAULT'],
+            },
+          ],
+        },
+      },
+      androidManifestJson
+    );
+
     androidManifestJson = await setAndroidIntentFilters(
       {
         android: {

--- a/packages/config/src/android/__tests__/Manifest-test.js
+++ b/packages/config/src/android/__tests__/Manifest-test.js
@@ -6,7 +6,7 @@ const manifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
 
 describe('Permissions', () => {
   it(`adds a new permission`, async () => {
-    const manifest = await Manifest.readAsync(manifestPath);
+    const manifest = await Manifest.readAndroidManifestAsync(manifestPath);
     const didAdd = Manifest.ensurePermission(manifest, 'EXPO_TEST_PERMISSION');
     const permissions = Manifest.getPermissions(manifest);
     expect(didAdd).toBe(true);
@@ -15,7 +15,7 @@ describe('Permissions', () => {
   });
 
   it(`prevents adding a duplicate permission`, async () => {
-    const manifest = await Manifest.readAsync(manifestPath);
+    const manifest = await Manifest.readAndroidManifestAsync(manifestPath);
     const didAdd = Manifest.ensurePermission(manifest, 'INTERNET');
     const permissions = Manifest.getPermissions(manifest);
     expect(didAdd).toBe(false);
@@ -24,7 +24,7 @@ describe('Permissions', () => {
   });
 
   it(`ensures multiple permissions`, async () => {
-    const manifest = await Manifest.readAsync(manifestPath);
+    const manifest = await Manifest.readAndroidManifestAsync(manifestPath);
     const permissionsToAdd = ['VALUE_1', 'VALUE_2'];
     const results = Manifest.ensurePermissions(manifest, permissionsToAdd);
     expect(results).toMatchSnapshot();
@@ -34,7 +34,7 @@ describe('Permissions', () => {
   });
 
   it(`removes permissions by name`, async () => {
-    const manifest = await Manifest.readAsync(manifestPath);
+    const manifest = await Manifest.readAndroidManifestAsync(manifestPath);
     expect(Manifest.ensurePermission(manifest, 'VALUE_TO_REMOVE_1')).toBe(true);
     expect(Manifest.ensurePermission(manifest, 'VALUE_TO_REMOVE_2')).toBe(true);
     expect(Manifest.getPermissions(manifest).length).toBe(3);
@@ -44,7 +44,7 @@ describe('Permissions', () => {
   });
 
   it(`removes all permissions`, async () => {
-    const manifest = await Manifest.readAsync(manifestPath);
+    const manifest = await Manifest.readAndroidManifestAsync(manifestPath);
     expect(Manifest.ensurePermission(manifest, 'VALUE_TO_REMOVE_1')).toBe(true);
     expect(Manifest.ensurePermission(manifest, 'VALUE_TO_REMOVE_2')).toBe(true);
     expect(Manifest.getPermissions(manifest).length).toBe(3);
@@ -55,7 +55,7 @@ describe('Permissions', () => {
   });
 
   it(`can write with a pretty format`, async () => {
-    const manifest = await Manifest.readAsync(manifestPath);
+    const manifest = await Manifest.readAndroidManifestAsync(manifestPath);
     expect(Manifest.ensurePermission(manifest, 'NEW_PERMISSION_1')).toBe(true);
     expect(Manifest.ensurePermission(manifest, 'NEW_PERMISSION_2')).toBe(true);
     expect(Manifest.getPermissions(manifest).length).toBe(3);
@@ -87,7 +87,7 @@ describe('Permissions', () => {
         await Manifest.persistAndroidPermissionsAsync(fixturesPath, permissionsToPersist)
       ).toBe(true);
 
-      const manifest = await Manifest.readAsync(appManifestPath);
+      const manifest = await Manifest.readAndroidManifestAsync(appManifestPath);
       expect(Manifest.getPermissions(manifest)).toStrictEqual(
         permissionsToPersist.map(Manifest.ensurePermissionNameFormat)
       );

--- a/packages/config/src/android/__tests__/NavigationBar-test.js
+++ b/packages/config/src/android/__tests__/NavigationBar-test.js
@@ -1,0 +1,97 @@
+import fs from 'fs-extra';
+import { dirname, resolve } from 'path';
+import {
+  getNavigationBarColor,
+  getNavigationBarImmersiveMode,
+  getNavigationBarStyle,
+  setNavigationBarConfig,
+} from '../NavigationBar';
+import { readStylesXMLAsync } from '../Styles';
+import { getProjectColorsXMLPathAsync, readColorsXMLAsync } from '../Colors';
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleStylesXMLPath = resolve(fixturesPath, 'styles.xml');
+
+describe('Android navigation bar', () => {
+  it(`returns 'translucent' if no status bar color is provided`, () => {
+    expect(getNavigationBarColor({})).toBe(null);
+    expect(getNavigationBarColor({ androidNavigationBar: {} })).toBe(null);
+  });
+
+  it(`returns navigation bar color if provided`, () => {
+    expect(getNavigationBarColor({ androidNavigationBar: { backgroundColor: '#111111' } })).toMatch(
+      '#111111'
+    );
+  });
+
+  it(`returns navigation bar style if provided`, () => {
+    expect(getNavigationBarStyle({ androidNavigationBar: { barStyle: 'dark-content' } })).toMatch(
+      'dark-content'
+    );
+  });
+
+  it(`default navigation bar style to light-content if none provided`, () => {
+    expect(getNavigationBarStyle({})).toMatch('light-content');
+  });
+
+  it(`return navigation bar visible if present`, () => {
+    expect(
+      getNavigationBarImmersiveMode({ androidNavigationBar: { visible: 'leanback' } })
+    ).toMatch('leanback');
+  });
+
+  it(`default navigation bar visible to null`, () => {
+    expect(getNavigationBarImmersiveMode({})).toBe(null);
+  });
+
+  describe('e2e: write navigation color and style to files correctly', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const stylesXMLPath = resolve(fixturesPath, 'tmp/android/app/src/main/res/values/styles.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(stylesXMLPath));
+      await fs.copyFile(sampleStylesXMLPath, stylesXMLPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it(`sets the navigationBarColor item in styles.xml and adds color to colors.xml if 'androidNavigationBar.backgroundColor' is given. sets windowLightNavigation bar true`, async () => {
+      expect(
+        await setNavigationBarConfig(
+          { androidNavigationBar: { backgroundColor: '#111111', barStyle: 'dark-content' } },
+          projectDirectory
+        )
+      ).toBe(true);
+
+      let stylesJSON = await readStylesXMLAsync(stylesXMLPath);
+      let colorsXMLPath = await getProjectColorsXMLPathAsync(projectDirectory);
+      let colorsJSON = await readColorsXMLAsync(colorsXMLPath);
+      expect(
+        stylesJSON.resources.style
+          .filter(e => e['$']['name'] === 'AppTheme')[0]
+          .item.filter(item => item['$'].name === 'android:navigationBarColor')[0]['_']
+      ).toMatch('@color/navigationBarColor');
+      expect(
+        colorsJSON.resources.color.filter(e => e['$']['name'] === 'navigationBarColor')[0]['_']
+      ).toMatch('#111111');
+      expect(
+        stylesJSON.resources.style
+          .filter(e => e['$']['name'] === 'AppTheme')[0]
+          .item.filter(item => item['$'].name === 'android:windowLightNavigationBar')[0]['_']
+      ).toMatch('true');
+    });
+
+    it(`logs to console if androidNavigationBar.visible is provided`, async () => {
+      console.log = jest.fn();
+
+      await setNavigationBarConfig(
+        { androidNavigationBar: { visible: 'leanback' } },
+        projectDirectory
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        'Hiding the Android navigation bar must be done programatically. Please see the Android documentation: https://developer.android.com/training/system-ui/immersive'
+      );
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/NavigationBar-test.js
+++ b/packages/config/src/android/__tests__/NavigationBar-test.js
@@ -10,7 +10,8 @@ import { readStylesXMLAsync } from '../Styles';
 import { getProjectColorsXMLPathAsync, readColorsXMLAsync } from '../Colors';
 const fixturesPath = resolve(__dirname, 'fixtures');
 const sampleStylesXMLPath = resolve(fixturesPath, 'styles.xml');
-
+jest.mock('../../WarningAggregator');
+const { addWarningAndroid } = require('../../WarningAggregator');
 describe('Android navigation bar', () => {
   it(`returns 'translucent' if no status bar color is provided`, () => {
     expect(getNavigationBarColor({})).toBe(null);
@@ -82,16 +83,14 @@ describe('Android navigation bar', () => {
       ).toMatch('true');
     });
 
-    it(`logs to console if androidNavigationBar.visible is provided`, async () => {
-      console.log = jest.fn();
+    it(`adds android warning androidNavigationBar.visible is provided`, async () => {
+      addWarningAndroid.mockImplementationOnce();
 
       await setNavigationBarConfig(
         { androidNavigationBar: { visible: 'leanback' } },
         projectDirectory
       );
-      expect(console.log).toHaveBeenCalledWith(
-        'Hiding the Android navigation bar must be done programatically. Please see the Android documentation: https://developer.android.com/training/system-ui/immersive'
-      );
+      expect(addWarningAndroid).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/config/src/android/__tests__/Orientation-test.js
+++ b/packages/config/src/android/__tests__/Orientation-test.js
@@ -1,5 +1,4 @@
-import fs, { ensureDir } from 'fs-extra';
-import { dirname, resolve } from 'path';
+import { resolve } from 'path';
 import { readAndroidManifestAsync } from '../Manifest';
 
 import { getOrientation, setAndroidOrientation } from '../Orientation';
@@ -17,19 +16,9 @@ describe('Android orientation', () => {
   });
 
   describe('File changes', () => {
-    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
     let androidManifestJson;
-    beforeAll(async () => {
-      await fs.ensureDir(dirname(appManifestPath));
-      await fs.copyFile(sampleManifestPath, appManifestPath);
-    });
-
-    afterAll(async () => {
-      await fs.remove(resolve(fixturesPath, 'tmp/'));
-    });
-
     it('adds orientation attribute if not present', async () => {
-      androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
       androidManifestJson = await setAndroidOrientation(
         { orientation: 'landscape' },
         androidManifestJson
@@ -42,7 +31,7 @@ describe('Android orientation', () => {
     });
 
     it('replaces orientation attribute if present', async () => {
-      androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
 
       androidManifestJson = await setAndroidOrientation(
         { orientation: 'portrait' },

--- a/packages/config/src/android/__tests__/Orientation-test.js
+++ b/packages/config/src/android/__tests__/Orientation-test.js
@@ -1,0 +1,49 @@
+import fs, { ensureDir } from 'fs-extra';
+import { dirname, resolve } from 'path';
+
+import { getOrientation, setAndroidOrientation } from '../Orientation';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android orientation', () => {
+  it(`returns null if no orientation is provided`, () => {
+    expect(getOrientation({})).toBe(null);
+  });
+
+  it(`returns orientation if provided`, () => {
+    expect(getOrientation({ orientation: 'landscape' })).toMatch('landscape');
+  });
+
+  describe('File changes', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(appManifestPath));
+      await fs.copyFile(sampleManifestPath, appManifestPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it('adds orientation attribute if not present', async () => {
+      expect(await setAndroidOrientation({ orientation: 'landscape' }, projectDirectory)).toBe(
+        true
+      );
+    });
+
+    it('replaces orientation attribute if present', async () => {
+      expect(await setAndroidOrientation({ orientation: 'portrait' }, projectDirectory)).toBe(true);
+    });
+
+    it('does nothing if no orientation is provided', async () => {
+      expect(await setAndroidOrientation({}, projectDirectory)).toBe(false);
+    });
+
+    it('does nothing if no android manifest', async () => {
+      expect(await setAndroidOrientation({}, 'wrong/path')).toBe(false);
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/Package-test.js
+++ b/packages/config/src/android/__tests__/Package-test.js
@@ -1,0 +1,68 @@
+import { getPackage, setPackageInAndroidManifest, setPackageInBuildGradle } from '../Package';
+
+// TODO: use fixtures for manifest/build.gradle instead of inline strings
+
+const EXAMPLE_ANDROID_MANIFEST = `
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.helloworld">
+    <application
+    android:name=".MainApplication"
+    android:label="@string/app_name"
+    android:icon="@mipmap/ic_launcher"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:allowBackup="false"
+    android:theme="@style/AppTheme">
+    <activity
+      android:name=".MainActivity"
+      android:label="@string/app_name"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+      android:windowSoftInputMode="adjustResize">
+      <intent-filter>
+          <action android:name="android.intent.action.MAIN" />
+          <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+  </application>
+
+</manifest>
+`;
+
+const EXAMPLE_BUILD_GRADLE = `
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        applicationId "com.helloworld"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+}
+`;
+
+describe('package', () => {
+  it(`returns null if no package is provided`, () => {
+    expect(getPackage({})).toBe(null);
+  });
+
+  it(`returns the package if provided`, () => {
+    expect(getPackage({ android: { package: 'com.example.xyz' } })).toBe('com.example.xyz');
+  });
+
+  it(`sets the applicationId in build.gradle if package is given`, () => {
+    expect(
+      setPackageInBuildGradle({ android: { package: 'my.new.app' } }, EXAMPLE_BUILD_GRADLE)
+    ).toMatch("applicationId 'my.new.app'");
+  });
+
+  it(`sets the android:name in AndroidManifest.xml if package is given`, () => {
+    expect(
+      setPackageInAndroidManifest({ android: { package: 'my.new.app' } }, EXAMPLE_ANDROID_MANIFEST)
+    ).toMatch('package="my.new.app"');
+  });
+
+  // TODO: add test cases for passing in a different package name to replace in third param
+});

--- a/packages/config/src/android/__tests__/Package-test.js
+++ b/packages/config/src/android/__tests__/Package-test.js
@@ -1,5 +1,4 @@
-import { dirname, resolve } from 'path';
-import fs from 'fs-extra';
+import { resolve } from 'path';
 import { getPackage, setPackageInAndroidManifest, setPackageInBuildGradle } from '../Package';
 import { readAndroidManifestAsync } from '../Manifest';
 
@@ -36,26 +35,13 @@ describe('package', () => {
     ).toMatch("applicationId 'my.new.app'");
   });
 
-  describe('sets the package in AndroidManifest.xml if package is given', () => {
-    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+  it('adds package to android manifest', async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifestJson = await setPackageInAndroidManifest(
+      { android: { package: 'com.test.package' } },
+      androidManifestJson
+    );
 
-    beforeAll(async () => {
-      await fs.ensureDir(dirname(appManifestPath));
-      await fs.copyFile(sampleManifestPath, appManifestPath);
-    });
-
-    afterAll(async () => {
-      await fs.remove(resolve(fixturesPath, 'tmp/'));
-    });
-
-    it('adds package to android manifest', async () => {
-      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
-      androidManifestJson = await setPackageInAndroidManifest(
-        { android: { package: 'com.test.package' } },
-        androidManifestJson
-      );
-
-      expect(androidManifestJson['manifest']['$']['package']).toMatch('com.test.package');
-    });
+    expect(androidManifestJson['manifest']['$']['package']).toMatch('com.test.package');
   });
 });

--- a/packages/config/src/android/__tests__/Package-test.js
+++ b/packages/config/src/android/__tests__/Package-test.js
@@ -37,7 +37,6 @@ describe('package', () => {
   });
 
   describe('sets the package in AndroidManifest.xml if package is given', () => {
-    const projectDirectory = resolve(fixturesPath, 'tmp/');
     const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
 
     beforeAll(async () => {
@@ -50,13 +49,12 @@ describe('package', () => {
     });
 
     it('adds package to android manifest', async () => {
-      expect(
-        await setPackageInAndroidManifest(
-          { android: { package: 'com.test.package' } },
-          projectDirectory
-        )
-      ).toBe(true);
       let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await setPackageInAndroidManifest(
+        { android: { package: 'com.test.package' } },
+        androidManifestJson
+      );
+
       expect(androidManifestJson['manifest']['$']['package']).toMatch('com.test.package');
     });
   });

--- a/packages/config/src/android/__tests__/Permissions-test.js
+++ b/packages/config/src/android/__tests__/Permissions-test.js
@@ -18,7 +18,6 @@ describe('Android permissions', () => {
   });
 
   describe('adds permissions in AndroidManifest.xml if given', () => {
-    const projectDirectory = resolve(fixturesPath, 'tmp/');
     const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
 
     beforeAll(async () => {
@@ -36,16 +35,13 @@ describe('Android permissions', () => {
         'com.android.launcher.permission.INSTALL_SHORTCUT',
         'com.android.launcher.permission.INSTALL_SHORTCUT',
       ];
-      expect(
-        await setAndroidPermissions(
-          { android: { permissions: givenPermissions } },
-          projectDirectory
-        )
-      ).toBe(true);
+      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await setAndroidPermissions(
+        { android: { permissions: givenPermissions } },
+        androidManifestJson
+      );
 
-      let manifestPermissionsJSON = (await readAndroidManifestAsync(appManifestPath)).manifest[
-        'uses-permission'
-      ];
+      let manifestPermissionsJSON = androidManifestJson.manifest['uses-permission'];
       let manifestPermissions = manifestPermissionsJSON.map(e => e['$']['android:name']);
 
       expect(

--- a/packages/config/src/android/__tests__/Permissions-test.js
+++ b/packages/config/src/android/__tests__/Permissions-test.js
@@ -1,0 +1,61 @@
+import { dirname, resolve } from 'path';
+import fs from 'fs-extra';
+import { getAndroidPermissions, requiredPermissions, setAndroidPermissions } from '../Permissions';
+import { readAndroidManifestAsync } from '../Manifest';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android permissions', () => {
+  it(`returns empty array if no android permissions key is provided`, () => {
+    expect(getAndroidPermissions({})).toMatchObject([]);
+  });
+
+  it(`returns android permissions if array is provided`, () => {
+    expect(
+      getAndroidPermissions({ android: { permissions: ['CAMERA', 'RECORD_AUDIO'] } })
+    ).toMatchObject(['CAMERA', 'RECORD_AUDIO']);
+  });
+
+  describe('adds permissions in AndroidManifest.xml if given', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(appManifestPath));
+      await fs.copyFile(sampleManifestPath, appManifestPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it('adds permissions if not present, does not duplicate permissions', async () => {
+      let givenPermissions = [
+        'android.permission.READ_CONTACTS',
+        'com.android.launcher.permission.INSTALL_SHORTCUT',
+        'com.android.launcher.permission.INSTALL_SHORTCUT',
+      ];
+      expect(
+        await setAndroidPermissions(
+          { android: { permissions: givenPermissions } },
+          projectDirectory
+        )
+      ).toBe(true);
+
+      let manifestPermissionsJSON = (await readAndroidManifestAsync(appManifestPath)).manifest[
+        'uses-permission'
+      ];
+      let manifestPermissions = manifestPermissionsJSON.map(e => e['$']['android:name']);
+
+      expect(
+        manifestPermissions.every(permission =>
+          givenPermissions.concat(requiredPermissions).includes(permission)
+        )
+      ).toBe(true);
+      expect(
+        manifestPermissions.filter(e => e === 'com.android.launcher.permission.INSTALL_SHORTCUT')
+      ).toHaveLength(1);
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/Permissions-test.js
+++ b/packages/config/src/android/__tests__/Permissions-test.js
@@ -1,5 +1,4 @@
-import { dirname, resolve } from 'path';
-import fs from 'fs-extra';
+import { resolve } from 'path';
 import { getAndroidPermissions, requiredPermissions, setAndroidPermissions } from '../Permissions';
 import { readAndroidManifestAsync } from '../Manifest';
 
@@ -17,41 +16,28 @@ describe('Android permissions', () => {
     ).toMatchObject(['CAMERA', 'RECORD_AUDIO']);
   });
 
-  describe('adds permissions in AndroidManifest.xml if given', () => {
-    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+  it('adds permissions if not present, does not duplicate permissions', async () => {
+    let givenPermissions = [
+      'android.permission.READ_CONTACTS',
+      'com.android.launcher.permission.INSTALL_SHORTCUT',
+      'com.android.launcher.permission.INSTALL_SHORTCUT',
+    ];
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    androidManifestJson = await setAndroidPermissions(
+      { android: { permissions: givenPermissions } },
+      androidManifestJson
+    );
 
-    beforeAll(async () => {
-      await fs.ensureDir(dirname(appManifestPath));
-      await fs.copyFile(sampleManifestPath, appManifestPath);
-    });
+    let manifestPermissionsJSON = androidManifestJson.manifest['uses-permission'];
+    let manifestPermissions = manifestPermissionsJSON.map(e => e['$']['android:name']);
 
-    afterAll(async () => {
-      await fs.remove(resolve(fixturesPath, 'tmp/'));
-    });
-
-    it('adds permissions if not present, does not duplicate permissions', async () => {
-      let givenPermissions = [
-        'android.permission.READ_CONTACTS',
-        'com.android.launcher.permission.INSTALL_SHORTCUT',
-        'com.android.launcher.permission.INSTALL_SHORTCUT',
-      ];
-      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
-      androidManifestJson = await setAndroidPermissions(
-        { android: { permissions: givenPermissions } },
-        androidManifestJson
-      );
-
-      let manifestPermissionsJSON = androidManifestJson.manifest['uses-permission'];
-      let manifestPermissions = manifestPermissionsJSON.map(e => e['$']['android:name']);
-
-      expect(
-        manifestPermissions.every(permission =>
-          givenPermissions.concat(requiredPermissions).includes(permission)
-        )
-      ).toBe(true);
-      expect(
-        manifestPermissions.filter(e => e === 'com.android.launcher.permission.INSTALL_SHORTCUT')
-      ).toHaveLength(1);
-    });
+    expect(
+      manifestPermissions.every(permission =>
+        givenPermissions.concat(requiredPermissions).includes(permission)
+      )
+    ).toBe(true);
+    expect(
+      manifestPermissions.filter(e => e === 'com.android.launcher.permission.INSTALL_SHORTCUT')
+    ).toHaveLength(1);
   });
 });

--- a/packages/config/src/android/__tests__/PrimaryColor-test.js
+++ b/packages/config/src/android/__tests__/PrimaryColor-test.js
@@ -1,0 +1,48 @@
+import fs from 'fs-extra';
+import { dirname, resolve } from 'path';
+import { getPrimaryColor, setPrimaryColor } from '../PrimaryColor';
+import { readStylesXMLAsync } from '../Styles';
+import { getProjectColorsXMLPathAsync, readColorsXMLAsync } from '../Colors';
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleStylesXMLPath = resolve(fixturesPath, 'styles.xml');
+
+describe('Android primary color', () => {
+  it(`returns default if no primary color is provided`, () => {
+    expect(getPrimaryColor({})).toBe('#023c69');
+  });
+
+  it(`returns primary color if provided`, () => {
+    expect(getPrimaryColor({ primaryColor: '#111111' })).toMatch('#111111');
+  });
+
+  describe('E2E: write primary color to colors.xml and styles.xml correctly', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const stylesXMLPath = resolve(fixturesPath, 'tmp/android/app/src/main/res/values/styles.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(stylesXMLPath));
+      await fs.copyFile(sampleStylesXMLPath, stylesXMLPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it(`sets the colorPrimary item in Styles.xml if backgroundColor is given`, async () => {
+      expect(await setPrimaryColor({ primaryColor: '#654321' }, projectDirectory)).toBe(true);
+
+      let stylesJSON = await readStylesXMLAsync(stylesXMLPath);
+      let colorsXMLPath = await getProjectColorsXMLPathAsync(projectDirectory);
+      let colorsJSON = await readColorsXMLAsync(colorsXMLPath);
+
+      expect(
+        stylesJSON.resources.style
+          .filter(e => e['$']['name'] === 'AppTheme')[0]
+          .item.filter(item => item['$'].name === 'colorPrimary')[0]['_']
+      ).toMatch('@color/colorPrimary');
+      expect(
+        colorsJSON.resources.color.filter(e => e['$']['name'] === 'colorPrimary')[0]['_']
+      ).toMatch('#654321');
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/RootViewBackgroundColor-test.js
+++ b/packages/config/src/android/__tests__/RootViewBackgroundColor-test.js
@@ -1,0 +1,58 @@
+import fs from 'fs-extra';
+import { dirname, resolve } from 'path';
+import { getRootViewBackgroundColor, setRootViewBackgroundColor } from '../RootViewBackgroundColor';
+import { readStylesXMLAsync } from '../Styles';
+import { getProjectColorsXMLPathAsync, readColorsXMLAsync } from '../Colors';
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleStylesXMLPath = resolve(fixturesPath, 'styles.xml');
+
+describe('Root view background color', () => {
+  it(`returns null if no backgroundColor is provided`, () => {
+    expect(getRootViewBackgroundColor({})).toBe(null);
+  });
+
+  it(`returns backgroundColor if provided`, () => {
+    expect(getRootViewBackgroundColor({ backgroundColor: '#111111' })).toMatch('#111111');
+  });
+
+  it(`returns the backgroundColor under android if provided`, () => {
+    expect(
+      getRootViewBackgroundColor({
+        backgroundColor: '#111111',
+        android: { backgroundColor: '#222222' },
+      })
+    ).toMatch('#222222');
+  });
+
+  describe('write colors.xml correctly', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const stylesXMLPath = resolve(fixturesPath, 'tmp/android/app/src/main/res/values/styles.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(stylesXMLPath));
+      await fs.copyFile(sampleStylesXMLPath, stylesXMLPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it(`sets the android:windowBackground in Styles.xml if backgroundColor is given`, async () => {
+      expect(
+        await setRootViewBackgroundColor({ backgroundColor: '#654321' }, projectDirectory)
+      ).toBe(true);
+
+      let stylesJSON = await readStylesXMLAsync(stylesXMLPath);
+      let colorsXMLPath = await getProjectColorsXMLPathAsync(projectDirectory);
+      let colorsJSON = await readColorsXMLAsync(colorsXMLPath);
+      expect(
+        stylesJSON.resources.style
+          .filter(e => e['$']['name'] === 'AppTheme')[0]
+          .item.filter(item => item['$'].name === 'android:windowBackground')[0]['_']
+      ).toMatch('@color/activityBackground');
+      expect(
+        colorsJSON.resources.color.filter(e => e['$']['name'] === 'activityBackground')[0]['_']
+      ).toMatch('#654321');
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/Scheme-test.js
+++ b/packages/config/src/android/__tests__/Scheme-test.js
@@ -1,0 +1,46 @@
+import { dirname, resolve } from 'path';
+import fs from 'fs-extra';
+import { getScheme, setScheme } from '../Scheme';
+import { readAndroidManifestAsync } from '../Manifest';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('scheme', () => {
+  it(`returns null if no scheme is provided`, () => {
+    expect(getScheme({})).toBe(null);
+  });
+
+  it(`returns the scheme if provided`, () => {
+    expect(getScheme({ scheme: 'myapp' })).toBe('myapp');
+  });
+
+  describe('sets the android:scheme in AndroidManifest.xml if scheme is given', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(appManifestPath));
+      await fs.copyFile(sampleManifestPath, appManifestPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it('adds scheme to android manifest', async () => {
+      expect(await setScheme({ scheme: 'myapp' }, projectDirectory)).toBe(true);
+      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      let intentFilters = androidManifestJson.manifest.application[0].activity.filter(
+        e => e['$']['android:name'] === '.MainActivity'
+      )[0]['intent-filter'];
+      let schemeIntent = intentFilters.filter(e => {
+        if (e.hasOwnProperty('data')) {
+          return e['data'][0]['$']['android:scheme'] === 'myapp';
+        }
+        return false;
+      });
+      expect(schemeIntent).toHaveLength(1);
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/Scheme-test.js
+++ b/packages/config/src/android/__tests__/Scheme-test.js
@@ -16,7 +16,6 @@ describe('scheme', () => {
   });
 
   describe('sets the android:scheme in AndroidManifest.xml if scheme is given', () => {
-    const projectDirectory = resolve(fixturesPath, 'tmp/');
     const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
 
     beforeAll(async () => {
@@ -29,8 +28,9 @@ describe('scheme', () => {
     });
 
     it('adds scheme to android manifest', async () => {
-      expect(await setScheme({ scheme: 'myapp' }, projectDirectory)).toBe(true);
       let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
+      androidManifestJson = await setScheme({ scheme: 'myapp' }, androidManifestJson);
+
       let intentFilters = androidManifestJson.manifest.application[0].activity.filter(
         e => e['$']['android:name'] === '.MainActivity'
       )[0]['intent-filter'];

--- a/packages/config/src/android/__tests__/StatusBar-test.js
+++ b/packages/config/src/android/__tests__/StatusBar-test.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import { dirname, resolve } from 'path';
-import { getStatusBarColor, getStatusBarStyle, setStatusBarColor } from '../StatusBar';
+import { getStatusBarColor, getStatusBarStyle, setStatusBarConfig } from '../StatusBar';
 import { readStylesXMLAsync } from '../Styles';
 import { getProjectColorsXMLPathAsync, readColorsXMLAsync } from '../Colors';
 const fixturesPath = resolve(__dirname, 'fixtures');
@@ -43,7 +43,7 @@ describe('Android status bar', () => {
 
     it(`sets the colorPrimaryDark item in styles.xml and adds color to colors.xml if 'androidStatusBar.backgroundColor' is given`, async () => {
       expect(
-        await setStatusBarColor(
+        await setStatusBarConfig(
           { androidStatusBar: { backgroundColor: '#654321', barStyle: 'dark-content' } },
           projectDirectory
         )
@@ -68,7 +68,7 @@ describe('Android status bar', () => {
     });
 
     it(`sets the status bar to translucent if no 'androidStatusBar.backgroundColor' is given`, async () => {
-      expect(await setStatusBarColor({}, projectDirectory)).toBe(true);
+      expect(await setStatusBarConfig({}, projectDirectory)).toBe(true);
     });
   });
 });

--- a/packages/config/src/android/__tests__/StatusBar-test.js
+++ b/packages/config/src/android/__tests__/StatusBar-test.js
@@ -1,0 +1,74 @@
+import fs from 'fs-extra';
+import { dirname, resolve } from 'path';
+import { getStatusBarColor, getStatusBarStyle, setStatusBarColor } from '../StatusBar';
+import { readStylesXMLAsync } from '../Styles';
+import { getProjectColorsXMLPathAsync, readColorsXMLAsync } from '../Colors';
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleStylesXMLPath = resolve(fixturesPath, 'styles.xml');
+
+describe('Android status bar', () => {
+  it(`returns 'translucent' if no status bar color is provided`, () => {
+    expect(getStatusBarColor({})).toMatch('translucent');
+    expect(getStatusBarColor({ androidStatusBar: {} })).toMatch('translucent');
+  });
+
+  it(`returns statusbar color if provided`, () => {
+    expect(getStatusBarColor({ androidStatusBar: { backgroundColor: '#111111' } })).toMatch(
+      '#111111'
+    );
+  });
+
+  it(`returns statusbar style if provided`, () => {
+    expect(getStatusBarStyle({ androidStatusBar: { barStyle: 'dark-content' } })).toMatch(
+      'dark-content'
+    );
+  });
+
+  it(`default statusbar style to light-content if none provided`, () => {
+    expect(getStatusBarStyle({})).toMatch('light-content');
+  });
+
+  describe('e2e: write statusbar color and style to files correctly', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const stylesXMLPath = resolve(fixturesPath, 'tmp/android/app/src/main/res/values/styles.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(stylesXMLPath));
+      await fs.copyFile(sampleStylesXMLPath, stylesXMLPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it(`sets the colorPrimaryDark item in styles.xml and adds color to colors.xml if 'androidStatusBar.backgroundColor' is given`, async () => {
+      expect(
+        await setStatusBarColor(
+          { androidStatusBar: { backgroundColor: '#654321', barStyle: 'dark-content' } },
+          projectDirectory
+        )
+      ).toBe(true);
+
+      let stylesJSON = await readStylesXMLAsync(stylesXMLPath);
+      let colorsXMLPath = await getProjectColorsXMLPathAsync(projectDirectory);
+      let colorsJSON = await readColorsXMLAsync(colorsXMLPath);
+      expect(
+        stylesJSON.resources.style
+          .filter(e => e['$']['name'] === 'AppTheme')[0]
+          .item.filter(item => item['$'].name === 'colorPrimaryDark')[0]['_']
+      ).toMatch('@color/colorPrimaryDark');
+      expect(
+        colorsJSON.resources.color.filter(e => e['$']['name'] === 'colorPrimaryDark')[0]['_']
+      ).toMatch('#654321');
+      expect(
+        stylesJSON.resources.style
+          .filter(e => e['$']['name'] === 'AppTheme')[0]
+          .item.filter(item => item['$'].name === 'android:windowLightStatusBar')[0]['_']
+      ).toMatch('true');
+    });
+
+    it(`sets the status bar to translucent if no 'androidStatusBar.backgroundColor' is given`, async () => {
+      expect(await setStatusBarColor({}, projectDirectory)).toBe(true);
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/UserInterfaceStyle-test.js
+++ b/packages/config/src/android/__tests__/UserInterfaceStyle-test.js
@@ -70,7 +70,6 @@ describe('User interface style', () => {
   });
 
   describe('write file correctly', () => {
-    const projectDirectory = resolve(fixturesPath, 'tmp/');
     const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
 
     beforeAll(async () => {
@@ -83,16 +82,17 @@ describe('User interface style', () => {
     });
 
     it(`sets the android:configChanges in AndroidManifest.xml if userInterfaceStyle is given`, async () => {
-      expect(
-        await setUiModeAndroidManifest({ userInterfaceStyle: 'light' }, projectDirectory)
-      ).toBe(true);
-      //read file
-    });
+      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
 
-    it(`makes no changes to the androidManifest or MainActivity if userInterfaceStyle value provided`, async () => {
-      expect(await setUiModeAndroidManifest({}, projectDirectory)).toBe(false);
-      expect(addOnConfigurationChangedMainActivity({}, EXAMPLE_MAIN_ACTIVITY_BEFORE)).toMatch(
-        EXAMPLE_MAIN_ACTIVITY_BEFORE
+      androidManifestJson = await setUiModeAndroidManifest(
+        { userInterfaceStyle: 'light' },
+        androidManifestJson
+      );
+      let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+        e => e['$']['android:name'] === '.MainActivity'
+      );
+      expect(mainActivity[0]['$']['android:configChanges']).toMatch(
+        'keyboard|keyboardHidden|orientation|screenSize|uiMode'
       );
     });
   });

--- a/packages/config/src/android/__tests__/UserInterfaceStyle-test.js
+++ b/packages/config/src/android/__tests__/UserInterfaceStyle-test.js
@@ -1,0 +1,99 @@
+import fs from 'fs-extra';
+import { dirname, resolve } from 'path';
+import {
+  ON_CONFIGURATION_CHANGED,
+  addOnConfigurationChangedMainActivity,
+  getUserInterfaceStyle,
+  setUiModeAndroidManifest,
+} from '../UserInterfaceStyle';
+import { readAndroidManifestAsync } from '../Manifest';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+const EXAMPLE_MAIN_ACTIVITY_BEFORE = `
+package com.helloworld;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
+public class MainActivity extends ReactActivity {
+
+    /**
+     * Returns the name of the main component registered from JavaScript.
+     * This is used to schedule rendering of the component.
+     */
+    @Override
+    protected String getMainComponentName() {
+        return "HelloWorld";
+    }
+
+    @Override
+    protected ReactActivityDelegate createReactActivityDelegate() {
+        return new ReactActivityDelegate(this, getMainComponentName()) {
+            @Override
+            protected ReactRootView createRootView() {
+                return new RNGestureHandlerEnabledRootView(MainActivity.this);
+            }
+        };
+    }
+}
+`;
+
+describe('User interface style', () => {
+  it(`returns null if no userInterfaceStyle is provided`, () => {
+    expect(getUserInterfaceStyle({})).toBe(null);
+  });
+
+  it(`returns the userInterfaceStyle if provided`, () => {
+    expect(getUserInterfaceStyle({ userInterfaceStyle: 'light' })).toBe('light');
+  });
+
+  it(`returns the userInterfaceStyle under android if provided`, () => {
+    expect(
+      getUserInterfaceStyle({
+        userInterfaceStyle: 'dark',
+        android: { userInterfaceStyle: 'light' },
+      })
+    ).toBe('light');
+  });
+
+  it(`adds the onConfigurationChanged method in MainActivity.java if userInterfaceStyle is given`, () => {
+    expect(
+      addOnConfigurationChangedMainActivity(
+        { userInterfaceStyle: 'light' },
+        EXAMPLE_MAIN_ACTIVITY_BEFORE
+      )
+    ).toMatch(ON_CONFIGURATION_CHANGED);
+  });
+
+  describe('write file correctly', () => {
+    const projectDirectory = resolve(fixturesPath, 'tmp/');
+    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+
+    beforeAll(async () => {
+      await fs.ensureDir(dirname(appManifestPath));
+      await fs.copyFile(sampleManifestPath, appManifestPath);
+    });
+
+    afterAll(async () => {
+      await fs.remove(resolve(fixturesPath, 'tmp/'));
+    });
+
+    it(`sets the android:configChanges in AndroidManifest.xml if userInterfaceStyle is given`, async () => {
+      expect(
+        await setUiModeAndroidManifest({ userInterfaceStyle: 'light' }, projectDirectory)
+      ).toBe(true);
+      //read file
+    });
+
+    it(`makes no changes to the androidManifest or MainActivity if userInterfaceStyle value provided`, async () => {
+      expect(await setUiModeAndroidManifest({}, projectDirectory)).toBe(false);
+      expect(addOnConfigurationChangedMainActivity({}, EXAMPLE_MAIN_ACTIVITY_BEFORE)).toMatch(
+        EXAMPLE_MAIN_ACTIVITY_BEFORE
+      );
+    });
+  });
+});

--- a/packages/config/src/android/__tests__/UserInterfaceStyle-test.js
+++ b/packages/config/src/android/__tests__/UserInterfaceStyle-test.js
@@ -1,5 +1,4 @@
-import fs from 'fs-extra';
-import { dirname, resolve } from 'path';
+import { resolve } from 'path';
 import {
   ON_CONFIGURATION_CHANGED,
   addOnConfigurationChangedMainActivity,
@@ -69,31 +68,18 @@ describe('User interface style', () => {
     ).toMatch(ON_CONFIGURATION_CHANGED);
   });
 
-  describe('write file correctly', () => {
-    const appManifestPath = resolve(fixturesPath, 'tmp/android/app/src/main/AndroidManifest.xml');
+  it(`sets the android:configChanges in AndroidManifest.xml if userInterfaceStyle is given`, async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
 
-    beforeAll(async () => {
-      await fs.ensureDir(dirname(appManifestPath));
-      await fs.copyFile(sampleManifestPath, appManifestPath);
-    });
-
-    afterAll(async () => {
-      await fs.remove(resolve(fixturesPath, 'tmp/'));
-    });
-
-    it(`sets the android:configChanges in AndroidManifest.xml if userInterfaceStyle is given`, async () => {
-      let androidManifestJson = await readAndroidManifestAsync(appManifestPath);
-
-      androidManifestJson = await setUiModeAndroidManifest(
-        { userInterfaceStyle: 'light' },
-        androidManifestJson
-      );
-      let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
-        e => e['$']['android:name'] === '.MainActivity'
-      );
-      expect(mainActivity[0]['$']['android:configChanges']).toMatch(
-        'keyboard|keyboardHidden|orientation|screenSize|uiMode'
-      );
-    });
+    androidManifestJson = await setUiModeAndroidManifest(
+      { userInterfaceStyle: 'light' },
+      androidManifestJson
+    );
+    let mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+      e => e['$']['android:name'] === '.MainActivity'
+    );
+    expect(mainActivity[0]['$']['android:configChanges']).toMatch(
+      'keyboard|keyboardHidden|orientation|screenSize|uiMode'
+    );
   });
 });

--- a/packages/config/src/android/__tests__/Version-test.js
+++ b/packages/config/src/android/__tests__/Version-test.js
@@ -1,0 +1,77 @@
+import { getVersionCode, getVersionName, setVersionCode, setVersionName } from '../Version';
+
+// TODO: use fixtures for manifest/build.gradle instead of inline strings
+
+const EXAMPLE_BUILD_GRADLE = `
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        applicationId "com.helloworld"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.2.3"
+    }
+}
+`;
+
+const EXAMPLE_BUILD_GRADLE_2 = `
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        applicationId "com.helloworld"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 4
+        versionName "2.0"
+    }
+}
+`;
+
+describe('versionName', () => {
+  it(`returns null if no version is provided`, () => {
+    expect(getVersionName({})).toBe(null);
+  });
+
+  it(`returns the version name if provided`, () => {
+    expect(getVersionName({ version: '1.2.3' })).toBe('1.2.3');
+  });
+
+  it(`sets the version name in build.gradle if version name is given`, () => {
+    expect(setVersionName({ version: '1.2.3' }, EXAMPLE_BUILD_GRADLE)).toMatch(
+      'versionName "1.2.3"'
+    );
+  });
+
+  it(`replaces provided version name in build.gradle if version name is given`, () => {
+    expect(setVersionName({ version: '1.2.3' }, EXAMPLE_BUILD_GRADLE_2, '2.0')).toMatch(
+      'versionName "1.2.3"'
+    );
+  });
+});
+
+describe('versionCode', () => {
+  it(`returns null if no version code is provided`, () => {
+    expect(getVersionCode({})).toBe(null);
+  });
+
+  it(`returns the version code if provided`, () => {
+    expect(getVersionCode({ android: { versionCode: '5' } })).toBe('5');
+  });
+
+  it(`sets the version code in build.gradle if version code is given`, () => {
+    expect(setVersionCode({ android: { versionCode: '5' } }, EXAMPLE_BUILD_GRADLE)).toMatch(
+      'versionCode 5'
+    );
+  });
+
+  it(`replaces provided version code in build.gradle if version code is given`, () => {
+    expect(setVersionCode({ android: { versionCode: '5' } }, EXAMPLE_BUILD_GRADLE_2, '4')).toMatch(
+      'versionCode 5'
+    );
+  });
+});

--- a/packages/config/src/android/__tests__/fixtures/google-services.json
+++ b/packages/config/src/android/__tests__/fixtures/google-services.json
@@ -1,0 +1,15 @@
+{
+  "project_info": {
+    "project_number": "123",
+    "project_id": "myprojectid"
+  },
+  "client": [
+    {
+      "client_info": {
+        "android_client_info": {
+          "package_name": "com.yourapp.packagename"
+        }
+      }
+    }
+  ]
+}

--- a/packages/config/src/android/__tests__/fixtures/styles.xml
+++ b/packages/config/src/android/__tests__/fixtures/styles.xml
@@ -1,0 +1,9 @@
+<resources>
+
+    <!-- Base application theme. -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- Customize your theme here. -->
+        <item name="android:windowBackground">#222222</item>
+    </style>
+
+</resources>

--- a/packages/config/src/android/index.ts
+++ b/packages/config/src/android/index.ts
@@ -16,6 +16,7 @@ import * as Permissions from './Permissions';
 import * as PrimaryColor from './PrimaryColor';
 import * as RootViewBackgroundColor from './RootViewBackgroundColor';
 import * as Scheme from './Scheme';
+import * as SplashScreen from './SplashScreen';
 import * as StatusBar from './StatusBar';
 import * as Styles from './Styles';
 import * as UserInterfaceStyle from './UserInterfaceStyle';
@@ -39,6 +40,7 @@ export {
   PrimaryColor,
   RootViewBackgroundColor,
   Scheme,
+  SplashScreen,
   StatusBar,
   Styles,
   UserInterfaceStyle,

--- a/packages/config/src/android/index.ts
+++ b/packages/config/src/android/index.ts
@@ -1,1 +1,42 @@
-export * from './Manifest';
+import * as Manifest from './Manifest';
+
+import * as Branch from './Branch';
+import * as Colors from './Colors';
+import * as Facebook from './Facebook';
+import * as GoogleMapsApiKey from './GoogleMapsApiKey';
+import * as GoogleMobileAds from './GoogleMobileAds';
+import * as GoogleServices from './GoogleServices';
+import * as IntentFilters from './IntentFilters';
+import * as NavigationBar from './NavigationBar';
+import * as Orientation from './Orientation';
+import * as Package from './Package';
+import * as Permissions from './Permissions';
+import * as PrimaryColor from './PrimaryColor';
+import * as RootViewBackgroundColor from './RootViewBackgroundColor';
+import * as Scheme from './Scheme';
+import * as StatusBar from './StatusBar';
+import * as Styles from './Styles';
+import * as UserInterfaceStyle from './UserInterfaceStyle';
+import * as Version from './Version';
+
+export {
+  Manifest,
+  Branch,
+  Colors,
+  Facebook,
+  GoogleMapsApiKey,
+  GoogleMobileAds,
+  GoogleServices,
+  IntentFilters,
+  NavigationBar,
+  Orientation,
+  Package,
+  Permissions,
+  PrimaryColor,
+  RootViewBackgroundColor,
+  Scheme,
+  StatusBar,
+  Styles,
+  UserInterfaceStyle,
+  Version,
+};

--- a/packages/config/src/android/index.ts
+++ b/packages/config/src/android/index.ts
@@ -1,7 +1,9 @@
 import * as Manifest from './Manifest';
 
+import * as AdaptiveIcon from './AdaptiveIcon';
 import * as Branch from './Branch';
 import * as Colors from './Colors';
+import * as Icon from './Icon';
 import * as Facebook from './Facebook';
 import * as GoogleMapsApiKey from './GoogleMapsApiKey';
 import * as GoogleMobileAds from './GoogleMobileAds';
@@ -20,6 +22,7 @@ import * as UserInterfaceStyle from './UserInterfaceStyle';
 import * as Version from './Version';
 
 export {
+  AdaptiveIcon,
   Manifest,
   Branch,
   Colors,
@@ -27,6 +30,7 @@ export {
   GoogleMapsApiKey,
   GoogleMobileAds,
   GoogleServices,
+  Icon,
   IntentFilters,
   NavigationBar,
   Orientation,

--- a/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
@@ -96,6 +96,7 @@ export default async function configureAndroidProjectAsync(projectRoot: string) 
   await AndroidConfig.GoogleServices.setGoogleServicesFile(exp, projectRoot);
 
   // TODOs
+  await AndroidConfig.SplashScreen.setSplashScreenAsync(exp, projectRoot);
   await AndroidConfig.Icon.setIconAsync(exp, projectRoot);
   await AndroidConfig.AdaptiveIcon.setAdaptiveIconAsync(exp, projectRoot);
 }

--- a/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
@@ -1,7 +1,48 @@
-import { IOSConfig, getConfig } from '@expo/config';
+import { AndroidConfig, getConfig } from '@expo/config';
+import { sync as globSync } from 'glob';
+import fs from 'fs-extra';
 import path from 'path';
+import buildGeneric from '@expo/build-tools/dist/platforms/android/generic/builder';
+
+async function modifyBuildGradleAsync(
+  projectRoot: string,
+  callback: (buildGradle: string) => string
+) {
+  let buildGradlePath = path.join(projectRoot, 'android', 'app', 'build.gradle');
+  let buildGradleString = fs.readFileSync(buildGradlePath).toString();
+  // console.log(buildGradleString);
+  let result = callback(buildGradleString);
+  console.log(result);
+  fs.writeFileSync(buildGradlePath, result);
+}
+
+async function modifyAndroidManifestAsync() {}
 
 export default async function configureAndroidProjectAsync(projectRoot: string) {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
-  // TODO: implement this ;P
+
+  await modifyBuildGradleAsync(projectRoot, (buildGradle: string) => {
+    buildGradle = AndroidConfig.Package.setPackageInBuildGradle(exp, buildGradle);
+    buildGradle = AndroidConfig.Version.setVersionCode(exp, buildGradle);
+    buildGradle = AndroidConfig.Version.setVersionName(exp, buildGradle);
+    return buildGradle;
+  });
+
+  // await modifyAndroidManifestAsync(projectRoot, androidManifest => {
+  // TODO: modify androidManifest once, make `setX` functions take the androidManifest xml object and do the work on that
+  // });
+  await AndroidConfig.Package.setPackageInAndroidManifest(exp, projectRoot);
+  await AndroidConfig.Orientation.setAndroidOrientation(exp, projectRoot);
+  await AndroidConfig.Permissions.setAndroidPermissions(exp, projectRoot);
+  await AndroidConfig.RootViewBackgroundColor.setRootViewBackgroundColor(exp, projectRoot);
+  await AndroidConfig.Branch.setBranchApiKey(exp, projectRoot);
+  await AndroidConfig.Facebook.setFacebookConfig(exp, projectRoot);
+  await AndroidConfig.NavigationBar.setNavigationBarConfig(exp, projectRoot);
+  await AndroidConfig.StatusBar.setStatusBarConfig(exp, projectRoot);
+  await AndroidConfig.PrimaryColor.setPrimaryColor(exp, projectRoot);
+  await AndroidConfig.UserInterfaceStyle.setUiModeAndroidManifest(exp, projectRoot);
+  await AndroidConfig.GoogleServices.setGoogleServicesFile(exp, projectRoot);
+  await AndroidConfig.GoogleMobileAds.setGoogleMobileAdsConfig(exp, projectRoot);
+  await AndroidConfig.GoogleMapsApiKey.setGoogleMapsApiKey(exp, projectRoot);
+  await AndroidConfig.IntentFilters.setAndroidIntentFilters(exp, projectRoot);
 }

--- a/packages/expo-cli/src/commands/index.ts
+++ b/packages/expo-cli/src/commands/index.ts
@@ -5,7 +5,6 @@ const COMMANDS = [
   // old command build:status is the same as new build:status so we disable it when the new one is available
   // new command only for testing, shouldn't be visible for users
   process.env.EXPO_ENABLE_NEW_TURTLE ? require('./build-native') : require('./build'),
-  process.env.EXPO_DEV && require('./apply'),
   require('./bundle-assets'),
   require('./client'),
   require('./credentials'),
@@ -37,6 +36,10 @@ const COMMANDS = [
   require('./webhooks'),
   require('./whoami'),
 ];
+
+if (process.env.EXPO_DEV) {
+  COMMANDS.push(require('./apply'));
+}
 
 export function registerCommands(program: Command) {
   COMMANDS.forEach(commandModule => {


### PR DESCRIPTION
- [x] version
- [x] versionCode
- [x] scheme
- [x] Permissions
- [x] userInterfaceStyle - also iOS and android specific values. default to `light`
- [x] orientation
- [x] backgroundColor - also iOS and android specific values
- [x] primaryColor
- [x] androidStatusBar
- [x] androidNavigationBar 
- [x] googleServicesFile
- [x] “Config” object - branch, googleMapsApiKey, googleMobileAdsAppId, googleMobileAdsAutoInit
- [x] intentfilters

Facebook:
- [x] facebookappid
- [x] Facebookautoinitenabled
- [x] facebookAutoLogAppEventsEnabled
- [x] facebookAdvertiserIDCollectionEnabled
- [x] facebookDisplayName
- [x] facebookScheme

Log Warnings for:
- [x] adaptiveIcon
- [x] icon
- [x] Splash 