### PR TITLE
Add FYI guide to uri-scheme for android setup

### DIFF
--- a/packages/uri-scheme/src/Android.ts
+++ b/packages/uri-scheme/src/Android.ts
@@ -29,7 +29,7 @@ export async function addAsync({ dryRun, uri, projectRoot }: Options): Promise<b
 
   if (!Scheme.ensureManifestHasValidIntentFilter(manifest)) {
     throw new CommandError(
-      `Cannot add scheme "${uri}" because the provided manifest does not have a valid Activity with \`android:launchMode="singleTask"\``,
+      `Cannot add scheme "${uri}" because the provided manifest does not have a valid Activity with \`android:launchMode="singleTask"\`.\nThis guide can help you get setup properly https://expo.fyi/setup-android-uri-scheme`,
       'add'
     );
   }
@@ -59,7 +59,7 @@ export async function removeAsync({ dryRun, uri, projectRoot }: Options): Promis
 
   if (!Scheme.ensureManifestHasValidIntentFilter(manifest)) {
     throw new CommandError(
-      `Cannot remove scheme "${uri}" because the provided manifest does not have a valid Activity with \`android:launchMode="singleTask"\``,
+      `Cannot remove scheme "${uri}" because the provided manifest does not have a valid Activity with \`android:launchMode="singleTask"\`.\nThis guide can help you get setup properly https://expo.fyi/setup-android-uri-scheme`,
       'remove'
     );
   }


### PR DESCRIPTION
Append the following to the error message about the project being misconfigured: `\nThis guide can help you get setup properly https://expo.fyi/setup-android-uri-scheme`