### PR TITLE
feat: add sourceExts to default Metro config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,14 @@ workflows:
           e: node-10
           requires:
             - build10
+      - test-metro-config:
+          e: node-10
+          requires:
+            - build10
+      - test-metro-config:
+          e: node-12
+          requires:
+            - build12
 jobs:
   build:
     parameters:
@@ -114,7 +122,7 @@ jobs:
           name: Bootstrap (Link) Internal Dependencies
           command: yarn bootstrap
       - persist_to_workspace:
-          root: '~'
+          root: "~"
           paths:
             - expo-cli
       - save_cache:
@@ -130,7 +138,7 @@ jobs:
     working_directory: ~/expo-cli/packages/dev-tools
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-config:
     parameters:
@@ -140,7 +148,7 @@ jobs:
     working_directory: ~/expo-cli/packages/config
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-json-file:
     parameters:
@@ -150,7 +158,7 @@ jobs:
     working_directory: ~/expo-cli/packages/json-file
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-expo-cli:
     parameters:
@@ -160,7 +168,7 @@ jobs:
     working_directory: ~/expo-cli/packages/expo-cli
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-expo-codemod:
     parameters:
@@ -170,7 +178,7 @@ jobs:
     working_directory: ~/expo-cli/packages/expo-codemod
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-webpack-config-unit:
     parameters:
@@ -180,7 +188,7 @@ jobs:
     working_directory: ~/expo-cli/packages/webpack-config
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test:unit
   test-webpack-config-e2e:
     parameters:
@@ -190,7 +198,7 @@ jobs:
     working_directory: ~/expo-cli/packages/webpack-config
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run:
           name: Install test project dependencies
           command: cd e2e/basic && yarn; cd ../..
@@ -203,7 +211,7 @@ jobs:
     working_directory: ~/expo-cli/packages/webpack-config
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run:
           name: Install test project dependencies
           command: cd e2e/nextjs && yarn; cd ../..
@@ -216,7 +224,7 @@ jobs:
     working_directory: ~/expo-cli/packages/schemer
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-expo-pwa:
     parameters:
@@ -226,7 +234,7 @@ jobs:
     working_directory: ~/expo-cli/packages/pwa
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-coverage:
     parameters:
@@ -236,7 +244,7 @@ jobs:
     working_directory: ~/expo-cli
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test-coverage
   test-electron-adapter:
     parameters:
@@ -246,7 +254,7 @@ jobs:
     working_directory: ~/expo-cli/packages/electron-adapter
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-plist:
     parameters:
@@ -256,5 +264,15 @@ jobs:
     working_directory: ~/expo-cli/packages/plist
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
+      - run: yarn test
+  test-metro-config:
+    parameters:
+      e:
+        type: executor
+    executor: << parameters.e >>
+    working_directory: ~/expo-cli/packages/metro-config
+    steps:
+      - attach_workspace:
+          at: "~"
       - run: yarn test

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -45,7 +45,6 @@
   ],
   "dependencies": {
     "@babel/register": "^7.8.3",
-    "@expo/babel-preset-cli": "0.2.8",
     "@expo/json-file": "8.2.8",
     "@expo/plist": "0.0.2",
     "@types/invariant": "^2.2.30",
@@ -55,12 +54,13 @@
     "jest-message-util": "^25.1.0",
     "plist": "^3.0.1",
     "resolve-from": "^5.0.0",
+    "semver": "^7.1.3",
     "slugify": "^1.3.4",
     "xcode": "^2.1.0",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.6",
+    "@expo/babel-preset-cli": "0.2.8",
     "@types/invariant": "^2.2.30",
     "@types/plist": "^3.0.1",
     "@types/xml2js": "^0.4.5",

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -311,16 +311,16 @@ export function getNameFromConfig(exp: ExpoConfig = {}): { appName: string; webN
   };
 }
 
