### PR TITLE
fix: remove extraneous '--output' option from --help page

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -355,7 +355,6 @@ function runAsync(programName: string) {
     program.name(programName);
     program
       .version(packageJSON.version)
-      .option('-o, --output [format]', 'Output format. pretty (default), raw')
       .option(
         '--non-interactive',
         'Fail, if an interactive prompt would be required to continue. Enabled by default if stdin is not a TTY.'


### PR DESCRIPTION
closes https://github.com/expo/expo-cli/issues/459

Removing this since it has no effect, and if a command _does_ provide the option to give raw output, it is enabled with `expo [command] --raw`