### PR TITLE
fix(image-utils): add minimal required sharp cli version back

### DIFF
--- a/packages/image-utils/src/sharp.ts
+++ b/packages/image-utils/src/sharp.ts
@@ -4,6 +4,7 @@ import resolveFrom from 'resolve-from';
 import { Options, SharpCommandOptions, SharpGlobalOptions } from './sharp.types';
 
 const SHARP_HELP_PATTERN = /\n\nSpecify --help for available options/g;
+const SHARP_REQUIRED_VERSION = '^1.10.0';
 
 export async function resizeBufferAsync(buffer: Buffer, sizes: number[]): Promise<Buffer[]> {
   const sharp = await findSharpInstanceAsync();
@@ -96,15 +97,12 @@ async function findSharpBinAsync(): Promise<string> {
   if (_sharpBin) {
     return _sharpBin;
   }
-  const requiredCliVersion = require('@expo/image-utils/package.json').peerDependencies[
-    'sharp-cli'
-  ];
   try {
     const sharpCliPackage = require('sharp-cli/package.json');
     const libVipsVersion = require('sharp').versions.vips;
     if (
       sharpCliPackage &&
-      semver.satisfies(sharpCliPackage.version, requiredCliVersion) &&
+      semver.satisfies(sharpCliPackage.version, SHARP_REQUIRED_VERSION) &&
       typeof sharpCliPackage.bin.sharp === 'string' &&
       typeof libVipsVersion === 'string'
     ) {
@@ -119,11 +117,11 @@ async function findSharpBinAsync(): Promise<string> {
   try {
     installedCliVersion = (await spawnAsync('sharp', ['--version'])).stdout.toString().trim();
   } catch (e) {
-    throw notFoundError(requiredCliVersion);
+    throw notFoundError(SHARP_REQUIRED_VERSION);
   }
 
-  if (!semver.satisfies(installedCliVersion, requiredCliVersion)) {
-    showVersionMismatchWarning(requiredCliVersion, installedCliVersion);
+  if (!semver.satisfies(installedCliVersion, SHARP_REQUIRED_VERSION)) {
+    showVersionMismatchWarning(SHARP_REQUIRED_VERSION, installedCliVersion);
   }
   _sharpBin = 'sharp';
   return _sharpBin;


### PR DESCRIPTION
Fixes #1900

This hardcodes the minimal required sharp cli version back to image-utils. As reported in the issue, the problematic [commit is this](https://github.com/expo/expo-cli/commit/8b9b581c732b5a5e8c7f6907de5f7f141f9cf585). It removes the sharp-cli peer dependency from the package, which is actually used by the sharp detection code. As alternatives, we could also revert the change and add the peer dependency back. Or even remove the version required fully.