### PR TITLE
Convert web console color to node console color

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1670,7 +1670,7 @@ function convertWebColorToChalk(logObj: MessageWithColorSupport): string {
     .split('%c')
     .filter((x: string) => x)
     .map((part: string, idx: number) => {
-      return colors[idx] ? chalk.hex(colors[idx])(part) : part;
+      return colors[idx] ? chalk.hex(colors[idx]).inverse(part) : part;
     })
     .join('');
 }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -75,6 +75,7 @@ import * as IosPlist from './detach/IosPlist';
 // @ts-ignore IosWorkspace not yet converted to TypeScript
 import * as IosWorkspace from './detach/IosWorkspace';
 import { ConnectionStatus } from './xdl';
+import chalk from 'chalk';
 
 const EXPO_CDN = 'https://d1wp6m56sqw74a.cloudfront.net';
 const MINIMUM_BUNDLE_SIZE = 500;
@@ -1652,6 +1653,21 @@ function _isAppRegistryStartupMessage(body: any[]) {
 }
 
 type ConsoleLogLevel = 'info' | 'warn' | 'error' | 'debug';
+  
+function convertWebColorToChalk(logObj) {
+   const { msg, colors } = logObj;
+   if (!colors) {
+    return msg;
+   }
+  
+   return msg
+    .split('%c')
+    .filter(x => x)
+    .map((part, idx) => {
+      return colors[idx] ?  chalk.hex(colors[idx])(part) : part;
+    })
+    .join('');
+}
 
 function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: string, logs: any) {
   for (let i = 0; i < logs.length; i++) {
@@ -1665,40 +1681,65 @@ function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: st
     if (_isAppRegistryStartupMessage(body)) {
       body = [`Running application on ${deviceName}.`];
     }
+  
+    const args = body
+        .reduce((result:any, msg: any) => {
+          if (typeof msg === 'undefined') {
+            result.push({ msg: 'undefined' });
+            return result;
+          }
+  
+          if (msg === 'null') {
+            result.push({ msg: 'null' });
+            return result;
+          }
+  
+          const last = result && result.length && result[result.length - 1];
+          if (last && last.hasWebColorHash && msg.match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)) {
+            last.colors = last.colors || [];
+            last.colors.push(msg.trim());
+          } else if (last && last.hasWebColorHash && msg.match(/^color:/)) {
+            last.colors = last.colors || [];
+            last.colors.push(msg.replace('color:', '').trim());
+          } else {
+            const hasWebColorHash = msg.indexOf('%c') >= 0;
+            result.push({ msg, hasWebColorHash });
+          }
+          return result;
+        }, [])
+        .map(obj => {
+          if (typeof obj.msg === 'string') {
+            return convertWebColorToChalk(obj);
+          }
+  
+          if (typeof obj.msg === 'number' || typeof obj.msg === 'boolean') {
+            return obj.msg;
+          }
+  
+          try {
+            return JSON.stringify(obj.msg);
+          } catch (e) {
+            return obj.toString();
+          }
+        });
 
-    const args = body.map((obj: any) => {
-      if (typeof obj === 'undefined') {
-        return 'undefined';
-      }
-      if (obj === 'null') {
-        return 'null';
-      }
-      if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean') {
-        return obj;
-      }
-      try {
-        return JSON.stringify(obj);
-      } catch (e) {
-        return obj.toString();
-      }
-    });
-    const logLevel =
+      const logLevel =
       level === 'info' || level === 'warn' || level === 'error' || level === 'debug'
         ? (level as ConsoleLogLevel)
         : 'info';
-    ProjectUtils.getLogger(projectRoot)[logLevel](
-      {
-        tag: 'device',
-        deviceId,
-        deviceName,
-        groupDepth: log.groupDepth,
-        shouldHide: log.shouldHide,
-        includesStack: log.includesStack,
-      },
-      ...args
-    );
+      ProjectUtils.getLogger(projectRoot)[logLevel](
+        {
+          tag: 'device',
+          deviceId,
+          deviceName,
+          groupDepth: log.groupDepth,
+          shouldHide: log.shouldHide,
+          includesStack: log.includesStack,
+        },
+        ...args
+      );
+    }
   }
