### PR TITLE
[image-utils] Created methods for generating favicons and icons

### DIFF
--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@expo/spawn-async": "1.5.0",
     "jimp": "^0.9.3",
+    "parse-png": "^2.1.0",
     "resolve-from": "^5.0.0",
     "semver": "6.1.1"
   },

--- a/packages/image-utils/src/Cache.ts
+++ b/packages/image-utils/src/Cache.ts
@@ -1,0 +1,99 @@
+import crypto from 'crypto';
+import { ensureDir, readFile, readFileSync, readdirSync, remove, writeFile } from 'fs-extra';
+import { join, resolve } from 'path';
+
+import { ImageOptions } from './Image.types';
+
+const CACHE_LOCATION = '.expo/web/cache/production/images';
+
+const cacheKeys: { [key: string]: string } = {};
+
+// Calculate SHA256 Checksum value of a file based on its contents
+function calculateHash(filePath: string): string {
+  const contents = filePath.startsWith('http') ? filePath : readFileSync(filePath);
+  return crypto
+    .createHash('sha256')
+    .update(contents)
+    .digest('hex');
+}
+
+// Create a hash key for caching the images between builds
+export function createCacheKey(fileSource: string, properties: string[]): string {
+  const hash = calculateHash(fileSource);
+  return [hash]
+    .concat(properties)
+    .filter(Boolean)
+    .join('-');
+}
+
+export async function createCacheKeyWithDirectoryAsync(
+  projectRoot: string,
+  type: string,
+  icon: ImageOptions
+): Promise<string> {
+  const cacheKey = `${type}-${createCacheKey(icon.src, [icon.resizeMode, icon.backgroundColor])}`;
+  if (!(cacheKey in cacheKeys)) {
+    cacheKeys[cacheKey] = await ensureCacheDirectory(projectRoot, type, cacheKey);
+  }
+
+  return cacheKey;
+}
+
+export async function ensureCacheDirectory(
+  projectRoot: string,
+  type: string,
+  cacheKey: string
+): Promise<string> {
+  const cacheFolder = join(projectRoot, CACHE_LOCATION, type, cacheKey);
+  await ensureDir(cacheFolder);
+  return cacheFolder;
+}
+
+export async function getImageFromCacheAsync(
+  fileName: string,
+  cacheKey: string
+): Promise<null | Buffer> {
+  try {
+    return await readFile(resolve(cacheKeys[cacheKey], fileName));
+  } catch (_) {
+    return null;
+  }
+}
+
+export async function cacheImageAsync(
+  fileName: string,
+  buffer: Buffer,
+  cacheKey: string
+): Promise<void> {
+  try {
+    await writeFile(resolve(cacheKeys[cacheKey], fileName), buffer);
+  } catch ({ message }) {
+    console.warn(`Error caching image: "${fileName}". ${message}`);
+  }
+}
+
+export async function clearUnusedCachesAsync(projectRoot: string, type: string): Promise<void> {
+  // Clean up any old caches
+  const cacheFolder = join(projectRoot, CACHE_LOCATION, type);
+  await ensureDir(cacheFolder);
+  const currentCaches = readdirSync(cacheFolder);
+
+  if (!Array.isArray(currentCaches)) {
+    console.warn('Failed to read the icon cache');
+    return;
+  }
+  const deleteCachePromises: Promise<void>[] = [];
+  for (const cache of currentCaches) {
+    // skip hidden folders
+    if (cache.startsWith('.')) {
+      continue;
+    }
+
+    // delete
+    if (!(cache in cacheKeys)) {
+      deleteCachePromises.push(remove(join(cacheFolder, cache)));
+    }
+  }
+
+  await Promise.all(deleteCachePromises);
+}

