### PR TITLE
[config] Move define plugin reducer method to webpack-config

### DIFF
--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -1,5 +1,3 @@
-import JsonFile from '@expo/json-file';
-
 import { getConfig } from './Config';
 import { AppJSONConfig, ExpoConfig } from './Config.types';
 
@@ -324,42 +322,4 @@ export function ensurePWAConfig(
     config.web.startupImages = inferWebStartupImages(config, getAbsolutePath, options);
   }
   return config;
-}
-
-export function createEnvironmentConstants(appManifest: ExpoConfig, pwaManifestLocation: string) {
-  let web;
-  try {
-    web = JsonFile.read(pwaManifestLocation);
-  } catch (e) {
-    web = {};
-  }
-
-  return {
-    ...appManifest,
-    name: appManifest.displayName || appManifest.name,
-    /**
-     * Omit app.json properties that get removed during the native turtle build
-     *
-     * `facebookScheme`
-     * `facebookAppId`
-     * `facebookDisplayName`
-     */
-    facebookScheme: undefined,
-    facebookAppId: undefined,
-    facebookDisplayName: undefined,
-
-    // Remove iOS and Android.
-    ios: undefined,
-    android: undefined,
-
-    // Use the PWA `manifest.json` as the native web manifest.
-    web: {
-      ...web,
-
-      // Pass through config properties that are not stored in the
-      // PWA `manifest.json`, but still need to be accessible
-      // through `Constants.manifest`.
-      config: appManifest.web?.config,
-    },
-  };
 }

--- a/packages/webpack-config/src/addons/withUnimodules.ts
+++ b/packages/webpack-config/src/addons/withUnimodules.ts
@@ -114,7 +114,6 @@ export default function withUnimodules(
       mode,
       publicUrl,
       config,
-      productionManifestPath: locations.production.manifest,
     })
   );
 

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -238,7 +238,6 @@ export default async function(
         mode,
         publicUrl,
         config,
-        productionManifestPath: locations.production.manifest,
       }),
 
       // This is necessary to emit hot updates (currently CSS only):


### PR DESCRIPTION
This doesn't need to be in the config library.

## Related

- Moved from https://github.com/expo/expo-cli/pull/1686