### PR TITLE
[xdl] don't fail if the downloaded file is smaller than 10 bytes

### DIFF
--- a/packages/xdl/src/detach/ExponentTools.ts
+++ b/packages/xdl/src/detach/ExponentTools.ts
@@ -39,12 +39,7 @@ function parseSdkMajorVersion(expSdkVersion: string) {
 function saveUrlToPathAsync(url: string, path: string) {
   return new Promise(function(resolve, reject) {
     let stream = fs.createWriteStream(path);
-    stream.on('close', () => {
-      if (_getFilesizeInBytes(path) < 10) {
-        reject(new Error(`${url} is too small`));
-      }
-      resolve();
-    });
+    stream.on('close', resolve);
     stream.on('error', reject);
     pipeRequest({ url, timeout: 20000 })
       .on('error', reject)


### PR DESCRIPTION
## Why

This is going to fi.x https://github.com/expo/expo/issues/7701 once we update xdl in Turtle.
expo-cli treats json files as assets. It's totally fine - those could be used for translations. However, we don't handle small json files properly. If a user added a json file with empty json inside (`{}`) to his project and tries to build the app with Turtle he gets an error saying that one of the assets is too small.

```bash
$ echo "{}" > a.json
$  ls -lah a.json
-rw-r--r--  1 dsokal  staff     3B Apr  8 12:15 a.json
```
A file with an empty json is 4 bytes and we require each asset file to be at least 10 bytes.

## How 

I got rid of the `if` checking for the size of the asset entirely. If downloading the asset failed we would receive some HTTP error anyway. We don't need to have this strange condition. This conditional is > 3 years old and I think the limit has been set arbitrarily. Probably at that point, we didn't have support for json files.