### PR TITLE
[xdl] add default paths for saving embedded assets to disk

### DIFF
--- a/packages/xdl/src/EmbeddedAssets.ts
+++ b/packages/xdl/src/EmbeddedAssets.ts
@@ -64,14 +64,14 @@ async function _maybeWriteArtifactsToDiskAsync(config: EmbeddedAssetsConfigurati
     await fs.ensureDir(supportingDirectory);
     await fs.ensureDir(androidAssetsDir);
 
-    androidBundlePath = path.join(androidAssetsDir, 'shell-app.bundle');
-    androidManifestPath = path.join(androidAssetsDir, 'shell-app-manifest.json');
-    iosBundlePath = path.join(supportingDirectory, 'shell-app.bundle');
-    iosManifestPath = path.join(supportingDirectory, 'shell-app-manifest.json');
+    androidBundlePath = path.join(androidAssetsDir, 'app.bundle');
+    androidManifestPath = path.join(androidAssetsDir, 'app.manifest');
+    iosBundlePath = path.join(supportingDirectory, 'app.bundle');
+    iosManifestPath = path.join(supportingDirectory, 'app.manifest');
 
     if (!fs.existsSync(iosBundlePath) || !fs.existsSync(iosManifestPath)) {
       logger.global.warn(
-        'Creating shell-app-manifest.json and shell-app.bundle inside of your ios/<project>/Supporting directory.\nBe sure to add these files to your Xcode project. More info at https://expo.fyi/embedded-assets'
+        'Creating app.manifest and app.bundle inside of your ios/<project>/Supporting directory.\nBe sure to add these files to your Xcode project. More info at https://expo.fyi/embedded-assets'
       );
     }
   }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -871,7 +871,8 @@ export async function publishAsync(
   if (
     validPostPublishHooks.length ||
     (exp.ios && exp.ios.publishManifestPath) ||
-    (exp.android && exp.android.publishManifestPath)
+    (exp.android && exp.android.publishManifestPath) ||
+    pkg.dependencies['expo-updates']
   ) {
     [androidManifest, iosManifest] = await Promise.all([
       ExponentTools.getManifestAsync(response.url, {

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -21,6 +21,7 @@ import * as IosWorkspace from './IosWorkspace';
 import * as AndroidShellApp from './AndroidShellApp';
 
 import Api from '../Api';
+import * as EmbeddedAssets from '../EmbeddedAssets';
 import UserManager from '../User';
 import XDLError from '../XDLError';
 import StandaloneBuildFlags from './StandaloneBuildFlags';
@@ -516,15 +517,13 @@ export async function bundleAssetsAsync(projectDir, args) {
     return;
   }
   const { exp } = options;
-  let publishManifestPath =
-    args.platform === 'ios' ? exp.ios.publishManifestPath : exp.android.publishManifestPath;
-  if (!publishManifestPath) {
+  let bundledManifestPath = EmbeddedAssets.getEmbeddedManifestPath(args.platform, projectDir, exp);
+  if (!bundledManifestPath) {
     logger.warn(
       `Skipped assets bundling because the '${args.platform}.publishManifestPath' key is not specified in the app manifest.`
     );
     return;
   }
-  let bundledManifestPath = path.join(projectDir, publishManifestPath);
   let manifest;
   try {
     manifest = JSON.parse(await fs.readFile(bundledManifestPath, 'utf8'));


### PR DESCRIPTION
(depends on #1740)

This PR adds default paths for saving embedded assets to disk in projects with `expo-updates` installed. This removes the need for developers to configure the `ios.publishManifestPath`, `ios.publishBundlePath`, `android.publishManifestPath`, and `android.publishBundlePath` app.json fields upon installation of expo-updates; they can still configure these fields if they want a different location than the default.

The logic here assumes that all ExpoKit apps **will** still have these fields specified (ok since we write them to app.json automatically upon eject), but if `expo-updates` is installed, it will write the files whether or not these fields are specified.

Also, if the iOS files are being created anew, the command will log a reminder to add the files to the Xcode project. This only needs to be done once.

# Test Plan

On `expo publish` or `expo export`...

- [x] project with expo-updates installed writes to default location if nothing is specified in app.json
- [x] project with expo-updates installed writes to custom location if specified in app.json
- [x] project without expo-updates installed writes to location if specified in app.json
- [x] project without expo-updates installed does not write files if not specified in app.json
- [x] if writing the iOS files and they do not already exist, warning message about adding them to Xcode project is logged

# Todos (not blocking)

- [x] expo/fyi PR adding the referenced doc (https://github.com/expo/fyi/pull/3)
- [x] remove README instructions to add app.json fields
- [x] remove from template bare projects (https://github.com/expo/expo/pull/7533)