### PR TITLE
[expo-cli] Created option for clearing web caches

### DIFF
--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -108,6 +108,7 @@ export default function(program: Command) {
 
   program
     .command('build:web [project-dir]')
+    .option('-c, --clear', 'Clear all cached build files and assets.')
     .option(
       '--no-pwa',
       'Prevent webpack from generating the manifest.json and injecting meta into the index.html head.'
@@ -115,7 +116,7 @@ export default function(program: Command) {
     .option('-d, --dev', 'Turns dev flag on before bundling')
     .description('Build a production bundle for your project, compressed and ready for deployment.')
     .asyncActionProjectDir(
-      (projectDir: string, options: { pwa: boolean; dev: boolean }) => {
+      (projectDir: string, options: { pwa: boolean; clear: boolean; dev: boolean }) => {
         return Webpack.bundleAsync(projectDir, {
           ...options,
           dev: typeof options.dev === 'undefined' ? false : options.dev,

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -36,6 +36,7 @@ interface WebpackSettings {
 
 type CLIWebOptions = {
   dev?: boolean;
+  clear?: boolean;
   pwa?: boolean;
   nonInteractive?: boolean;
   port?: number;
@@ -45,6 +46,7 @@ type CLIWebOptions = {
 
 type BundlingOptions = {
   dev?: boolean;
+  clear?: boolean;
   pwa?: boolean;
   isImageEditingEnabled?: boolean;
   webpackEnv?: Object;
@@ -86,6 +88,14 @@ export function printConnectionInstructions(projectRoot: string, options = {}) {
   });
 }
 
+async function clearWebCacheAsync(projectRoot: string, mode: string): Promise<void> {
+  const cacheFolder = path.join(projectRoot, '.expo', 'web', 'cache', mode);
+  try {
+    withTag(chalk.dim(`Clearing ${mode} cache directory...`));
+    await fs.remove(cacheFolder);
+  } catch (_) {}
+}
+
 export async function startAsync(
   projectRoot: string,
   options: CLIWebOptions = {},
@@ -112,6 +122,10 @@ export async function startAsync(
   const fullOptions = transformCLIOptions(options);
 
   const env = await getWebpackConfigEnvFromBundlingOptionsAsync(projectRoot, fullOptions);
+
+  if (fullOptions.clear) {
+    await clearWebCacheAsync(projectRoot, env.mode);
+  }
 
   if (env.https) {
     if (!process.env.SSL_CRT_FILE || !process.env.SSL_KEY_FILE) {
@@ -313,6 +327,10 @@ export async function bundleAsync(projectRoot: string, options?: BundlingOptions
     // Force production
     mode: 'production',
   });
+
+  if (fullOptions.clear) {
+    await clearWebCacheAsync(projectRoot, env.mode);
+  }
 
   const config = await createWebpackConfigAsync(env, fullOptions);
 


### PR DESCRIPTION
# Why

We create an asset cache and a Webpack cache for files to speed up rebuilds. This PR adds a `expo build:web --clear` to clear those caches for more thorough testing.

## Related

- Moved from https://github.com/expo/expo-cli/pull/1686