--- a/packages/image-utils/src/Download.ts
+++ b/packages/image-utils/src/Download.ts
@@ -1,0 +1,41 @@
+import fs from 'fs-extra';
+import fetch from 'node-fetch';
+import path from 'path';
+import stream from 'stream';
+import temporary from 'tempy';
+import util from 'util';
+
+// cache downloaded images into memory
+const cacheDownloadedKeys: Record<string, string> = {};
+
+function stripQueryParams(url: string): string {
+  return url.split('?')[0].split('#')[0];
+}
+
+export async function downloadOrUseCachedImage(url: string): Promise<string> {
+  if (url in cacheDownloadedKeys) {
+    return cacheDownloadedKeys[url];
+  }
+  if (url.startsWith('http')) {
+    cacheDownloadedKeys[url] = await downloadImage(url);
+  } else {
+    cacheDownloadedKeys[url] = url;
+  }
+  return cacheDownloadedKeys[url];
+}
+
+export async function downloadImage(url: string): Promise<string> {
+  const outputPath = temporary.directory();
+  const localPath = path.join(outputPath, path.basename(stripQueryParams(url)));
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`It was not possible to download image from '${url}'`);
+  }
+
+  // Download to local file
+  const streamPipeline = util.promisify(stream.pipeline);
+  await streamPipeline(response.body, fs.createWriteStream(localPath));
+
+  return localPath;
+}

--- a/packages/image-utils/src/Ico.ts
+++ b/packages/image-utils/src/Ico.ts
@@ -1,0 +1,119 @@
+// Inspired by https://github.com/kevva/to-ico but reuses existing packages to keep bundle size small.
+import parsePng from 'parse-png';
+
+type PNG = {
+  data: Buffer;
+  width: number;
+  height: number;
+  bpp: number;
+};
+
+const constants = {
+  directorySize: 16,
+  bitmapSize: 40,
+  headerSize: 6,
+  colorMode: 0,
+};
+
+function createHeader(header: number): Buffer {
+  const buffer = Buffer.alloc(constants.headerSize);
+
+  buffer.writeUInt16LE(0, 0);
+  buffer.writeUInt16LE(1, 2);
+  buffer.writeUInt16LE(header, 4);
+
+  return buffer;
+}
+
+function createDirectory(data: PNG, offset: number): Buffer {
+  const buffer = Buffer.alloc(constants.directorySize);
+  const size = data.data.length + constants.bitmapSize;
+  const width = data.width === 256 ? 0 : data.width;
+  const height = data.height === 256 ? 0 : data.height;
+  const bpp = data.bpp * 8;
+
+  buffer.writeUInt8(width, 0);
+  buffer.writeUInt8(height, 1);
+  buffer.writeUInt8(0, 2);
+  buffer.writeUInt8(0, 3);
+  buffer.writeUInt16LE(1, 4);
+  buffer.writeUInt16LE(bpp, 6);
+  buffer.writeUInt32LE(size, 8);
+  buffer.writeUInt32LE(offset, 12);
+
+  return buffer;
+}
+
+function createBitmap(data: PNG, compression: number): Buffer {
+  const buffer = Buffer.alloc(constants.bitmapSize);
+
+  buffer.writeUInt32LE(constants.bitmapSize, 0);
+  buffer.writeInt32LE(data.width, 4);
+  buffer.writeInt32LE(data.height * 2, 8);
+  buffer.writeUInt16LE(1, 12);
+  buffer.writeUInt16LE(data.bpp * 8, 14);
+  buffer.writeUInt32LE(compression, 16);
+  buffer.writeUInt32LE(data.data.length, 20);
+  buffer.writeInt32LE(0, 24);
+  buffer.writeInt32LE(0, 28);
+  buffer.writeUInt32LE(0, 32);
+  buffer.writeUInt32LE(0, 36);
+
+  return buffer;
+}
+
+function createDIB(data: Buffer, width: number, height: number, bpp: number): Buffer {
+  const cols = width * bpp;
+  const rows = height * cols;
+  const end = rows - cols;
+  const buffer = Buffer.alloc(data.length);
+
+  for (let row = 0; row < rows; row += cols) {
+    for (let col = 0; col < cols; col += bpp) {
+      let pos = row + col;
+
+      const r = data.readUInt8(pos);
+      const g = data.readUInt8(pos + 1);
+      const b = data.readUInt8(pos + 2);
+      const a = data.readUInt8(pos + 3);
+
+      pos = end - row + col;
+
+      buffer.writeUInt8(b, pos);
+      buffer.writeUInt8(g, pos + 1);
+      buffer.writeUInt8(r, pos + 2);
+      buffer.writeUInt8(a, pos + 3);
+    }
+  }
+
+  return buffer;
+}
+
+function generateFromPNGs(pngs: PNG[]): Buffer {
+  const header = createHeader(pngs.length);
+  const arr = [header];
+
+  let len = header.length;
+  let offset = constants.headerSize + constants.directorySize * pngs.length;
+
+  for (const png of pngs) {
+    const dir = createDirectory(png, offset);
+    arr.push(dir);
+    len += dir.length;
+    offset += png.data.length + constants.bitmapSize;
+  }
+
+  for (const png of pngs) {
+    const header = createBitmap(png, constants.colorMode);
+    const dib = createDIB(png.data, png.width, png.height, png.bpp);
+    arr.push(header, dib);
+    len += header.length + dib.length;
+  }
+
+  return Buffer.concat(arr, len);
+}
+
+export async function generateAsync(buffers: Buffer[]): Promise<Buffer> {
+  const pngs: PNG[] = await Promise.all(buffers.map(x => parsePng(x)));
+  return generateFromPNGs(pngs);
+}

