### PR TITLE
Feature/upgrade codemod

### DIFF
--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -195,14 +195,16 @@ async function makeBreakingChangesToConfigAsync(
 async function makeChangesToCodeAsync(
   projectRoot: string,
   targetSdkVersion: SDKVersion,
-  targetSdkVersionString: string,
+  targetSdkVersionString: string
 ): Promise<string[]> {
   const step = logNewSection('Checking if your code requires additional changes...');
   const majorSdkVersion = targetSdkVersionString.split('.')[0];
   let transforms: string[] = [];
 
   try {
-    const transformList = await spawnAsync('npx', ['expo-codemod', '--list', majorSdkVersion], { cwd: projectRoot });
+    const transformList = await spawnAsync('npx', ['expo-codemod', '--list', majorSdkVersion], {
+      cwd: projectRoot,
+    });
     const transformParsed = transformList.output[0]?.split(', ');
 
     transforms = transformParsed
@@ -214,8 +216,9 @@ async function makeChangesToCodeAsync(
       text: chalk.yellow(
         `Please check if your ${terminalLink(
           'code requires additional changes',
-          targetSdkVersion.releaseNoteUrl || 'https://docs.expo.io/versions/latest/workflow/upgrading-expo-sdk-walkthrough/'
-        )}`,
+          targetSdkVersion.releaseNoteUrl ||
+            'https://docs.expo.io/versions/latest/workflow/upgrading-expo-sdk-walkthrough/'
+        )}`
       ),
     });
     return [];
@@ -237,10 +240,12 @@ async function makeChangesToCodeAsync(
       text: chalk.red(
         `Please manually update your${terminalLink(
           'code for the required changes',
-          targetSdkVersion.releaseNoteUrl || 'https://docs.expo.io/versions/latest/workflow/upgrading-expo-sdk-walkthrough/'
-        )}`,
+          targetSdkVersion.releaseNoteUrl ||
+            'https://docs.expo.io/versions/latest/workflow/upgrading-expo-sdk-walkthrough/'
+        )}`
       ),
     });
+    return [];
   }
 
   step.succeed(`Updated your code with additional changes.`);
@@ -601,7 +606,11 @@ export async function upgradeAsync(
   }
 
   // Run codemod to automatically upgrade imports from separated modules and install them if necessary
-  const transforms = await makeChangesToCodeAsync(projectRoot, targetSdkVersion, targetSdkVersionString);
+  const transforms = await makeChangesToCodeAsync(
+    projectRoot,
+    targetSdkVersion,
+    targetSdkVersionString
+  );
 
   log.newLine();
   log(chalk.bold.green(`👏 Automated upgrade steps complete.`));

--- a/packages/expo-codemod/src/cli.ts
+++ b/packages/expo-codemod/src/cli.ts
@@ -17,6 +17,13 @@ export async function runAsync(argv: string[]) {
   const [transform, ...paths] = options._.slice(2);
   const parser = options.parser;
 
+  if (options.list) {
+    const list = await listTransformsForSdkVersionAsync(options.list);
+    console.log(list.join(', '));
+    process.exit(0);
+    return;
+  }
+
   const transforms = await listTransformsAsync();
   if (options.help || !transform || paths.length === 0) {
     console.log(`
@@ -30,6 +37,8 @@ Options:
   -h, --help                       print this help message
   -p, --parser <babel|flow|ts|tsx> parser to use to parse the source files
                                    (default: babel, ts or tsx based on the file extension)
+  -l, --list <sdkVersion>          list all available transforms for sdk versions
+                                   (e.g. 36 or 37)
 
 Transforms available:
   ${transforms.join('\n  ')}`);
@@ -122,4 +131,9 @@ async function transformAsync({
 async function listTransformsAsync() {
   const modules = await globby(['*.js'], { cwd: transformDir });
   return modules.map(filename => path.basename(filename, '.js'));
+}
+
+async function listTransformsForSdkVersionAsync(majorSdkVersion: string) {
+  const transforms = await listTransformsAsync();
+  return transforms.filter(name => name.startsWith(`sdk${majorSdkVersion}`));
 }


### PR DESCRIPTION
The basics of adding `expo-codemod` to `expo upgrade` are here, but I think its good to polish some of these parts.

**Stuff to polish**
1. We need to know the exact transform name to apply (e.g. `sdk37-imports`). Right now I added a `expo-codemod --list 37` option (also requires a codemod publish when merging PR), to get a comma separated list of all imports available for the major version of the SDK. Would definitely prefer either adding option to run `expo-codemod` by sdk name, or fetch a list of codemods to apply from the versions API.
2. Probably need to add a range of all major SDK versions between start and end and perform each codemod per sdk. Before I start on this, I first want to fine tune point 1.
3. Me and @fson talked about invoking codemod programmatically, but that requires adding a specific codemod version to the CLI. When we add more codemods, we would need to update the CLI too. I avoided this by using `spawnAsync('npx', ['expo-codemod', ...]);`, maybe there is a better way?

**Examples**

<details>
<summary>Successfully upgrading from 36 to 37</summary>
<img src="https://user-images.githubusercontent.com/1203991/78803609-811b8400-79bf-11ea-9c1a-d1454b50ce8c.png" />
</details>

<details>
<summary>Successfully upgrading from 35 to 36 (no codemod)</summary>
<img src="https://user-images.githubusercontent.com/1203991/78803620-84af0b00-79bf-11ea-9e0f-603869112065.png" />
</details>

<details>
<summary>Failure when checking if a codemod is available</summary>
<img src="https://user-images.githubusercontent.com/1203991/78803638-88429200-79bf-11ea-919b-da3017cd8aff.png" />
</details>

<details>
<summary>Failure during a codemod</summary>
<img src="https://user-images.githubusercontent.com/1203991/78803663-8b3d8280-79bf-11ea-97ae-d8f758e6eb05.png" />
</details>
