### PR TITLE
[webpack-config] Use dynamic aliases for Webpack

### DIFF
--- a/packages/electron-adapter/src/Webpack.ts
+++ b/packages/electron-adapter/src/Webpack.ts
@@ -1,7 +1,7 @@
 import { withAlias } from '@expo/webpack-config/addons';
 import { createBabelLoaderFromEnvironment } from '@expo/webpack-config/loaders';
 import { ExpoDefinePlugin, ExpoInterpolateHtmlPlugin } from '@expo/webpack-config/plugins';
-import { getConfig, getModuleFileExtensions, getPaths } from '@expo/webpack-config/env';
+import { getAliases, getConfig, getModuleFileExtensions, getPaths } from '@expo/webpack-config/env';
 import {
   getPluginsByName,
   getRulesByMatchingFiles,
@@ -16,11 +16,11 @@ export function withExpoWebpack(
   config: AnyConfiguration,
   options: { projectRoot?: string; skipEntry?: boolean } = {}
 ) {
+  const projectRoot = options.projectRoot || process.cwd();
+
   // Support React Native aliases
   // @ts-ignore: webpack version mismatch
-  config = withAlias(config);
-
-  const projectRoot = options.projectRoot || process.cwd();
+  config = withAlias(config, getAliases(projectRoot));
 
   const env: any = {
     platform: 'electron',

--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -281,10 +281,10 @@ import { getMode } from '@expo/webpack-config/env';
 import { validateEnvironment } from '@expo/webpack-config/env';
 ```
 
-#### `aliases`
+#### `getAliases`
 
 ```js
-import { aliases } from '@expo/webpack-config/env';
+import { getAliases } from '@expo/webpack-config/env';
 ```
 
 #### `getPaths`

--- a/packages/webpack-config/src/addons/__tests__/withAlias-test.js
+++ b/packages/webpack-config/src/addons/__tests__/withAlias-test.js
@@ -1,21 +1,14 @@
 import withAlias from '../withAlias';
-import { aliases } from '../../env';
 
 it(`defines default aliases`, () => {
   expect(
-    withAlias({
-      mode: 'production',
-    }).resolve.alias
-  ).toStrictEqual(aliases);
-});
-
-it(`uses existing aliases over defaults`, () => {
-  expect(
-    withAlias({
-      mode: 'production',
-      resolve: { alias: { 'react-native$': 'foobar' } },
-    }).resolve.alias['react-native$']
-  ).toBe('foobar');
+    withAlias(
+      {
+        mode: 'production',
+      },
+      { foo: 'bar' }
+    ).resolve.alias
+  ).toStrictEqual({ foo: 'bar' });
 });
 
 it(`allows for custom input aliases`, () => {

--- a/packages/webpack-config/src/addons/withAlias.ts
+++ b/packages/webpack-config/src/addons/withAlias.ts
@@ -1,5 +1,4 @@
 import { AnyConfiguration } from '../types';
-import { aliases } from '../env';
 
 /**
  * Inject the required aliases for using React Native web and the extended Expo web ecosystem. Optionally can also safely append aliases to a Webpack config.
@@ -15,7 +14,6 @@ export default function withAlias(
   // Mix in aliases
   if (!webpackConfig.resolve) webpackConfig.resolve = {};
   webpackConfig.resolve.alias = {
-    ...aliases,
     ...(webpackConfig.resolve.alias || {}),
     ...alias,
   };

--- a/packages/webpack-config/src/addons/withUnimodules.ts
+++ b/packages/webpack-config/src/addons/withUnimodules.ts
@@ -2,6 +2,7 @@ import path from 'path';
 
 import { getPossibleProjectRoot } from '@expo/config/paths';
 import {
+  getAliases,
   getConfig,
   getMode,
   getModuleFileExtensions,
@@ -30,7 +31,10 @@ export default function withUnimodules(
   env: InputEnvironment = {},
   argv: Arguments = {}
 ): AnyConfiguration {
-  webpackConfig = withAlias(webpackConfig);
+  // @ts-ignore: We should attempt to use the project root that the other config is already using (used for Gatsby support).
+  env.projectRoot = env.projectRoot || webpackConfig.context || getPossibleProjectRoot();
+
+  webpackConfig = withAlias(webpackConfig, getAliases(env.projectRoot));
 
   if (!webpackConfig.module) webpackConfig.module = { rules: [] };
   else if (!webpackConfig.module.rules)
@@ -39,9 +43,6 @@ export default function withUnimodules(
   if (!webpackConfig.plugins) webpackConfig.plugins = [];
   if (!webpackConfig.resolve) webpackConfig.resolve = {};
   if (!webpackConfig.output) webpackConfig.output = {};
-
-  // @ts-ignore: We should attempt to use the project root that the other config is already using (used for Gatsby support).
-  env.projectRoot = env.projectRoot || webpackConfig.context || getPossibleProjectRoot();
 
   // Attempt to use the input webpack config mode
   env.mode = env.mode || webpackConfig.mode;

--- a/packages/webpack-config/src/env/alias.ts
+++ b/packages/webpack-config/src/env/alias.ts
@@ -1,27 +1,39 @@
 /** @internal */ /** */
 
-/**
- * @category env
- * @internal
- */
-export const aliases = {
-  // Alias direct react-native imports to react-native-web
-  'react-native$': 'react-native-web',
-  '@react-native-community/netinfo': 'react-native-web/dist/exports/NetInfo',
+import { projectHasModule } from '@expo/config';
+
+export function getAliases(projectRoot: string): Record<string, string> {
+  // Even if the module isn't installed, react-native should be aliased to react-native-web for better errors.
+  let aliases: Record<string, string> = {
+    // Alias direct react-native imports to react-native-web
+    'react-native$': 'react-native-web',
+    // Alias internal react-native modules to react-native-web
+    'react-native/Libraries/Components/View/ViewStylePropTypes$':
+      'react-native-web/dist/exports/View/ViewStylePropTypes',
+    'react-native/Libraries/EventEmitter/RCTDeviceEventEmitter$':
+      'react-native-web/dist/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter',
+    'react-native/Libraries/vendor/emitter/EventEmitter$':
+      'react-native-web/dist/vendor/react-native/emitter/EventEmitter',
+    'react-native/Libraries/vendor/emitter/EventSubscriptionVendor$':
+      'react-native-web/dist/vendor/react-native/emitter/EventSubscriptionVendor',
+    'react-native/Libraries/EventEmitter/NativeEventEmitter$':
+      'react-native-web/dist/vendor/react-native/NativeEventEmitter',
+  };
+  // Check if the installed version of react-native-web still supports NetInfo.
+  if (projectHasModule('react-native-web/dist/exports/NetInfo', projectRoot, {})) {
+    aliases['@react-native-community/netinfo'] = 'react-native-web/dist/exports/NetInfo';
+  }
+
   // Add polyfills for modules that react-native-web doesn't support
   // Depends on expo-asset
-  'react-native/Libraries/Image/AssetSourceResolver$': 'expo-asset/build/AssetSourceResolver',
-  'react-native/Libraries/Image/assetPathUtils$': 'expo-asset/build/Image/assetPathUtils',
-  'react-native/Libraries/Image/resolveAssetSource$': 'expo-asset/build/resolveAssetSource',
-  // Alias internal react-native modules to react-native-web
-  'react-native/Libraries/Components/View/ViewStylePropTypes$':
-    'react-native-web/dist/exports/View/ViewStylePropTypes',
-  'react-native/Libraries/EventEmitter/RCTDeviceEventEmitter$':
-    'react-native-web/dist/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter',
-  'react-native/Libraries/vendor/emitter/EventEmitter$':
-    'react-native-web/dist/vendor/react-native/emitter/EventEmitter',
-  'react-native/Libraries/vendor/emitter/EventSubscriptionVendor$':
-    'react-native-web/dist/vendor/react-native/emitter/EventSubscriptionVendor',
-  'react-native/Libraries/EventEmitter/NativeEventEmitter$':
-    'react-native-web/dist/vendor/react-native/NativeEventEmitter',
-};
+  if (projectHasModule('expo-asset', projectRoot, {})) {
+    aliases['react-native/Libraries/Image/AssetSourceResolver$'] =
+      'expo-asset/build/AssetSourceResolver';
+    aliases['react-native/Libraries/Image/assetPathUtils$'] =
+      'expo-asset/build/Image/assetPathUtils';
+    aliases['react-native/Libraries/Image/resolveAssetSource$'] =
+      'expo-asset/build/resolveAssetSource';
+  }
+
+  return aliases;
+}

--- a/packages/webpack-config/src/env/index.ts
+++ b/packages/webpack-config/src/env/index.ts
@@ -1,6 +1,6 @@
 export { default as getConfig } from './getConfig';
 export { default as getMode } from './getMode';
 export { validateEnvironment } from './validate';
-export { aliases } from './alias';
+export { getAliases } from './alias';
 export * from './paths';
 export * from './extensions';

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -15,7 +15,14 @@ import path from 'path';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 
 import { projectHasModule } from '@expo/config';
-import { getConfig, getMode, getModuleFileExtensions, getPathsAsync, getPublicPaths } from './env';
+import {
+  getAliases,
+  getConfig,
+  getMode,
+  getModuleFileExtensions,
+  getPathsAsync,
+  getPublicPaths,
+} from './env';
 import { createAllLoaders } from './loaders';
 import {
   ExpoDefinePlugin,
@@ -333,5 +340,5 @@ export default async function(
     });
   }
 
-  return withNodeMocks(withAlias(webpackConfig));
+  return withNodeMocks(withAlias(webpackConfig, getAliases(env.projectRoot)));
 }


### PR DESCRIPTION
# Why

Instead of enforcing the versions of `react-native-web`, dynamically resolve aliases based on file availability.

# Test Plan

Run a project with `"@react-native-community/netinfo": "^5.6.2", "react-native-web": "~0.11.7"`. 

Importing `@react-native-community/netinfo` should reflect:

```js
{
  "default": {
    "isConnected": {}
  }
}
```

Using `"react-native-web": "~0.12.2"` should disable the alias and use the community module, resulting in:

```js
{
  "NetInfoStateType": {
    "unknown": "unknown",
    "none": "none",
    "cellular": "cellular",
    "wifi": "wifi",
    "bluetooth": "bluetooth",
    "ethernet": "ethernet",
    "wimax": "wimax",
    "vpn": "vpn",
    "other": "other"
  },
  "NetInfoCellularGeneration": {
    "2g": "2g",
    "3g": "3g",
    "4g": "4g"
  },
  "default": {}
}
```

## Related

https://github.com/expo/expo-cli/pull/1655