### PR TITLE
[webpack-config] Deprecate noJavaScriptMessage

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -496,11 +496,6 @@ export type WebPlatformConfig = {
      * Viewport meta tag for your index.html. By default this is optimized for mobile usage, disabling zooming, and resizing for iPhone X.
      */
     viewport?: string;
-    /**
-     * Message that is rendered when the browser using your page doesn't have JS enabled.
-     * @fallback Oh no! It looks like JavaScript is not enabled in your browser.
-     */
-    noJavaScriptMessage?: string;
   };
   /**
    * Configuration for PWA splash screens.

--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -9,7 +9,6 @@ const DEFAULT_VIEWPORT =
 // Use root to work better with create-react-app
 const DEFAULT_BUILD_PATH = `web-build`;
 const DEFAULT_LANGUAGE_ISO_CODE = `en`;
-const DEFAULT_NO_JS_MESSAGE = `Oh no! It looks like JavaScript is not enabled in your browser.`;
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_START_URL = '.';
 const DEFAULT_DISPLAY = 'standalone';
@@ -100,7 +99,6 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
   const { appName, webName } = getNameFromConfig(appJSON);
 
   const languageISOCode = webManifest.lang || DEFAULT_LANGUAGE_ISO_CODE;
-  const noJavaScriptMessage = webDangerous.noJavaScriptMessage || DEFAULT_NO_JS_MESSAGE;
   const buildOutputPath = getWebOutputPath(appJSON);
   const publicPath = sanitizePublicPath(webManifest.publicPath);
   const primaryColor = appManifest.primaryColor;
@@ -173,10 +171,7 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
         output: buildOutputPath,
         publicPath,
       },
-      dangerous: {
-        ...webDangerous,
-        noJavaScriptMessage,
-      },
+      dangerous: webDangerous,
       scope,
       crossorigin,
       description,

--- a/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
@@ -24,7 +24,7 @@ export default class InterpolateHtmlPlugin extends OriginalInterpolateHtmlPlugin
       WEB_TITLE: config.web.name,
       LANG_ISO_CODE: lang,
       // These are for legacy ejected web/index.html files
-      NO_SCRIPT: `<form action="location.reload()" method="POST" style="background-color:#fff;position:fixed;top:0;left:0;right:0;bottom:0;z-index:9999;"><div style="font-size:18px;font-family:Helvetica,sans-serif;line-height:24px;margin:10%;width:80%;"> <p>Oh no! It looks like JavaScript is not enabled in your browser.</p> <p style="margin:20px 0;"> <button type="submit" style="background-color: #4630EB; border-radius: 100px; border: none; box-shadow: none; color: #fff; cursor: pointer; font-weight: bold; line-height: 20px; padding: 6px 16px;">Reload</button> </p> </div> </form>`,
+      NO_SCRIPT: `<form action="" style="background-color:#fff;position:fixed;top:0;left:0;right:0;bottom:0;z-index:9999;"><div style="font-size:18px;font-family:Helvetica,sans-serif;line-height:24px;margin:10%;width:80%;"> <p>Oh no! It looks like JavaScript is not enabled in your browser.</p> <p style="margin:20px 0;"> <button type="submit" style="background-color: #4630EB; border-radius: 100px; border: none; box-shadow: none; color: #fff; cursor: pointer; font-weight: bold; line-height: 20px; padding: 6px 16px;">Reload</button> </p> </div> </form>`,
       ROOT_ID: 'root',
     });
   };

--- a/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
@@ -5,16 +5,6 @@ import { Environment } from '../types';
 import { getConfig, getPublicPaths } from '../env';
 
 /**
- *
- * @param message
- * @internal
- */
-export function createNoJSComponent(message: string): string {
-  // from twitter.com
-  return `" <form action="location.reload()" method="POST" style="background-color:#fff;position:fixed;top:0;left:0;right:0;bottom:0;z-index:9999;"><div style="font-size:18px;font-family:Helvetica,sans-serif;line-height:24px;margin:10%;width:80%;"> <p>${message}</p> <p style="margin:20px 0;"> <button type="submit" style="background-color: #4630EB; border-radius: 100px; border: none; box-shadow: none; color: #fff; cursor: pointer; font-weight: bold; line-height: 20px; padding: 6px 16px;">Reload</button> </p> </div> </form> "`;
-}
-
-/**
  * Add variables to the `index.html`.
  *
  * @category plugins
@@ -28,15 +18,13 @@ export default class InterpolateHtmlPlugin extends OriginalInterpolateHtmlPlugin
     const { publicPath } = getPublicPaths(env);
 
     const { lang } = config.web;
-    const { noJavaScriptMessage } = config.web.dangerous;
-    const noJSComponent = createNoJSComponent(noJavaScriptMessage);
 
     return new InterpolateHtmlPlugin(HtmlWebpackPlugin, {
       WEB_PUBLIC_URL: publicPath,
       WEB_TITLE: config.web.name,
-      NO_SCRIPT: noJSComponent,
       LANG_ISO_CODE: lang,
-      // This is for legacy ejected web/index.html files
+      // These are for legacy ejected web/index.html files
+      NO_SCRIPT: `<form action="location.reload()" method="POST" style="background-color:#fff;position:fixed;top:0;left:0;right:0;bottom:0;z-index:9999;"><div style="font-size:18px;font-family:Helvetica,sans-serif;line-height:24px;margin:10%;width:80%;"> <p>Oh no! It looks like JavaScript is not enabled in your browser.</p> <p style="margin:20px 0;"> <button type="submit" style="background-color: #4630EB; border-radius: 100px; border: none; box-shadow: none; color: #fff; cursor: pointer; font-weight: bold; line-height: 20px; padding: 6px 16px;">Reload</button> </p> </div> </form>`,
       ROOT_ID: 'root',
     });
   };

--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -62,8 +62,7 @@
     -->
     <noscript>
       <form
-        action="location.reload()"
-        method="POST"
+        action=""
         style="background-color:#fff;position:fixed;top:0;left:0;right:0;bottom:0;z-index:9999;"
       >
         <div

--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -56,7 +56,32 @@
   </head>
 
   <body>
-    <noscript>%NO_SCRIPT%</noscript>
-    <div id="%ROOT_ID%"></div>
+    <!-- 
+      A generic no script element with a reload button and a message.
+      Feel free to customize this however you'd like.
+    -->
+    <noscript>
+      <form
+        action="location.reload()"
+        method="POST"
+        style="background-color:#fff;position:fixed;top:0;left:0;right:0;bottom:0;z-index:9999;"
+      >
+        <div
+          style="font-size:18px;font-family:Helvetica,sans-serif;line-height:24px;margin:10%;width:80%;"
+        >
+          <p>Oh no! It looks like JavaScript is not enabled in your browser.</p>
+          <p style="margin:20px 0;">
+            <button
+              type="submit"
+              style="background-color: #4630EB; border-radius: 100px; border: none; box-shadow: none; color: #fff; cursor: pointer; font-weight: bold; line-height: 20px; padding: 6px 16px;"
+            >
+              Reload
+            </button>
+          </p>
+        </div>
+      </form>
+    </noscript>
+    <!-- The root element for your Expo app. -->
+    <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
# Why 

This feature was marked as dangerous, it hasn't been useful.

# How 

- Add noscript to the default `web/index.html`
- Fix root interpolation
- Add legacy interpolation