### PR TITLE
[webpack-config] Deprecate the expo.web.dangerous.viewport meta tag

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -491,11 +491,6 @@ export type WebPlatformConfig = {
    */
   dangerous?: {
     [key: string]: any;
-
-    /**
-     * Viewport meta tag for your index.html. By default this is optimized for mobile usage, disabling zooming, and resizing for iPhone X.
-     */
-    viewport?: string;
   };
   /**
    * Configuration for PWA splash screens.

--- a/packages/config/src/Web.ts
+++ b/packages/config/src/Web.ts
@@ -3,9 +3,6 @@ import { AppJSONConfig, ExpoConfig } from './Config.types';
 
 const APP_JSON_FILE_NAME = 'app.json';
 
-// To work with the iPhone X "notch" add `viewport-fit=cover` to the `viewport` meta tag.
-const DEFAULT_VIEWPORT =
-  'width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover';
 // Use root to work better with create-react-app
 const DEFAULT_BUILD_PATH = `web-build`;
 const DEFAULT_LANGUAGE_ISO_CODE = `en`;
@@ -109,7 +106,6 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
   const shortName = webManifest.shortName || webName;
   const display = webManifest.display || DEFAULT_DISPLAY;
   const startUrl = webManifest.startUrl || DEFAULT_START_URL;
-  const webViewport = meta.viewport || DEFAULT_VIEWPORT;
   const { scope, crossorigin } = webManifest;
   const barStyle = apple.barStyle || webManifest.barStyle || DEFAULT_STATUS_BAR;
 
@@ -164,7 +160,6 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
           touchFullscreen: apple.touchFullscreen || 'yes',
           barStyle,
         },
-        viewport: webViewport,
       },
       build: {
         ...webBuild,

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -50,6 +50,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "4.0.0-alpha.2",
     "is-wsl": "^2.0.0",
+    "node-html-parser": "^1.2.12",
     "mini-css-extract-plugin": "^0.5.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "pnp-webpack-plugin": "^1.5.0",

--- a/packages/webpack-config/src/plugins/ModifyHtmlWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/ModifyHtmlWebpackPlugin.ts
@@ -1,0 +1,82 @@
+import { Compiler, Plugin, compilation } from 'webpack';
+
+function maybeFetchPlugin(compiler: Compiler, name: string): Plugin | undefined {
+  return compiler.options?.plugins
+    ?.map(({ constructor }) => constructor)
+    .find(constructor => constructor && constructor.name === name);
+}
+
+export type HTMLPluginData = {
+  assetTags: any;
+  outputName: string;
+  plugin: any;
+};
+
+export type HTMLLinkNode = {
+  rel?: string;
+  name?: string;
+  content?: string;
+  media?: string;
+  href?: string;
+  sizes?: string;
+  node: any;
+};
+
+export default class ModifyHtmlWebpackPlugin {
+  constructor(private modifyOptions: { inject?: boolean | Function } = {}) {}
+
+  async modifyAsync(
+    compiler: Compiler,
+    compilation: compilation.Compilation,
+    data: HTMLPluginData
+  ): Promise<HTMLPluginData> {
+    return data;
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.make.tapPromise(
+      this.constructor.name,
+      async (compilation: compilation.Compilation) => {
+        // Hook into the html-webpack-plugin processing and add the html
+        const HtmlWebpackPlugin = maybeFetchPlugin(compiler, 'HtmlWebpackPlugin') as any;
+        if (HtmlWebpackPlugin) {
+          if (typeof HtmlWebpackPlugin.getHooks === 'undefined') {
+            compilation.errors.push(
+              new Error(
+                'ModifyHtmlWebpackPlugin - This ModifyHtmlWebpackPlugin version is not compatible with your current HtmlWebpackPlugin version.\n'
+              )
+            );
+            return;
+          }
+
+          HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapAsync(
+            this.constructor.name,
+            async (
+              data: HTMLPluginData,
+              htmlCallback: (error: Error | null, data: HTMLPluginData) => void
+            ) => {
+              // Skip if a custom injectFunction returns false or if
+              // the htmlWebpackPlugin optuons includes a `favicons: false` flag
+              const isInjectionAllowed =
+                typeof this.modifyOptions.inject === 'function'
+                  ? this.modifyOptions.inject(data.plugin)
+                  : data.plugin.options.pwaManifest !== false;
+
+              if (isInjectionAllowed === false) {
+                return htmlCallback(null, data);
+              }
+
+              try {
+                data = await this.modifyAsync(compiler, compilation, data);
+              } catch (error) {
+                compilation.errors.push(error);
+              }
+
+              htmlCallback(null, data);
+            }
+          );
+        }
+      }
+    );
+  }
+}

--- a/packages/webpack-config/src/plugins/index.ts
+++ b/packages/webpack-config/src/plugins/index.ts
@@ -2,3 +2,4 @@ export { default as ExpoDefinePlugin } from './ExpoDefinePlugin';
 export { default as ExpoHtmlWebpackPlugin } from './ExpoHtmlWebpackPlugin';
 export { default as ExpoInterpolateHtmlPlugin } from './ExpoInterpolateHtmlPlugin';
 export { default as ExpoProgressBarPlugin } from './ExpoProgressBarPlugin';
+export { default as ModifyHtmlWebpackPlugin } from './ModifyHtmlWebpackPlugin';

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -13,6 +13,8 @@ import CopyWebpackPlugin from 'copy-webpack-plugin';
 import { boolish } from 'getenv';
 import path from 'path';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
+import { readFileSync } from 'fs-extra';
+import { parse } from 'node-html-parser';
 
 import { projectHasModule } from '@expo/config';
 import { getConfig, getMode, getModuleFileExtensions, getPathsAsync, getPublicPaths } from './env';
@@ -25,6 +27,7 @@ import {
 } from './plugins';
 import { withAlias, withDevServer, withNodeMocks, withOptimizations } from './addons';
 
+import { HTMLLinkNode } from './plugins/ModifyHtmlWebpackPlugin';
 import { Arguments, DevConfiguration, Environment, FilePaths, Mode } from './types';
 import { overrideWithPropertyOrConfig } from './utils';
 
@@ -195,6 +198,8 @@ export default async function(
     });
   }
 
+  const templateIndex = parse(readFileSync(locations.template.indexHtml, { encoding: 'utf8' }));
+
   let webpackConfig: DevConfiguration = {
     mode,
     entry: {
@@ -219,7 +224,7 @@ export default async function(
       isProd && new CopyWebpackPlugin(filesToCopy),
 
       // Generate the `index.html`
-      new ExpoHtmlWebpackPlugin(env),
+      new ExpoHtmlWebpackPlugin(env, templateIndex),
 
       ExpoInterpolateHtmlPlugin.fromEnv(env, ExpoHtmlWebpackPlugin),
 

--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+    <!-- 
+      This viewport works for phones with notches.
+      It's optimized for gestures by disabling global zoom.
+     -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover"
+    />
     <title>%WEB_TITLE%</title>
     <link rel="shortcut icon" href="%WEB_PUBLIC_URL%favicon.ico" />
     <style>

--- a/packages/webpack-pwa-manifest-plugin/src/createMetatagsFromConfig.ts
+++ b/packages/webpack-pwa-manifest-plugin/src/createMetatagsFromConfig.ts
@@ -27,14 +27,7 @@ function populateMetatagObject(schema, input): { [key: string]: any } {
 export default function createMetatagsFromConfig(config: ExpoConfig = {}): { [key: string]: any } {
   const { web = {} } = config;
   const { themeColor, meta = {} } = web;
-  const {
-    viewport,
-    googleSiteVerification,
-    apple = {},
-    twitter = {},
-    openGraph = {},
-    microsoft = {},
-  } = meta;
+  const { googleSiteVerification, apple = {}, twitter = {}, openGraph = {}, microsoft = {} } = meta;
 
   const openGraphMetatags = populateMetatagObject(Metatags.openGraph, openGraph);
   const twitterMetatags = populateMetatagObject(Metatags.twitter, twitter);
@@ -51,7 +44,6 @@ export default function createMetatagsFromConfig(config: ExpoConfig = {}): { [ke
   };
 
   const metaTags: { [key: string]: any } = {
-    viewport,
     description: config.description,
     ...openGraphMetatags,
     ...microsoftMetatags,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10892,6 +10892,11 @@ hashids@1.1.4:
   resolved "https://registry.yarnpkg.com/hashids/-/hashids-1.1.4.tgz#e4ff92ad66b684a3bd6aace7c17d66618ee5fa21"
   integrity sha512-U/fnTE3edW0AV92ZI/BfEluMZuVcu3MDOopsN7jS+HqDYcarQo8rXQiWlsBlm0uX48/taYSdxRsfzh2HRg5Z6w==
 
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
+
 he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -14559,6 +14564,13 @@ node-gyp@^5.0.2:
     semver "~5.3.0"
     tar "^4.4.12"
     which "1"
+
+node-html-parser@^1.2.12:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.2.13.tgz#8f59c7654ed317e58064423095e2be5d976658ef"
+  integrity sha512-RTG5oDk3nh1oXQGYtQQa9w0v9LjltgzzO1tv3cpXzb9M/UkpFIZ5v4osx3OYAcnWx/ETBXjxs2cgtD9fhn6Bjw==
+  dependencies:
+    he "1.1.1"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
# Why

To move past beta, we're resolving all features from the `expo.web.dangerous` object. One of the outstanding ones is the viewport which we currently inject into the `index.html`. This PR makes the viewport static in the template html.

# How

- Add default viewport to the default index.html
- For users with legacy `index.html`s, parse the template and log out that they should add the tag to their project.
  - `<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover" />`

# Test Plan

- Running `expo build:web` and `expo start:web` shouldn't log any warnings, the result `index.html` should have a viewport meta tag in the head.
- Running `expo build:web` and `expo start:web` with a custom `web/index.html` without a viewport tag, should log a warning, the result `index.html` should have a viewport meta tag in the head.
