### PR TITLE
[cli] add skip credentials flag

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.types.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.types.ts
@@ -21,6 +21,7 @@ export type IosOptions = CommonOptions & {
   pushId?: string;
   pushP8Path?: string;
   provisioningProfilePath?: string;
+  skipCredentialsCheck?: boolean;
 };
 
 export type AndroidOptions = CommonOptions & {

--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -49,6 +49,7 @@ export default function(program: Command) {
       '--public-url <url>',
       'The URL of an externally hosted manifest (for self-hosted apps).'
     )
+    .option('--skip-credentials-check', 'Skip checking credentials.')
     .description(
       'Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.'
     )

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -121,9 +121,6 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
         log('Skipping credentials check...');
         return;
       }
-      log(
-        'Gathering and validating necessary credentials. To skip this step, pass in the --skip-credentials-check flag'
-      );
       await this.produceCredentials(context, experienceName, bundleIdentifier);
     } catch (e) {
       log(

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -117,6 +117,13 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
     await this.clearAndRevokeCredentialsIfRequested(context, { experienceName, bundleIdentifier });
 
     try {
+      if (this.options.skipCredentialsCheck) {
+        log('Skipping credentials check...');
+        return;
+      }
+      log(
+        'Gathering and validating necessary credentials. To skip this step, pass in the --skip-credentials-check flag'
+      );
       await this.produceCredentials(context, experienceName, bundleIdentifier);
     } catch (e) {
       log(


### PR DESCRIPTION
# why

- add support for a user to skip checking credentials if they are sure they have everything configured properly. Use case: credentials checking can take some time, and people who run builds frequently will want to skip checks

# tests

- [x] credentials checking runs with no flag set
- [x] credentials checking is skipped when flag is set