### PR TITLE
fix: handle Ctrl+C correctly in PowerShell/CMD

### DIFF
--- a/packages/expo-cli/src/exit.ts
+++ b/packages/expo-cli/src/exit.ts
@@ -5,18 +5,6 @@ export function installExitHooks(
   projectDir: string,
   onStop: (projectDir: string) => Promise<void> = Project.stopAsync
 ): void {
-  // install ctrl+c handler that writes non-running state to directory
-  if (process.platform === 'win32') {
-    require('readline')
-      .createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      })
-      .on('SIGINT', () => {
-        process.kill(process.pid, 'SIGINT');
-      });
-  }
-
   const killSignals: ['SIGINT', 'SIGTERM'] = ['SIGINT', 'SIGTERM'];
   for (const signal of killSignals) {
     process.on(signal, () => {


### PR DESCRIPTION
Previously, stopping the expo dev server with `Ctrl+C` in PowerShell or
Windows Command Prompt caused the process to end abruptly without
printing "Closing Expo server" or setting the fields of `packager-info.json`
to `null`.

Fixes #1608.

# Test Plan
*Tested in Windows Command Prompt, Windows PowerShell 5.1, PowerShell Core 7.0, and git bash on Windows 10.*

1. Navigate to `packages/expo-cli` in the terminal you want to test.
2. `node bin/expo.js start /path/to/any/project`
3. Wait for the QR code to display, then press `Ctrl+C` or `Ctrl+D`.

**Expected behavior:**  
* Expo dev server prints 
    ```
    Stopping packager...
    › Closing Expo server
    › Stopping Metro bundler
    Packager stopped.
    ```
    and then terminates.
* The Node process is terminated. 
* All fieds except `devToolsPort` in the project's `.expo/packager-info.json` are set to null.