-export async function getDefaultTargetAsync(projectRoot: string): Promise<ProjectTarget> {
+export function getDefaultTarget(projectRoot: string): ProjectTarget {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   // before SDK 37, always default to managed to preserve previous behavior
   if (exp.sdkVersion && exp.sdkVersion !== 'UNVERSIONED' && semver.lt(exp.sdkVersion, '37.0.0')) {
     return 'managed';
   }
-  return (await isBareWorkflowProjectAsync(projectRoot)) ? 'bare' : 'managed';
+  return isBareWorkflowProject(projectRoot) ? 'bare' : 'managed';
 }
 
-async function isBareWorkflowProjectAsync(projectRoot: string): Promise<boolean> {
+function isBareWorkflowProject(projectRoot: string): boolean {
   const { pkg } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
@@ -329,13 +329,13 @@ async function isBareWorkflowProjectAsync(projectRoot: string): Promise<boolean>
   }
 
   if (fs.existsSync(path.resolve(projectRoot, 'ios'))) {
-    const xcodeprojFiles = await globby([path.join(projectRoot, 'ios', '/**/*.xcodeproj')]);
+    const xcodeprojFiles = globby.sync([path.join(projectRoot, 'ios', '/**/*.xcodeproj')]);
     if (xcodeprojFiles.length) {
       return true;
     }
   }
   if (fs.existsSync(path.resolve(projectRoot, 'android'))) {
-    const gradleFiles = await globby([path.join(projectRoot, 'android', '/**/*.gradle')]);
+    const gradleFiles = globby.sync([path.join(projectRoot, 'android', '/**/*.gradle')]);
     if (gradleFiles.length) {
       return true;
     }

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -936,6 +936,8 @@ export type ExpoConfig = {
 };
 export type ExpRc = { [key: string]: any };
 export type Platform = 'android' | 'ios' | 'web';
+export type ProjectTarget = 'managed' | 'bare';
+
 export type ConfigErrorCode =
   | 'NO_APP_JSON'
   | 'NOT_OBJECT'

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -5,6 +5,7 @@ import validator from 'validator';
 import path from 'path';
 import targz from 'targz';
 import { Project, ProjectSettings, UrlUtils } from '@expo/xdl';
+import { ProjectTarget, getDefaultTargetAsync } from '@expo/config';
 import { Command } from 'commander';
 
 import log from '../log';
@@ -20,7 +21,7 @@ type Options = {
   dev: boolean;
   clear: boolean;
   quiet: boolean;
-  target?: Project.ProjectTarget;
+  target?: ProjectTarget;
   dumpAssetmap: boolean;
   dumpSourcemap: boolean;
   maxWorkers?: number;
@@ -44,7 +45,7 @@ export async function action(projectDir: string, options: Options) {
     console.warn(`Dev Mode: publicUrl ${options.publicUrl} does not conform to HTTP format.`);
   }
 
-  const target = options.target ?? (await Project.getDefaultTargetAsync(projectDir));
+  const target = options.target ?? (await getDefaultTargetAsync(projectDir));
 
   const status = await Project.currentStatus(projectDir);
   let shouldStartOurOwn = false;

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -5,7 +5,7 @@ import validator from 'validator';
 import path from 'path';
 import targz from 'targz';
 import { Project, ProjectSettings, UrlUtils } from '@expo/xdl';
-import { ProjectTarget, getDefaultTargetAsync } from '@expo/config';
+import { ProjectTarget, getDefaultTarget } from '@expo/config';
 import { Command } from 'commander';
 
 import log from '../log';
@@ -45,7 +45,7 @@ export async function action(projectDir: string, options: Options) {
     console.warn(`Dev Mode: publicUrl ${options.publicUrl} does not conform to HTTP format.`);
   }
 
-  const target = options.target ?? (await getDefaultTargetAsync(projectDir));
+  const target = options.target ?? getDefaultTarget(projectDir);
 
   const status = await Project.currentStatus(projectDir);
   let shouldStartOurOwn = false;

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -1,4 +1,4 @@
-import { getConfig } from '@expo/config';
+import { ProjectTarget, getConfig, getDefaultTargetAsync } from '@expo/config';
 import simpleSpinner from '@expo/simple-spinner';
 import { Exp, Project, ProjectSettings } from '@expo/xdl';
 import chalk from 'chalk';
@@ -14,7 +14,7 @@ type Options = {
   clear?: boolean;
   sendTo?: string | boolean;
   quiet?: boolean;
-  target?: Project.ProjectTarget;
+  target?: ProjectTarget;
   releaseChannel?: string;
   duringBuild?: boolean;
   maxWorkers?: number;
@@ -42,7 +42,7 @@ export async function action(projectDir: string, options: Options = {}) {
     );
   }
 
-  const target = options.target ?? (await Project.getDefaultTargetAsync(projectDir));
+  const target = options.target ?? (await getDefaultTargetAsync(projectDir));
 
   const status = await Project.currentStatus(projectDir);
   let shouldStartOurOwn = false;

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -1,4 +1,4 @@
-import { ProjectTarget, getConfig, getDefaultTargetAsync } from '@expo/config';
+import { ProjectTarget, getConfig, getDefaultTarget } from '@expo/config';
 import simpleSpinner from '@expo/simple-spinner';
 import { Exp, Project, ProjectSettings } from '@expo/xdl';
 import chalk from 'chalk';
@@ -42,7 +42,7 @@ export async function action(projectDir: string, options: Options = {}) {
     );
   }
 
-  const target = options.target ?? (await getDefaultTargetAsync(projectDir));
+  const target = options.target ?? getDefaultTarget(projectDir);
 
   const status = await Project.currentStatus(projectDir);
   let shouldStartOurOwn = false;

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -46,8 +46,7 @@
     "jest": "^25.2.6",
     "metro": "^0.59.0",
     "metro-config": "^0.59.0",
-    "react-native": "0.61.4",
-    "typescript": "3.4.5"
+    "react-native": "0.61.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ProjectTarget, getConfig, getDefaultTargetAsync, resolveModule } from '@expo/config';
+import { ProjectTarget, getConfig, getDefaultTarget, resolveModule } from '@expo/config';
 import { getBareExtensions, getManagedExtensions } from '@expo/config/paths';
 import { Reporter } from 'metro';
 import { ConfigT, InputConfigT, loadConfig } from 'metro-config';
@@ -29,7 +29,20 @@ export function getDefaultConfig(
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   const reactNativePath = resolveModule('react-native', projectRoot, exp);
 
-  const target = options.target ?? getDefaultTargetAsync(projectRoot);
+  const target = options.target ?? process.env.EXPO_TARGET ?? getDefaultTarget(projectRoot);
+  if (!(target === 'managed' || target === 'bare')) {
+    throw new Error(
+      `Invalid target: '${target}'. Debug info: \n${JSON.stringify(
+        {
+          'options.target': options.target,
+          EXPO_TARGET: process.env.EXPO_TARGET,
+          default: getDefaultTarget(projectRoot),
+        },
+        null,
+        2
+      )}`
+    );
+  }
   const sourceExtsConfig = { isTS: true, isReact: true, isModern: false };
   const sourceExts =
     target === 'bare'

--- a/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -5,14 +5,22 @@ import { getDefaultConfig, loadAsync } from '../ExpoMetroConfig';
 const projectRoot = path.join(__dirname, '__fixtures__', 'hello-world');
 
 describe('getDefaultConfig', () => {
+  const propertyMatchers = {
+    transformer: {
+      assetPlugins: expect.arrayContaining([expect.stringContaining('hashAssetFiles')]),
+      assetRegistryPath: expect.stringContaining('AssetRegistry'),
+      babelTransformerPath: expect.stringContaining('transformer.js'),
+    },
+  };
+
   it('loads default configuration', async () => {
-    expect(await getDefaultConfig(projectRoot)).toMatchSnapshot({
-      transformer: {
-        assetPlugins: expect.arrayContaining([expect.stringContaining('hashAssetFiles')]),
-        assetRegistryPath: expect.stringContaining('AssetRegistry'),
-        babelTransformerPath: expect.stringContaining('transformer.js'),
-      },
-    });
+    expect(await getDefaultConfig(projectRoot)).toMatchSnapshot(propertyMatchers);
+  });
+
+  it('loads default configuration for bare apps', async () => {
+    expect(await getDefaultConfig(projectRoot, { target: 'bare' })).toMatchSnapshot(
+      propertyMatchers
+    );
   });
 });
 

--- a/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -13,14 +13,26 @@ describe('getDefaultConfig', () => {
     },
   };
 
-  it('loads default configuration', async () => {
-    expect(await getDefaultConfig(projectRoot)).toMatchSnapshot(propertyMatchers);
+  it('loads default configuration', () => {
+    expect(getDefaultConfig(projectRoot)).toMatchSnapshot(propertyMatchers);
   });
 
-  it('loads default configuration for bare apps', async () => {
-    expect(await getDefaultConfig(projectRoot, { target: 'bare' })).toMatchSnapshot(
-      propertyMatchers
-    );
+  it('loads default configuration for bare apps', () => {
+    expect(getDefaultConfig(projectRoot, { target: 'bare' })).toMatchSnapshot(propertyMatchers);
+  });
+
+  it('complains about an invalid target setting', () => {
+    process.env.EXPO_TARGET = 'bare';
+    // @ts-ignore incorrect `target` value passed on purpose
+    expect(() => getDefaultConfig(projectRoot, { target: 'blooper' }))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Invalid target: 'blooper'. Debug info: 
+      {
+        \\"options.target\\": \\"blooper\\",
+        \\"EXPO_TARGET\\": \\"bare\\",
+        \\"default\\": \\"managed\\"
+      }"
+    `);
   });
 });
 

--- a/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -23,16 +23,10 @@ describe('getDefaultConfig', () => {
 
   it('complains about an invalid target setting', () => {
     process.env.EXPO_TARGET = 'bare';
-    // @ts-ignore incorrect `target` value passed on purpose
-    expect(() => getDefaultConfig(projectRoot, { target: 'blooper' }))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Invalid target: 'blooper'. Debug info: 
-      {
-        \\"options.target\\": \\"blooper\\",
-        \\"EXPO_TARGET\\": \\"bare\\",
-        \\"default\\": \\"managed\\"
-      }"
-    `);
+    expect(() =>
+      // @ts-ignore incorrect `target` value passed on purpose
+      getDefaultConfig(projectRoot, { target: 'blooper' })
+    ).toThrowErrorMatchingSnapshot();
   });
 });
 

--- a/packages/metro-config/src/__tests__/__snapshots__/ExpoMetroConfig-test.ts.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/ExpoMetroConfig-test.ts.snap
@@ -13,6 +13,57 @@ Object {
       "browser",
       "main",
     ],
+    "sourceExts": Array [
+      "expo.ts",
+      "expo.tsx",
+      "expo.js",
+      "expo.jsx",
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "wasm",
+    ],
+  },
+  "serializer": Object {
+    "getModulesRunBeforeMainModule": [Function],
+    "getPolyfills": [Function],
+  },
+  "symbolicator": Object {
+    "customizeFrame": [Function],
+  },
+  "transformer": Object {
+    "assetPlugins": ArrayContaining [
+      StringContaining "hashAssetFiles",
+    ],
+    "assetRegistryPath": StringContaining "AssetRegistry",
+    "babelTransformerPath": StringContaining "transformer.js",
+  },
+}
+`;
+
+exports[`getDefaultConfig loads default configuration for bare apps 1`] = `
+Object {
+  "resolver": Object {
+    "platforms": Array [
+      "ios",
+      "android",
+      "native",
+    ],
+    "resolverMainFields": Array [
+      "react-native",
+      "browser",
+      "main",
+    ],
+    "sourceExts": Array [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "wasm",
+    ],
   },
   "serializer": Object {
     "getModulesRunBeforeMainModule": [Function],

--- a/packages/metro-config/src/__tests__/__snapshots__/ExpoMetroConfig-test.ts.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/ExpoMetroConfig-test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getDefaultConfig complains about an invalid target setting 1`] = `
+"Invalid target: 'blooper'. Debug info: 
+{
+  \\"options.target\\": \\"blooper\\",
+  \\"EXPO_TARGET\\": \\"bare\\",
+  \\"default\\": \\"managed\\"
+}"
+`;
+
 exports[`getDefaultConfig loads default configuration 1`] = `
 Object {
   "resolver": Object {

--- a/packages/xdl/src/EmbeddedAssets.ts
+++ b/packages/xdl/src/EmbeddedAssets.ts
@@ -1,7 +1,6 @@
-import { ExpoConfig, PackageJSONConfig } from '@expo/config';
+import { ExpoConfig, PackageJSONConfig, ProjectTarget } from '@expo/config';
 import fs from 'fs-extra';
 import path from 'path';
-import { ProjectTarget } from './Project';
 
 import * as ExponentTools from './detach/ExponentTools';
 import * as IosPlist from './detach/IosPlist';

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2336,6 +2336,12 @@ export async function startAsync(
     developerTool: Config.developerTool,
   });
 
+  if (options.target) {
+    // EXPO_TARGET is used by @expo/metro-config to determine the target when getDefaultConfig is
+    // called from metro.config.js and the --target option is used to override the default target.
+    process.env.EXPO_TARGET = options.target;
+  }
+
   let { exp } = getConfig(projectRoot);
   if (options.webOnly) {
     await Webpack.restartAsync(projectRoot, options);

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2,6 +2,7 @@ import {
   ExpoConfig,
   PackageJSONConfig,
   Platform,
+  ProjectTarget,
   configFilename,
   getConfig,
   readExpRcAsync,
@@ -187,41 +188,6 @@ export async function currentStatus(projectDir: string): Promise<ProjectStatus> 
   } else {
     return 'exited';
   }
-}
-
-export type ProjectTarget = 'managed' | 'bare';
-
-export async function getDefaultTargetAsync(projectDir: string): Promise<ProjectTarget> {
-  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
-  // before SDK 37, always default to managed to preserve previous behavior
-  if (exp.sdkVersion && exp.sdkVersion !== 'UNVERSIONED' && semver.lt(exp.sdkVersion, '37.0.0')) {
-    return 'managed';
-  }
-  return (await isBareWorkflowProjectAsync(projectDir)) ? 'bare' : 'managed';
-}
-
-export async function isBareWorkflowProjectAsync(projectDir: string): Promise<boolean> {
-  const { pkg } = getConfig(projectDir, {
-    skipSDKVersionRequirement: true,
-  });
-  if (pkg.dependencies && pkg.dependencies.expokit) {
-    return false;
-  }
-
-  if (fs.existsSync(path.resolve(projectDir, 'ios'))) {
-    const xcodeprojFiles = await glob(path.join(projectDir, 'ios', '/**/*.xcodeproj'));
-    if (xcodeprojFiles && xcodeprojFiles.length) {
-      return true;
-    }
-  }
-  if (fs.existsSync(path.resolve(projectDir, 'android'))) {
-    const gradleFiles = await glob(path.join(projectDir, 'android', '/**/*.gradle'));
-    if (gradleFiles && gradleFiles.length) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 // DECPRECATED: use UrlUtils.constructManifestUrlAsync

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -5,6 +5,7 @@ import {
   ProjectTarget,
   configFilename,
   getConfig,
+  getDefaultTarget,
   readExpRcAsync,
   resolveModule,
 } from '@expo/config';
@@ -21,7 +22,6 @@ import delayAsync from 'delay-async';
 import express from 'express';
 import freeportAsync from 'freeport-async';
 import fs from 'fs-extra';
-import glob from 'glob-promise';
 import HashIds from 'hashids';
 import joi from 'joi';
 import chunk from 'lodash/chunk';
@@ -50,7 +50,6 @@ import ApiV2 from './ApiV2';
 import { writeArtifactSafelyAsync } from './tools/ArtifactUtils';
 import Config from './Config';
 import * as ExponentTools from './detach/ExponentTools';
-import StandaloneContext from './detach/StandaloneContext';
 import * as DevSession from './DevSession';
 import * as EmbeddedAssets from './EmbeddedAssets';
 import { maySkipManifestValidation } from './Env';
@@ -530,7 +529,7 @@ export async function exportForAppHosting(
   } = {}
 ): Promise<void> {
   await _validatePackagerReadyAsync(projectRoot);
-  const defaultTarget = await getDefaultTargetAsync(projectRoot);
+  const defaultTarget = getDefaultTarget(projectRoot);
   const target = options.publishOptions?.target ?? defaultTarget;
 
   // build the bundles
@@ -757,7 +756,7 @@ export async function publishAsync(
   options: PublishOptions = {}
 ): Promise<{ url: string; ids: string[]; err?: string }> {
   const user = await UserManager.ensureLoggedInAsync();
-  const target = options.target ?? (await getDefaultTargetAsync(projectRoot));
+  const target = options.target ?? getDefaultTarget(projectRoot);
   await _validatePackagerReadyAsync(projectRoot);
   Analytics.logEvent('Publish', {
     projectRoot,

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -1,4 +1,5 @@
 import JsonFile from '@expo/json-file';
+import { ProjectTarget } from '@expo/config';
 import fs from 'fs-extra';
 import defaults from 'lodash/defaults';
 import path from 'path';
@@ -32,7 +33,7 @@ type PackagerInfo = {
   ngrokPid?: number | null;
   devToolsPort?: number | null;
   webpackServerPort?: number | null;
-  target?: 'managed' | 'bare';
+  target?: ProjectTarget;
 };
 const packagerInfoFile = 'packager-info.json';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22484,11 +22484,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
-
 typescript@3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"


### PR DESCRIPTION
Earlier discussion: https://github.com/expo/expo-cli/pull/1777#discussion_r402875727

Configuring the `sourceExts` setting of Metro bundler has previously been difficult with Expo CLI (see https://github.com/expo/expo-cli/issues/1019, https://github.com/expo/expo-cli/issues/1786), because we've been passing the `sourceExts` option to RN CLI, which overrides the setting specified in `metro.config.js`.

This PR adds `sourceExts` to the default Metro configuration added in https://github.com/expo/expo-cli/pull/1777. Once Expo CLI has been updated to load the configuration using the new package (I'm working on this), it will be possible to make use of these defaults when writing a custom `metro.config.js` file.

#### Usage with `metro.config.js`

For example, to add an extension to `sourceExts` in a managed/bare Expo app, one will be able to do this:
```js
// metro.config.js
const { getDefaultConfig } = require('@expo/metro-config');

const defaultConfig = getDefaultConfig(__dirname);

module.exports = {
  resolver: {
    sourceExts: [...defaultConfig.resolver.sourceExts, "svg"]
  }
};
```
~However, a notable corner case are *bare apps that can also run in Expo Client* (when published with `expo publish --target managed`). For those apps, instead of~
```js
const defaultConfig = getDefaultConfig(__dirname);
```
~you would have to use~
```js
const defaultConfig = getDefaultConfig(__dirname, { target });
```
~where `target` is the value of the `--target` flag passed to `expo publish`. One way to do this could be to write~
```js
const defaultConfig = getDefaultConfig(__dirname, { target: process.env.TARGET });
```
~and publish the app with `TARGET=managed expo publish --target managed`.~
UPDATE: bare apps publishing to a `managed` target are also handled, see https://github.com/expo/expo-cli/pull/1821#issuecomment-610434473