### PR TITLE
[pod-install] Add support for react-native projects

### DIFF
--- a/packages/package-manager/src/CocoaPodsPackageManager.ts
+++ b/packages/package-manager/src/CocoaPodsPackageManager.ts
@@ -1,6 +1,5 @@
 import spawnAsync, { SpawnOptions, SpawnResult } from '@expo/spawn-async';
 import chalk from 'chalk';
-import findWorkspaceRoot from 'find-yarn-workspace-root';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -11,11 +10,14 @@ export class CocoaPodsPackageManager implements PackageManager {
   private log: Logger;
   private silent: boolean;
 
+  static getPodProjectRoot(projectRoot: string): string | null {
+    if (CocoaPodsPackageManager.isUsingPods(projectRoot)) return projectRoot;
+    const iosProject = path.join(projectRoot, 'ios');
+    if (CocoaPodsPackageManager.isUsingPods(iosProject)) return iosProject;
+    return null;
+  }
+
   static isUsingPods(projectRoot: string): boolean {
-    const workspaceRoot = findWorkspaceRoot(projectRoot);
-    if (workspaceRoot) {
-      return fs.existsSync(path.join(workspaceRoot, 'ios', 'Podfile'));
-    }
     return fs.existsSync(path.join(projectRoot, 'Podfile'));
   }
 

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -31,9 +31,13 @@ async function runAsync(): Promise<void> {
     console.log(chalk.red('CocoaPods is only supported on darwin machines'));
     return;
   }
-  if (!CocoaPodsPackageManager.isUsingPods(projectRoot)) {
+
+  const possibleProjectRoot = CocoaPodsPackageManager.getPodProjectRoot(projectRoot);
+  if (!possibleProjectRoot) {
     console.log(chalk.yellow('CocoaPods is not supported in this project'));
     return;
+  } else {
+    projectRoot = possibleProjectRoot;
   }
 
   if (!(await CocoaPodsPackageManager.isCLIInstalledAsync())) {


### PR DESCRIPTION
If you run in a project that has an `ios/Podfile`, then pods will be installed in that project. This is the same as running `npx pod-install ios`