### PR TITLE
[cli] better auth error messages, tweak use case

### DIFF
--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -78,7 +78,7 @@ function _getAppleIdFromParams({ appleId, appleIdPassword }: Options): AppleCred
   // partial apple id params were set, assume user has intention of passing it in
   if (!every([appleId, passedAppleIdPassword])) {
     throw new Error(
-      'In order to provide your Apple ID credentials, you must set the `--apple-id` flag and set the EXPO_APPLE_PASSWORD env var.'
+      'In order to provide your Apple ID credentials, you must set the --apple-id flag and set the EXPO_APPLE_PASSWORD environment variable.'
     );
   }
 


### PR DESCRIPTION
# what
There is a bug in our code, where if a user runs `expo build:ios --apple-id <their apple id> --non-interactive`, we return:
```
[20:37:26] Input is required, but Expo CLI is in non-interactive mode.
Pass your Apple ID using the --apple-id flag.
```
We tell `inquirer` not to ask this question if someone has set the `--apple-id` flag, but our problem arises when we also pass in the `--non-interactive` flag. This is because we check `nonInteractive` mode and throw an error before we evaluate whether we should ask the question in the `when` option we pass to `inquirer`. 

# consider changing CLI use case
our code is currently built so that you can pass in one of `{appleId, applePassword}`, and it will prompt you to provide any credential that is missing. I don't really see a use-case where someone would want to pass in *only* one parameter. If we are ok not supporting this use case, we can simplify our code so that:
1. If none of `{appleId, applePassword}` is set, we default to user prompting
2. If one of `{appleId, applePassword}` is set, we assume user was trying to pass in creds and we error
3. If both of `{appleId, applePassword}` are set, we bypass user prompting and use the provided creds

This would also fix the original problem.

# misc fix
- i also added some debug to `team-id` non interactive help prompt

# tests

for `non-interactive` and interactive mode, tested:
- [x] no args, expect prompting in interactive, failure in non interactive
- [x] just `EXPO_APPLE_PASSWORD`, expect error
- [x] just `--apple-id`, expect error
- [x] both `EXPO_APPLE_PASSWORD` and `--apple-id`, expect an attempt to login to apple
