### PR TITLE
fix(config): add missing globby dependency

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -50,6 +50,7 @@
     "@types/invariant": "^2.2.30",
     "find-yarn-workspace-root": "^1.2.1",
     "fs-extra": "^7.0.1",
+    "globby": "^11.0.0",
     "invariant": "^2.2.4",
     "jest-message-util": "^25.1.0",
     "plist": "^3.0.1",


### PR DESCRIPTION
I'm updating the Standard Version Expo library and came across this. [`globby` is used in `Config.ts`](https://github.com/expo/expo-cli/blob/58a6cf7556e6e1a708feab52dcc3eec46f17dd5c/packages/config/src/Config.ts#L3), I think it should be added here 😄 It works with this version, but do correct this if it needs an older one!