### PR TITLE
refactor: add @expo/dev-server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/cache@v1
         id: cache-build
         with:
-          path: '.'
+          path: "."
           key: ${{ github.sha }}
   test:
     runs-on: ubuntu-latest
@@ -29,6 +29,7 @@ jobs:
           [
             babel-preset-cli,
             config,
+            dev-server,
             expo-cli,
             expo-codemod,
             json-file,
@@ -46,7 +47,7 @@ jobs:
       - uses: actions/cache@v1
         id: restore-build
         with:
-          path: '.'
+          path: "."
           key: ${{ github.sha }}
       - name: Coverage ${{ matrix.package }}
         run: cd packages/${{ matrix.package }} && yarn test --coverage

--- a/packages/babel-preset-cli/ts-declarations/metro-config/index.d.ts
+++ b/packages/babel-preset-cli/ts-declarations/metro-config/index.d.ts
@@ -1,6 +1,16 @@
 declare module 'metro-config' {
   import { IncomingMessage, ServerResponse } from 'http';
-  import { JsTransformerConfig, Reporter } from 'metro';
+  import {
+    DeltaResult,
+    Graph,
+    Module,
+    SerializerOptions,
+    JsTransformerConfig,
+    Reporter,
+    TransformResult,
+    Server,
+    TransformVariants,
+  } from 'metro';
 
   // TODO: import { CacheStore } from 'metro-cache';
   type CacheStore = unknown;
@@ -9,17 +19,6 @@ declare module 'metro-config' {
   // TODO: import { BasicSourceMap, MixedSourceMap } from 'metro-source-map';
   type BasicSourceMap = unknown;
   type MixedSourceMap = unknown;
-  // TODO: import { DeltaResult, Graph, Module, SerializerOptions } from 'metro/src/DeltaBundler/types';
-  type DeltaResult = unknown;
-  type Graph = unknown;
-  type Module = unknown;
-  type SerializerOptions = unknown;
-  // TODO: import { TransformResult } from 'metro/src/DeltaBundler';
-  type TransformResult = unknown;
-  // TODO:  import { TransformVariants } from 'metro/src/ModuleGraph/types';
-  type TransformVariants = unknown;
-  // TODO: import Server from 'metro/src/Server';
-  type Server = unknown;
 
   //#region metro/packages/metro-config/src/configTypes.flow.js
 

--- a/packages/babel-preset-cli/ts-declarations/metro/index.d.ts
+++ b/packages/babel-preset-cli/ts-declarations/metro/index.d.ts
@@ -1,5 +1,229 @@
 declare module 'metro' {
-  //#region metro/packages/metro/src/JSTransformer/worker.js
+  //#region metro/src/Assets.js
+
+  type AssetDataWithoutFiles = {
+    readonly __packager_asset: boolean;
+    readonly fileSystemLocation: string;
+    readonly hash: string;
+    readonly height: number | null | undefined;
+    readonly httpServerLocation: string;
+    readonly name: string;
+    readonly scales: Array<number>;
+    readonly type: string;
+    readonly width: number | null | undefined;
+  };
+
+  type AssetData = AssetDataWithoutFiles & { readonly files: Array<string> };
+
+  //#endregion
+  //#region metro/src/DeltaBundler/types.flow.js
+
+  interface MixedOutput {
+    readonly data: unknown;
+    readonly type: string;
+  }
+
+  interface BabelSourceLocation {
+    start: { line: number; column: number };
+    end: { line: number; column: number };
+    identifierName?: string;
+  }
+
+  interface TransformResultDependency {
+    /**
+     * The literal name provided to a require or import call. For example 'foo' in
+     * case of `require('foo')`.
+     */
+    readonly name: string;
+
+    /**
+     * Extra data returned by the dependency extractor. Whatever is added here is
+     * blindly piped by Metro to the serializers.
+     */
+    readonly data: {
+      /**
+       * If `true` this dependency is due to a dynamic `import()` call. If `false`,
+       * this dependency was pulled using a synchronous `require()` call.
+       */
+      readonly isAsync: boolean;
+
+      /**
+       * The dependency is actually a `__prefetchImport()` call.
+       */
+      readonly isPrefetchOnly?: true;
+
+      /**
+       * The condition for splitting on this dependency edge.
+       */
+      readonly splitCondition?: {
+        readonly mobileConfigName: string;
+      };
+
+      /**
+       * The dependency is enclosed in a try/catch block.
+       */
+      readonly isOptional?: boolean;
+
+      readonly locs: ReadonlyArray<BabelSourceLocation>;
+    };
+  }
+
+  interface Dependency {
+    readonly absolutePath: string;
+    readonly data: TransformResultDependency;
+  }
+
+  export interface Module<T = MixedOutput> {
+    readonly dependencies: Map<string, Dependency>;
+    readonly inverseDependencies: Set<string>;
+    readonly output: ReadonlyArray<T>;
+    readonly path: string;
+    readonly getSource: () => Buffer;
+  }
+
+  export interface Graph<T = MixedOutput> {
+    dependencies: Map<string, Module<T>>;
+    importBundleNames: Set<string>;
+    readonly entryPoints: ReadonlyArray<string>;
+  }
+
+  export type TransformResult<T = MixedOutput> = Readonly<{
+    dependencies: ReadonlyArray<TransformResultDependency>;
+    output: ReadonlyArray<T>;
+  }>;
+
+  interface AllowOptionalDependenciesWithOptions {
+    readonly exclude: Array<string>;
+  }
+  type AllowOptionalDependencies = boolean | AllowOptionalDependenciesWithOptions;
+
+  export interface DeltaResult<T = MixedOutput> {
+    readonly added: Map<string, Module<T>>;
+    readonly modified: Map<string, Module<T>>;
+    readonly deleted: Set<string>;
+    readonly reset: boolean;
+  }
+
+  export interface SerializerOptions {
+    readonly asyncRequireModulePath: string;
+    readonly createModuleId: (arg0: string) => number;
+    readonly dev: boolean;
+    readonly getRunModuleStatement: (arg0: number | string) => string;
+    readonly inlineSourceMap: boolean | null | undefined;
+    readonly modulesOnly: boolean;
+    readonly processModuleFilter: (module: Module) => boolean;
+    readonly projectRoot: string;
+    readonly runBeforeMainModule: ReadonlyArray<string>;
+    readonly runModule: boolean;
+    readonly sourceMapUrl: string | null | undefined;
+    readonly sourceUrl: string | null | undefined;
+  }
+
+  //#endregion
+  //#region metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
+
+  interface RamBundleInfo {
+    getDependencies: (filePath: string) => Set<string>;
+    startupModules: ReadonlyArray<ModuleTransportLike>;
+    lazyModules: ReadonlyArray<ModuleTransportLike>;
+    groups: Map<number, Set<number>>;
+  }
+
+  //#endregion
+  //#region metro/src/index.js
+
+  import { Server as HttpServer } from 'http';
+  import { Server as HttpsServer } from 'https';
+  import { loadConfig, ConfigT, InputConfigT, Middleware } from 'metro-config';
+
+  type MetroMiddleWare = {
+    attachHmrServer: (httpServer: HttpServer | HttpsServer) => void;
+    end: () => void;
+    metroServer: Server;
+    middleware: Middleware;
+  };
+
+  type RunServerOptions = {
+    hasReducedPerformance?: boolean;
+    hmrEnabled?: boolean;
+    host?: string;
+    onError?: (arg0: Error & { code?: string }) => void;
+    onReady?: (server: HttpServer | HttpsServer) => void;
+    runInspectorProxy?: boolean;
+    secure?: boolean;
+    secureCert?: string;
+    secureKey?: string;
+  };
+
+  type BuildGraphOptions = {
+    entries: ReadonlyArray<string>;
+    customTransformOptions?: CustomTransformOptions;
+    dev?: boolean;
+    minify?: boolean;
+    onProgress?: (transformedFileCount: number, totalFileCount: number) => void;
+    platform?: string;
+    type?: 'module' | 'script';
+  };
+
+  type RunBuildOptions = {
+    entry: string;
+    dev?: boolean;
+    out?: string;
+    onBegin?: () => void;
+    onComplete?: () => void;
+    onProgress?: (transformedFileCount: number, totalFileCount: number) => void;
+    minify?: boolean;
+    output?: {
+      build: (
+        arg0: Server,
+        arg1: RequestOptions
+      ) => Promise<{
+        code: string;
+        map: string;
+      }>;
+      save: (
+        arg0: {
+          code: string;
+          map: string;
+        },
+        arg1: OutputOptions,
+        arg2: (...args: Array<string>) => void
+      ) => Promise<unknown>;
+    };
+    platform?: string;
+    sourceMap?: boolean;
+    sourceMapUrl?: string;
+  };
+
+  export function runMetro(config: InputConfigT, options?: ServerOptions): Promise<Server>;
+
+  export { loadConfig };
+
+  export function createConnectMiddleware(
+    config: ConfigT,
+    options?: ServerOptions
+  ): Promise<MetroMiddleWare>;
+
+  export function runServer(
+    config: ConfigT,
+    options: RunServerOptions
+  ): Promise<HttpServer | HttpsServer>;
+
+  export function runBuild(
+    config: ConfigT,
+    options: RunBuildOptions
+  ): Promise<{
+    code: string;
+    map: string;
+  }>;
+
+  export function buildGraph(config: InputConfigT, options: BuildGraphOptions): Promise<Graph>;
+  //#endregion
+  //#region metro/src/JSTransformer/worker.js
+
+  type CustomTransformOptions = {
+    [key: string]: unknown;
+  };
 
   export type JsTransformerConfig = Readonly<{
     assetPlugins: ReadonlyArray<string>;
@@ -18,7 +242,7 @@ declare module 'metro' {
   }>;
 
   //#endregion
-  //#region metro/packages/metro/src/lib/reporting.js
+  //#region metro/src/lib/reporting.js
 
   /**
    * A tagged union of all the actions that may happen and we may want to
@@ -119,6 +343,142 @@ declare module 'metro' {
   export interface Reporter {
     update(event: ReportableEvent): void;
   }
+
+  //#endregion
+  //#region metro/src/ModuleGraph/types.flow.js
+
+  export type TransformVariants = {
+    readonly [name: string]: {};
+  };
+
+  //#endregion
+  //#region metro/src/Server.js
+
+  type ServerOptions = Readonly<{
+    watch?: boolean;
+  }>;
+
+  //#endregion
+  //#region metro/src/Server/index.js
+
+  import { IncomingMessage, ServerResponse } from 'http';
+
+  // TODO: type declaration
+  type IncrementalBundler = unknown;
+
+  export class Server {
+    constructor(config: ConfigT, options?: ServerOptions);
+
+    end(): void;
+
+    getBundler(): IncrementalBundler;
+
+    getCreateModuleId(): (path: string) => number;
+
+    build(
+      options: BundleOptions
+    ): Promise<{
+      code: string;
+      map: string;
+    }>;
+
+    getRamBundleInfo(options: BundleOptions): Promise<RamBundleInfo>;
+
+    getAssets(options: BundleOptions): Promise<ReadonlyArray<AssetData>>;
+
+    getOrderedDependencyPaths(options: {
+      readonly dev: boolean;
+      readonly entryFile: string;
+      readonly minify: boolean;
+      readonly platform: string;
+    }): Promise<Array<string>>;
+
+    processRequest(
+      req: IncomingMessage,
+      res: ServerResponse,
+      next: (arg0: Error | null | undefined) => unknown
+    ): void;
+
+    getNewBuildID(): string;
+
+    getPlatforms(): ReadonlyArray<string>;
+
+    getWatchFolders(): ReadonlyArray<string>;
+
+    static DEFAULT_GRAPH_OPTIONS: {
+      customTransformOptions: any;
+      dev: boolean;
+      hot: boolean;
+      minify: boolean;
+    };
+
+    static DEFAULT_BUNDLE_OPTIONS: typeof Server.DEFAULT_GRAPH_OPTIONS & {
+      excludeSource: false;
+      inlineSourceMap: false;
+      modulesOnly: false;
+      onProgress: null;
+      runModule: true;
+      shallow: false;
+      sourceMapUrl: null;
+      sourceUrl: null;
+    };
+  }
+
+  //#endregion
+  //#region metro/src/shared/types.flow.js
+
+  type BundleType = 'bundle' | 'delta' | 'meta' | 'map' | 'ram' | 'cli' | 'hmr' | 'todo' | 'graph';
+
+  type MetroSourceMapOrMappings = MixedSourceMap | Array<MetroSourceMapSegmentTuple>;
+
+  type BundleOptions = {
+    bundleType: BundleType;
+    customTransformOptions: CustomTransformOptions;
+    dev: boolean;
+    entryFile: string;
+    readonly excludeSource: boolean;
+    readonly hot: boolean;
+    readonly inlineSourceMap: boolean;
+    minify: boolean;
+    readonly modulesOnly: boolean;
+    onProgress: (doneCont: number, totalCount: number) => unknown | null | undefined;
+    readonly platform: string | null | undefined;
+    readonly runModule: boolean;
+    readonly shallow: boolean;
+    sourceMapUrl: string | null | undefined;
+    sourceUrl: string | null | undefined;
+    createModuleIdFactory?: () => (path: string) => number;
+  };
+
+  type ModuleTransportLike = {
+    readonly code: string;
+    readonly id: number;
+    readonly map: MetroSourceMapOrMappings | null | undefined;
+    readonly name?: string;
+    readonly sourcePath: string;
+  };
+
+  type OutputOptions = {
+    bundleOutput: string;
+    bundleEncoding?: 'utf8' | 'utf16le' | 'ascii';
+    dev?: boolean;
+    indexedRamBundle?: boolean;
+    platform: string;
+    sourcemapOutput?: string;
+    sourcemapSourcesRoot?: string;
+    sourcemapUseAbsolutePath?: boolean;
+  };
+
+  type RequestOptions = {
+    entryFile: string;
+    inlineSourceMap?: boolean;
+    sourceMapUrl?: string;
+    dev?: boolean;
+    minify: boolean;
+    platform: string;
+    createModuleIdFactory?: () => (path: string) => number;
+    onProgress?: (transformedFileCount: number, totalFileCount: number) => void;
+  };
 
   //#endregion
 }

--- a/packages/babel-preset-cli/ts-declarations/react-native-community__cli-server-api/index.d.ts
+++ b/packages/babel-preset-cli/ts-declarations/react-native-community__cli-server-api/index.d.ts
@@ -1,0 +1,33 @@
+/// <reference types="node" />
+/// <reference types="ws" />
+declare module '@react-native-community/cli-server-api' {
+  import http from 'http';
+  import { Server as HttpsServer } from 'https';
+
+  type MiddlewareOptions = {
+    host?: string;
+    watchFolders: ReadonlyArray<string>;
+    port: number;
+  };
+
+  export function createDevServerMiddleware(
+    options: MiddlewareOptions
+  ): {
+    attachToServer(
+      server: http.Server | HttpsServer
+    ): {
+      debuggerProxy: {
+        server: import('ws').Server;
+        isDebuggerConnected(): boolean;
+      };
+      eventsSocket: {
+        reportEvent: (event: any) => void;
+      };
+      messageSocket: {
+        broadcast: (method: string, params?: Record<string, any> | undefined) => void;
+      };
+    };
+    middleware: any;
+  };
+  //# sourceMappingURL=index.d.ts.map
+}

--- a/packages/dev-server/.gitignore
+++ b/packages/dev-server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/packages/dev-server/LICENSE
+++ b/packages/dev-server/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-present 650 Industries, Inc. (aka Expo)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/dev-server/LICENSE
+++ b/packages/dev-server/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-present 650 Industries, Inc. (aka Expo)
+Copyright (c) 2020-present 650 Industries, Inc. (aka Expo)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -1,0 +1,1 @@
+# dev-server

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -1,1 +1,5 @@
 # dev-server
+
+A React Native development server.
+
+This package is used by Expo CLI to run a development server for React Native apps. It is built on [Metro](https://facebook.github.io/metro/) (a JavaScript bundler) and [`@react-native-community/cli-server-api`](https://github.com/react-native-community/cli/tree/master/packages/cli-server-api) (the HTTP and WebSocket API for React Native apps to interface with the development server).

--- a/packages/dev-server/babel.config.js
+++ b/packages/dev-server/babel.config.js
@@ -1,0 +1,11 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    // Only use this when running tests
+    env: {
+      test: {
+        presets: ['@expo/babel-preset-cli'],
+      },
+    },
+  };
+};

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -44,6 +44,7 @@
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.1.4",
     "@expo/metro-config": "0.0.9",
+    "@react-native-community/cli-server-api": "4.8.0",
     "body-parser": "1.19.0",
     "serialize-error": "6.0.0",
     "metro": "0.58.0"

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@expo/dev-server",
+  "version": "0.0.0",
+  "description": "Development servers for starting React Native projects",
+  "main": "build/MetroDevServer.js",
+  "scripts": {
+    "watch": "tsc --watch",
+    "build": "tsc",
+    "prepare": "yarn run clean && yarn build",
+    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "lint": "eslint .",
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "roots": [
+      "src"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo-cli.git",
+    "directory": "packages/dev-server"
+  },
+  "keywords": [
+    "json",
+    "react-native",
+    "expo",
+    "react",
+    "metro",
+    "dev-server",
+    "bundler"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/expo/expo-cli/issues"
+  },
+  "homepage": "https://github.com/expo/expo-cli/tree/master/packages/dev-server#readme",
+  "files": [
+    "build",
+    "external"
+  ],
+  "dependencies": {
+    "@expo/bunyan": "^3.0.2",
+    "@expo/config": "3.1.2",
+    "@expo/metro-config": "0.0.7",
+    "metro": "^0.58.0"
+  },
+  "devDependencies": {
+    "@expo/babel-preset-cli": "^0.2.1",
+    "body-parser": "^1.19.0",
+    "jest": "^25.3.0",
+    "node-fetch": "^2.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -41,10 +41,10 @@
     "external"
   ],
   "dependencies": {
-    "@expo/bunyan": "^3.0.2",
+    "@expo/bunyan": "3.0.2",
     "@expo/config": "3.1.2",
     "@expo/metro-config": "0.0.7",
-    "metro": "^0.58.0"
+    "metro": "0.58.0"
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "^0.2.1",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -44,6 +44,8 @@
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.1.4",
     "@expo/metro-config": "0.0.9",
+    "body-parser": "^1.19.0",
+    "serialize-error": "^6.0.0",
     "metro": "0.58.0"
   },
   "devDependencies": {

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -42,8 +42,8 @@
   ],
   "dependencies": {
     "@expo/bunyan": "3.0.2",
-    "@expo/config": "3.1.2",
-    "@expo/metro-config": "0.0.7",
+    "@expo/config": "3.1.4",
+    "@expo/metro-config": "0.0.9",
     "metro": "0.58.0"
   },
   "devDependencies": {

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -46,8 +46,7 @@
     "@expo/metro-config": "0.0.9",
     "@react-native-community/cli-server-api": "4.8.0",
     "body-parser": "1.19.0",
-    "serialize-error": "6.0.0",
-    "metro": "0.58.0"
+    "serialize-error": "6.0.0"
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "^0.2.1",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -44,8 +44,8 @@
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.1.4",
     "@expo/metro-config": "0.0.9",
-    "body-parser": "^1.19.0",
-    "serialize-error": "^6.0.0",
+    "body-parser": "1.19.0",
+    "serialize-error": "6.0.0",
     "metro": "0.58.0"
   },
   "devDependencies": {

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "^0.2.1",
+    "@types/connect": "^3.4.33",
     "jest": "^25.3.0",
     "node-fetch": "^2.6.0"
   },

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/expo/expo-cli/tree/master/packages/dev-server#readme",
   "files": [
     "build",
-    "external"
+    "!*/__tests__/*"
   ],
   "dependencies": {
     "@expo/bunyan": "3.0.2",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -50,7 +50,6 @@
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "^0.2.1",
-    "body-parser": "^1.19.0",
     "jest": "^25.3.0",
     "node-fetch": "^2.6.0"
   },

--- a/packages/dev-server/src/LogReporter.ts
+++ b/packages/dev-server/src/LogReporter.ts
@@ -1,0 +1,21 @@
+import Log from '@expo/bunyan';
+import { serializeError } from 'serialize-error';
+
+export default class LogReporter {
+  logger: Log;
+  reportEvent: (event: any) => void;
+
+  constructor(logger: Log, reportEvent: (event: any) => void = () => {}) {
+    this.logger = logger;
+    this.reportEvent = reportEvent;
+  }
+
+  update(event: any) {
+    if ('error' in event && event.error instanceof Error) {
+      event.error = serializeError(event.error);
+    }
+    // TODO(ville): replace xdl.PackagerLogsStream with a reporter to avoid serializing to JSON.
+    this.logger.info({ tag: 'metro' }, JSON.stringify(event));
+    this.reportEvent(event);
+  }
+}

--- a/packages/dev-server/src/LogReporter.ts
+++ b/packages/dev-server/src/LogReporter.ts
@@ -2,10 +2,7 @@ import Log from '@expo/bunyan';
 import { serializeError } from 'serialize-error';
 
 export default class LogReporter {
-  logger: Log;
-  reportEvent: (event: any) => void;
-
-  constructor(logger: Log, reportEvent: (event: any) => void = () => {}) {
+  constructor(public logger: Log, public reportEvent: (event: any) => void = () => {}) {
     this.logger = logger;
     this.reportEvent = reportEvent;
   }

--- a/packages/dev-server/src/LogReporter.ts
+++ b/packages/dev-server/src/LogReporter.ts
@@ -11,7 +11,7 @@ export default class LogReporter {
   }
 
   update(event: any) {
-    if ('error' in event && event.error instanceof Error) {
+    if (event.error instanceof Error) {
       event.error = serializeError(event.error);
     }
     // TODO(ville): replace xdl.PackagerLogsStream with a reporter to avoid serializing to JSON.

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -4,10 +4,9 @@ import Log from '@expo/bunyan';
 import * as ExpoMetroConfig from '@expo/metro-config';
 import clientLogsMiddleware from './middleware/clientLogsMiddleware';
 
-export async function runMetroDevServerAsync(
-  projectRoot: string,
-  options: ExpoMetroConfig.LoadOptions & { logger: Log }
-) {
+export type MetroDevServerOptions = ExpoMetroConfig.LoadOptions & { logger: Log };
+
+export async function runMetroDevServerAsync(projectRoot: string, options: MetroDevServerOptions) {
   let reportEvent: ((event: any) => void) | undefined;
   // TODO(ville): implement a reporter
   const reporter = {
@@ -41,4 +40,9 @@ export async function runMetroDevServerAsync(
 
   const { eventsSocket } = attachToServer(serverInstance);
   reportEvent = eventsSocket.reportEvent;
+
+  return {
+    server: serverInstance,
+    middleware,
+  };
 }

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -25,7 +25,7 @@ export async function runMetroDevServerAsync(projectRoot: string, options: Metro
     port: metroConfig.server.port,
     watchFolders: metroConfig.watchFolders,
   });
-  middleware.use(clientLogsMiddleware(options.logger));
+  middleware.use('/logs', clientLogsMiddleware(options.logger));
 
   const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;
   // @ts-ignore can't mutate readonly config

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -1,0 +1,45 @@
+import Metro from 'metro';
+import { createDevServerMiddleware } from '@react-native-community/dev-server-api';
+import Log from '@expo/bunyan';
+import * as ExpoMetroConfig from '@expo/metro-config';
+import clientLogsMiddleware from './middleware/clientLogsMiddleware';
+
+export async function runMetroDevServerAsync(
+  projectRoot: string,
+  options: ExpoMetroConfig.LoadOptions & { logger: Log }
+) {
+  let reportEvent: ((event: any) => void) | undefined;
+  // TODO(ville): implement a reporter
+  const reporter = {
+    update(event: any) {
+      const { type, ...data } = event;
+      console.log(`[${event.type}]`, data);
+      if (reportEvent) {
+        reportEvent(event);
+      }
+    },
+  };
+
+  const metroConfig = await ExpoMetroConfig.loadAsync(projectRoot, { reporter, ...options });
+
+  const { middleware, attachToServer } = createDevServerMiddleware({
+    port: metroConfig.server.port,
+    // @ts-ignore can't pass a mutable array
+    watchFolders: metroConfig.watchFolders,
+  });
+  middleware.use(clientLogsMiddleware(options.logger));
+
+  const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;
+  // @ts-ignore can't mutate readonly config
+  metroConfig.server.enhanceMiddleware = (metroMiddleware: any, server: unknown) => {
+    if (customEnhanceMiddleware) {
+      metroMiddleware = customEnhanceMiddleware(metroMiddleware, server);
+    }
+    return middleware.use(metroMiddleware);
+  };
+
+  const serverInstance = await Metro.runServer(metroConfig, { hmrEnabled: true });
+
+  const { eventsSocket } = attachToServer(serverInstance);
+  reportEvent = eventsSocket.reportEvent;
+}

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -24,14 +24,13 @@ export async function runMetroDevServerAsync(
 
   const { middleware, attachToServer } = createDevServerMiddleware({
     port: metroConfig.server.port,
-    // @ts-ignore can't pass a mutable array
     watchFolders: metroConfig.watchFolders,
   });
   middleware.use(clientLogsMiddleware(options.logger));
 
   const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;
   // @ts-ignore can't mutate readonly config
-  metroConfig.server.enhanceMiddleware = (metroMiddleware: any, server: unknown) => {
+  metroConfig.server.enhanceMiddleware = (metroMiddleware: any, server: Metro.Server) => {
     if (customEnhanceMiddleware) {
       metroMiddleware = customEnhanceMiddleware(metroMiddleware, server);
     }

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -2,6 +2,7 @@ import { getConfig, resolveModule } from '@expo/config';
 import { createDevServerMiddleware } from '@react-native-community/dev-server-api';
 import Log from '@expo/bunyan';
 import * as ExpoMetroConfig from '@expo/metro-config';
+import bodyParser from 'body-parser';
 
 import clientLogsMiddleware from './middleware/clientLogsMiddleware';
 import LogReporter from './LogReporter';
@@ -20,6 +21,7 @@ export async function runMetroDevServerAsync(projectRoot: string, options: Metro
     port: metroConfig.server.port,
     watchFolders: metroConfig.watchFolders,
   });
+  middleware.use(bodyParser.json());
   middleware.use('/logs', clientLogsMiddleware(options.logger));
 
   const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -1,4 +1,4 @@
-import Metro from 'metro';
+import { getConfig, resolveModule } from '@expo/config';
 import { createDevServerMiddleware } from '@react-native-community/dev-server-api';
 import Log from '@expo/bunyan';
 import * as ExpoMetroConfig from '@expo/metro-config';
@@ -7,6 +7,8 @@ import clientLogsMiddleware from './middleware/clientLogsMiddleware';
 export type MetroDevServerOptions = ExpoMetroConfig.LoadOptions & { logger: Log };
 
 export async function runMetroDevServerAsync(projectRoot: string, options: MetroDevServerOptions) {
+  const { exp } = getConfig(projectRoot);
+  const Metro = require(resolveModule('metro', projectRoot, exp));
   let reportEvent: ((event: any) => void) | undefined;
   // TODO(ville): implement a reporter
   const reporter = {

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -19,7 +19,7 @@ export async function runMetroDevServerAsync(projectRoot: string, options: Metro
 
   const { middleware, attachToServer } = createDevServerMiddleware({
     port: metroConfig.server.port,
-    watchFolders: metroConfig.watchFolders,
+    watchFolders: [...metroConfig.watchFolders],
   });
   middleware.use(bodyParser.json());
   middleware.use('/logs', clientLogsMiddleware(options.logger));

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -1,5 +1,5 @@
 import { getConfig, resolveModule } from '@expo/config';
-import { createDevServerMiddleware } from '@react-native-community/dev-server-api';
+import { createDevServerMiddleware } from '@react-native-community/cli-server-api';
 import Log from '@expo/bunyan';
 import * as ExpoMetroConfig from '@expo/metro-config';
 import bodyParser from 'body-parser';
@@ -12,7 +12,7 @@ export type MetroDevServerOptions = ExpoMetroConfig.LoadOptions & { logger: Log 
 export async function runMetroDevServerAsync(projectRoot: string, options: MetroDevServerOptions) {
   const { exp } = getConfig(projectRoot);
   const Metro = require(resolveModule('metro', projectRoot, exp));
-  // TODO(ville): implement a reporter
+
   const reporter = new LogReporter(options.logger);
 
   const metroConfig = await ExpoMetroConfig.loadAsync(projectRoot, { reporter, ...options });

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -10,7 +10,7 @@ import LogReporter from './LogReporter';
 export type MetroDevServerOptions = ExpoMetroConfig.LoadOptions & { logger: Log };
 
 export async function runMetroDevServerAsync(projectRoot: string, options: MetroDevServerOptions) {
-  const { exp } = getConfig(projectRoot);
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   const Metro = require(resolveModule('metro', projectRoot, exp));
 
   const reporter = new LogReporter(options.logger);

--- a/packages/dev-server/src/middleware/__tests__/__snapshots__/clientLogsMiddleware-test.ts.snap
+++ b/packages/dev-server/src/middleware/__tests__/__snapshots__/clientLogsMiddleware-test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`logs messages from the device 1`] = `
+Array [
+  "iPhone: [info] Hello world!",
+  "iPhone: [error] Something went wrong...",
+]
+`;

--- a/packages/dev-server/src/middleware/__tests__/clientLogsMiddleware-test.ts
+++ b/packages/dev-server/src/middleware/__tests__/clientLogsMiddleware-test.ts
@@ -1,0 +1,115 @@
+import http from 'http';
+
+import bodyParser from 'body-parser';
+import bunyan from '@expo/bunyan';
+import connect from 'connect';
+import fetch from 'node-fetch';
+
+import clientLogsMiddleware from '../clientLogsMiddleware';
+
+const headers = {
+  'content-type': 'application/json',
+  'device-id': '11111111-CAFE-0000-0000-111111111111',
+  'session-id': '22222222-C0DE-0000-0000-222222222222',
+  'device-name': 'iPhone',
+};
+
+it('logs messages from the device', async () => {
+  const { server, url, logStream } = await createServerAsync();
+  try {
+    const response = await fetch(`${url}/logs`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify([
+        {
+          count: 1,
+          level: 'info',
+          body: ['Hello world!'],
+          includesStack: false,
+          groupDepth: 0,
+        },
+        {
+          count: 2,
+          level: 'error',
+          body: [
+            {
+              message: 'Something went wrong...',
+              stack: 'App.js:3:12 in <global>',
+            },
+          ],
+          includesStack: true,
+          groupDepth: 0,
+        },
+        {
+          // We want this to be filtered out.
+          count: 3,
+          level: 'info',
+          body: [
+            'BugReporting extraData:',
+            'Object {\n' +
+              '  "AppRegistry.runApplication1": "Running \\"main\\" with yada yada yada",\n' +
+              '}',
+          ],
+          includesStack: false,
+          groupDepth: 0,
+        },
+      ]),
+    });
+    expect(response.ok).toBe(true);
+    expect(logStream.output).toMatchSnapshot();
+  } finally {
+    server.close();
+  }
+});
+
+class TestLogStream {
+  output: string[] = [];
+
+  write(record: any) {
+    const message = record.includesStack ? JSON.parse(record.msg).message : record.msg;
+    const deviceName = record.deviceName ?? '';
+    if (record.level < bunyan.INFO) {
+      this.output.push(`${deviceName}: [debug] ${message}`);
+    } else if (record.level < bunyan.WARN) {
+      this.output.push(`${deviceName}: [info] ${message}`);
+    } else if (record.level < bunyan.ERROR) {
+      this.output.push(`${deviceName}: [warn] ${message}`);
+    } else {
+      this.output.push(`${deviceName}: [error] ${message}`);
+    }
+  }
+}
+
+async function createServerAsync() {
+  const logStream = new TestLogStream();
+  const logger = bunyan.createLogger({
+    name: 'expo-test',
+    streams: [
+      {
+        type: 'raw',
+        stream: logStream,
+        level: 'info',
+      },
+    ],
+  });
+  const app = connect()
+    .use(bodyParser.json())
+    .use(clientLogsMiddleware(logger));
+
+  const server = http.createServer(app);
+  await new Promise((resolve, reject) =>
+    server.listen((error: any) => {
+      if (error) reject(error);
+      else resolve();
+    })
+  );
+
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server has no port');
+
+  return {
+    server,
+    url: `http://localhost:${address.port}`,
+    logStream,
+  };
+}

--- a/packages/dev-server/src/middleware/clientLogsMiddleware.ts
+++ b/packages/dev-server/src/middleware/clientLogsMiddleware.ts
@@ -1,0 +1,83 @@
+import http from 'http';
+import Log from '@expo/bunyan';
+
+export default function clientLogsMiddleware(logger: Log) {
+  return function(
+    req: http.IncomingMessage & { body?: any },
+    res: http.ServerResponse,
+    next: (err?: any) => void
+  ) {
+    try {
+      const deviceId = req.headers['device-id'];
+      const deviceName = req.headers['device-name'];
+      if (deviceId && deviceName && req.body) {
+        _handleDeviceLogs(logger, deviceId.toString(), deviceName.toString(), req.body);
+      }
+    } catch (error) {
+      logger.error({ tag: 'expo' }, `Error getting device logs: ${error} ${error.stack}`);
+      next(error);
+    }
+    res.end('Success');
+  };
+}
+
+function _isIgnorableBugReportingExtraData(body: any[]) {
+  return body.length === 2 && body[0] === 'BugReporting extraData:';
+}
+
+function _isAppRegistryStartupMessage(body: any[]) {
+  return (
+    body.length === 1 &&
+    (/^Running application "main" with appParams:/.test(body[0]) ||
+      /^Running "main" with \{/.test(body[0]))
+  );
+}
+
+type ConsoleLogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+function _handleDeviceLogs(logger: Log, deviceId: string, deviceName: string, logs: any) {
+  for (let i = 0; i < logs.length; i++) {
+    const log = logs[i];
+    let body = typeof log.body === 'string' ? [log.body] : log.body;
+    let { level } = log;
+
+    if (_isIgnorableBugReportingExtraData(body)) {
+      level = 'debug';
+    }
+    if (_isAppRegistryStartupMessage(body)) {
+      body = [`Running application on ${deviceName}.`];
+    }
+
+    const args = body.map((obj: any) => {
+      if (typeof obj === 'undefined') {
+        return 'undefined';
+      }
+      if (obj === 'null') {
+        return 'null';
+      }
+      if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean') {
+        return obj;
+      }
+      try {
+        return JSON.stringify(obj);
+      } catch (e) {
+        return obj.toString();
+      }
+    });
+    const logLevel =
+      level === 'info' || level === 'warn' || level === 'error' || level === 'debug'
+        ? (level as ConsoleLogLevel)
+        : 'info';
+    logger[logLevel](
+      {
+        tag: 'device',
+        deviceId,
+        deviceName,
+        groupDepth: log.groupDepth,
+        shouldHide: log.shouldHide,
+        includesStack: log.includesStack,
+      },
+      ...args
+    );
+  }
+}

--- a/packages/dev-server/src/middleware/clientLogsMiddleware.ts
+++ b/packages/dev-server/src/middleware/clientLogsMiddleware.ts
@@ -12,9 +12,19 @@ export default function clientLogsMiddleware(logger: Log) {
     try {
       const deviceId = req.headers['device-id'];
       const deviceName = req.headers['device-name'];
-      if (deviceId && deviceName && req.body) {
-        handleDeviceLogs(logger, deviceId.toString(), deviceName.toString(), req.body);
+      if (!deviceId) {
+        res.writeHead(400).end('Missing Device-Id.');
+        return;
       }
+      if (!deviceName) {
+        res.writeHead(400).end('Missing Device-Name.');
+        return;
+      }
+      if (!req.body) {
+        res.writeHead(400).end('Missing request body.');
+        return;
+      }
+      handleDeviceLogs(logger, deviceId.toString(), deviceName.toString(), req.body);
     } catch (error) {
       logger.error({ tag: 'expo' }, `Error getting device logs: ${error} ${error.stack}`);
       next(error);

--- a/packages/dev-server/src/middleware/clientLogsMiddleware.ts
+++ b/packages/dev-server/src/middleware/clientLogsMiddleware.ts
@@ -8,7 +8,7 @@ export default function clientLogsMiddleware(logger: Log): HandleFunction {
   return function(
     req: http.IncomingMessage & { body?: any },
     res: http.ServerResponse,
-    next: (err?: any) => void
+    next: (err?: Error) => void
   ) {
     try {
       const deviceId = req.headers['device-id'];

--- a/packages/dev-server/src/middleware/clientLogsMiddleware.ts
+++ b/packages/dev-server/src/middleware/clientLogsMiddleware.ts
@@ -47,8 +47,7 @@ function isAppRegistryStartupMessage(body: any[]): boolean {
 }
 
 function handleDeviceLogs(logger: Log, deviceId: string, deviceName: string, logs: any): void {
-  for (let i = 0; i < logs.length; i++) {
-    const log = logs[i];
+  for (const log of logs) {
     let body = typeof log.body === 'string' ? [log.body] : log.body;
     let { level } = log;
 

--- a/packages/dev-server/src/middleware/clientLogsMiddleware.ts
+++ b/packages/dev-server/src/middleware/clientLogsMiddleware.ts
@@ -1,9 +1,10 @@
 import http from 'http';
+import { HandleFunction } from 'connect';
 import Log from '@expo/bunyan';
 
 type ConsoleLogLevel = 'info' | 'warn' | 'error' | 'debug';
 
-export default function clientLogsMiddleware(logger: Log) {
+export default function clientLogsMiddleware(logger: Log): HandleFunction {
   return function(
     req: http.IncomingMessage & { body?: any },
     res: http.ServerResponse,
@@ -33,11 +34,11 @@ export default function clientLogsMiddleware(logger: Log) {
   };
 }
 
-function isIgnorableBugReportingExtraData(body: any[]) {
+function isIgnorableBugReportingExtraData(body: any[]): boolean {
   return body.length === 2 && body[0] === 'BugReporting extraData:';
 }
 
-function isAppRegistryStartupMessage(body: any[]) {
+function isAppRegistryStartupMessage(body: any[]): boolean {
   return (
     body.length === 1 &&
     (/^Running application "main" with appParams:/.test(body[0]) ||
@@ -45,7 +46,7 @@ function isAppRegistryStartupMessage(body: any[]) {
   );
 }
 
-function handleDeviceLogs(logger: Log, deviceId: string, deviceName: string, logs: any) {
+function handleDeviceLogs(logger: Log, deviceId: string, deviceName: string, logs: any): void {
   for (let i = 0; i < logs.length; i++) {
     const log = logs[i];
     let body = typeof log.body === 'string' ? [log.body] : log.body;

--- a/packages/dev-server/src/middleware/clientLogsMiddleware.ts
+++ b/packages/dev-server/src/middleware/clientLogsMiddleware.ts
@@ -48,7 +48,7 @@ function isAppRegistryStartupMessage(body: any[]): boolean {
 
 function handleDeviceLogs(logger: Log, deviceId: string, deviceName: string, logs: any): void {
   for (const log of logs) {
-    let body = typeof log.body === 'string' ? [log.body] : log.body;
+    let body = Array.isArray(log.body) ? log.body : [log.body];
     let { level } = log;
 
     if (isIgnorableBugReportingExtraData(body)) {

--- a/packages/dev-server/tsconfig.json
+++ b/packages/dev-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@expo/babel-preset-cli/tsconfig.base",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  }
+}

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -34,7 +34,8 @@
     "transformer.js"
   ],
   "dependencies": {
-    "@expo/config": "3.1.4"
+    "@expo/config": "3.1.4",
+    "metro-react-native-babel-transformer": "^0.58.0"
   },
   "peerDependencies": {
     "metro": "^0.56.0",

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -71,7 +71,7 @@ export function getDefaultConfig(
       },
     },
     transformer: {
-      babelTransformerPath: require.resolve('../transformer'),
+      babelTransformerPath: require.resolve('metro-react-native-babel-transformer'),
       // TODO: Bacon: Add path for web platform
       assetRegistryPath: path.join(reactNativePath, 'Libraries/Image/AssetRegistry'),
       assetPlugins: [resolveModule('expo/tools/hashAssetFiles', projectRoot, exp)],

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -27,7 +27,9 @@ export function getDefaultConfig(
   options: DefaultConfigOptions = {}
 ): InputConfigT {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
-  const reactNativePath = resolveModule('react-native', projectRoot, exp);
+  const reactNativePath = path.dirname(
+    resolveModule('react-native/package.json', projectRoot, exp)
+  );
 
   const target = options.target ?? process.env.EXPO_TARGET ?? getDefaultTarget(projectRoot);
   if (!(target === 'managed' || target === 'bare')) {

--- a/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -9,7 +9,7 @@ describe('getDefaultConfig', () => {
     transformer: {
       assetPlugins: expect.arrayContaining([expect.stringContaining('hashAssetFiles')]),
       assetRegistryPath: expect.stringContaining('AssetRegistry'),
-      babelTransformerPath: expect.stringContaining('transformer.js'),
+      babelTransformerPath: expect.stringContaining('metro-react-native-babel-transformer'),
     },
   };
 

--- a/packages/metro-config/src/__tests__/__snapshots__/ExpoMetroConfig-test.ts.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/ExpoMetroConfig-test.ts.snap
@@ -47,7 +47,7 @@ Object {
       StringContaining "hashAssetFiles",
     ],
     "assetRegistryPath": StringContaining "AssetRegistry",
-    "babelTransformerPath": StringContaining "transformer.js",
+    "babelTransformerPath": StringContaining "metro-react-native-babel-transformer",
   },
 }
 `;
@@ -86,7 +86,7 @@ Object {
       StringContaining "hashAssetFiles",
     ],
     "assetRegistryPath": StringContaining "AssetRegistry",
-    "babelTransformerPath": StringContaining "transformer.js",
+    "babelTransformerPath": StringContaining "metro-react-native-babel-transformer",
   },
 }
 `;

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.1.4",
+    "@expo/dev-server": "0.0.0",
     "@expo/json-file": "8.2.12",
     "@expo/ngrok": "2.4.3",
     "@expo/osascript": "2.0.15",

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -38,6 +38,7 @@ import { AddressInfo } from 'net';
 import os from 'os';
 import path from 'path';
 import http from 'http';
+import { URL } from 'url';
 import readLastLines from 'read-last-lines';
 import semver from 'semver';
 import split from 'split';
@@ -1928,6 +1929,13 @@ function shouldExposeEnvironmentVariableInManifest(key: string) {
   return key.startsWith('REACT_NATIVE_') || key.startsWith('EXPO_');
 }
 
+function stripPort(host: string | undefined): string | undefined {
+  if (!host) {
+    return host;
+  }
+  return new URL('/', `http://${host}`).hostname;
+}
+
 function getManifestHandler(projectRoot: string) {
   return async (
     req: express.Request | http.IncomingMessage,
@@ -1965,7 +1973,7 @@ function getManifestHandler(projectRoot: string) {
       let path = `/${encodeURI(mainModuleName)}.bundle?platform=${encodeURIComponent(
         platform
       )}&${queryParams}`;
-      const hostname = req.headers.host;
+      const hostname = stripPort(req.headers.host);
       manifest.bundleUrl =
         (await UrlUtils.constructBundleUrlAsync(projectRoot, bundleUrlPackagerOpts, hostname)) +
         path;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1965,13 +1965,14 @@ function getManifestHandler(projectRoot: string) {
       let path = `/${encodeURI(mainModuleName)}.bundle?platform=${encodeURIComponent(
         platform
       )}&${queryParams}`;
+      const hostname = req.headers.host;
       manifest.bundleUrl =
-        (await UrlUtils.constructBundleUrlAsync(projectRoot, bundleUrlPackagerOpts, req.hostname)) +
+        (await UrlUtils.constructBundleUrlAsync(projectRoot, bundleUrlPackagerOpts, hostname)) +
         path;
-      manifest.debuggerHost = await UrlUtils.constructDebuggerHostAsync(projectRoot, req.hostname);
+      manifest.debuggerHost = await UrlUtils.constructDebuggerHostAsync(projectRoot, hostname);
       manifest.mainModuleName = mainModuleName;
-      manifest.logUrl = await UrlUtils.constructLogUrlAsync(projectRoot, req.hostname);
-      manifest.hostUri = await UrlUtils.constructHostUriAsync(projectRoot, req.hostname);
+      manifest.logUrl = await UrlUtils.constructLogUrlAsync(projectRoot, hostname);
+      manifest.hostUri = await UrlUtils.constructHostUriAsync(projectRoot, hostname);
       await _resolveManifestAssets(
         projectRoot,
         manifest as PublicConfig,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2147,7 +2147,9 @@ async function startDevServerAsync(projectRoot: string, startOptions: StartOptio
     options.maxWorkers = startOptions.maxWorkers;
   }
   if (startOptions.target) {
-    options.target = startOptions.target;
+    // EXPO_TARGET is used by @expo/metro-config to determine the target when getDefaultConfig is
+    // called from metro.config.js and the --target option is used to override the default target.
+    process.env.EXPO_TARGET = options.target;
   }
   const { middleware } = await runMetroDevServerAsync(projectRoot, options);
   middleware.use(getManifestHandler(projectRoot));
@@ -2382,12 +2384,6 @@ export async function startAsync(
     projectRoot,
     developerTool: Config.developerTool,
   });
-
-  if (options.target) {
-    // EXPO_TARGET is used by @expo/metro-config to determine the target when getDefaultConfig is
-    // called from metro.config.js and the --target option is used to override the default target.
-    process.env.EXPO_TARGET = options.target;
-  }
 
   let { exp } = getConfig(projectRoot);
   if (options.webOnly) {

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -25,6 +25,7 @@ const projectSettingsDefaults: ProjectSettings = {
 };
 
 type PackagerInfo = {
+  devServerPort?: number;
   expoServerPort?: number | null;
   packagerPort?: number | null;
   packagerPid?: number | null;

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -25,7 +25,6 @@ const projectSettingsDefaults: ProjectSettings = {
 };
 
 type PackagerInfo = {
-  devServerPort?: number;
   expoServerPort?: number | null;
   packagerPort?: number | null;
   packagerPid?: number | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,6 +2956,13 @@
   dependencies:
     serve-static "^1.13.1"
 
+"@react-native-community/cli-debugger-ui@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.8.0.tgz#9a6419b29be69422e0056bbb1874775750351d22"
+  integrity sha512-Eq9lHINDXiBAwmFRCMN8jeKk6FTDnTxAfITkjPUNNTj7q3K+fH/oyOMJjxbIZbryIJY6g+g/ln6vsS2WzISNYQ==
+  dependencies:
+    serve-static "^1.13.1"
+
 "@react-native-community/cli-platform-android@^3.0.0-alpha.1":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-3.1.4.tgz#61f964dc311623e60b0fb29c5f3732cc8a6f076f"
@@ -2979,6 +2986,20 @@
     js-yaml "^3.13.1"
     xcode "^2.0.0"
 
+"@react-native-community/cli-server-api@4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-4.8.0.tgz#d66a14a8e3258f5e3ab3325acaa3b6783f1aab32"
+  integrity sha512-LqsxavpgqOhF+4wtQcl67c4kbPq8vI1SLE0zrs3WQv2HMwKlaWrEQobpkZdttJk59R5VMBzn0+HwOBDNsPoFSw==
+  dependencies:
+    "@react-native-community/cli-debugger-ui" "^4.8.0"
+    "@react-native-community/cli-tools" "^4.8.0"
+    compression "^1.7.1"
+    connect "^3.6.5"
+    errorhandler "^1.5.0"
+    pretty-format "^25.1.0"
+    serve-static "^1.13.1"
+    ws "^1.1.0"
+
 "@react-native-community/cli-tools@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-3.0.0.tgz#fe48b80822ed7e49b8af051f9fe41e22a2a710b1"
@@ -2988,6 +3009,18 @@
     lodash "^4.17.5"
     mime "^2.4.1"
     node-fetch "^2.5.0"
+
+"@react-native-community/cli-tools@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-4.8.0.tgz#144a029c741c2cf40a7f9c059819ce9a69e7f1e3"
+  integrity sha512-voXGruhYyyhCbEYM2uZ54dMZcBgXFFcQxVK3nLwJDG9nSQGObZInj9Zf76ix5qGnvKKGWIGUcbmRhyLpAzTXuQ==
+  dependencies:
+    chalk "^3.0.0"
+    lodash "^4.17.15"
+    mime "^2.4.1"
+    node-fetch "^2.6.0"
+    open "^6.2.0"
+    shell-quote "1.6.1"
 
 "@react-native-community/cli-types@^3.0.0":
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19320,6 +19320,13 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+serialize-error@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-6.0.0.tgz#ccfb887a1dd1c48d6d52d7863b92544331fd752b"
+  integrity sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==
+  dependencies:
+    type-fest "^0.12.0"
+
 serialize-error@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
@@ -19331,13 +19338,6 @@ serialize-error@^5.0.0:
   integrity sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==
   dependencies:
     type-fest "^0.8.0"
-
-serialize-error@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-6.0.0.tgz#ccfb887a1dd1c48d6d52d7863b92544331fd752b"
-  integrity sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==
-  dependencies:
-    type-fest "^0.12.0"
 
 serialize-javascript@1.6.1:
   version "1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3224,6 +3224,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/connect@^3.4.33":
+  version "3.4.33"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
+  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/copy-webpack-plugin@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/copy-webpack-plugin/-/copy-webpack-plugin-5.0.0.tgz#db7f9c9763b10b2af5c83f598fa9b5a13733b20b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,7 +568,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
+"@babel/plugin-syntax-object-rest-spread@^7.0.0":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz#47cf220d19d6d0d7b154304701f468fc1cc6ff46"
+  integrity sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
@@ -1340,7 +1347,7 @@
     plist "^3.0.1"
     uuid "^3.3.3"
 
-"@expo/bunyan@3.0.2":
+"@expo/bunyan@3.0.2", "@expo/bunyan@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@expo/bunyan/-/bunyan-3.0.2.tgz#775680bd479a8b79ada4a5676936a58eef1579c9"
   integrity sha512-fQRc4+RG+rEw1IdjFx/5t2AvOlJT8ktv2dfObD3aW838ohZxCx1QvFUY/Gdx5JA1JY/KrHRGuEqQLH9ayiexyg==
@@ -1586,6 +1593,16 @@
     jest-util "^25.2.6"
     slash "^3.0.0"
 
+"@jest/console@^25.3.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-25.3.0.tgz#33b56b81238427bf3ebe3f7b3378d2f79cdbd409"
+  integrity sha512-LvSDNqpmZIZyweFaEQ6wKY7CbexPitlsLHGJtcooNECo0An/w49rFhjCJzu6efeb6+a3ee946xss1Jcd9r03UQ==
+  dependencies:
+    "@jest/source-map" "^25.2.6"
+    chalk "^3.0.0"
+    jest-util "^25.3.0"
+    slash "^3.0.0"
+
 "@jest/core@^25.2.6":
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-25.2.6.tgz#4bcb2919268d92c3813e1ff7c97443cde7a2873a"
@@ -1620,6 +1637,40 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/core@^25.3.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-25.3.0.tgz#80f97a7a8b59dde741a24f30871cc26d0197d426"
+  integrity sha512-+D5a/tFf6pA/Gqft2DLBp/yeSRgXhlJ+Wpst0X/ZkfTRP54qDR3C61VfHwaex+GzZBiTcE9vQeoZ2v5T10+Mqw==
+  dependencies:
+    "@jest/console" "^25.3.0"
+    "@jest/reporters" "^25.3.0"
+    "@jest/test-result" "^25.3.0"
+    "@jest/transform" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.3"
+    jest-changed-files "^25.3.0"
+    jest-config "^25.3.0"
+    jest-haste-map "^25.3.0"
+    jest-message-util "^25.3.0"
+    jest-regex-util "^25.2.6"
+    jest-resolve "^25.3.0"
+    jest-resolve-dependencies "^25.3.0"
+    jest-runner "^25.3.0"
+    jest-runtime "^25.3.0"
+    jest-snapshot "^25.3.0"
+    jest-util "^25.3.0"
+    jest-validate "^25.3.0"
+    jest-watcher "^25.3.0"
+    micromatch "^4.0.2"
+    p-each-series "^2.1.0"
+    realpath-native "^2.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
 "@jest/environment@^25.2.6":
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-25.2.6.tgz#8f7931e79abd81893ce88b7306f0cc4744835000"
@@ -1628,6 +1679,15 @@
     "@jest/fake-timers" "^25.2.6"
     "@jest/types" "^25.2.6"
     jest-mock "^25.2.6"
+
+"@jest/environment@^25.3.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-25.3.0.tgz#587f28ddb4b0dfe97404d3d4a4c9dbfa0245fb2e"
+  integrity sha512-vgooqwJTHLLak4fE+TaCGeYP7Tz1Y3CKOsNxR1sE0V3nx3KRUHn3NUnt+wbcfd5yQWKZQKAfW6wqbuwQLrXo3g==
+  dependencies:
+    "@jest/fake-timers" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    jest-mock "^25.3.0"
 
 "@jest/fake-timers@^24.9.0":
   version "24.9.0"
@@ -1647,6 +1707,17 @@
     jest-message-util "^25.2.6"
     jest-mock "^25.2.6"
     jest-util "^25.2.6"
+    lolex "^5.0.0"
+
+"@jest/fake-timers@^25.3.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-25.3.0.tgz#995aad36d5c8984165ca5db12e740ab8dbf7042a"
+  integrity sha512-NHAj7WbsyR3qBJPpBwSwqaq2WluIvUQsyzpJTN7XDVk7VnlC/y1BAnaYZL3vbPIP8Nhm0Ae5DJe0KExr/SdMJQ==
+  dependencies:
+    "@jest/types" "^25.3.0"
+    jest-message-util "^25.3.0"
+    jest-mock "^25.3.0"
+    jest-util "^25.3.0"
     lolex "^5.0.0"
 
 "@jest/reporters@^25.2.6":
@@ -1671,6 +1742,37 @@
     jest-haste-map "^25.2.6"
     jest-resolve "^25.2.6"
     jest-util "^25.2.6"
+    jest-worker "^25.2.6"
+    slash "^3.0.0"
+    source-map "^0.6.0"
+    string-length "^3.1.0"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^4.0.1"
+  optionalDependencies:
+    node-notifier "^6.0.0"
+
+"@jest/reporters@^25.3.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-25.3.0.tgz#7f39f0e6911561cc5112a1b54656de18faee269b"
+  integrity sha512-1u0ZBygs0C9DhdYgLCrRfZfNKQa+9+J7Uo+Z9z0RWLHzgsxhoG32lrmMOtUw48yR6bLNELdvzormwUqSk4H4Vg==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^25.3.0"
+    "@jest/test-result" "^25.3.0"
+    "@jest/transform" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.2"
+    jest-haste-map "^25.3.0"
+    jest-resolve "^25.3.0"
+    jest-util "^25.3.0"
     jest-worker "^25.2.6"
     slash "^3.0.0"
     source-map "^0.6.0"
@@ -1717,6 +1819,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
+"@jest/test-result@^25.3.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-25.3.0.tgz#137fab5e5c6fed36e5d40735d1eb029325e3bf06"
+  integrity sha512-mqrGuiiPXl1ap09Mydg4O782F3ouDQfsKqtQzIjitpwv3t1cHDwCto21jThw6WRRE+dKcWQvLG70GpyLJICfGw==
+  dependencies:
+    "@jest/console" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
 "@jest/test-sequencer@^25.2.6":
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-25.2.6.tgz#62026007610b0323e646ad70db59c69c7ed4785c"
@@ -1726,6 +1838,16 @@
     jest-haste-map "^25.2.6"
     jest-runner "^25.2.6"
     jest-runtime "^25.2.6"
+
+"@jest/test-sequencer@^25.3.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-25.3.0.tgz#271ad5f2b8f8137d092ccedc87e16a50f8676209"
+  integrity sha512-Xvns3xbji7JCvVcDGvqJ/pf4IpmohPODumoPEZJ0/VgC5gI4XaNVIBET2Dq5Czu6Gk3xFcmhtthh/MBOTljdNg==
+  dependencies:
+    "@jest/test-result" "^25.3.0"
+    jest-haste-map "^25.3.0"
+    jest-runner "^25.3.0"
+    jest-runtime "^25.3.0"
 
 "@jest/transform@^25.2.6", "@jest/transform@^25.3.0":
   version "25.3.0"
@@ -5166,7 +5288,7 @@ babel-extract-comments@^1.0.0:
   dependencies:
     babylon "^6.18.0"
 
-babel-jest@^25.2.0, babel-jest@^25.2.6:
+babel-jest@^25.2.0, babel-jest@^25.2.6, babel-jest@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.3.0.tgz#999d0c19e8427f66b796bf9ea233eedf087b957c"
   integrity sha512-qiXeX1Cmw4JZ5yQ4H57WpkO0MZ61Qj+YnsVUwAMnDV5ls+yHon11XjarDdgP7H8lTmiEi6biiZA8y3Tmvx6pCg==
@@ -5567,7 +5689,7 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -8931,6 +9053,18 @@ expect@^25.2.6:
     jest-message-util "^25.2.6"
     jest-regex-util "^25.2.6"
 
+expect@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-25.3.0.tgz#5fd36e51befd05afb7184bc954f8a4792d184c71"
+  integrity sha512-buboTXML2h/L0Kh44Ys2Cx49mX20ISc5KDirkxIs3Q9AJv0kazweUAbukegr+nHDOvFRKmxdojjIHCjqAceYfg==
+  dependencies:
+    "@jest/types" "^25.3.0"
+    ansi-styles "^4.0.0"
+    jest-get-type "^25.2.6"
+    jest-matcher-utils "^25.3.0"
+    jest-message-util "^25.3.0"
+    jest-regex-util "^25.2.6"
+
 expo-asset@~8.1.3:
   version "8.1.4"
   resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-8.1.4.tgz#5265c28c1c279b2f9779269195bec4caf250ba5d"
@@ -12046,6 +12180,14 @@ istanbul-reports@^3.0.0:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+istanbul-reports@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
+  integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 iterall@1.2.2, iterall@^1.1.3, iterall@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
@@ -12057,6 +12199,15 @@ jest-changed-files@^25.2.6:
   integrity sha512-F7l2m5n55jFnJj4ItB9XbAlgO+6umgvz/mdK76BfTd2NGkvGf9x96hUXP/15a1K0k14QtVOoutwpRKl360msvg==
   dependencies:
     "@jest/types" "^25.2.6"
+    execa "^3.2.0"
+    throat "^5.0.0"
+
+jest-changed-files@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-25.3.0.tgz#85d8de6f4bd13dafda9d7f1e3f2565fc0e183c78"
+  integrity sha512-eqd5hyLbUjIVvLlJ3vQ/MoPxsxfESVXG9gvU19XXjKzxr+dXmZIqCXiY0OiYaibwlHZBJl2Vebkc0ADEMzCXew==
+  dependencies:
+    "@jest/types" "^25.3.0"
     execa "^3.2.0"
     throat "^5.0.0"
 
@@ -12075,6 +12226,25 @@ jest-cli@^25.2.6:
     jest-config "^25.2.6"
     jest-util "^25.2.6"
     jest-validate "^25.2.6"
+    prompts "^2.0.1"
+    realpath-native "^2.0.0"
+    yargs "^15.3.1"
+
+jest-cli@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-25.3.0.tgz#d9e11f5700cc5946583cf0d01a9bdebceed448d2"
+  integrity sha512-XpNQPlW1tzpP7RGG8dxpkRegYDuLjzSiENu92+CYM87nEbmEPb3b4+yo8xcsHOnj0AG7DUt9b3uG8LuHI3MDzw==
+  dependencies:
+    "@jest/core" "^25.3.0"
+    "@jest/test-result" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    import-local "^3.0.2"
+    is-ci "^2.0.0"
+    jest-config "^25.3.0"
+    jest-util "^25.3.0"
+    jest-validate "^25.3.0"
     prompts "^2.0.1"
     realpath-native "^2.0.0"
     yargs "^15.3.1"
@@ -12103,6 +12273,30 @@ jest-config@^25.2.6:
     pretty-format "^25.2.6"
     realpath-native "^2.0.0"
 
+jest-config@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-25.3.0.tgz#112b5e2f2e57dec4501dd2fe979044c06fb1317e"
+  integrity sha512-CmF1JnNWFmoCSPC4tnU52wnVBpuxHjilA40qH/03IHxIevkjUInSMwaDeE6ACfxMPTLidBGBCO3EbxvzPbo8wA==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    babel-jest "^25.3.0"
+    chalk "^3.0.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.1"
+    jest-environment-jsdom "^25.3.0"
+    jest-environment-node "^25.3.0"
+    jest-get-type "^25.2.6"
+    jest-jasmine2 "^25.3.0"
+    jest-regex-util "^25.2.6"
+    jest-resolve "^25.3.0"
+    jest-util "^25.3.0"
+    jest-validate "^25.3.0"
+    micromatch "^4.0.2"
+    pretty-format "^25.3.0"
+    realpath-native "^2.0.0"
+
 jest-dev-server@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/jest-dev-server/-/jest-dev-server-4.3.0.tgz#27c9cdc96d9f735bc90a309ca39305b76f2c0edd"
@@ -12126,10 +12320,27 @@ jest-diff@^25.1.0, jest-diff@^25.2.6:
     jest-get-type "^25.2.6"
     pretty-format "^25.2.6"
 
+jest-diff@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.3.0.tgz#0d7d6f5d6171e5dacde9e05be47b3615e147c26f"
+  integrity sha512-vyvs6RPoVdiwARwY4kqFWd4PirPLm2dmmkNzKqo38uZOzJvLee87yzDjIZLmY1SjM3XR5DwsUH+cdQ12vgqi1w==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.6"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.3.0"
+
 jest-docblock@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.2.6.tgz#4b09f1e7b7d6b3f39242ef3647ac7106770f722b"
   integrity sha512-VAYrljEq0upq0oERfIaaNf28gC6p9gORndhHstCYF8NWGNQJnzoaU//S475IxfWMk4UjjVmS9rJKLe5Jjjbixw==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-docblock@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.3.0.tgz#8b777a27e3477cd77a168c05290c471a575623ef"
+  integrity sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==
   dependencies:
     detect-newline "^3.0.0"
 
@@ -12144,6 +12355,17 @@ jest-each@^25.2.6:
     jest-util "^25.2.6"
     pretty-format "^25.2.6"
 
+jest-each@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-25.3.0.tgz#a319eecf1f6076164ab86f99ca166a55b96c0bd4"
+  integrity sha512-aBfS4VOf/Qs95yUlX6d6WBv0szvOcTkTTyCIaLuQGj4bSHsT+Wd9dDngVHrCe5uytxpN8VM+NAloI6nbPjXfXw==
+  dependencies:
+    "@jest/types" "^25.3.0"
+    chalk "^3.0.0"
+    jest-get-type "^25.2.6"
+    jest-util "^25.3.0"
+    pretty-format "^25.3.0"
+
 jest-environment-jsdom@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.2.6.tgz#b7ae41c6035905b8e58d63a8f63cf8eaa00af279"
@@ -12156,6 +12378,18 @@ jest-environment-jsdom@^25.2.6:
     jest-util "^25.2.6"
     jsdom "^15.2.1"
 
+jest-environment-jsdom@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.3.0.tgz#c493ab8c41f28001520c70ef67dd88b88be6af05"
+  integrity sha512-jdE4bQN+k2QEZ9sWOxsqDJvMzbdFSCN/4tw8X0TQaCqyzKz58PyEf41oIr4WO7ERdp7WaJGBSUKF7imR3UW1lg==
+  dependencies:
+    "@jest/environment" "^25.3.0"
+    "@jest/fake-timers" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    jest-mock "^25.3.0"
+    jest-util "^25.3.0"
+    jsdom "^15.2.1"
+
 jest-environment-node@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-25.2.6.tgz#ad4398432867113f474d94fe37b071ed04b30f3d"
@@ -12166,6 +12400,18 @@ jest-environment-node@^25.2.6:
     "@jest/types" "^25.2.6"
     jest-mock "^25.2.6"
     jest-util "^25.2.6"
+    semver "^6.3.0"
+
+jest-environment-node@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-25.3.0.tgz#9845f0e63991e8498448cb0ae804935689533db9"
+  integrity sha512-XO09S29Nx1NU7TiMPHMoDIkxoGBuKSTbE+sHp0gXbeLDXhIdhysUI25kOqFFSD9AuDgvPvxWCXrvNqiFsOH33g==
+  dependencies:
+    "@jest/environment" "^25.3.0"
+    "@jest/fake-timers" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    jest-mock "^25.3.0"
+    jest-util "^25.3.0"
     semver "^6.3.0"
 
 jest-environment-puppeteer@^4.3.0:
@@ -12249,6 +12495,29 @@ jest-jasmine2@^25.2.6:
     pretty-format "^25.2.6"
     throat "^5.0.0"
 
+jest-jasmine2@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-25.3.0.tgz#16ae4f68adef65fb45001b26c864bcbcbf972830"
+  integrity sha512-NCYOGE6+HNzYFSui52SefgpsnIzvxjn6KAgqw66BdRp37xpMD/4kujDHLNW5bS5i53os5TcMn6jYrzQRO8VPrQ==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^25.3.0"
+    "@jest/source-map" "^25.2.6"
+    "@jest/test-result" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    chalk "^3.0.0"
+    co "^4.6.0"
+    expect "^25.3.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^25.3.0"
+    jest-matcher-utils "^25.3.0"
+    jest-message-util "^25.3.0"
+    jest-runtime "^25.3.0"
+    jest-snapshot "^25.3.0"
+    jest-util "^25.3.0"
+    pretty-format "^25.3.0"
+    throat "^5.0.0"
+
 jest-leak-detector@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.2.6.tgz#68fbaf651142292b03e30641f33e15af9b8c62b1"
@@ -12256,6 +12525,14 @@ jest-leak-detector@^25.2.6:
   dependencies:
     jest-get-type "^25.2.6"
     pretty-format "^25.2.6"
+
+jest-leak-detector@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.3.0.tgz#5b6bf04903b35be56038915a55f47291771f769f"
+  integrity sha512-jk7k24dMIfk8LUSQQGN8PyOy9+J0NAfHZWiDmUDYVMctY8FLJQ1eQ8+PjMoN8PgwhLIggUqgYJnyRFvUz3jLRw==
+  dependencies:
+    jest-get-type "^25.2.6"
+    pretty-format "^25.3.0"
 
 jest-matcher-utils@^25.2.6:
   version "25.2.6"
@@ -12266,6 +12543,16 @@ jest-matcher-utils@^25.2.6:
     jest-diff "^25.2.6"
     jest-get-type "^25.2.6"
     pretty-format "^25.2.6"
+
+jest-matcher-utils@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.3.0.tgz#76765788a26edaa8bc5f0100aea52ae383559648"
+  integrity sha512-ZBUJ2fchNIZt+fyzkuCFBb8SKaU//Rln45augfUtbHaGyVxCO++ANARdBK9oPGXU3hEDgyy7UHnOP/qNOJXFUg==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.3.0"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.3.0"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -12294,6 +12581,19 @@ jest-message-util@^25.2.6:
     slash "^3.0.0"
     stack-utils "^1.0.1"
 
+jest-message-util@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-25.3.0.tgz#e3836826fe5ca538a337b87d9bd2648190867f85"
+  integrity sha512-5QNy9Id4WxJbRITEbA1T1kem9bk7y2fD0updZMSTNHtbEDnYOGLDPAuFBhFgVmOZpv0n6OMdVkK+WhyXEPCcOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^25.3.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^3.0.0"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
+    stack-utils "^1.0.1"
+
 jest-mock@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"
@@ -12307,6 +12607,13 @@ jest-mock@^25.2.6:
   integrity sha512-vc4nibavi2RGPdj/MyZy/azuDjZhpYZLvpfgq1fxkhbyTpKVdG7CgmRVKJ7zgLpY5kuMjTzDYA6QnRwhsCU+tA==
   dependencies:
     "@jest/types" "^25.2.6"
+
+jest-mock@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.3.0.tgz#d72644509e40987a732a9a2534a1054f4649402c"
+  integrity sha512-yRn6GbuqB4j3aYu+Z1ezwRiZfp0o9om5uOcBovVtkcRLeBCNP5mT0ysdenUsxAHnQUgGwPOE1wwhtQYe6NKirQ==
+  dependencies:
+    "@jest/types" "^25.3.0"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
@@ -12335,12 +12642,33 @@ jest-resolve-dependencies@^25.2.6:
     jest-regex-util "^25.2.6"
     jest-snapshot "^25.2.6"
 
+jest-resolve-dependencies@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-25.3.0.tgz#b0e4ae053dd44ddacc18c6ee12b5b7c28e445a90"
+  integrity sha512-bDUlLYmHW+f7J7KgcY2lkq8EMRqKonRl0XoD4Wp5SJkgAxKJnsaIOlrrVNTfXYf+YOu3VCjm/Ac2hPF2nfsCIA==
+  dependencies:
+    "@jest/types" "^25.3.0"
+    jest-regex-util "^25.2.6"
+    jest-snapshot "^25.3.0"
+
 jest-resolve@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-25.2.6.tgz#84694ead5da13c2890ac04d4a78699ba937f3896"
   integrity sha512-7O61GVdcAXkLz/vNGKdF+00A80/fKEAA47AEXVNcZwj75vEjPfZbXDaWFmAQCyXj4oo9y9dC9D+CLA11t8ieGw==
   dependencies:
     "@jest/types" "^25.2.6"
+    browser-resolve "^1.11.3"
+    chalk "^3.0.0"
+    jest-pnp-resolver "^1.2.1"
+    realpath-native "^2.0.0"
+    resolve "^1.15.1"
+
+jest-resolve@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-25.3.0.tgz#cb90a5bbea54a02eccdbbf4126a819595dcf91d6"
+  integrity sha512-IHoQAAybulsJ+ZgWis+ekYKDAoFkVH5Nx/znpb41zRtpxj4fr2WNV9iDqavdSm8GIpMlsfZxbC/fV9DhW0q9VQ==
+  dependencies:
+    "@jest/types" "^25.3.0"
     browser-resolve "^1.11.3"
     chalk "^3.0.0"
     jest-pnp-resolver "^1.2.1"
@@ -12372,6 +12700,31 @@ jest-runner@^25.2.6:
     source-map-support "^0.5.6"
     throat "^5.0.0"
 
+jest-runner@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-25.3.0.tgz#673ef2ac79d2810eb6b2c1a3f82398375a3d1174"
+  integrity sha512-csDqSC9qGHYWDrzrElzEgFbteztFeZJmKhSgY5jlCIcN0+PhActzRNku0DA1Xa1HxGOb0/AfbP1EGJlP4fGPtA==
+  dependencies:
+    "@jest/console" "^25.3.0"
+    "@jest/environment" "^25.3.0"
+    "@jest/test-result" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.3"
+    jest-config "^25.3.0"
+    jest-docblock "^25.3.0"
+    jest-haste-map "^25.3.0"
+    jest-jasmine2 "^25.3.0"
+    jest-leak-detector "^25.3.0"
+    jest-message-util "^25.3.0"
+    jest-resolve "^25.3.0"
+    jest-runtime "^25.3.0"
+    jest-util "^25.3.0"
+    jest-worker "^25.2.6"
+    source-map-support "^0.5.6"
+    throat "^5.0.0"
+
 jest-runtime@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-25.2.6.tgz#417e8d548c92bd10e659393a3bd5aa8cbdd71e6d"
@@ -12398,6 +12751,37 @@ jest-runtime@^25.2.6:
     jest-snapshot "^25.2.6"
     jest-util "^25.2.6"
     jest-validate "^25.2.6"
+    realpath-native "^2.0.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^15.3.1"
+
+jest-runtime@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-25.3.0.tgz#af4d40dbcc590fa5de9910cb6a120a13d131050b"
+  integrity sha512-gn5KYB1wxXRM3nfw8fVpthFu60vxQUCr+ShGq41+ZBFF3DRHZRKj3HDWVAVB4iTNBj2y04QeAo5cZ/boYaPg0w==
+  dependencies:
+    "@jest/console" "^25.3.0"
+    "@jest/environment" "^25.3.0"
+    "@jest/source-map" "^25.2.6"
+    "@jest/test-result" "^25.3.0"
+    "@jest/transform" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.3"
+    jest-config "^25.3.0"
+    jest-haste-map "^25.3.0"
+    jest-message-util "^25.3.0"
+    jest-mock "^25.3.0"
+    jest-regex-util "^25.2.6"
+    jest-resolve "^25.3.0"
+    jest-snapshot "^25.3.0"
+    jest-util "^25.3.0"
+    jest-validate "^25.3.0"
     realpath-native "^2.0.0"
     slash "^3.0.0"
     strip-bom "^4.0.0"
@@ -12436,6 +12820,26 @@ jest-snapshot@^25.2.6:
     make-dir "^3.0.0"
     natural-compare "^1.4.0"
     pretty-format "^25.2.6"
+    semver "^6.3.0"
+
+jest-snapshot@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-25.3.0.tgz#d4feb457494f4aaedcc83fbbf1ca21808fc3df71"
+  integrity sha512-GGpR6Oro2htJPKh5RX4PR1xwo5jCEjtvSPLW1IS7N85y+2bWKbiknHpJJRKSdGXghElb5hWaeQASJI4IiRayGg==
+  dependencies:
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^25.3.0"
+    "@types/prettier" "^1.19.0"
+    chalk "^3.0.0"
+    expect "^25.3.0"
+    jest-diff "^25.3.0"
+    jest-get-type "^25.2.6"
+    jest-matcher-utils "^25.3.0"
+    jest-message-util "^25.3.0"
+    jest-resolve "^25.3.0"
+    make-dir "^3.0.0"
+    natural-compare "^1.4.0"
+    pretty-format "^25.3.0"
     semver "^6.3.0"
 
 jest-util@^24.9.0:
@@ -12490,6 +12894,18 @@ jest-validate@^25.2.6:
     leven "^3.1.0"
     pretty-format "^25.2.6"
 
+jest-validate@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-25.3.0.tgz#eb95fdee0039647bcd5d4be641b21e4a142a880c"
+  integrity sha512-3WuXgIZ4HXUvW6gk9twFFkT9j6zUorKnF2oEY8VEsHb7x5LGvVlN3WUsbqazVKuyXwvikO2zFJ/YTySMsMje2w==
+  dependencies:
+    "@jest/types" "^25.3.0"
+    camelcase "^5.3.1"
+    chalk "^3.0.0"
+    jest-get-type "^25.2.6"
+    leven "^3.1.0"
+    pretty-format "^25.3.0"
+
 jest-watcher@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-25.2.6.tgz#19fc571d27f89a238ef497b9e037d8d41cf4a204"
@@ -12500,6 +12916,18 @@ jest-watcher@^25.2.6:
     ansi-escapes "^4.2.1"
     chalk "^3.0.0"
     jest-util "^25.2.6"
+    string-length "^3.1.0"
+
+jest-watcher@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-25.3.0.tgz#fd03fd5ca52f02bd3161ab177466bf1bfdd34e5c"
+  integrity sha512-dtFkfidFCS9Ucv8azOg2hkiY3sgJEHeTLtGFHS+jfBEE7eRtrO6+2r1BokyDkaG2FOD7485r/SgpC1MFAENfeA==
+  dependencies:
+    "@jest/test-result" "^25.3.0"
+    "@jest/types" "^25.3.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    jest-util "^25.3.0"
     string-length "^3.1.0"
 
 jest-worker@^24.6.0, jest-worker@^24.9.0:
@@ -12526,6 +12954,15 @@ jest@^25.2.6:
     "@jest/core" "^25.2.6"
     import-local "^3.0.2"
     jest-cli "^25.2.6"
+
+jest@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-25.3.0.tgz#7a5e59741d94b8662664c77a9f346246d6bf228b"
+  integrity sha512-iKd5ShQSHzFT5IL/6h5RZJhApgqXSoPxhp5HEi94v6OAw9QkF8T7X+liEU2eEHJ1eMFYTHmeWLrpBWulsDpaUg==
+  dependencies:
+    "@jest/core" "^25.3.0"
+    import-local "^3.0.2"
+    jest-cli "^25.3.0"
 
 jetifier@^1.6.2:
   version "1.6.5"
@@ -13868,6 +14305,24 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+metro-babel-register@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.58.0.tgz#5c44786d49a044048df56cf476a2263491d4f53a"
+  integrity sha512-P5+G3ufhSYL6cA3a7xkbSJzzFBvtivj/PhWvGXFXnuFssDlMAX1CTktff+0gpka5Cd6B6QLt0UAMWulUAAE4Eg==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-proposal-class-properties" "^7.0.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
+    "@babel/plugin-transform-async-to-generator" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
+    "@babel/register" "^7.0.0"
+    core-js "^2.2.2"
+    escape-string-regexp "^1.0.5"
+
 metro-babel-register@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.59.0.tgz#2bcff65641b36794cf083ba732fbc46cf870fb43"
@@ -13900,6 +14355,14 @@ metro-babel-register@^0.56.0, metro-babel-register@^0.56.4:
     core-js "^2.2.2"
     escape-string-regexp "^1.0.5"
 
+metro-babel-transformer@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.58.0.tgz#317c83b863cceb0573943815f1711fbcbe69b106"
+  integrity sha512-yBX3BkRhw2TCNPhe+pmLSgsAEA3huMvnX08UwjFqSXXI1aiqzRQobn92uKd1U5MM1Vx8EtXVomlJb95ZHNAv6A==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    metro-source-map "0.58.0"
+
 metro-babel-transformer@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.59.0.tgz#dda99c75d831b00142c42c020c51c103b29f199d"
@@ -13915,6 +14378,16 @@ metro-babel-transformer@^0.56.4:
   dependencies:
     "@babel/core" "^7.0.0"
     metro-source-map "^0.56.4"
+
+metro-cache@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.58.0.tgz#630ea0a4626dfb9591c71fdb85dce14b5e9a04ec"
+  integrity sha512-jjW9zCTKxhgKcVkyQ6LHyna9Zdf4TK/45vvT1fPyyTk1RY82ZYjU1qs+84ycKEd08Ka4YcK9xcUew9SIDJYI8Q==
+  dependencies:
+    jest-serializer "^24.4.0"
+    metro-core "0.58.0"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
 
 metro-cache@0.59.0:
   version "0.59.0"
@@ -13935,6 +14408,18 @@ metro-cache@^0.56.4:
     metro-core "^0.56.4"
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
+
+metro-config@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.58.0.tgz#1e24b43a5a00971d75662b1a0d3c04a13d4a1746"
+  integrity sha512-4vgBliXwL56vjUlYplvGMVSNrJJpkHuLcD+O20trV3FvPxKg4ZsvuOcNSxqDSMU26FCtIEJ15ojcuCbRL7KY0w==
+  dependencies:
+    cosmiconfig "^5.0.5"
+    jest-validate "^24.7.0"
+    metro "0.58.0"
+    metro-cache "0.58.0"
+    metro-core "0.58.0"
+    pretty-format "^24.7.0"
 
 metro-config@0.59.0, metro-config@^0.59.0:
   version "0.59.0"
@@ -13959,6 +14444,16 @@ metro-config@^0.56.0, metro-config@^0.56.4:
     metro-core "^0.56.4"
     pretty-format "^24.7.0"
 
+metro-core@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.58.0.tgz#ad9f6645a2b439a3fbce7ce4e19b01b00375768a"
+  integrity sha512-RzXUjGFmCLOyzUqcKDvr91AldGtIOxnzNZrWUIiG8uC3kerVLo0mQp4YH3+XVm6fMNiLMg6iER7HLqD+MbpUjQ==
+  dependencies:
+    jest-haste-map "^24.7.1"
+    lodash.throttle "^4.1.1"
+    metro-resolver "0.58.0"
+    wordwrap "^1.0.0"
+
 metro-core@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.59.0.tgz#958cde3fe5c8cd84a78e1899af801ad69e9c83b1"
@@ -13978,6 +14473,17 @@ metro-core@^0.56.0, metro-core@^0.56.4:
     lodash.throttle "^4.1.1"
     metro-resolver "^0.56.4"
     wordwrap "^1.0.0"
+
+metro-inspector-proxy@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.58.0.tgz#6fefb0cdf25655919d56c82ebe09cd26eb00e636"
+  integrity sha512-oFqTyNTJdCdvcw1Ha6SKE7ITbSaoTbO4xpYownIoJR+WZ0ZfxbWpp225JkHuBJm9UcBAnG9c0CME924m3uBbaw==
+  dependencies:
+    connect "^3.6.5"
+    debug "^2.2.0"
+    rxjs "^5.4.3"
+    ws "^1.1.5"
+    yargs "^14.2.0"
 
 metro-inspector-proxy@0.59.0:
   version "0.59.0"
@@ -14000,6 +14506,13 @@ metro-inspector-proxy@^0.56.4:
     ws "^1.1.5"
     yargs "^9.0.0"
 
+metro-minify-uglify@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.58.0.tgz#7e1066954bfd4f767ba6aca7feef676ca44c68b8"
+  integrity sha512-vRHsA7bCi7eCn3LXLm20EfY2NoWDyYOnmWaq/N8LB0OxL2L5DXRqMYAQK+prWGJ5S1yvVnDuuNVP+peQ9851TA==
+  dependencies:
+    uglify-es "^3.1.9"
+
 metro-minify-uglify@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.59.0.tgz#6491876308d878742f7b894d7fca4af356886dd5"
@@ -14013,6 +14526,47 @@ metro-minify-uglify@^0.56.4:
   integrity sha512-BHgj7+BKEK2pHvWHUR730bIrsZwl8DPtr49x9L0j2grPZ5/UROWXzEr8VZgIss7fl64t845uu1HXNNyuSj2EhA==
   dependencies:
     uglify-es "^3.1.9"
+
+metro-react-native-babel-preset@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz#18f48d33fe124280ffabc000ab8b42c488d762a2"
+  integrity sha512-MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==
+  dependencies:
+    "@babel/plugin-proposal-class-properties" "^7.0.0"
+    "@babel/plugin-proposal-export-default-from" "^7.0.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
+    "@babel/plugin-syntax-export-default-from" "^7.0.0"
+    "@babel/plugin-syntax-flow" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.0.0"
+    "@babel/plugin-transform-block-scoping" "^7.0.0"
+    "@babel/plugin-transform-classes" "^7.0.0"
+    "@babel/plugin-transform-computed-properties" "^7.0.0"
+    "@babel/plugin-transform-destructuring" "^7.0.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+    "@babel/plugin-transform-for-of" "^7.0.0"
+    "@babel/plugin-transform-function-name" "^7.0.0"
+    "@babel/plugin-transform-literals" "^7.0.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
+    "@babel/plugin-transform-object-assign" "^7.0.0"
+    "@babel/plugin-transform-parameters" "^7.0.0"
+    "@babel/plugin-transform-react-display-name" "^7.0.0"
+    "@babel/plugin-transform-react-jsx" "^7.0.0"
+    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
+    "@babel/plugin-transform-regenerator" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.0.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
+    "@babel/plugin-transform-spread" "^7.0.0"
+    "@babel/plugin-transform-sticky-regex" "^7.0.0"
+    "@babel/plugin-transform-template-literals" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.5.0"
+    "@babel/plugin-transform-unicode-regex" "^7.0.0"
+    "@babel/template" "^7.0.0"
+    react-refresh "^0.4.0"
 
 metro-react-native-babel-preset@0.59.0:
   version "0.59.0"
@@ -14110,6 +14664,13 @@ metro-react-native-babel-transformer@^0.56.0:
     metro-react-native-babel-preset "^0.56.4"
     metro-source-map "^0.56.4"
 
+metro-resolver@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.58.0.tgz#4d03edc52e2e25d45f16688adf3b3f268ea60df9"
+  integrity sha512-XFbAKvCHN2iWqKeiRARzEXn69eTDdJVJC7lu16S4dPQJ+Dy82dZBr5Es12iN+NmbJuFgrAuIHbpWrdnA9tOf6Q==
+  dependencies:
+    absolute-path "^0.0.0"
+
 metro-resolver@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.59.0.tgz#fbc9d7c95f094c52807877d0011feffb9e896fad"
@@ -14123,6 +14684,19 @@ metro-resolver@^0.56.4:
   integrity sha512-Ug4ulVfpkKZ1Wu7mdYj9XLGuOqZTuWCqEhyx3siKTc/2eBwKZQXmiNo5d/IxWNvmwL/87Abeb724I6CMzMfjiQ==
   dependencies:
     absolute-path "^0.0.0"
+
+metro-source-map@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.58.0.tgz#e951b99f4c653239ce9323bb08339c6f1978a112"
+  integrity sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==
+  dependencies:
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    invariant "^2.2.4"
+    metro-symbolicate "0.58.0"
+    ob1 "0.58.0"
+    source-map "^0.5.6"
+    vlq "^1.0.0"
 
 metro-source-map@0.59.0:
   version "0.59.0"
@@ -14150,6 +14724,17 @@ metro-source-map@^0.56.0, metro-source-map@^0.56.4:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
+metro-symbolicate@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.58.0.tgz#ba9fd52549c41fc1b656adaad7c8875726dd5abe"
+  integrity sha512-uIVxUQC1E26qOMj13dKROhwAa2FmZk5eR0NcBqej/aXmQhpr8LjJg2sondkoLKUp827Tf/Fm9+pS4icb5XiqCw==
+  dependencies:
+    invariant "^2.2.4"
+    metro-source-map "0.58.0"
+    source-map "^0.5.6"
+    through2 "^2.0.1"
+    vlq "^1.0.0"
+
 metro-symbolicate@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.59.0.tgz#fc7f93957a42b02c2bfc57ed1e8f393f5f636a54"
@@ -14171,6 +14756,68 @@ metro-symbolicate@^0.56.4:
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
+
+metro@0.58.0, metro@^0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.58.0.tgz#c037318c112f80dc96199780c8b401ab72cfd142"
+  integrity sha512-yi/REXX+/s4r7RjzXht+E+qE6nzvFIrEXO5Q61h+70Q7RODMU8EnlpXx04JYk7DevHuMhFaX+NWhCtRINzR4zA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/core" "^7.0.0"
+    "@babel/generator" "^7.5.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/plugin-external-helpers" "^7.0.0"
+    "@babel/template" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    absolute-path "^0.0.0"
+    async "^2.4.0"
+    babel-preset-fbjs "^3.3.0"
+    buffer-crc32 "^0.2.13"
+    chalk "^2.4.1"
+    ci-info "^2.0.0"
+    concat-stream "^1.6.0"
+    connect "^3.6.5"
+    debug "^2.2.0"
+    denodeify "^1.2.1"
+    eventemitter3 "^3.0.0"
+    fbjs "^1.0.0"
+    fs-extra "^1.0.0"
+    graceful-fs "^4.1.3"
+    image-size "^0.6.0"
+    invariant "^2.2.4"
+    jest-haste-map "^24.7.1"
+    jest-worker "^24.6.0"
+    json-stable-stringify "^1.0.1"
+    lodash.throttle "^4.1.1"
+    merge-stream "^1.0.1"
+    metro-babel-register "0.58.0"
+    metro-babel-transformer "0.58.0"
+    metro-cache "0.58.0"
+    metro-config "0.58.0"
+    metro-core "0.58.0"
+    metro-inspector-proxy "0.58.0"
+    metro-minify-uglify "0.58.0"
+    metro-react-native-babel-preset "0.58.0"
+    metro-resolver "0.58.0"
+    metro-source-map "0.58.0"
+    metro-symbolicate "0.58.0"
+    mime-types "2.1.11"
+    mkdirp "^0.5.1"
+    node-fetch "^2.2.0"
+    nullthrows "^1.1.1"
+    resolve "^1.5.0"
+    rimraf "^2.5.4"
+    serialize-error "^2.1.0"
+    source-map "^0.5.6"
+    strip-ansi "^4.0.0"
+    temp "0.8.3"
+    throat "^4.1.0"
+    wordwrap "^1.0.0"
+    write-file-atomic "^1.2.0"
+    ws "^1.1.5"
+    xpipe "^1.0.5"
+    yargs "^14.2.0"
 
 metro@0.59.0, metro@^0.59.0:
   version "0.59.0"
@@ -15364,6 +16011,11 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
+ob1@0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.58.0.tgz#484a1e9a63a8b79d9ea6f3a83b2a42110faac973"
+  integrity sha512-uZP44cbowAfHafP1k4skpWItk5iHCoRevMfrnUvYCfyNNPPJd3rfDCyj0exklWi2gDXvjlj2ObsfiqP/bs/J7Q==
 
 ob1@0.59.0:
   version "0.59.0"
@@ -17100,6 +17752,16 @@ pretty-format@^25.1.0, pretty-format@^25.2.6:
   integrity sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==
   dependencies:
     "@jest/types" "^25.2.6"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.3.0.tgz#d0a4f988ff4a6cd350342fdabbb809aeb4d49ad5"
+  integrity sha512-wToHwF8bkQknIcFkBqNfKu4+UZqnrLn/Vr+wwKQwwvPzkBfDDKp/qIabFqdgtoi5PEnM8LFByVsOrHoa3SpTVA==
+  dependencies:
+    "@jest/types" "^25.3.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14664,6 +14664,17 @@ metro-react-native-babel-transformer@^0.56.0:
     metro-react-native-babel-preset "^0.56.4"
     metro-source-map "^0.56.4"
 
+metro-react-native-babel-transformer@^0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.58.0.tgz#5da0e5a1b83c01d11626905fa59f34fda53a21a5"
+  integrity sha512-3A73+cRq1eUPQ8g+hPNGgMUMCGmtQjwqHfoG1DwinAoJ/kr4WOXWWbGZo0xHJNBe/zdHGl0uHcDCp2knPglTdQ==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    babel-preset-fbjs "^3.3.0"
+    metro-babel-transformer "0.58.0"
+    metro-react-native-babel-preset "0.58.0"
+    metro-source-map "0.58.0"
+
 metro-resolver@0.58.0:
   version "0.58.0"
   resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.58.0.tgz#4d03edc52e2e25d45f16688adf3b3f268ea60df9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19299,6 +19299,13 @@ serialize-error@^5.0.0:
   dependencies:
     type-fest "^0.8.0"
 
+serialize-error@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-6.0.0.tgz#ccfb887a1dd1c48d6d52d7863b92544331fd752b"
+  integrity sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==
+  dependencies:
+    type-fest "^0.12.0"
+
 serialize-javascript@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
@@ -20942,6 +20949,11 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.12.0.tgz#f57a27ab81c68d136a51fd71467eff94157fa1ee"
+  integrity sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==
 
 type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,7 +1347,7 @@
     plist "^3.0.1"
     uuid "^3.3.3"
 
-"@expo/bunyan@3.0.2", "@expo/bunyan@^3.0.2":
+"@expo/bunyan@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@expo/bunyan/-/bunyan-3.0.2.tgz#775680bd479a8b79ada4a5676936a58eef1579c9"
   integrity sha512-fQRc4+RG+rEw1IdjFx/5t2AvOlJT8ktv2dfObD3aW838ohZxCx1QvFUY/Gdx5JA1JY/KrHRGuEqQLH9ayiexyg==
@@ -14757,7 +14757,7 @@ metro-symbolicate@^0.56.4:
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro@0.58.0, metro@^0.58.0:
+metro@0.58.0:
   version "0.58.0"
   resolved "https://registry.yarnpkg.com/metro/-/metro-0.58.0.tgz#c037318c112f80dc96199780c8b401ab72cfd142"
   integrity sha512-yi/REXX+/s4r7RjzXht+E+qE6nzvFIrEXO5Q61h+70Q7RODMU8EnlpXx04JYk7DevHuMhFaX+NWhCtRINzR4zA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5689,7 +5689,7 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
-body-parser@1.19.0, body-parser@^1.19.0:
+body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14305,24 +14305,6 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-metro-babel-register@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.58.0.tgz#5c44786d49a044048df56cf476a2263491d4f53a"
-  integrity sha512-P5+G3ufhSYL6cA3a7xkbSJzzFBvtivj/PhWvGXFXnuFssDlMAX1CTktff+0gpka5Cd6B6QLt0UAMWulUAAE4Eg==
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-async-to-generator" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/register" "^7.0.0"
-    core-js "^2.2.2"
-    escape-string-regexp "^1.0.5"
-
 metro-babel-register@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.59.0.tgz#2bcff65641b36794cf083ba732fbc46cf870fb43"
@@ -14379,16 +14361,6 @@ metro-babel-transformer@^0.56.4:
     "@babel/core" "^7.0.0"
     metro-source-map "^0.56.4"
 
-metro-cache@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.58.0.tgz#630ea0a4626dfb9591c71fdb85dce14b5e9a04ec"
-  integrity sha512-jjW9zCTKxhgKcVkyQ6LHyna9Zdf4TK/45vvT1fPyyTk1RY82ZYjU1qs+84ycKEd08Ka4YcK9xcUew9SIDJYI8Q==
-  dependencies:
-    jest-serializer "^24.4.0"
-    metro-core "0.58.0"
-    mkdirp "^0.5.1"
-    rimraf "^2.5.4"
-
 metro-cache@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.59.0.tgz#ef3c055f276933979b731455dc8317d7a66f0f2d"
@@ -14408,18 +14380,6 @@ metro-cache@^0.56.4:
     metro-core "^0.56.4"
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
-
-metro-config@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.58.0.tgz#1e24b43a5a00971d75662b1a0d3c04a13d4a1746"
-  integrity sha512-4vgBliXwL56vjUlYplvGMVSNrJJpkHuLcD+O20trV3FvPxKg4ZsvuOcNSxqDSMU26FCtIEJ15ojcuCbRL7KY0w==
-  dependencies:
-    cosmiconfig "^5.0.5"
-    jest-validate "^24.7.0"
-    metro "0.58.0"
-    metro-cache "0.58.0"
-    metro-core "0.58.0"
-    pretty-format "^24.7.0"
 
 metro-config@0.59.0, metro-config@^0.59.0:
   version "0.59.0"
@@ -14444,16 +14404,6 @@ metro-config@^0.56.0, metro-config@^0.56.4:
     metro-core "^0.56.4"
     pretty-format "^24.7.0"
 
-metro-core@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.58.0.tgz#ad9f6645a2b439a3fbce7ce4e19b01b00375768a"
-  integrity sha512-RzXUjGFmCLOyzUqcKDvr91AldGtIOxnzNZrWUIiG8uC3kerVLo0mQp4YH3+XVm6fMNiLMg6iER7HLqD+MbpUjQ==
-  dependencies:
-    jest-haste-map "^24.7.1"
-    lodash.throttle "^4.1.1"
-    metro-resolver "0.58.0"
-    wordwrap "^1.0.0"
-
 metro-core@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.59.0.tgz#958cde3fe5c8cd84a78e1899af801ad69e9c83b1"
@@ -14473,17 +14423,6 @@ metro-core@^0.56.0, metro-core@^0.56.4:
     lodash.throttle "^4.1.1"
     metro-resolver "^0.56.4"
     wordwrap "^1.0.0"
-
-metro-inspector-proxy@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.58.0.tgz#6fefb0cdf25655919d56c82ebe09cd26eb00e636"
-  integrity sha512-oFqTyNTJdCdvcw1Ha6SKE7ITbSaoTbO4xpYownIoJR+WZ0ZfxbWpp225JkHuBJm9UcBAnG9c0CME924m3uBbaw==
-  dependencies:
-    connect "^3.6.5"
-    debug "^2.2.0"
-    rxjs "^5.4.3"
-    ws "^1.1.5"
-    yargs "^14.2.0"
 
 metro-inspector-proxy@0.59.0:
   version "0.59.0"
@@ -14505,13 +14444,6 @@ metro-inspector-proxy@^0.56.4:
     rxjs "^5.4.3"
     ws "^1.1.5"
     yargs "^9.0.0"
-
-metro-minify-uglify@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.58.0.tgz#7e1066954bfd4f767ba6aca7feef676ca44c68b8"
-  integrity sha512-vRHsA7bCi7eCn3LXLm20EfY2NoWDyYOnmWaq/N8LB0OxL2L5DXRqMYAQK+prWGJ5S1yvVnDuuNVP+peQ9851TA==
-  dependencies:
-    uglify-es "^3.1.9"
 
 metro-minify-uglify@0.59.0:
   version "0.59.0"
@@ -14675,13 +14607,6 @@ metro-react-native-babel-transformer@^0.58.0:
     metro-react-native-babel-preset "0.58.0"
     metro-source-map "0.58.0"
 
-metro-resolver@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.58.0.tgz#4d03edc52e2e25d45f16688adf3b3f268ea60df9"
-  integrity sha512-XFbAKvCHN2iWqKeiRARzEXn69eTDdJVJC7lu16S4dPQJ+Dy82dZBr5Es12iN+NmbJuFgrAuIHbpWrdnA9tOf6Q==
-  dependencies:
-    absolute-path "^0.0.0"
-
 metro-resolver@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.59.0.tgz#fbc9d7c95f094c52807877d0011feffb9e896fad"
@@ -14767,68 +14692,6 @@ metro-symbolicate@^0.56.4:
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
-
-metro@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.58.0.tgz#c037318c112f80dc96199780c8b401ab72cfd142"
-  integrity sha512-yi/REXX+/s4r7RjzXht+E+qE6nzvFIrEXO5Q61h+70Q7RODMU8EnlpXx04JYk7DevHuMhFaX+NWhCtRINzR4zA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/core" "^7.0.0"
-    "@babel/generator" "^7.5.0"
-    "@babel/parser" "^7.0.0"
-    "@babel/plugin-external-helpers" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@babel/types" "^7.0.0"
-    absolute-path "^0.0.0"
-    async "^2.4.0"
-    babel-preset-fbjs "^3.3.0"
-    buffer-crc32 "^0.2.13"
-    chalk "^2.4.1"
-    ci-info "^2.0.0"
-    concat-stream "^1.6.0"
-    connect "^3.6.5"
-    debug "^2.2.0"
-    denodeify "^1.2.1"
-    eventemitter3 "^3.0.0"
-    fbjs "^1.0.0"
-    fs-extra "^1.0.0"
-    graceful-fs "^4.1.3"
-    image-size "^0.6.0"
-    invariant "^2.2.4"
-    jest-haste-map "^24.7.1"
-    jest-worker "^24.6.0"
-    json-stable-stringify "^1.0.1"
-    lodash.throttle "^4.1.1"
-    merge-stream "^1.0.1"
-    metro-babel-register "0.58.0"
-    metro-babel-transformer "0.58.0"
-    metro-cache "0.58.0"
-    metro-config "0.58.0"
-    metro-core "0.58.0"
-    metro-inspector-proxy "0.58.0"
-    metro-minify-uglify "0.58.0"
-    metro-react-native-babel-preset "0.58.0"
-    metro-resolver "0.58.0"
-    metro-source-map "0.58.0"
-    metro-symbolicate "0.58.0"
-    mime-types "2.1.11"
-    mkdirp "^0.5.1"
-    node-fetch "^2.2.0"
-    nullthrows "^1.1.1"
-    resolve "^1.5.0"
-    rimraf "^2.5.4"
-    serialize-error "^2.1.0"
-    source-map "^0.5.6"
-    strip-ansi "^4.0.0"
-    temp "0.8.3"
-    throat "^4.1.0"
-    wordwrap "^1.0.0"
-    write-file-atomic "^1.2.0"
-    ws "^1.1.5"
-    xpipe "^1.0.5"
-    yargs "^14.2.0"
 
 metro@0.59.0, metro@^0.59.0:
   version "0.59.0"


### PR DESCRIPTION
`@expo/dev-server` will use the new `dev-server-api` and `@expo/metro-config` packages to set up a Metro dev server compatible with React Native projects. In addition to the React Native development endpoints, it will include additional endpoints e.g. for serving Expo manifests and receiving logs from Expo client.