### PR TITLE
[xdl] Assemble/bundle only the :app project

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1233,16 +1233,16 @@ async function buildShellAppAsync(context, sdkVersion, buildType, buildMode) {
   let outputPath;
   if (buildType === 'app-bundle') {
     if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 36) {
-      gradleBuildCommand = `bundle${debugOrRelease}`;
+      gradleBuildCommand = `:app:bundle${debugOrRelease}`;
       outputPath = path.join(outputDirPath, debugOrReleaseL, `app-${debugOrReleaseL}.aab`);
     } else if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 33) {
-      gradleBuildCommand = `bundle${debugOrRelease}`;
+      gradleBuildCommand = `:app:bundle${debugOrRelease}`;
       outputPath = path.join(outputDirPath, debugOrReleaseL, `app.aab`);
     } else if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 32) {
-      gradleBuildCommand = `bundle${devOrProd}Kernel${debugOrRelease}`;
+      gradleBuildCommand = `:app:bundle${devOrProd}Kernel${debugOrRelease}`;
       outputPath = path.join(outputDirPath, `${devOrProdL}Kernel${debugOrRelease}`, `app.aab`);
     } else {
-      // gradleBuildCommand = `bundle${devOrProd}MinSdk${devOrProd}Kernel${debugOrRelease}`;
+      // gradleBuildCommand = `:app:bundle${devOrProd}MinSdk${devOrProd}Kernel${debugOrRelease}`;
       // outputPath = path.join(
       //   outputDirPath,
       //   `${devOrProdL}MinSdk${devOrProd}Kernel`,
@@ -1256,10 +1256,10 @@ async function buildShellAppAsync(context, sdkVersion, buildType, buildMode) {
     }
   } else {
     if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 33) {
-      gradleBuildCommand = `assemble${debugOrRelease}`;
+      gradleBuildCommand = `:app:assemble${debugOrRelease}`;
       outputPath = path.join(outputDirPath, debugOrReleaseL, `app-${debugOrReleaseL}.apk`);
     } else if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 32) {
-      gradleBuildCommand = `assemble${devOrProd}Kernel${debugOrRelease}`;
+      gradleBuildCommand = `:app:assemble${devOrProd}Kernel${debugOrRelease}`;
       outputPath = path.join(
         outputDirPath,
         `${devOrProdL}Kernel`,
@@ -1267,7 +1267,7 @@ async function buildShellAppAsync(context, sdkVersion, buildType, buildMode) {
         `app-${devOrProdL}Kernel-${debugOrReleaseL}.apk`
       );
     } else {
-      gradleBuildCommand = `assemble${devOrProd}MinSdk${devOrProd}Kernel${debugOrRelease}`;
+      gradleBuildCommand = `:app:assemble${devOrProd}MinSdk${devOrProd}Kernel${debugOrRelease}`;
       outputPath = path.join(
         outputDirPath,
         `${devOrProdL}MinSdk${devOrProd}Kernel`,


### PR DESCRIPTION
# Why

I have noticed that not only the `app` project is being built on Turtle, but all the projects.

# How

I've scoped the Gradle command to only build/assemble the `:app` project. It should be safe to do for all SDKs, since on all SDKs the app project was called `app`.

# Test plan

Published an alpha version of XDL to NPM, upgraded Turtle to it, deployed to staging and ran the build. It was over a minute faster than without this change ([new](https://staging.expo.io/dashboard/sjchmiela/builds/5c386cef-e808-49d3-91d8-9ce42af77c36) vs [old](https://staging.expo.io/dashboard/sjchmiela/builds/3d36340e-6ae1-4476-91cb-07d81f1edd1e)).