### PR TITLE
[webpack-config] Use a better progress plugin for improved logging

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -63,6 +63,7 @@
     "webpack-bundle-analyzer": "^3.0.4",
     "webpack-deep-scope-plugin": "1.6.0",
     "webpack-manifest-plugin": "^2.2.0",
+    "webpackbar": "^4.0.0",
     "workbox-webpack-plugin": "^3.6.3",
     "worker-loader": "^2.0.0",
     "yup": "^0.27.0"

--- a/packages/webpack-config/src/plugins/ExpoProgressBarPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoProgressBarPlugin.ts
@@ -1,6 +1,5 @@
-import chalk from 'chalk';
-import ProgressBar from 'progress';
-import { ProgressPlugin as OriginalProgressPlugin } from 'webpack';
+// @ts-ignore: no types
+import OriginalWebpackBar from 'webpackbar';
 
 /**
  * Fork of https://github.com/clessg/progress-bar-webpack-plugin
@@ -9,68 +8,11 @@ import { ProgressPlugin as OriginalProgressPlugin } from 'webpack';
  * @category plugins
  * @internal
  */
-export default class ProgressPlugin extends OriginalProgressPlugin {
+export default class WebpackBar extends OriginalWebpackBar {
   constructor() {
-    const stream = process.stderr;
-    const enabled = stream && stream.isTTY;
-
-    if (!enabled) {
-      super();
-      return;
-    }
-
-    var barLeft = chalk.bold('[');
-    var barRight = chalk.bold(']');
-    var preamble = chalk.cyan.bold('  build ') + barLeft;
-
-    //`[:bar] ${chalk.green.bold(':percent')} (:elapsed seconds)`
-    var barFormat = preamble + ':bar' + barRight + chalk.magenta.bold(' :percent');
-    var summary = true;
-
-    const barOptions = {
-      complete: '=',
-      incomplete: ' ',
-      width: 20,
-      total: 100,
-      clear: false,
-    };
-
-    const bar = new ProgressBar(barFormat, barOptions);
-
-    let running = false;
-    let startTime = 0;
-    let lastPercent = 0;
-
-    super((percent, msg) => {
-      if (!running && lastPercent !== 0) {
-        stream.write('\n');
-      }
-
-      var newPercent = Math.floor(percent * barOptions.width);
-
-      if (lastPercent < newPercent || newPercent === 0) {
-        bar.update(percent, {
-          msg,
-        });
-        lastPercent = newPercent;
-      }
-
-      if (!running) {
-        running = true;
-        startTime = Date.now();
-        lastPercent = 0;
-      } else if (percent === 1) {
-        var now = Date.now();
-        var buildTime = (now - startTime) / 1000 + 's';
-
-        bar.terminate();
-
-        if (summary) {
-          stream.write(chalk.green.bold('Build completed in ' + buildTime + '\n\n'));
-        }
-
-        running = false;
-      }
+    super({
+      name: 'Expo Webpack',
+      reporters: ['fancy'],
     });
   }
 }

--- a/packages/webpack-config/src/utils/__tests__/search-test.js
+++ b/packages/webpack-config/src/utils/__tests__/search-test.js
@@ -26,7 +26,7 @@ it(`getPluginsByName gets a known plugin`, async () => {
     platform: 'web',
   });
 
-  const plugins = LoaderUtils.getPluginsByName(config, 'ProgressPlugin');
+  const plugins = LoaderUtils.getPluginsByName(config, 'ManifestPlugin');
   expect(plugins.length).toBe(1);
   const expectedPlugin = plugins[0];
   expect(config.plugins[expectedPlugin.index]).toBe(expectedPlugin.plugin);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4873,6 +4873,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
 ansi-styles@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
@@ -6511,6 +6519,11 @@ chrome-trace-event@^1.0.0, chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
+ci-info@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -7039,6 +7052,11 @@ connect-history-api-fallback@^1.3.0, connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
+
+consola@^2.10.0:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/consola/-/consola-2.11.3.tgz#f7315836224c143ac5094b47fd4c816c2cd1560e"
+  integrity sha512-aoW0YIIAmeftGR8GSpw6CGQluNdkWMWh3yEFjH/hmynTYnMtibXszii3lxCXmk8YxJtI3FAK5aTiquA5VH68Gw==
 
 console-browserify@^1.1.0:
   version "1.2.0"
@@ -16459,6 +16477,11 @@ pretty-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
+pretty-time@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-time/-/pretty-time-1.1.0.tgz#ffb7429afabb8535c346a34e41873adf3d74dd0e"
+  integrity sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==
+
 private@^0.1.6, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -18613,6 +18636,13 @@ statuses@~1.4.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
   integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
+std-env@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-2.2.1.tgz#2ffa0fdc9e2263e0004c1211966e960948a40f6b"
+  integrity sha512-IjYQUinA3lg5re/YMlwlfhqNRTzMZMqE+pezevdcTaHceqx8ngEi1alX9nNCk9Sc81fy1fLDeQoaCzeiW1yBOQ==
+  dependencies:
+    ci-info "^1.6.0"
+
 stealthy-require@^1.1.0, stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -20555,6 +20585,20 @@ webpack@4.39.0:
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
 
+webpackbar@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/webpackbar/-/webpackbar-4.0.0.tgz#ee7a87f16077505b5720551af413c8ecd5b1f780"
+  integrity sha512-k1qRoSL/3BVuINzngj09nIwreD8wxV4grcuhHTD8VJgUbGcy8lQSPqv+bM00B7F+PffwIsQ8ISd4mIwRbr23eQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.2"
+    consola "^2.10.0"
+    figures "^3.0.0"
+    pretty-time "^1.1.0"
+    std-env "^2.2.1"
+    text-table "^0.2.0"
+    wrap-ansi "^6.0.0"
+
 websocket-driver@>=0.5.1:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.3.tgz#a2d4e0d4f4f116f1e6297eba58b05d430100e9f9"
@@ -20866,6 +20910,15 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-ansi@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
We currently cannot log out any warnings about the build or rebuild without the progress bar format breaking. This will fix that.

## Related

- Moved from https://github.com/expo/expo-cli/pull/1686