### PR TITLE
fix(expo-cli): terminate bundle progress bar when finished

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -261,6 +261,7 @@ Command.prototype.asyncActionProjectDir = function(
 
         if (bar) {
           log.setBundleProgressBar(null);
+          bar.terminate();
           bar = null;
 
           if (err) {


### PR DESCRIPTION
Fixes #1770

We can also keep the status bar, and just add a new line. But because [the progress bar is initialized explicitly with `{ clear: true }`](https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/exp.ts#L245) I thought this was the most appropriate fix.

> Edit: If we want to keep the status bar listed as completed, removing `{ clear: true }` will fix that. [Terminate checks if it should be removed or "new-lined"](https://github.com/visionmedia/node-progress/blob/master/lib/node-progress.js#L227-L236)