--- a/packages/image-utils/src/Image.ts
+++ b/packages/image-utils/src/Image.ts
@@ -1,0 +1,153 @@
+import chalk from 'chalk';
+import mime from 'mime';
+
+import * as Cache from './Cache';
+import * as Download from './Download';
+import * as Ico from './Ico';
+import { ImageOptions } from './Image.types';
+import * as Jimp from './jimp';
+import * as Sharp from './sharp';
+
+const supportedMimeTypes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+
+let hasWarned: boolean = false;
+
+async function resizeImagesAsync(buffer: Buffer, sizes: number[]): Promise<Buffer[]> {
+  const sharp = await getSharpAsync();
+  if (!sharp) {
+    return Jimp.resizeBufferAsync(buffer, sizes);
+  }
+  return Sharp.resizeBufferAsync(buffer, sizes);
+}
+
+async function resizeAsync(imageOptions: ImageOptions): Promise<Buffer> {
+  let sharp: any = await getSharpAsync();
+  const { width, height, backgroundColor, resizeMode } = imageOptions;
+  if (!sharp) {
+    const inputOptions: any = { input: imageOptions.src, quality: 100 };
+    const jimp = await Jimp.resize(inputOptions, {
+      width,
+      height,
+      fit: resizeMode,
+      background: backgroundColor,
+    });
+    const imgBuffer = await jimp.getBufferAsync(jimp.getMIME());
+    return imgBuffer;
+  }
+  try {
+    let sharpBuffer = sharp(imageOptions.src)
+      .ensureAlpha()
+      .resize(width, height, { fit: resizeMode, background: 'transparent' });
+
+    // Skip an extra step if the background is explicitly transparent.
+    if (backgroundColor && backgroundColor !== 'transparent') {
+      // Add the background color to the image
+      sharpBuffer = sharpBuffer.composite([
+        {
+          // create a background color
+          input: {
+            create: {
+              width,
+              height,
+              // allow alpha colors
+              channels: 4,
+              background: backgroundColor,
+            },
+          },
+          // dest-over makes the first image (input) appear on top of the created image (background color)
+          blend: 'dest-over',
+        },
+      ]);
+    }
+
+    return await sharpBuffer.png().toBuffer();
+  } catch ({ message }) {
+    throw new Error(
+      `It was not possible to generate splash screen '${imageOptions.src}'. ${message}`
+    );
+  }
+}
+
+async function getSharpAsync(): Promise<any> {
+  let sharp: any;
+  if (await Sharp.isAvailableAsync()) sharp = await Sharp.findSharpInstanceAsync();
+  return sharp;
+}
+
+function getDimensionsId(imageOptions: Pick<ImageOptions, 'width' | 'height'>): string {
+  return imageOptions.width === imageOptions.height
+    ? `${imageOptions.width}`
+    : `${imageOptions.width}x${imageOptions.height}`;
+}
+
+async function maybeWarnAboutInstallingSharpAsync() {
+  // Putting the warning here will prevent the warning from showing if all images were reused from the cache
+  if (!hasWarned && !(await Sharp.isAvailableAsync())) {
+    hasWarned = true;
+    console.log();
+    console.log(
+      chalk.bgYellow.black(
+        `Using node to generate images. This is much slower than using native packages.`
+      )
+    );
+    console.log(
+      chalk.yellow(
+        `\u203A Optionally you can stop the process and try again after successfully running \`npm install -g sharp-cli\`.\n\u203A If you are using \`expo-cli\` to build your project then you could use the \`--no-pwa\` flag to skip the PWA asset generation step entirely.`
+      )
+    );
+  }
+}
+
+async function ensureImageOptionsAsync(imageOptions: ImageOptions): Promise<ImageOptions> {
+  const icon = {
+    ...imageOptions,
+    src: await Download.downloadOrUseCachedImage(imageOptions.src),
+  };
+
+  const mimeType = mime.getType(icon.src);
+
+  if (!mimeType) {
+    throw new Error(`Invalid mimeType for image with source: ${icon.src}`);
+  }
+  if (!supportedMimeTypes.includes(mimeType)) {
+    throw new Error(`Supplied image is not a supported image type: ${imageOptions.src}`);
+  }
+
+  if (!icon.name) {
+    icon.name = `icon_${getDimensionsId(imageOptions)}.${mime.getExtension(mimeType)}`;
+  }
+
+  return icon;
+}
+
+export async function generateImageAsync(
+  options: { projectRoot: string; cacheType: string },
+  imageOptions: ImageOptions
+): Promise<{ source: Buffer; name: string }> {
+  const icon = await ensureImageOptionsAsync(imageOptions);
+
+  const cacheKey = await Cache.createCacheKeyWithDirectoryAsync(
+    options.projectRoot,
+    options.cacheType,
+    icon
+  );
+
+  const name = icon.name!;
+  let source: Buffer | null = await Cache.getImageFromCacheAsync(name, cacheKey);
+
+  if (!source) {
+    await maybeWarnAboutInstallingSharpAsync();
+    source = await resizeAsync(icon);
+    await Cache.cacheImageAsync(name, source, cacheKey);
+  }
+
+  return { name, source };
+}
+
+export async function generateFaviconAsync(
+  pngImageBuffer: Buffer,
+  sizes: number[] = [16, 32, 48]
+): Promise<Buffer> {
+  const buffers = await resizeImagesAsync(pngImageBuffer, sizes);
+  return await Ico.generateAsync(buffers);
+}

