### PR TITLE
Remove bootstrap from yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prebootstrap": "yarn",
     "postinstall": "expo-yarn-workspaces check-workspace-dependencies",
     "publish": "echo \"This script is deprecated. Run \\\"node ./scripts/publish.js\\\" instead.\"; exit 1",
-    "start": "yarn run bootstrap && lerna run watch --parallel --ignore @expo/dev-tools --ignore expo-optimize --ignore @expo/next-adapter --ignore @expo/electron-adapter",
+    "start": "lerna run watch --parallel --ignore @expo/dev-tools --ignore expo-optimize --ignore @expo/next-adapter --ignore @expo/electron-adapter",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1",
     "lint": "eslint . --ext js,ts",
     "test-coverage": "jest --coverage && codecov"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "postbootstrap": "lerna run prepare --stream",
-    "prebootstrap": "yarn",
     "postinstall": "expo-yarn-workspaces check-workspace-dependencies",
     "publish": "echo \"This script is deprecated. Run \\\"node ./scripts/publish.js\\\" instead.\"; exit 1",
     "start": "lerna run watch --parallel --ignore @expo/dev-tools --ignore expo-optimize --ignore @expo/next-adapter --ignore @expo/electron-adapter",


### PR DESCRIPTION
- fix https://github.com/expo/expo-cli/issues/1836
- Instead of clean, just run `yarn bootstrap` again.
- Removed `"prebootstrap": "yarn",` as `learna bootstrap` [already runs `yarn`](https://github.com/lerna/lerna/tree/master/commands/bootstrap#usage).