-}
 export async function startReactNativeServerAsync(
   projectRoot: string,
   options: StartOptions = {},

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -43,6 +43,7 @@ import urljoin from 'url-join';
 import { promisify } from 'util';
 import uuid from 'uuid';
 
+import chalk from 'chalk';
 import * as Analytics from './Analytics';
 import * as Android from './Android';
 import Api from './Api';
@@ -75,7 +76,6 @@ import * as IosPlist from './detach/IosPlist';
 // @ts-ignore IosWorkspace not yet converted to TypeScript
 import * as IosWorkspace from './detach/IosWorkspace';
 import { ConnectionStatus } from './xdl';
-import chalk from 'chalk';
 
 const EXPO_CDN = 'https://d1wp6m56sqw74a.cloudfront.net';
 const MINIMUM_BUNDLE_SIZE = 500;
@@ -1653,20 +1653,20 @@ function _isAppRegistryStartupMessage(body: any[]) {
 }
 
 type ConsoleLogLevel = 'info' | 'warn' | 'error' | 'debug';
-  
-function convertWebColorToChalk(logObj) {
-   const { msg, colors } = logObj;
-   if (!colors) {
-    return msg;
-   }
-  
-   return msg
-    .split('%c')
-    .filter(x => x)
-    .map((part, idx) => {
-      return colors[idx] ?  chalk.hex(colors[idx])(part) : part;
-    })
-    .join('');
+
+function convertWebColorToChalk(logObj) {
+  const { msg, colors } = logObj;
+  if (!colors) {
+    return msg;
+  }
+
+  return msg
+    .split('%c')
+    .filter(x => x)
+    .map((part, idx) => {
+      return colors[idx] ? chalk.hex(colors[idx])(part) : part;
+    })
+    .join('');
 }
 
 function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: string, logs: any) {
@@ -1681,65 +1681,65 @@ function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: st
     if (_isAppRegistryStartupMessage(body)) {
       body = [`Running application on ${deviceName}.`];
     }
-  
-    const args = body
-        .reduce((result:any, msg: any) => {
-          if (typeof msg === 'undefined') {
-            result.push({ msg: 'undefined' });
-            return result;
-          }
-  
-          if (msg === 'null') {
-            result.push({ msg: 'null' });
-            return result;
-          }
-  
-          const last = result && result.length && result[result.length - 1];
-          if (last && last.hasWebColorHash && msg.match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)) {
-            last.colors = last.colors || [];
-            last.colors.push(msg.trim());
-          } else if (last && last.hasWebColorHash && msg.match(/^color:/)) {
-            last.colors = last.colors || [];
-            last.colors.push(msg.replace('color:', '').trim());
-          } else {
-            const hasWebColorHash = msg.indexOf('%c') >= 0;
-            result.push({ msg, hasWebColorHash });
-          }
-          return result;
-        }, [])
-        .map(obj => {
-          if (typeof obj.msg === 'string') {
-            return convertWebColorToChalk(obj);
-          }
-  
-          if (typeof obj.msg === 'number' || typeof obj.msg === 'boolean') {
-            return obj.msg;
-          }
-  
-          try {
-            return JSON.stringify(obj.msg);
-          } catch (e) {
-            return obj.toString();
-          }
-        });
 
-      const logLevel =
+    const args = body
+      .reduce((result: any, msg: any) => {
+        if (typeof msg === 'undefined') {
+          result.push({ msg: 'undefined' });
+          return result;
+        }
+
+        if (msg === 'null') {
+          result.push({ msg: 'null' });
+          return result;
+        }
+
+        const last = result && result.length && result[result.length - 1];
+        if (last && last.hasWebColorHash && msg.match(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)) {
+          last.colors = last.colors || [];
+          last.colors.push(msg.trim());
+        } else if (last && last.hasWebColorHash && msg.match(/^color:/)) {
+          last.colors = last.colors || [];
+          last.colors.push(msg.replace('color:', '').trim());
+        } else {
+          const hasWebColorHash = msg.indexOf('%c') >= 0;
+          result.push({ msg, hasWebColorHash });
+        }
+        return result;
+      }, [])
+      .map(obj => {
+        if (typeof obj.msg === 'string') {
+          return convertWebColorToChalk(obj);
+        }
+
+        if (typeof obj.msg === 'number' || typeof obj.msg === 'boolean') {
+          return obj.msg;
+        }
+
+        try {
+          return JSON.stringify(obj.msg);
+        } catch (e) {
+          return obj.toString();
+        }
+      });
+
+    const logLevel =
       level === 'info' || level === 'warn' || level === 'error' || level === 'debug'
         ? (level as ConsoleLogLevel)
         : 'info';
-      ProjectUtils.getLogger(projectRoot)[logLevel](
-        {
-          tag: 'device',
-          deviceId,
-          deviceName,
-          groupDepth: log.groupDepth,
-          shouldHide: log.shouldHide,
-          includesStack: log.includesStack,
-        },
-        ...args
-      );
-    }
+    ProjectUtils.getLogger(projectRoot)[logLevel](
+      {
+        tag: 'device',
+        deviceId,
+        deviceName,
+        groupDepth: log.groupDepth,
+        shouldHide: log.shouldHide,
+        includesStack: log.includesStack,
+      },
+      ...args
+    );
   }
+}
 export async function startReactNativeServerAsync(
   projectRoot: string,
   options: StartOptions = {},

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1654,7 +1654,13 @@ function _isAppRegistryStartupMessage(body: any[]) {
 
 type ConsoleLogLevel = 'info' | 'warn' | 'error' | 'debug';
 
-function convertWebColorToChalk(logObj) {
+type MessageWithColorSupport = {
+  msg: string;
+  colors?: Array<string>;
+  hasWebColorHash?: boolean;
+};
+
+function convertWebColorToChalk(logObj: MessageWithColorSupport): string {
   const { msg, colors } = logObj;
   if (!colors) {
     return msg;
@@ -1662,8 +1668,8 @@ function convertWebColorToChalk(logObj) {
 
   return msg
     .split('%c')
-    .filter(x => x)
-    .map((part, idx) => {
+    .filter((x: string) => x)
+    .map((part: string, idx: number) => {
       return colors[idx] ? chalk.hex(colors[idx])(part) : part;
     })
     .join('');
@@ -1683,7 +1689,7 @@ function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: st
     }
 
     const args = body
-      .reduce((result: any, msg: any) => {
+      .reduce((result: Array<MessageWithColorSupport>, msg: string) => {
         if (typeof msg === 'undefined') {
           result.push({ msg: 'undefined' });
           return result;
@@ -1707,7 +1713,7 @@ function _handleDeviceLogs(projectRoot: string, deviceId: string, deviceName: st
         }
         return result;
       }, [])
-      .map(obj => {
+      .map((obj: MessageWithColorSupport) => {
         if (typeof obj.msg === 'string') {
           return convertWebColorToChalk(obj);
         }


### PR DESCRIPTION
In `_handleDeviceLogs` we want to parse incoming logs to convert hex codes and special web characters to node friendly command line characters.

This includes support for using commas to separate console logs into multiple parts and adding color to parts individually by tracking historical color additions as we loop through the input.

I used ChalkJS because it is already used in other parts of the application. No new dependencies needed.