### PR TITLE
[credentials][android][apiv2] Fix upload keystore

### DIFF
--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import untildify from 'untildify';
-import { Android, Credentials } from '@expo/xdl';
+import { Android, AndroidCredentials, Credentials } from '@expo/xdl';
 import chalk from 'chalk';
 import get from 'lodash/get';
 
@@ -195,9 +195,9 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
         // read the keystore
         const keystoreData = await fs.readFile(keystorePath);
 
-        const credentials = {
+        const credentials: AndroidCredentials.Keystore = {
           keystore: keystoreData.toString('base64'),
-          keystoreAlias,
+          keyAlias: keystoreAlias,
           keystorePassword,
           keyPassword,
         };

--- a/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
+++ b/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
@@ -185,7 +185,7 @@ export default class AppSigningOptInProcess {
       {
         // @ts-ignore
         keystorePassword: this.uploadKeystoreCredentials.keystorePassword,
-        keystoreAlias: this.uploadKeystoreCredentials.keyAlias,
+        keyAlias: this.uploadKeystoreCredentials.keyAlias,
         keyPassword: this.uploadKeystoreCredentials.keyPassword,
         keystore: (await fs.readFile(this.uploadKeystore)).toString('base64'),
       },
@@ -198,8 +198,7 @@ export default class AppSigningOptInProcess {
     );
 
     log(
-      `The original keystore is stored in ${this
-        .signKeystore}; remove it only if you are sure that Google Play App Signing is enabled for your app.`
+      `The original keystore is stored in ${this.signKeystore}; remove it only if you are sure that Google Play App Signing is enabled for your app.`
     );
     if (!this.signKeystoreCredentials) {
       throw new Error(

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -1,5 +1,5 @@
 import { Platform, getConfig } from '@expo/config';
-import { ApiV2 } from '../xdl';
+import { AndroidCredentials, ApiV2 } from '../xdl';
 
 import Api from '../Api';
 import UserManager from '../User';
@@ -109,7 +109,7 @@ async function fetchCredentials(
 
 export async function updateCredentialsForPlatform(
   platform: 'android',
-  newCredentials: Credentials,
+  newCredentials: AndroidCredentials.Keystore,
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {
@@ -118,7 +118,7 @@ export async function updateCredentialsForPlatform(
     const user = await UserManager.ensureLoggedInAsync();
     const api = ApiV2.clientForUser(user);
     const result = await api.putAsync(`credentials/android/keystore/${experienceName}`, {
-      credentials: newCredentials,
+      keystore: newCredentials,
     });
 
     if (result.errors) {

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -1,5 +1,6 @@
 import { Platform, getConfig } from '@expo/config';
-import { AndroidCredentials, ApiV2 } from '../xdl';
+import { ApiV2 } from '../xdl';
+import { Keystore } from './AndroidCredentials';
 
 import Api from '../Api';
 import UserManager from '../User';
@@ -109,7 +110,7 @@ async function fetchCredentials(
 
 export async function updateCredentialsForPlatform(
   platform: 'android',
-  newCredentials: AndroidCredentials.Keystore,
+  newCredentials: Keystore,
   userCredentialsIds: Array<number>,
   metadata: CredentialMetadata
 ): Promise<void> {


### PR DESCRIPTION
# why

Android credentials were not being updated on the apiv2 endpoint when running `expo build:android -c`.

# how

The cli was sending incorrectly formatted credentials to the endpoint.

# test
Followed @wkozyra95 detalied repro:
```
export EXPO_NEXT_API=true
expo init testProject
cd testProject
expo credentials:manager  // and generate generate upload kesytore
expo fetch:android:hashes // returns some hashes
expo fetch:android:keystore // backup keystore (it's better to move it somwhere because it can be overwritten)
expo credentials:manager  // and generate generate upload kesytore new one
expo fetch:android:hashes // verified that hashes changed
expo build:android -c // and provided keystore generated first time
expo fetch:android:hashes // hashes should change back to orignal ones but stayed the same, you don't need to wait for the end of the build to run this command, if build is in queue keystore should be updated already```

