### PR TITLE
[credentials][apiv2] fix credentials bug

### DIFF
--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -113,7 +113,7 @@ export async function updateCredentialsForPlatform(
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {
-  if (process.env.EXPO_LECACY_API) {
+  if (process.env.EXPO_LEGACY_API) {
     const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {
       credentials: newCredentials,
       userCredentialsIds,
@@ -132,8 +132,8 @@ export async function updateCredentialsForPlatform(
       credentials: newCredentials,
     });
 
-    if (result.data.errors) {
-      throw new Error(`Error updating credentials: ${JSON.stringify(result.data.errors)}}`);
+    if (result.errors) {
+      throw new Error(`Error updating credentials: ${JSON.stringify(result.errors)}}`);
     }
   }
 }

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -121,8 +121,8 @@ export async function updateCredentialsForPlatform(
       credentials: newCredentials,
     });
 
-    if (result.data.errors) {
-      throw new Error(`Error updating credentials: ${JSON.stringify(result.data.errors)}}`);
+    if (result.errors) {
+      throw new Error(`Error updating credentials: ${JSON.stringify(result.errors)}}`);
     }
   } else {
     const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -113,18 +113,7 @@ export async function updateCredentialsForPlatform(
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {
-  if (process.env.EXPO_NEXT_API) {
-    const { experienceName } = metadata;
-    const user = await UserManager.ensureLoggedInAsync();
-    const api = ApiV2.clientForUser(user);
-    const result = await api.putAsync(`credentials/android/keystore/${experienceName}`, {
-      credentials: newCredentials,
-    });
-
-    if (result.data.errors) {
-      throw new Error(`Error updating credentials: ${JSON.stringify(result.data.errors)}}`);
-    }
-  } else {
+  if (process.env.EXPO_LECACY_API) {
     const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {
       credentials: newCredentials,
       userCredentialsIds,
@@ -134,6 +123,17 @@ export async function updateCredentialsForPlatform(
 
     if (err || !credentials) {
       throw new Error('Error updating credentials.');
+    }
+  } else {
+    const { experienceName } = metadata;
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    const result = await api.putAsync(`credentials/android/keystore/${experienceName}`, {
+      credentials: newCredentials,
+    });
+
+    if (result.data.errors) {
+      throw new Error(`Error updating credentials: ${JSON.stringify(result.data.errors)}}`);
     }
   }
 }

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -121,8 +121,8 @@ export async function updateCredentialsForPlatform(
       credentials: newCredentials,
     });
 
-    if (result.errors) {
-      throw new Error(`Error updating credentials: ${JSON.stringify(result.errors)}}`);
+    if (result.data.errors) {
+      throw new Error(`Error updating credentials: ${JSON.stringify(result.data.errors)}}`);
     }
   } else {
     const { err, credentials } = await Api.callMethodAsync('updateCredentials', [], 'post', {


### PR DESCRIPTION
# why
Close: https://github.com/expo/expo-cli/issues/1760 and https://github.com/expo/expo-cli/issues/1774

# how 
The cli was trying to read `result.data.errors` instead of `result.errors`.

Fixed this and made `EXPO_NEXT_API` the default again.

# test

- checked it built with user supplied keystore. 
- threw a dummy ApiError server side and confirmed it handled it.

# extra

The solution and the testing of this was suggested @byCedric 🙏 

