### PR TITLE
[expo-cli] add warning on publish if developer has both expokit and expo-updates installed

### DIFF
--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -36,13 +36,13 @@ export async function action(projectDir: string, options: Options = {}) {
 
   if (pkg.dependencies['expo-updates'] && pkg.dependencies['expokit']) {
     log.warn(
-      'Warning: You have both the `expokit` and `expo-updates` packages installed in package.json.'
+      `Warning: You have both the ${chalk.bold('expokit')} and ${chalk.bold('expo-updates')} packages installed in package.json.`
     );
     log.warn(
-      'These two packages are incompatible and publishing updates with expo-updates will not work if `expokit` is installed.'
+      `These two packages are incompatible and ${chalk.bold('publishing updates with expo-updates will not work if expokit is installed.')}`
     );
     log.warn(
-      'If you intent to use `expo-updates`, please remove `expokit` from your dependencies.'
+      `If you intent to use ${chalk.bold('expo-updates')}, please remove ${chalk.bold('expokit')} from your dependencies.`
     );
   }
 

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -29,6 +29,23 @@ export async function action(projectDir: string, options: Options = {}) {
     );
     process.exit(1);
   }
+
+  const { exp, pkg } = getConfig(projectDir, {
+    skipSDKVersionRequirement: true,
+  });
+
+  if (pkg.dependencies['expo-updates'] && pkg.dependencies['expokit']) {
+    log.warn(
+      'Warning: You have both the `expokit` and `expo-updates` packages installed in package.json.'
+    );
+    log.warn(
+      'These two packages are incompatible and publishing updates with expo-updates will not work if `expokit` is installed.'
+    );
+    log.warn(
+      'If you intent to use `expo-updates`, please remove `expokit` from your dependencies.'
+    );
+  }
+
   const hasOptimized = fs.existsSync(path.join(projectDir, '/.expo-shared/assets.json'));
   const nonInteractive = options.parent && options.parent.nonInteractive;
   if (!hasOptimized && !nonInteractive) {
@@ -104,10 +121,6 @@ export async function action(projectDir: string, options: Options = {}) {
       sdkVersion,
     });
   }
-
-  const { exp } = getConfig(projectDir, {
-    skipSDKVersionRequirement: true,
-  });
 
   if (
     'userHasBuiltExperienceBefore' in buildStatus &&


### PR DESCRIPTION
Since we now check the target when saving embedded assets (https://github.com/expo/expo-cli/commit/14d85cca1bf6c842c5baa1e8691885cf43cf0b75), if the user has the `expokit` package installed (probably from an incomplete migration from expokit to bare), `expo publish` will behave as if it's a managed workflow project and will not, by default, save embedded assets to disk.

This PR adds a warning when projects have both the `expokit` and `expo-updates` packages installed, saying the libraries are incompatible. This is mitigation for https://github.com/expo/expo/issues/7798 until we can have on demand updates working.