### PR TITLE
Make it clearer that the printed URLs are project manifest URLs, not website URLs

### DIFF
--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -140,7 +140,7 @@ export async function action(projectDir: string, options: Options = {}) {
     }
 
     log('Published');
-    log('Your URL is\n\n' + chalk.underline(url) + '\n');
+    log('Your project manifest URL is\n\n' + chalk.underline(url) + '\n');
     log.raw(url);
 
     if (recipient) {

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -12,7 +12,7 @@ async function action(projectDir: string, options: { sendTo?: string } & URLOpti
 
   let url = await UrlUtils.constructManifestUrlAsync(projectDir);
 
-  log('Your URL is\n\n' + chalk.underline(url) + '\n');
+  log('Your project manifest URL is\n\n' + chalk.underline(url) + '\n');
   log.raw(url);
 
   let shouldQuit = false;


### PR DESCRIPTION
The project manifest URLs (exp.host/@user/project) are different from the website URLs (expo.io/@user/project). The API server sends back a project manifest URL, not a website URL.

This commit changes the text we show to make this slightly clearer.