### PR TITLE
[image-utils] Create method for getting sharp instance

### DIFF
--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@expo/spawn-async": "1.5.0",
     "jimp": "^0.9.3",
+    "resolve-from": "^5.0.0",
     "semver": "6.1.1"
   },
   "peerDependencies": {

--- a/packages/image-utils/src/Image.types.ts
+++ b/packages/image-utils/src/Image.types.ts
@@ -1,0 +1,13 @@
+export type ResizeMode = 'contain' | 'cover' | 'fill' | 'inside' | 'outside';
+
+export type ImageFormat = 'input' | 'jpeg' | 'jpg' | 'png' | 'raw' | 'tiff' | 'webp';
+
+export type ImageOptions = {
+  src: string;
+  name?: string;
+  resizeMode: ResizeMode;
+  backgroundColor: string;
+  width: number;
+  height: number;
+  padding?: number;
+};

--- a/packages/image-utils/src/index.ts
+++ b/packages/image-utils/src/index.ts
@@ -1,6 +1,7 @@
+import { ImageFormat, ResizeMode } from './Image.types';
 import { convertFormat, jimpAsync } from './jimp';
-import { isAvailableAsync, sharpAsync } from './sharp';
-import { ImageFormat, ResizeMode, SharpCommandOptions, SharpGlobalOptions } from './sharp.types';
+import { findSharpInstanceAsync, isAvailableAsync, sharpAsync } from './sharp';
+import { SharpCommandOptions, SharpGlobalOptions } from './sharp.types';
 
 export async function imageAsync(
   options: SharpGlobalOptions,
@@ -15,6 +16,6 @@ export async function imageAsync(
   );
 }
 
-export { jimpAsync, isAvailableAsync, sharpAsync };
+export { jimpAsync, findSharpInstanceAsync, isAvailableAsync, sharpAsync };
 
 export { SharpGlobalOptions, SharpCommandOptions, ResizeMode, ImageFormat };

--- a/packages/image-utils/src/sharp.types.ts
+++ b/packages/image-utils/src/sharp.types.ts
@@ -1,3 +1,5 @@
+import { ImageFormat, ResizeMode } from './Image.types';
+
 export type SharpGlobalOptions = {
   compressionLevel?: '';
   format?: ImageFormat;
@@ -16,10 +18,6 @@ export type FlattenOptions = {
   operation: 'flatten';
   background: string;
 };
-
-export type ResizeMode = 'contain' | 'cover' | 'fill' | 'inside' | 'outside';
-
-export type ImageFormat = 'input' | 'jpeg' | 'jpg' | 'png' | 'raw' | 'tiff' | 'webp';
 
 export type RemoveAlphaOptions = {
   operation: 'removeAlpha';


### PR DESCRIPTION
# Why

The sharp CLI is sometimes not powerful enough to do what we need. This PR enables us to get access to the instance of sharp used by the globally installed CLI.

## Issues with the CLI

- Writing all image operations to temporary directories can cause your computer to get slow over time (ofc this resets after restarting your computer but that's no fun). A better alternative is to use the instance to get a Buffer.
- Webpack requires Buffers of images, meaning we'd be writing to the FS just to read that Buffer again and do nothing with the written file.
- [Compositing](https://sharp.pixelplumbing.com/api-composite) images doesn't work as expected with the CLI.

## Related

- Moved from https://github.com/expo/expo-cli/pull/1686
