### PR TITLE
Deprecate custom `expo.web.build.rootId` key

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -411,12 +411,6 @@ export type WebPlatformConfig = {
     [key: string]: any;
 
     /**
-     * ID of the root DOM element in your index.html. By default this is "root".
-     * @fallback root
-     */
-    rootId?: string;
-
-    /**
      * Choose a custom style of source mapping to enhance the debugging process. These values can affect build and rebuild speed dramatically.
      */
     devtool?: Devtool;

--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -102,7 +102,6 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
 
   const languageISOCode = webManifest.lang || DEFAULT_LANGUAGE_ISO_CODE;
   const noJavaScriptMessage = webDangerous.noJavaScriptMessage || DEFAULT_NO_JS_MESSAGE;
-  const rootId = webBuild.rootId || DEFAULT_ROOT_ID;
   const buildOutputPath = getWebOutputPath(appJSON);
   const publicPath = sanitizePublicPath(webManifest.publicPath);
   const primaryColor = appManifest.primaryColor;
@@ -173,7 +172,6 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
       build: {
         ...webBuild,
         output: buildOutputPath,
-        rootId,
         publicPath,
       },
       dangerous: {

--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -7,7 +7,6 @@ const APP_JSON_FILE_NAME = 'app.json';
 const DEFAULT_VIEWPORT =
   'width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover';
 // Use root to work better with create-react-app
-const DEFAULT_ROOT_ID = `root`;
 const DEFAULT_BUILD_PATH = `web-build`;
 const DEFAULT_LANGUAGE_ISO_CODE = `en`;
 const DEFAULT_NO_JS_MESSAGE = `Oh no! It looks like JavaScript is not enabled in your browser.`;

--- a/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
@@ -27,8 +27,7 @@ export default class InterpolateHtmlPlugin extends OriginalInterpolateHtmlPlugin
     const config = env.config || getConfig(env);
     const { publicPath } = getPublicPaths(env);
 
-    const { build: buildConfig = {}, lang } = config.web;
-    const { rootId } = buildConfig;
+    const { lang } = config.web;
     const { noJavaScriptMessage } = config.web.dangerous;
     const noJSComponent = createNoJSComponent(noJavaScriptMessage);
 
@@ -37,7 +36,8 @@ export default class InterpolateHtmlPlugin extends OriginalInterpolateHtmlPlugin
       WEB_TITLE: config.web.name,
       NO_SCRIPT: noJSComponent,
       LANG_ISO_CODE: lang,
-      ROOT_ID: rootId,
+      // This is for legacy ejected web/index.html files
+      ROOT_ID: 'root',
     });
   };
 }

--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -5,15 +5,14 @@
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
     <title>%WEB_TITLE%</title>
     <link rel="shortcut icon" href="%WEB_PUBLIC_URL%favicon.ico" />
-    <!-- TODO: Bacon: build a reliable system for testing these style changes -->
     <style>
       /**
-       * Building on the RNWeb reset:
+       * Extend the react-native-web reset:
        * https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/StyleSheet/initialRules.js
        */
       html,
       body,
-      #%ROOT_ID% {
+      #root {
         width: 100%;
         /* To smooth any scrolling behavior */
         -webkit-overflow-scrolling: touch;
@@ -22,7 +21,7 @@
         /* Allows content to fill the viewport and go beyond the bottom */
         min-height: 100%;
       }
-      #%ROOT_ID% {
+      #root {
         flex-shrink: 0;
         flex-basis: auto;
         flex-grow: 1;


### PR DESCRIPTION
# Why

- `web/index.html` is invalid HTML with this feature enabled.
- This feature has been around for a year and hasn't been used for anything. 
- We should be a bit more prescriptive about the default template to cut down on surface area.