--- a/packages/image-utils/src/index.ts
+++ b/packages/image-utils/src/index.ts
@@ -1,4 +1,5 @@
-import { ImageFormat, ResizeMode } from './Image.types';
+import { generateFaviconAsync, generateImageAsync } from './Image';
+import { ImageFormat, ImageOptions, ResizeMode } from './Image.types';
 import { convertFormat, jimpAsync } from './jimp';
 import { findSharpInstanceAsync, isAvailableAsync, sharpAsync } from './sharp';
 import { SharpCommandOptions, SharpGlobalOptions } from './sharp.types';
@@ -16,6 +17,13 @@ export async function imageAsync(
   );
 }
 
-export { jimpAsync, findSharpInstanceAsync, isAvailableAsync, sharpAsync };
+export {
+  jimpAsync,
+  findSharpInstanceAsync,
+  isAvailableAsync,
+  sharpAsync,
+  generateImageAsync,
+  generateFaviconAsync,
+};
 
-export { SharpGlobalOptions, SharpCommandOptions, ResizeMode, ImageFormat };
+export { SharpGlobalOptions, SharpCommandOptions, ResizeMode, ImageFormat, ImageOptions };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15415,6 +15415,13 @@ parse-path@^4.0.0:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
 
+parse-png@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-png/-/parse-png-2.1.0.tgz#2a42ad719fedf90f81c59ebee7ae59b280d6b338"
+  integrity sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==
+  dependencies:
+    pngjs "^3.3.0"
+
 parse-url@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
@@ -15758,7 +15765,7 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-pngjs@3.4.0, pngjs@^3.0.0, pngjs@^3.3.3:
+pngjs@3.4.0, pngjs@^3.0.0, pngjs@^3.3.0, pngjs@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==


### PR DESCRIPTION
# Why

There are only a few limited types of image operations we use across the monorepo, this PR combines all of the expected behavior from Webpack and makes it accessible to the whole repo. 
- Adds support for generating favicons
- Adds support for creating icons using .expo cache, download cache, and jimp fallbacks.

## Related

- Moved from https://github.com/expo/expo-cli/pull/1686
