### PR TITLE
fix(expo-cli): use expo editor env before guessing default editor

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -18,7 +18,7 @@ import wordwrap from 'wordwrap';
 import { loginOrRegisterIfLoggedOut } from '../../accounts';
 import log from '../../log';
 import urlOpts from '../../urlOpts';
-import { startEditorAsync } from '../utils/EditorUtils';
+import { startProjectInEditorAsync } from '../utils/EditorUtils';
 
 const CTRL_C = '\u0003';
 const CTRL_D = '\u0004';
@@ -57,17 +57,17 @@ const printUsage = async (projectDir: string, options: Pick<StartOptions, 'webOn
  \u203A Press ${platformInfo}.
  \u203A Press ${b`c`} to show info on ${u`c`}onnecting new devices.
  \u203A Press ${b`d`} to open DevTools in the default web browser.
- \u203A Press ${b`shift-d`} to ${
-    openDevToolsAtStartup ? 'disable' : 'enable'
-  } automatically opening ${u`D`}evTools at startup.${
-    options.webOnly ? '' : `\n \u203A Press ${b`e`} to send an app link with ${u`e`}mail.`
-  }
+ \u203A Press ${b`shift-d`} to ${openDevToolsAtStartup
+    ? 'disable'
+    : 'enable'} automatically opening ${u`D`}evTools at startup.${options.webOnly
+    ? ''
+    : `\n \u203A Press ${b`e`} to send an app link with ${u`e`}mail.`}
  \u203A Press ${b`p`} to toggle ${u`p`}roduction mode. (current mode: ${i(devMode)})
  \u203A Press ${b`r`} to ${u`r`}estart bundler, or ${b`shift-r`} to restart and clear cache.
  \u203A Press ${b`o`} to ${u`o`}pen the project in your editor.
- \u203A Press ${b`s`} to ${u`s`}ign ${
-    username ? `out. (Signed in as ${i('@' + username)}.)` : 'in.'
-  }
+ \u203A Press ${b`s`} to ${u`s`}ign ${username
+    ? `out. (Signed in as ${i('@' + username)}.)`
+    : 'in.'}
 `);
 };
 
@@ -272,7 +272,7 @@ export const startAsync = async (projectDir: string, options: StartOptions) => {
       }
       case 'D': {
         clearConsole();
-        const enabled = !(await UserSettings.getAsync('openDevToolsAtStartup', true));
+        const enabled = !await UserSettings.getAsync('openDevToolsAtStartup', true);
         await UserSettings.setAsync('openDevToolsAtStartup', enabled);
         log(
           `Automatically opening DevTools ${b(
@@ -328,7 +328,7 @@ Please reload the project in the Expo app for the change to take effect.`
       }
       case 'o':
         log('Trying to open the project in your editor...');
-        await startEditorAsync(projectDir);
+        await startProjectInEditorAsync(projectDir);
     }
   }
 };


### PR DESCRIPTION
This hotfixes the open editor feature for MacOS and terminal editors.

It works, but there are some things that I don't like about the current state:
- Using `EXPO_EDITOR=vim expo start` doesn't open Vim on MacOS. It's because probably because osascript can't resolve vim as name. (even though I have vim installed on MacOS and can execute from terminal).
- The list of "supported" editors by name is less compared to [React's dev tools list](https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/launchEditor.js). We can't reuse this because of the same reason we can't use `open-editor`, it opens files only (not folders).

Maybe it's better to update FileSystem to support all platforms, and move this code to that part. But that would be a significant change. 