### PR TITLE
Fix app.json parse errors not reported correctly

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -56,7 +56,14 @@ function getConfigContext(
     if (typeof rawConfig.expo === 'object') {
       rawConfig = rawConfig.expo as JSONObject;
     }
-  } catch (_) {}
+  } catch (err) {
+    if (
+      options.strict &&
+      err.code !== 'ENOENT' // File not found. This is OK, because app.json is optional.
+    ) {
+      throw err;
+    }
+  }
 
   const { exp: configFromPkg } = ensureConfigHasDefaultValues(projectRoot, rawConfig, pkg, true);
 

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -940,4 +940,5 @@ export type ConfigContext = {
 export type GetConfigOptions = {
   configPath?: string;
   skipSDKVersionRequirement?: boolean;
+  strict?: boolean;
 };

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -450,9 +450,12 @@ async function validateAsync(projectRoot: string, allowNetwork: boolean): Promis
 
   let exp, pkg;
   try {
-    const config = getConfig(projectRoot);
+    const config = getConfig(projectRoot, {
+      strict: true,
+    });
     exp = config.exp;
     pkg = config.pkg;
+    ProjectUtils.clearNotification(projectRoot, 'doctor-config-json-not-read');
   } catch (e) {
     ProjectUtils.logError(
       projectRoot,
@@ -460,7 +463,7 @@ async function validateAsync(projectRoot: string, allowNetwork: boolean): Promis
       `Error: could not load config json at ${projectRoot}: ${e.toString()}`,
       'doctor-config-json-not-read'
     );
-    return FATAL;
+    return ERROR;
   }
 
   let status = await _checkNpmVersionAsync(projectRoot);


### PR DESCRIPTION
When `app.json` contains invalid json it would fall-though the config loading process and result in an empty JSON object. No error message is then printed pointing to the error location in the JSON file that contains the syntax error. Instead, schema validation errors would be printed which are confusing:
```
• is missing required property 'name'.
 • is missing required property 'slug'.
```

After this PR, any syntax errors in your `app.json` file, now report errors like this:

```
Error: could not load config json at /Users/hein/repos/Expo/scratch/blur-animated: JsonFileError: Error parsing JSON: {
  "expo": {
    "name2": "Blank Template (TypeScript)",
    "slug2": "blur-animated",
    "privacy": "public",
    "sdkVersion": "UNVERSIONED",
    "platforms": ["ios", "android", "web"],
    "version": "1.0.0",
    "orientation": "portrait",
    "icon": "./assets/icon.png",
    here is the error
    "splash": {
      "image": "./assets/splash.png",
      "resizeMode": "contain",
      "backgroundColor": "#ffffff"
    },
    "updates": {
      "fallbackToCacheTimeout": 0
    },
    "assetBundlePatterns": ["**/*"],
    "ios": {
      "supportsTablet": true
    }
  }
}

└─ Cause: SyntaxError: JSON5: invalid character 'i' at 11:10
   9 |     "orientation": "portrait",
  10 |     "icon": "./assets/icon.png",
> 11 |     here is the error
     |          ^
  12 |     "splash": {
  13 |       "image": "./assets/splash.png",
  14 |       "resizeMode": "contain",
```

Fixes #1392.