### PR TITLE
[expo-cli][xdl][config] add expo publish --target managed|bare

### DIFF
--- a/packages/config/src/paths/extensions.ts
+++ b/packages/config/src/paths/extensions.ts
@@ -58,7 +58,27 @@ export function getManagedExtensions(
   const fileExtensions = getExtensions(platforms, getLanguageExtensionsInOrder(languageOptions), [
     'expo',
   ]);
-  // Always add this last with no platform extension
+  // Always add these last
+  _addMiscellaneousExtensions(fileExtensions);
+  return fileExtensions;
+}
+
+export function getBareExtensions(
+  platforms: string[],
+  languageOptions: LanguageOptions = { isTS: true, isModern: true, isReact: true }
+): string[] {
+  const fileExtensions = getExtensions(
+    platforms,
+    getLanguageExtensionsInOrder(languageOptions),
+    []
+  );
+  // Always add these last
+  _addMiscellaneousExtensions(fileExtensions);
+  return fileExtensions;
+}
+
+function _addMiscellaneousExtensions(fileExtensions: string[]): string[] {
+  // Always add these with no platform extension
   // In the future we may want to add platform and workspace extensions to json.
   fileExtensions.push('json');
   fileExtensions.push('wasm');

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -43,7 +43,7 @@ export async function action(projectDir: string, options: Options = {}) {
   }
 
   const target =
-    options.target ?? ((await Project.isBareWorkflowProject(projectDir)) ? 'bare' : 'managed');
+    options.target ?? ((await Project.isBareWorkflowProjectAsync(projectDir)) ? 'bare' : 'managed');
 
   const status = await Project.currentStatus(projectDir);
   let shouldStartOurOwn = false;

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -1,6 +1,6 @@
 import { getConfig } from '@expo/config';
 import simpleSpinner from '@expo/simple-spinner';
-import { Exp, Project } from '@expo/xdl';
+import { Exp, Project, ProjectSettings } from '@expo/xdl';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import fs from 'fs';
@@ -14,6 +14,7 @@ type Options = {
   clear?: boolean;
   sendTo?: string | boolean;
   quiet?: boolean;
+  target?: 'managed' | 'bare';
   releaseChannel?: string;
   duringBuild?: boolean;
   maxWorkers?: number;
@@ -40,16 +41,37 @@ export async function action(projectDir: string, options: Options = {}) {
       )}.`
     );
   }
+
+  const target =
+    options.target ?? ((await Project.isBareWorkflowProject(projectDir)) ? 'bare' : 'managed');
+
   const status = await Project.currentStatus(projectDir);
+  let shouldStartOurOwn = false;
+
+  if (status === 'running') {
+    const packagerInfo = await ProjectSettings.readPackagerInfoAsync(projectDir);
+    const runningPackagerTarget = packagerInfo.target ?? 'managed';
+    if (target !== runningPackagerTarget) {
+      log(
+        'Found an existing Expo CLI instance running for this project but the target did not match.'
+      );
+      await Project.stopAsync(projectDir);
+      log('Starting a new Expo CLI instance...');
+      shouldStartOurOwn = true;
+    }
+  } else {
+    log('Unable to find an existing Expo CLI instance for this directory; starting a new one...');
+    shouldStartOurOwn = true;
+  }
 
   let startedOurOwn = false;
-  if (status !== 'running') {
-    log('Unable to find an existing Expo CLI instance for this directory, starting a new one...');
+  if (shouldStartOurOwn) {
     installExitHooks(projectDir);
 
-    const startOpts: { reset?: boolean; nonPersistent: boolean; maxWorkers?: number } = {
+    const startOpts: Project.StartOptions = {
       reset: options.clear,
       nonPersistent: true,
+      target,
     };
     if (options.maxWorkers) {
       startOpts.maxWorkers = options.maxWorkers;
@@ -141,6 +163,10 @@ export default function(program: Command) {
     .option('-q, --quiet', 'Suppress verbose output from the React Native packager.')
     .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')
     .option('-c, --clear', 'Clear the React Native packager cache')
+    .option(
+      '-t, --target [env]',
+      'Target environment for which this publish is intended. Options are `managed` or `bare`.'
+    )
     // TODO(anp) set a default for this dynamically based on whether we're inside a container?
     .option('--max-workers [num]', 'Maximum number of tasks to allow Metro to spawn.')
     .option(

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -186,7 +186,7 @@ export async function currentStatus(projectDir: string): Promise<ProjectStatus> 
   }
 }
 
-export async function isBareWorkflowProject(projectDir: string): Promise<boolean> {
+export async function isBareWorkflowProjectAsync(projectDir: string): Promise<boolean> {
   const { pkg } = getConfig(projectDir, {
     skipSDKVersionRequirement: true,
   });

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -32,6 +32,7 @@ type PackagerInfo = {
   ngrokPid?: number | null;
   devToolsPort?: number | null;
   webpackServerPort?: number | null;
+  target?: 'managed' | 'bare';
 };
 const packagerInfoFile = 'packager-info.json';
 


### PR DESCRIPTION
# Why

https://www.notion.so/expo/App-entry-points-94433d55f7524837be7b37bccb2154a1

TL;DR In order to make `expo publish` able to create bundles for both the managed Expo client environment and bare native client environments, we need to be able to choose at runtime whether or not to resolve `.expo.*` files in the project source.

This PR adds a `--target` flag to `expo publish`; for `--target managed`, the packager resolves `.expo.*` files, and for `--target bare` the packager ignores them.

This PR also changes the default behavior for bare projects. Previously, `expo publish` **always** resolved `.expo.*` files, but now it only does so by default for managed workflow projects.

This is a **breaking change** for people who rely on `expo publish` resolving `.expo.*` files in bare workflow projects -- these developers will need to add the explicit `--target managed` flag to the command after this commit.

# How

- Added a new `getBareExtensions` to @expo/config to match `getManagedExtensions` and thread `target` param through to `startReactNativeServerAsync`
- Save the `target` in the packager info on disk; if there is an existing server instance running we only use it if the `target` matches, and close and restart otherwise
- Added `Project.isBareWorkflowProject` util for distinguishing between managed & bare projects

# Test Plan

Tested on a new bare workflow project from https://github.com/expo/expo/pull/7466
- [x] `--target` field overrides default
- [x] publishing with `--target managed` produces a build that errors with `The Expo SDK requires Expo to run...`
- [x] publishing with `--target bare` or unspecified target produces a build that runs
- [x] if `expo start` is running in a different process, publishing with `--target managed` uses the same server instance
- [x] if `expo start` is running in a different process, publishing with `--target bare` closes that instance and starts a new one