### PR TITLE
[cli] fix publish:rollback

### DIFF
--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -29,8 +29,8 @@ export default (program: any) => {
       'Number of logs to view, maximum 100, default 5.',
       parseInt
     )
-    .option('-p, --platform <ios|android>', 'Filter by platform, android or ios.')
-    .option('-s, --sdk-version <version>', 'Filter by sdk version e.g. 35.0.0')
+    .option('-p, --platform <ios|android>', 'Filter by platform, android or ios. Defaults to both platforms.')
+    .option('-s, --sdk-version <version>', 'Filter by SDK version e.g. 35.0.0')
     .option('-r, --raw', 'Produce some raw output.')
     .asyncActionProjectDir(async (projectDir: string, options: HistoryOptions) => {
       const result = await getPublishHistoryAsync(projectDir, options);

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -1,16 +1,12 @@
-import ora from 'ora';
-import { getConfig } from '@expo/config';
-import { ApiV2, Project, UserManager } from '@expo/xdl';
 import { Command } from 'commander';
+import { uniqBy } from 'lodash';
 import log from '../log';
-import prompt from '../prompt';
 import * as table from '../commands/utils/cli-table';
 import {
   Publication,
   RollbackOptions,
   getPublicationDetailAsync,
   getPublishHistoryAsync,
-  printPublicationDetailAsync,
   rollbackPublicationFromChannelAsync,
   setPublishToChannelAsync,
 } from './utils/PublishUtils';
@@ -74,20 +70,105 @@ export default function(program: Command) {
         }
       ): Promise<void> => {
         if (options.channelId) {
-          throw new Error('This flag is deprecated and does not do anything. Please use --release-channel and --sdk-version instead.');
+          throw new Error(
+            'This flag is deprecated and does not do anything. Please use --release-channel and --sdk-version instead.'
+          );
         }
-        if (!options.releaseChannel) {
-          throw new Error('You must specify a release channel with -c or --release-channel. For example, -c default.');
-        }
-        if (!options.sdkVersion) {
-          throw new Error('You must specify an SDK version with -s or --sdk-version. For example, -s 37.0.0');
+        if (!options.releaseChannel || !options.sdkVersion) {
+          const usage = await getUsageAsync(projectDir);
+          throw new Error(usage);
         }
         if (options.platform) {
           if (options.platform !== 'android' && options.platform !== 'ios') {
-            throw new Error('Platform must be either android or ios. Leave out the platform flag to target both platforms.');
+            throw new Error(
+              'Platform must be either android or ios. Leave out the platform flag to target both platforms.'
+            );
           }
         }
         await rollbackPublicationFromChannelAsync(projectDir, options as RollbackOptions);
       }
     );
+}
+async function getUsageAsync(projectDir: string): Promise<string> {
+  try {
+    return await _getUsageAsync(projectDir);
+  } catch (e) {
+    log.warn(e);
+    // couldn't print out warning for some reason
+    return _getGenericUsage();
+  }
+}
+
+async function _getUsageAsync(projectDir: string): Promise<string> {
+  const allPlatforms = ['ios', 'android'];
+  const publishesResult = await getPublishHistoryAsync(projectDir, {
+    releaseChannel: 'default', // not specifying a channel will return most recent publishes but this is not neccesarily the most recent entry in a channel (user could have set an older publish to top of the channel)
+    count: allPlatforms.length,
+  });
+  const publishes = publishesResult.queryResult as Publication[];
+
+  // If the user published normally, there would be a publish for each platform with the same revisionId
+  const uniquePlatforms = uniqBy(publishes, publish => publish.platform);
+  if (uniquePlatforms.length !== allPlatforms.length) {
+    // User probably applied some custom `publish:set` or `publish:rollback` command
+    return _getGenericUsage();
+  }
+
+  const details = await Promise.all(
+    publishes.map(async publication => {
+      const detailOptions = {
+        publishId: publication.publicationId,
+      };
+      return await getPublicationDetailAsync(projectDir, detailOptions);
+    })
+  );
+
+  const uniqueRevisionIds = uniqBy(details, detail => detail.revisionId);
+  if (uniqueRevisionIds.length !== 1) {
+    // User probably applied some custom `publish:set` or `publish:rollback` command
+    return _getGenericUsage();
+  }
+
+  const { channel } = publishes[0];
+  const { revisionId, publishedTime, sdkVersion } = details[0];
+  const timeDifferenceString = _getTimeDifferenceString(new Date(), new Date(publishedTime));
+
+  return (
+    `--release-channel and --sdk-version arguments are required. \n` +
+    `For example, to roll back the revision [${revisionId}] on release channel [${channel}] (published ${timeDifferenceString}), \n` +
+    `run: expo publish:rollback --release-channel ${channel} --sdk-version ${sdkVersion}`
+  );
+}
+
+function _getTimeDifferenceString(t0: Date, t1: Date): string {
+  const minutesInMs = 60 * 1000;
+  const hourInMs = 60 * minutesInMs;
+  const dayInMs = 24 * hourInMs; // hours*minutes*seconds*milliseconds
+  const diffMs = Math.abs(t1.getTime() - t0.getTime());
+
+  const diffDays = Math.round(diffMs / dayInMs);
+  if (diffDays > 0) {
+    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  }
+
+  const diffHours = Math.round(diffMs / hourInMs);
+  if (diffHours > 0) {
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  }
+
+  const diffMinutes = Math.round(diffMs / minutesInMs);
+  if (diffMinutes > 0) {
+    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  }
+
+  return 'recently';
+}
+
+function _getGenericUsage(): string {
+  return (
+    `--release-channel and --sdk-version arguments are required. \n` +
+    `For example, to roll back the latest publishes on the default channel for sdk 37.0.0, \n` +
+    `run: expo publish:rollback --release-channel defaul --sdk-version 37.0.0 \n` +
+    `To rollback a specific platform, use the --platform flag.`
+  );
 }

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -74,17 +74,17 @@ export default function(program: Command) {
         }
       ): Promise<void> => {
         if (options.channelId) {
-          throw new Error('This flag is deprecated');
+          throw new Error('This flag is deprecated and does not do anything. Please use --release-channel and --sdk-version instead.');
         }
         if (!options.releaseChannel) {
-          throw new Error('You must specify a release channel.');
+          throw new Error('You must specify a release channel with -c or --release-channel. For example, -c default.');
         }
         if (!options.sdkVersion) {
-          throw new Error('You must specify an sdk version.');
+          throw new Error('You must specify an SDK version with -s or --sdk-version. For example, -s 37.0.0');
         }
         if (options.platform) {
           if (options.platform !== 'android' && options.platform !== 'ios') {
-            throw new Error('Platform must be either android or ios');
+            throw new Error('Platform must be either android or ios. Leave out the platform flag to target both platforms.');
           }
         }
         await rollbackPublicationFromChannelAsync(projectDir, options as RollbackOptions);

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -1,0 +1,305 @@
+import { getConfig } from '@expo/config';
+import { Api, ApiV2, FormData, Project, UserManager } from '@expo/xdl';
+import ora from 'ora';
+import * as table from './cli-table';
+import log from '../../log';
+import prompt from '../../prompt';
+
+export type HistoryOptions = {
+  releaseChannel?: string;
+  count?: number;
+  platform?: 'android' | 'ios';
+  raw?: boolean;
+  sdkVersion?: string;
+};
+
+export type DetailOptions = {
+  publishId?: string;
+  raw?: boolean;
+};
+
+export type SetOptions = { releaseChannel: string; publishId: string };
+
+export type RollbackOptions = {
+  releaseChannel: string;
+  sdkVersion: string;
+  platform?: 'android' | 'ios';
+  parent?: { nonInteractive?: boolean };
+};
+
+export type Publication = {
+  fullName: string;
+  channel: string;
+  channelId: string;
+  publicationId: string;
+  appVersion: string;
+  sdkVersion: string;
+  publishedTime: string;
+  platform: 'android' | 'ios';
+};
+
+export type PublicationDetail = {
+  manifest: {
+    [key: string]: string;
+  };
+  publishedTime: string;
+  publishingUsername: string;
+  packageUsername: string;
+  packageName: string;
+  fullName: string;
+  hash: string;
+  sdkVersion: string;
+  s3Key: string;
+  s3Url: string;
+  abiVersion: string | null;
+  bundleUrl: string | null;
+  platform: string;
+  version: string;
+  revisionId: string;
+  channels: { [key: string]: string }[];
+  publicationId: string;
+};
+
+const VERSION = 2;
+
+export async function getPublishHistoryAsync(
+  projectDir: string,
+  options: HistoryOptions
+): Promise<any> {
+  if (options.count && (isNaN(options.count) || options.count < 1 || options.count > 100)) {
+    throw new Error('-n must be a number between 1 and 100 inclusive');
+  }
+
+  // TODO(ville): handle the API result for not authenticated user instead of checking upfront
+  const user = await UserManager.ensureLoggedInAsync();
+  const { exp } = getConfig(projectDir, {
+    skipSDKVersionRequirement: true,
+  });
+
+  let result: any;
+  if (process.env.EXPO_LEGACY_API === 'true') {
+    // TODO(ville): move request from multipart/form-data to JSON once supported by the endpoint.
+    let formData = new FormData();
+    formData.append('queryType', 'history');
+    if (exp.owner) {
+      formData.append('owner', exp.owner);
+    }
+    formData.append('slug', await Project.getSlugAsync(projectDir));
+    formData.append('version', VERSION);
+    if (options.releaseChannel) {
+      formData.append('releaseChannel', options.releaseChannel);
+    }
+    if (options.count) {
+      formData.append('count', options.count);
+    }
+    if (options.platform) {
+      formData.append('platform', options.platform);
+    }
+    if (options.sdkVersion) {
+      formData.append('sdkVersion', options.sdkVersion);
+    }
+
+    result = await Api.callMethodAsync('publishInfo', [], 'post', null, {
+      formData,
+    });
+  } else {
+    const api = ApiV2.clientForUser(user);
+    result = await api.postAsync('publish/history', {
+      owner: exp.owner,
+      slug: await Project.getSlugAsync(projectDir),
+      version: VERSION,
+      releaseChannel: options.releaseChannel,
+      count: options.count,
+      platform: options.platform,
+      sdkVersion: options.sdkVersion,
+    });
+  }
+  return result;
+}
+
+export async function setPublishToChannelAsync(
+  projectDir: string,
+  options: SetOptions
+): Promise<any> {
+  const user = await UserManager.ensureLoggedInAsync();
+  const api = ApiV2.clientForUser(user);
+  return await api.postAsync('publish/set', {
+    releaseChannel: options.releaseChannel,
+    publishId: options.publishId,
+    slug: await Project.getSlugAsync(projectDir),
+  });
+}
+
+async function _rollbackPublicationFromChannelForPlatformAsync(
+  projectDir: string,
+  platform: 'android' | 'ios',
+  options: Omit<RollbackOptions, 'platform'>
+) {
+  const { releaseChannel, sdkVersion } = options;
+  // get the 2 most recent things in the channel history
+  const historyQueryResult = await getPublishHistoryAsync(projectDir, {
+    releaseChannel,
+    platform,
+    sdkVersion,
+    count: 2,
+  });
+
+  const history = historyQueryResult.queryResult as Publication[];
+  if (history.length === 0) {
+    throw new Error(
+      `There isn't anything published for release channel: ${releaseChannel}, sdk version: ${sdkVersion}, platform: ${platform}`
+    );
+  } else if (history.length === 1) {
+    throw new Error(
+      `There is only 1 publication for release channel: ${releaseChannel}, sdk version: ${sdkVersion}, platform: ${platform}. There won't be anything for users to receive if we rollback.`
+    );
+  }
+
+  // The second most recent publication in the history
+  const secondMostRecent = history[history.length - 1];
+
+  const nonInteractiveOptions = options.parent ? { parent: options.parent } : {};
+  // confirm that users will be receiving the secondMostRecent item in the Publish history
+  await _printAndConfirm(
+    projectDir,
+    secondMostRecent.publicationId,
+    releaseChannel,
+    platform,
+    nonInteractiveOptions
+  );
+
+  // apply the revert publication to channel
+  const revertProgress = ora(
+    `${platform}: Applying a revert publication to channel ${releaseChannel}`
+  ).start();
+  await setPublishToChannelAsync(projectDir, {
+    releaseChannel,
+    publishId: secondMostRecent.publicationId,
+  });
+  revertProgress.succeed(
+    `${platform}: Successfully applied revert publication. You can view it with \`publish:history\``
+  );
+}
+
+export async function rollbackPublicationFromChannelAsync(
+  projectDir: string,
+  options: RollbackOptions
+) {
+  const { platform, ...restOfTheOptions } = options;
+
+  if (platform) {
+    return await _rollbackPublicationFromChannelForPlatformAsync(
+      projectDir,
+      platform,
+      restOfTheOptions
+    );
+  }
+
+  const platforms = ['android', 'ios'] as ('android' | 'ios')[];
+  const completedPlatforms = [] as ('android' | 'ios')[];
+  try {
+    for (const platform of platforms) {
+      await _rollbackPublicationFromChannelForPlatformAsync(projectDir, platform, restOfTheOptions);
+      completedPlatforms.push(platform);
+    }
+  } catch (e) {
+    if (completedPlatforms.length > 0) {
+      log.error(
+        `The platforms ${platforms.filter(
+          platform => !completedPlatforms.includes(platform)
+        )} have not been rolled back. You can complete the missing platforms by running \`expo publish:rollback\` with the --platform flag`
+      );
+    }
+    throw e;
+  }
+}
+
+async function _printAndConfirm(
+  projectDir: string,
+  publicationId: string,
+  channel: string,
+  platform: string,
+  partialOptions: { parent?: { nonInteractive?: boolean } }
+): Promise<void> {
+  const detailOptions = {
+    publishId: publicationId,
+  };
+  const detail = await getPublicationDetailAsync(projectDir, detailOptions);
+  await printPublicationDetailAsync(detail, detailOptions);
+
+  if (partialOptions.parent && partialOptions.parent.nonInteractive) {
+    return;
+  }
+  const { confirm } = await prompt([
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: `${platform}: Users on the '${channel}' channel will receive the above publication as a result of the rollback.`,
+    },
+  ]);
+
+  if (!confirm) {
+    throw new Error(`You can run 'publish:set' to send the desired publication to users`);
+  }
+}
+
+export async function getPublicationDetailAsync(
+  projectDir: string,
+  options: DetailOptions
+): Promise<PublicationDetail> {
+  // TODO(ville): handle the API result for not authenticated user instead of checking upfront
+  const user = await UserManager.ensureLoggedInAsync();
+  const { exp } = getConfig(projectDir, {
+    skipSDKVersionRequirement: true,
+  });
+  const slug = await Project.getSlugAsync(projectDir);
+  let result: any;
+  if (process.env.EXPO_LEGACY_API === 'true') {
+    let formData = new FormData();
+    formData.append('queryType', 'details');
+
+    if (exp.owner) {
+      formData.append('owner', exp.owner);
+    }
+    formData.append('publishId', options.publishId);
+    formData.append('slug', slug);
+
+    result = await Api.callMethodAsync('publishInfo', null, 'post', null, {
+      formData,
+    });
+  } else {
+    const api = ApiV2.clientForUser(user);
+    result = await api.postAsync('publish/details', {
+      owner: exp.owner,
+      publishId: options.publishId,
+      slug,
+    });
+  }
+
+  if (!result.queryResult) {
+    throw new Error('No records found matching your query.');
+  }
+
+  return result.queryResult;
+}
+
+export async function printPublicationDetailAsync(
+  detail: PublicationDetail,
+  options: DetailOptions
+) {
+  if (options.raw) {
+    console.log(JSON.stringify(detail));
+    return;
+  }
+
+  let manifest = detail.manifest;
+  delete detail.manifest;
+
+  // Print general release info
+  let generalTableString = table.printTableJson(detail, 'Release Description');
+  console.log(generalTableString);
+
+  // Print manifest info
+  let manifestTableString = table.printTableJson(manifest, 'Manifest Details');
+  console.log(manifestTableString);
+}


### PR DESCRIPTION
# why
fixes https://github.com/expo/expo-cli/issues/596

# how
- change implementation to do a `publish:set` of the second most recent thing in history for a given sdkVersion, platform and channel instead of actually deleting anything in the history
- add confirmation with the publication that clients will receive as a result of the rollback
- move shared methods into `PublishUtils`

# tests
- [ ] repro on a client
- [x] publish rollback unit tests pass