### PR TITLE
[xdl] Do not override google-services.json contents since SDK37

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1081,17 +1081,26 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       // No google-services.json file, let's use the placeholder one
       // and insert keys manually ("the old way").
 
+      // Let's not modify values of the original google-services.json file
+      // if they haven't been provided (in which case, googleAndroidApiKey
+      // and certificateHash will be an empty string). This will make sure
+      // we don't modify shell app's google-services needlessly.
+
       // Google sign in
-      await regexFileAsync(
-        /"current_key": "(.*?)"/,
-        `"current_key": "${googleAndroidApiKey}"`,
-        path.join(shellPath, 'app', 'google-services.json')
-      );
-      await regexFileAsync(
-        /"certificate_hash": "(.*?)"/,
-        `"certificate_hash": "${certificateHash}"`,
-        path.join(shellPath, 'app', 'google-services.json')
-      );
+      if (googleAndroidApiKey) {
+        await regexFileAsync(
+          /"current_key": "(.*?)"/,
+          `"current_key": "${googleAndroidApiKey}"`,
+          path.join(shellPath, 'app', 'google-services.json')
+        );
+      }
+      if (certificateHash) {
+        await regexFileAsync(
+          /"certificate_hash": "(.*?)"/,
+          `"certificate_hash": "${certificateHash}"`,
+          path.join(shellPath, 'app', 'google-services.json')
+        );
+      }
     } else if (googleAndroidApiKey || certificateHash) {
       // Both googleServicesFile and googleSignIn configuration have been provided.
       // Let's print a helpful warning and not modify google-services.json.


### PR DESCRIPTION
# Why

Following [Using FCM doc](https://docs.expo.io/versions/latest/guides/using-fcm/) or [GoogleSignIn - Usage with Firebase part](https://docs.expo.io/versions/latest/sdk/google-sign-in/#usage-with-firebase) would not render the expected results — `googleSignIn` configuration was always being applied onto `google-services.json`, even if a custom one has been provided by the user. Most probably this is not how this should work or what the user expect.

When pushed to Turtle builders, should fix https://github.com/expo/expo/issues/7727.

# How

Depending on the SDK version of the built project:
- if the SDK is >= 37:
  - only change `google-services.json` if none was provided (so we're operating on a placeholder one)
  - if both configuration settings are provided print a warning and not modify the custom `google-services.json`
- if the SDK is < 37:
  - if the user provides a custom `googleServicesFile`, print a warning that its contents are about to be modified,
  - always modify `google-services.json`, as it has been working before.

I have also moved the `replace "host.exp.exponent" with ${javaPackage}` to where the logic above is mentioned so that all `google-services.json` modifications are in one place.

# Test plan

- SDK37, only `googleServicesFile` — [job](https://staging.expo.io/dashboard/sjchmiela/builds/4dca157f-3ae5-4739-96a7-2a1fbcf2ec0e), no warning, used `google-services.json`
- SDK37, only `googleSignIn` — [job](https://staging.expo.io/dashboard/sjchmiela/builds/2c44d75e-9ce1-4098-ab64-04e76f01efda), no warning, uses placeholder project ID and `googleSignIn` key
- SDK37, both provided — [job](https://staging.expo.io/dashboard/sjchmiela/builds/23626002-acf2-4a30-a620-2062f134d671), warning present (google-services.json overrides others), used `google-services.json`
- SDK36, only `googleServicesFile` — ~[job](https://staging.expo.io/dashboard/sjchmiela/builds/8366c022-dcff-4047-bf0a-0264a52870a1), no warning, **removed key from google-services.json**~ force-pushed version where the warning should be printed and the key still removed
- SDK36, only `googleSignIn` — [job](https://staging.expo.io/dashboard/sjchmiela/builds/d59e4334-a815-4d6a-8ba2-108ab2f5d8bc), no warning, used `googleSignIn` and leaking project ID
- SDK36, both provided — [job](https://staging.expo.io/dashboard/sjchmiela/builds/d5a8ab8f-07f7-4aac-9c64-7012421d1b49), warning present (google-services.json overridden), google-services.json overridden
