### PR TITLE
[webpack-config] Added theme-color and description meta tag injection

### DIFF
--- a/packages/webpack-config/src/plugins/ApplePwaWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/ApplePwaWebpackPlugin.ts
@@ -35,8 +35,8 @@ export default class ApplePwaWebpackPlugin extends ModifyHtmlWebpackPlugin {
   ): Promise<HTMLPluginData> {
     // Meta
     if (this.meta.isWebAppCapable) {
-      data.assetTags.meta.push(metaTag('apple-mobile-web-app-capable', 'yes'));
       data.assetTags.meta.push(metaTag('mobile-web-app-capable', 'yes'));
+      data.assetTags.meta.push(metaTag('apple-mobile-web-app-capable', 'yes'));
     }
     if (this.meta.isFullScreen) {
       data.assetTags.meta.push(metaTag('apple-touch-fullscreen', 'yes'));

--- a/packages/webpack-config/src/plugins/ExpoHtmlWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoHtmlWebpackPlugin.ts
@@ -62,11 +62,17 @@ export default class HtmlWebpackPlugin extends OriginalHtmlWebpackPlugin {
       }
       // Meta tag to define a suggested color that browsers should use to customize the display of the page or of the surrounding user interface.
       // The meta tag overrides any theme-color set in the web app manifest.
-      if (!templateMeta.some((node: any) => node.getAttribute('name') === 'theme-color')) {
+      if (
+        config.web?.themeColor &&
+        !templateMeta.some((node: any) => node.getAttribute('name') === 'theme-color')
+      ) {
         meta['theme-color'] = config.web?.themeColor;
       }
 
-      if (!templateMeta.some((node: any) => node.getAttribute('name') === 'description')) {
+      if (
+        config.web?.description &&
+        !templateMeta.some((node: any) => node.getAttribute('name') === 'description')
+      ) {
         meta['description'] = config.web?.description;
       }
     }

--- a/packages/webpack-config/src/plugins/ExpoHtmlWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoHtmlWebpackPlugin.ts
@@ -60,6 +60,15 @@ export default class HtmlWebpackPlugin extends OriginalHtmlWebpackPlugin {
         meta.viewport =
           'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover';
       }
+      // Meta tag to define a suggested color that browsers should use to customize the display of the page or of the surrounding user interface.
+      // The meta tag overrides any theme-color set in the web app manifest.
+      if (!templateMeta.some((node: any) => node.getAttribute('name') === 'theme-color')) {
+        meta['theme-color'] = config.web?.themeColor;
+      }
+
+      if (!templateMeta.some((node: any) => node.getAttribute('name') === 'description')) {
+        meta['description'] = config.web?.description;
+      }
     }
 
     super({


### PR DESCRIPTION
theme-color and description meta tags went missing in the PWA redesign. This adds them back optionally when they aren't already in the template `index.html`.