### PR TITLE
[cli] refactor IQuit, contextual errors

### DIFF
--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -5,6 +5,7 @@ import get from 'lodash/get';
 import { XDLError } from '@expo/xdl';
 
 import { Dictionary } from 'lodash';
+import terminalLink from 'terminal-link';
 import BaseBuilder from '../BaseBuilder';
 import { PLATFORMS } from '../constants';
 import * as utils from '../utils';
@@ -17,7 +18,7 @@ import { displayProjectCredentials } from '../../../credentials/actions/list';
 import { SetupIosDist } from '../../../credentials/views/SetupIosDist';
 import { SetupIosPush } from '../../../credentials/views/SetupIosPush';
 import { SetupIosProvisioningProfile } from '../../../credentials/views/SetupIosProvisioningProfile';
-import CommandError from '../../../CommandError';
+import CommandError, { ErrorCodes } from '../../../CommandError';
 import log from '../../../log';
 
 import {
@@ -123,6 +124,15 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
       }
       await this.produceCredentials(context, experienceName, bundleIdentifier);
     } catch (e) {
+      if (e.code === ErrorCodes.NON_INTERACTIVE) {
+        const here = terminalLink('here', 'https://expo.fyi/credentials-non-interactive');
+        log(
+          chalk.bold.red(
+            `Additional information needed to setup credentials in non-interactive mode.`
+          )
+        );
+        log(chalk.bold.red(`Learn more about how to resolve this ${here}.`));
+      }
       log(
         chalk.bold.red(
           'Failed to prepare all credentials. \nThe next time you build, we will automatically use the following configuration:'

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -125,24 +125,37 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
       await this.produceCredentials(context, experienceName, bundleIdentifier);
     } catch (e) {
       if (e.code === ErrorCodes.NON_INTERACTIVE) {
-        const here = terminalLink('here', 'https://expo.fyi/credentials-non-interactive');
+        log.newLine();
+        const link = terminalLink(
+          'expo.fyi/credentials-non-interactive',
+          'https://expo.fyi/credentials-non-interactive'
+        );
         log(
           chalk.bold.red(
             `Additional information needed to setup credentials in non-interactive mode.`
           )
         );
-        log(chalk.bold.red(`Learn more about how to resolve this ${here}.`));
+        log(chalk.bold.red(`Learn more about how to resolve this: ${link}.`));
+        log.newLine();
+
+        // We don't want to display project credentials when we bail out due to
+        // non-interactive mode error, because we are unable to recover without
+        // user input.
+        throw new CommandError(
+          ErrorCodes.NON_INTERACTIVE,
+          'Unable to proceed, see the above error message.'
+        );
+      } else {
+        log(
+          chalk.bold.red(
+            'Failed to prepare all credentials. \nThe next time you build, we will automatically use the following configuration:'
+          )
+        );
       }
-      log(
-        chalk.bold.red(
-          'Failed to prepare all credentials. \nThe next time you build, we will automatically use the following configuration:'
-        )
-      );
-      throw e;
-    } finally {
-      const credentials = await context.ios.getAllCredentials();
-      displayProjectCredentials(experienceName, bundleIdentifier, credentials);
     }
+
+    const credentials = await context.ios.getAllCredentials();
+    displayProjectCredentials(experienceName, bundleIdentifier, credentials);
   }
 
   async produceCredentials(ctx: Context, experienceName: string, bundleIdentifier: string) {

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -170,26 +170,32 @@ export class QuitError extends Error {
   }
 }
 
-export type IQuit = (view: IView) => Promise<IView>;
-
-export async function doQuit(mainpage: IView): Promise<IView> {
-  throw new QuitError();
+export interface IQuit {
+  runAsync(mainpage: IView): Promise<IView>;
 }
 
-export async function askQuit(mainpage: IView): Promise<IView> {
-  const { selected } = await prompt([
-    {
-      type: 'list',
-      name: 'selected',
-      message: 'Do you want to quit Credential Manager',
-      choices: [
-        { value: 'exit', name: 'Quit Credential Manager' },
-        { value: 'mainpage', name: 'Go back to experience overview.' },
-      ],
-    },
-  ]);
-  if (selected === 'exit') {
-    process.exit(0);
+export class DoQuit implements IQuit {
+  async runAsync(mainpage: IView): Promise<IView> {
+    throw new QuitError();
   }
-  return mainpage;
+}
+
+export class AskQuit implements IQuit {
+  async runAsync(mainpage: IView): Promise<IView> {
+    const { selected } = await prompt([
+      {
+        type: 'list',
+        name: 'selected',
+        message: 'Do you want to quit Credential Manager',
+        choices: [
+          { value: 'exit', name: 'Quit Credential Manager' },
+          { value: 'mainpage', name: 'Go back to experience overview.' },
+        ],
+      },
+    ]);
+    if (selected === 'exit') {
+      process.exit(0);
+    }
+    return mainpage;
+  }
 }


### PR DESCRIPTION
# why
- refactor IQuits to classes
- if view errors and our Quit interface is AskQuit - show that view
- if view errors and our Quit interface is DoQuit - propagate error up to caller
- add contextual build errors to `IOSBuilder`

# related
https://github.com/expo/expo-cli/pull/1881

# TODO
land https://github.com/expo/fyi/pull/4