### PR TITLE
[dev-tools] Clean dev-tools when preparing

### DIFF
--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -9,7 +9,7 @@
     "build-server": "NODE_ENV=production tsc",
     "extract-fragment-types": "ts-node ./server/extract-fragment-types",
     "clean": "rm -rf ./build",
-    "prepare": "yarn build",
+    "prepare": "yarn run clean && yarn run build",
     "start": "yarn dev",
     "test": "jest --config jest.config.js"
   },


### PR DESCRIPTION
When publishing I noticed every time I ran `npm publish` (without success, but that's a different story) the _package size_ increased.