### PR TITLE
improve error message when using unsupported SDK

### DIFF
--- a/packages/expo-cli/src/commands/build/utils.ts
+++ b/packages/expo-cli/src/commands/build/utils.ts
@@ -9,10 +9,9 @@ export async function checkIfSdkIsSupported(
 ): Promise<void> {
   const isSupported = await Versions.canTurtleBuildSdkVersion(sdkVersion, platform);
   const minimumSdkVersionSupported = await Versions.oldestSupportedMajorVersionAsync();
-  const majorSdkVersion = sdkVersion.split('.')[0];
+  const majorSdkVersion = Number(sdkVersion.split('.')[0]);
 
   if (!isSupported) {
-    const storeName = platform === 'ios' ? 'Apple App Store' : 'Google Play Store';
     log.error(
       chalk.red(
         'Unsupported SDK version: our app builders ' +

--- a/packages/expo-cli/src/commands/build/utils.ts
+++ b/packages/expo-cli/src/commands/build/utils.ts
@@ -10,14 +10,15 @@ export async function checkIfSdkIsSupported(
   const isSupported = await Versions.canTurtleBuildSdkVersion(sdkVersion, platform);
   const minimumSdkVersionSupported = await Versions.oldestSupportedMajorVersionAsync();
   const majorSdkVersion = Number(sdkVersion.split('.')[0]);
+  const { version: latestSDKVersion } = await Versions.newestReleasedSdkVersionAsync();
 
   if (!isSupported) {
     log.error(
       chalk.red(
         'Unsupported SDK version: our app builders ' +
           (majorSdkVersion < minimumSdkVersionSupported
-            ? `no longer support SDK version ${majorSdkVersion}. Please upgrade to at least SDK ${minimumSdkVersionSupported}.`
-            : `do not support SDK version ${majorSdkVersion}, yet.`)
+            ? `no longer support SDK version ${majorSdkVersion}. Please upgrade to at least SDK ${minimumSdkVersionSupported}, or to the latest SDK version (${latestSDKVersion}).`
+            : `do not support SDK version ${majorSdkVersion}, yet. The latest SDK version is ${latestSDKVersion}.`)
       )
     );
     throw new Error('Unsupported SDK version');

--- a/packages/expo-cli/src/commands/build/utils.ts
+++ b/packages/expo-cli/src/commands/build/utils.ts
@@ -8,11 +8,17 @@ export async function checkIfSdkIsSupported(
   platform: 'android' | 'ios'
 ): Promise<void> {
   const isSupported = await Versions.canTurtleBuildSdkVersion(sdkVersion, platform);
+  const minimumSdkVersionSupported = await Versions.oldestSupportedMajorVersionAsync();
+  const majorSdkVersion = sdkVersion.split('.')[0];
+
   if (!isSupported) {
     const storeName = platform === 'ios' ? 'Apple App Store' : 'Google Play Store';
     log.error(
       chalk.red(
-        `Unsupported SDK version: our app builders don't have support for ${sdkVersion} version yet. Submitting the app to the ${storeName} may result in an unexpected behavior.`
+        'Unsupported SDK version: our app builders ' +
+          (majorSdkVersion < minimumSdkVersionSupported
+            ? `no longer support SDK version ${majorSdkVersion}. Please upgrade to at least SDK ${minimumSdkVersionSupported}.`
+            : `do not support SDK version ${majorSdkVersion}, yet.`)
       )
     );
     throw new Error('Unsupported SDK version');


### PR DESCRIPTION
tested locally, although the version endpoint needs to be updated to reflect recent changes in what SDKs we support