### PR TITLE
[xdl] Remove call to check-dynamic-macros

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -220,18 +220,6 @@ export async function copyInitialShellAppFilesAsync(
   isDetached,
   sdkVersion
 ) {
-  if (androidSrcPath && !isDetached) {
-    // check if Android template files exist
-    // since we take out the prebuild step later on
-    // and we should have generated those files earlier
-    await spawnAsyncThrowError('../../tools-public/check-dynamic-macros-android.sh', [], {
-      pipeToLogger: true,
-      loggerFields: { buildPhase: 'confirming that dynamic macros exist' },
-      cwd: path.join(androidSrcPath, 'app'),
-      env: process.env,
-    });
-  }
-
   const copyToShellApp = async fileName => {
     try {
       await fs.copy(path.join(androidSrcPath, fileName), path.join(shellPath, fileName));


### PR DESCRIPTION
# Why

This check has been added in https://github.com/expo/expo-cli/pull/98 as an effort to ensure that the shell apps contain the pregenerated macros as expected.

I'm not sure this is needed anymore — from my point of view the shell app creation process is very clear now ([one, simple script](https://github.com/expo/expo/blob/master/buildAndroidTarballLocally.sh)), `expotools` consistently generate the macros and I don't think XDL should be tied that closely to internals of the shell app.

If we wanted to, we could replace this check, run for every build, with a post-shell-app-build check in `expo/expo` repo, where the shell apps are created.

# How

Removed spawning of the aforementioned script.

# Test plan

As this only removed the call and doesn't add anything I don't see it breaking anything.

It's unlikely we will need to rebuild shell apps for old SDKs, where `expotools` may have not existed yet and even if so, since all current shell apps do contain the macros, I think it should be safe to assume that any additions to `sdk-XX` branches won't break the macros generation process.