### PR TITLE
[eject] Fix `GoogleService-Info.plist` file after ejecting to bare

### DIFF
--- a/packages/config/src/ios/Google.ts
+++ b/packages/config/src/ios/Google.ts
@@ -81,11 +81,11 @@ export function setGoogleServicesFile(config: ExpoConfig, projectRoot: string) {
   let googleServiceFilePath = path.resolve(projectRoot, googleServicesFileRelativePath);
   fs.copyFileSync(
     googleServiceFilePath,
-    path.join(getSourceRoot(projectRoot), 'GoogleServices-Info.plist')
+    path.join(getSourceRoot(projectRoot), 'GoogleService-Info.plist')
   );
 
   let project = getPbxproj(projectRoot);
   let projectName = getProjectName(projectRoot);
-  project = addFileToGroup(`${projectName}/GoogleServices-Info.plist`, projectName, project);
+  project = addFileToGroup(`${projectName}/GoogleService-Info.plist`, projectName, project);
   fs.writeFileSync(project.filepath, project.writeSync());
 }

--- a/packages/config/src/ios/__tests__/Google-test.ts
+++ b/packages/config/src/ios/__tests__/Google-test.ts
@@ -33,8 +33,8 @@ describe('ios google config', () => {
       })
     ).toBe('000');
     expect(
-      getGoogleServicesFile({ ios: { googleServicesFile: './path/to/GoogleServices-Info.plist' } })
-    ).toBe('./path/to/GoogleServices-Info.plist');
+      getGoogleServicesFile({ ios: { googleServicesFile: './path/to/GoogleService-Info.plist' } })
+    ).toBe('./path/to/GoogleService-Info.plist');
   });
 
   it(`sets the google maps api key if provided or returns plist`, () => {

--- a/packages/config/src/ios/utils/Xcodeproj.ts
+++ b/packages/config/src/ios/utils/Xcodeproj.ts
@@ -25,6 +25,7 @@ export function addFileToGroup(filepath: string, groupName: string, project: Pro
   file.fileRef = project.generateUuid();
   project.addToPbxFileReferenceSection(file);
   project.addToPbxBuildFileSection(file);
+  project.addToPbxSourcesBuildPhase(file);
   let group = project.pbxGroupByName(groupName);
   if (!group) {
     throw Error(`Group by name ${groupName} not found!`);


### PR DESCRIPTION
# Why

When ejecting to bare, the iOS `GoogleService-Info.plist` file is not copied to the correct location, nor is the `target membership` flag enabled. This will cause the Firebase SDKs to not be initialized.

# How

- Rename `GoogleServices-Info.plist` to `GoogleService-Info.plist`. 
- Enable the `target membership` flag for `GoogleService-Info.plist`.

# Test plan

## Before

![image](https://user-images.githubusercontent.com/6184593/78132547-362cca00-741d-11ea-985c-c073838cfee0.png)

![image](https://user-images.githubusercontent.com/6184593/78134973-52326a80-7421-11ea-8749-9e3c945c197c.png)

![image](https://user-images.githubusercontent.com/6184593/78133248-62951600-741e-11ea-9e70-e6a7228cdc60.png)

## After fix

![image](https://user-images.githubusercontent.com/6184593/78133068-1cd84d80-741e-11ea-8c30-a196b86dcb42.png)

![image](https://user-images.githubusercontent.com/6184593/78135873-e18c4d80-7422-11ea-9bc9-28a80b879888.png)


