### PR TITLE
[xdl][expo-cli] log message in `expo bundle-assets` if manifest is empty

### DIFF
--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -1,5 +1,9 @@
 import { Detach } from '@expo/xdl';
+import chalk from 'chalk';
 import { Command } from 'commander';
+import terminalLink from 'terminal-link';
+
+import log from '../log';
 
 type Options = {
   dest?: string;
@@ -7,7 +11,20 @@ type Options = {
 };
 
 async function action(projectDir: string, options: Options) {
-  await Detach.bundleAssetsAsync(projectDir, options);
+  try {
+    await Detach.bundleAssetsAsync(projectDir, options);
+  } catch (e) {
+    log.error(e);
+    log.error(
+      `Before making a release build, make sure you have run '${chalk.bold(
+        'expo publish'
+      )}' at least once. ${terminalLink(
+        'Learn more.',
+        'https://expo.fyi/release-builds-with-expo-updates'
+      )}`
+    );
+    process.exit(1);
+  }
 }
 
 export default function(program: Command) {

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -532,5 +532,8 @@ export async function bundleAssetsAsync(projectDir, args) {
       `Error reading the manifest file. Make sure the path '${bundledManifestPath}' is correct.\n\nError: ${ex.message}`
     );
   }
+  if (!manifest || !Object.keys(manifest).length) {
+    throw new Error(`The manifest at '${bundledManifestPath}' was empty or invalid.`);
+  }
   await AssetBundle.bundleAsync(null, manifest.bundledAssets, args.dest);
 }


### PR DESCRIPTION
https://exponent-internal.slack.com/archives/C5ERY0TAR/p1587135492115900?thread_ts=1587065441.099200&cid=C5ERY0TAR

Added throwing an error in the `bundleAssetsAsync` function if the manifest is empty. In the expo-cli command, we catch errors and log them along with a helpful reminder to run `expo publish`.

Tested by initializing a blank bare project with expo init and changing the asset bundle build steps in iOS/Android projects to use local expo-cli. Before running `expo publish`, both release builds failed and logged the expected message. After running `expo publish` they both succeeded.