### PR TITLE
[package-manager] Added offline support to Yarn

### DIFF
--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -4,8 +4,6 @@ import { Command } from 'commander';
 import { AppJSONConfig, BareAppConfig, ExpoConfig } from '@expo/config';
 import { Exp } from '@expo/xdl';
 import padEnd from 'lodash/padEnd';
-import semver from 'semver';
-import spawnAsync from '@expo/spawn-async';
 import npmPackageArg from 'npm-package-arg';
 import pacote from 'pacote';
 import ora from 'ora';
@@ -164,7 +162,7 @@ async function action(projectDir: string, command: Command) {
     packageManager = 'yarn';
   } else if (options.npm) {
     packageManager = 'npm';
-  } else if (await shouldUseYarnAsync()) {
+  } else if (PackageManager.shouldUseYarn()) {
     packageManager = 'yarn';
     log.newLine();
     log('🧶 Using Yarn to install packages. You can pass --npm to use npm instead.');
@@ -400,17 +398,6 @@ function isNonExistentOrEmptyDir(dir: string) {
     }
     throw error;
   }
-}
-
-async function shouldUseYarnAsync() {
-  try {
-    let version = (await spawnAsync('yarnpkg', ['--version'])).stdout.trim();
-    if (semver.valid(version)) {
-      return true;
-    }
-  } catch (e) {}
-
-  return false;
 }
 
 async function promptForBareConfig(

--- a/packages/package-manager/src/index.ts
+++ b/packages/package-manager/src/index.ts
@@ -1,3 +1,5 @@
 export * from './PackageManager';
 export * from './NodePackageManagers';
 export * from './CocoaPodsPackageManager';
+export { default as shouldUseYarn } from './utils/shouldUseYarn';
+export { default as isYarnOfflineAsync } from './utils/isYarnOfflineAsync';

--- a/packages/package-manager/src/utils/isYarnOfflineAsync.ts
+++ b/packages/package-manager/src/utils/isYarnOfflineAsync.ts
@@ -1,0 +1,48 @@
+import { execSync } from 'child_process';
+import dns from 'dns';
+import url from 'url';
+
+function getNpmProxy(): string | null {
+  if (process.env.https_proxy) {
+    return process.env.https_proxy ?? null;
+  }
+
+  try {
+    const httpsProxy = execSync('npm config get https-proxy')
+      .toString()
+      .trim();
+    return httpsProxy !== 'null' ? httpsProxy : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function isUrlAvailableAsync(url: string): Promise<boolean> {
+  return new Promise<boolean>(resolve => {
+    dns.lookup(url, err => {
+      resolve(!err);
+    });
+  });
+}
+
+/**
+ * Determine if you should use yarn offline or not.
+ */
+export default async function isYarnOfflineAsync(): Promise<boolean> {
+  if (await isUrlAvailableAsync('registry.yarnpkg.com')) {
+    return false;
+  }
+
+  const proxy = getNpmProxy();
+
+  if (!proxy) {
+    return true;
+  }
+
+  const { hostname } = url.parse(proxy);
+  if (!hostname) {
+    return true;
+  }
+
+  return !(await isUrlAvailableAsync(hostname));
+}

--- a/packages/package-manager/src/utils/shouldUseYarn.ts
+++ b/packages/package-manager/src/utils/shouldUseYarn.ts
@@ -1,0 +1,13 @@
+import { execSync } from 'child_process';
+
+export default function shouldUseYarn(): boolean {
+  try {
+    if (process.env.npm_config_user_agent?.startsWith('yarn')) {
+      return true;
+    }
+    execSync('yarnpkg --version', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
- Disable ads for installs
- Use offline flag in Yarn
- Use `yarn install` when no packages are passed to `addAsync` or `addDevAsync`
- shouldUseYarn now accounts for `process.env.npm_config_user_agent`