### PR TITLE
[expo-cli][xdl] make default target managed for all projects in SDK 36 and below

### DIFF
--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -20,7 +20,7 @@ type Options = {
   dev: boolean;
   clear: boolean;
   quiet: boolean;
-  target?: 'managed' | 'bare';
+  target?: Project.ProjectTarget;
   dumpAssetmap: boolean;
   dumpSourcemap: boolean;
   maxWorkers?: number;
@@ -44,8 +44,7 @@ export async function action(projectDir: string, options: Options) {
     console.warn(`Dev Mode: publicUrl ${options.publicUrl} does not conform to HTTP format.`);
   }
 
-  const target =
-    options.target ?? ((await Project.isBareWorkflowProjectAsync(projectDir)) ? 'bare' : 'managed');
+  const target = options.target ?? (await Project.getDefaultTargetAsync(projectDir));
 
   const status = await Project.currentStatus(projectDir);
   let shouldStartOurOwn = false;

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -14,7 +14,7 @@ type Options = {
   clear?: boolean;
   sendTo?: string | boolean;
   quiet?: boolean;
-  target?: 'managed' | 'bare';
+  target?: Project.ProjectTarget;
   releaseChannel?: string;
   duringBuild?: boolean;
   maxWorkers?: number;
@@ -42,8 +42,7 @@ export async function action(projectDir: string, options: Options = {}) {
     );
   }
 
-  const target =
-    options.target ?? ((await Project.isBareWorkflowProjectAsync(projectDir)) ? 'bare' : 'managed');
+  const target = options.target ?? (await Project.getDefaultTargetAsync(projectDir));
 
   const status = await Project.currentStatus(projectDir);
   let shouldStartOurOwn = false;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -130,7 +130,7 @@ export type StartOptions = {
   nonPersistent?: boolean;
   maxWorkers?: number;
   webOnly?: boolean;
-  target?: 'managed' | 'bare';
+  target?: ProjectTarget;
 };
 
 type PublishOptions = {
@@ -184,6 +184,17 @@ export async function currentStatus(projectDir: string): Promise<ProjectStatus> 
   } else {
     return 'exited';
   }
+}
+
+export type ProjectTarget = 'managed' | 'bare';
+
+export async function getDefaultTargetAsync(projectDir: string): Promise<ProjectTarget> {
+  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+  // before SDK 37, always default to managed to preserve previous behavior
+  if (exp.sdkVersion && semver.lt(exp.sdkVersion, '37.0.0')) {
+    return 'managed';
+  }
+  return (await isBareWorkflowProjectAsync(projectDir)) ? 'bare' : 'managed';
 }
 
 export async function isBareWorkflowProjectAsync(projectDir: string): Promise<boolean> {


### PR DESCRIPTION
This PR makes #1734 and #1736 no longer a breaking change for existing projects. SDK 36 and below projects will default to `--target managed` in expo publish and export.

Tested the following configurations to ensure the correct target was chosen:
- [x] SDK 37 bare project : `bare`
- [x] SDK 37 bare project with `--target managed` : `managed`
- [x] SDK 37 managed project : `managed`
- [x] SDK 37 managed project with `--target bare` : `bare`
- [x] SDK 36 bare project : `managed`
- [x] SDK 36 bare project with `--target bare` : `bare`