### PR TITLE
[cli] add support back for owner field when cred checking

### DIFF
--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -5,6 +5,7 @@ import { Android, AndroidCredentials, Credentials } from '@expo/xdl';
 import chalk from 'chalk';
 import get from 'lodash/get';
 
+import invariant from 'invariant';
 import log from '../../log';
 import BuildError from './BuildError';
 import BaseBuilder from './BaseBuilder';
@@ -93,7 +94,8 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
 
       const backupKeystoreOutputPath = path.resolve(this.projectDir, `${ctx.manifest.slug}.jks`);
 
-      const view = new DownloadKeystore(ctx.manifest.slug);
+      invariant(ctx.manifest.slug, 'app.json slug field must be set');
+      const view = new DownloadKeystore(ctx.manifest.slug as string);
       await view.fetch(ctx);
       await view.save(ctx, backupKeystoreOutputPath, true);
       await Credentials.removeCredentialsForPlatform(ANDROID, credentialMetadata);

--- a/packages/expo-cli/src/commands/fetch/android.ts
+++ b/packages/expo-cli/src/commands/fetch/android.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import get from 'lodash/get';
 
 import { AndroidCredentials } from '@expo/xdl';
+import invariant from 'invariant';
 import { DownloadKeystore } from '../../credentials/views/AndroidCredentials';
 import { Context } from '../../credentials';
 
@@ -31,7 +32,8 @@ export async function fetchAndroidKeystoreAsync(projectDir: string): Promise<voi
   await maybeRenameExistingFile(projectDir, keystoreFilename);
   const backupKeystoreOutputPath = path.resolve(projectDir, keystoreFilename);
 
-  const view = new DownloadKeystore(ctx.manifest.slug);
+  invariant(ctx.manifest.slug, 'app.json slug field must be set');
+  const view = new DownloadKeystore(ctx.manifest.slug as string);
   await view.fetch(ctx);
   await view.save(ctx, backupKeystoreOutputPath, true);
 }
@@ -41,7 +43,8 @@ export async function fetchAndroidHashesAsync(projectDir: string): Promise<void>
   await ctx.init(projectDir);
   const outputPath = path.resolve(projectDir, `${ctx.manifest.slug}.tmp.jks`);
   try {
-    const view = new DownloadKeystore(ctx.manifest.slug);
+    invariant(ctx.manifest.slug, 'app.json slug field must be set');
+    const view = new DownloadKeystore(ctx.manifest.slug as string);
     await view.fetch(ctx);
     await view.save(ctx, outputPath);
 
@@ -76,7 +79,8 @@ export async function fetchAndroidUploadCertAsync(projectDir: string): Promise<v
   const uploadKeyPath = path.resolve(projectDir, uploadKeyFilename);
 
   try {
-    const view = new DownloadKeystore(ctx.manifest.slug);
+    invariant(ctx.manifest.slug, 'app.json slug field must be set');
+    const view = new DownloadKeystore(ctx.manifest.slug as string);
     await view.fetch(ctx);
     await view.save(ctx, keystorePath);
 

--- a/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
+++ b/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
@@ -5,6 +5,7 @@ import get from 'lodash/get';
 
 import { AndroidCredentials, Credentials } from '@expo/xdl';
 import { ExpoConfig } from '@expo/config';
+import invariant from 'invariant';
 import { Context } from '../../credentials';
 import { DownloadKeystore } from '../../credentials/views/AndroidCredentials';
 
@@ -31,9 +32,10 @@ export default class AppSigningOptInProcess {
   async run(): Promise<void> {
     const ctx = new Context();
     await ctx.init(this.projectDir);
-    await this.init(ctx.manifest.slug);
+    invariant(ctx.manifest.slug, 'app.json slug field must be set');
+    await this.init(ctx.manifest.slug as string);
 
-    const view = new DownloadKeystore(ctx.manifest.slug);
+    const view = new DownloadKeystore(ctx.manifest.slug as string);
     await view.fetch(ctx);
     await view.save(ctx, this.signKeystore, true);
 

--- a/packages/expo-cli/src/credentials/__tests__/api-basic-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-basic-test.ts
@@ -1,0 +1,278 @@
+import { IosApi } from '../api';
+import {
+  getApiV2Mock,
+  getCtxMock,
+  jester,
+  jester2,
+  testAllCredentials,
+  testAppCredential,
+  testAppleTeam,
+  testBundleIdentifier,
+  testDistCert,
+  testExperienceName,
+  testLegacyPushCert,
+  testProvisioningProfile,
+  testPushKey,
+} from '../test-fixtures/mocks';
+
+const originalWarn = console.warn;
+const originalLog = console.log;
+beforeAll(() => {
+  console.warn = jest.fn();
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.warn = originalWarn;
+  console.log = originalLog;
+});
+beforeEach(() => {});
+
+describe("IosApi - With Jester 2's Project Context", () => {
+  let iosApi;
+  let apiV2Mock;
+  let ctxMock;
+
+  beforeEach(() => {
+    apiV2Mock = getApiV2Mock();
+    ctxMock = getCtxMock();
+    iosApi = new IosApi(jester).withApiClient(apiV2Mock).withProjectContext(ctxMock);
+  });
+  it('getAllCredentials', async () => {
+    const credsFromServer = await iosApi.getAllCredentials();
+    const credsFromMemory = await iosApi.getAllCredentials();
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('getDistCert', async () => {
+    const credsFromServer = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('createDistCert', async () => {
+    const postAsync = jest.fn(() => {
+      return { id: 666 };
+    });
+    apiV2Mock = getApiV2Mock({ postAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.createDistCert(testDistCert);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/dist', {
+      credentials: testDistCert,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testDistCert,
+      id: 666,
+    });
+  });
+  it('updateDistCert', async () => {
+    const credentialsId = 666;
+    const putAsync = jest.fn(() => {
+      return { id: credentialsId };
+    });
+    apiV2Mock = getApiV2Mock({ putAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.updateDistCert(credentialsId, testDistCert);
+
+    expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
+      credentials: testDistCert,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testDistCert,
+      id: credentialsId,
+    });
+  });
+  it('deleteDistCert', async () => {
+    const credentialsId = 666;
+    await iosApi.deleteDistCert(credentialsId);
+
+    expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
+      owner: jester2.username,
+    });
+  });
+  it('useDistCert', async () => {
+    const credentialsId = 666;
+    await iosApi.useDistCert(testExperienceName, testBundleIdentifier, credentialsId);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/use/dist', {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      userCredentialsId: credentialsId,
+      owner: jester2.username,
+    });
+  });
+  it('createPushKey', async () => {
+    const postAsync = jest.fn(() => {
+      return { id: 666 };
+    });
+    apiV2Mock = getApiV2Mock({ postAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.createPushKey(testPushKey);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/push', {
+      credentials: testPushKey,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testPushKey,
+      id: 666,
+    });
+  });
+  it('updatePushKey', async () => {
+    const credentialsId = 666;
+    const putAsync = jest.fn(() => {
+      return { id: credentialsId };
+    });
+    apiV2Mock = getApiV2Mock({ putAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.updatePushKey(credentialsId, testPushKey);
+
+    expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
+      credentials: testPushKey,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testPushKey,
+      id: credentialsId,
+    });
+  });
+  it('deletePushKey', async () => {
+    const credentialsId = 666;
+    await iosApi.deletePushKey(credentialsId);
+
+    expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
+      owner: jester2.username,
+    });
+  });
+  it('getPushKey', async () => {
+    const credsFromServer = await iosApi.getPushKey(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getPushKey(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('usePushKey', async () => {
+    const credentialsId = 666;
+    await iosApi.usePushKey(testExperienceName, testBundleIdentifier, credentialsId);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/use/push', {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      userCredentialsId: credentialsId,
+      owner: jester2.username,
+    });
+  });
+  it('getPushCert', async () => {
+    const testAppCredentialsWithLegacyCert = {
+      ...testAppCredential,
+      credentials: testLegacyPushCert,
+    };
+    const testAllCredentialsWithLegacyCert = {
+      ...testAllCredentials,
+    };
+    testAllCredentialsWithLegacyCert.appCredentials = [testAppCredentialsWithLegacyCert];
+    const getAsync = jest.fn(() => testAllCredentialsWithLegacyCert);
+    apiV2Mock = getApiV2Mock({ getAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+
+    const credsFromServer = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('deletePushCert', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+    await iosApi.deletePushCert(testExperienceName, testBundleIdentifier);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/pushCert/delete`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      owner: jester2.username,
+    });
+  });
+  it('updateProvisioningProfile', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+
+    await iosApi.updateProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier,
+      testProvisioningProfile,
+      testAppleTeam
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/update`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      credentials: { ...testProvisioningProfile, teamId: testAppleTeam.id },
+      owner: jester2.username,
+    });
+  });
+  it('getAppCredentials', async () => {
+    const credsFromServer = await iosApi.getAppCredentials(
+      testExperienceName,
+      testBundleIdentifier
+    );
+    const credsFromMemory = await await iosApi.getAppCredentials(
+      testExperienceName,
+      testBundleIdentifier
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('getProvisioningProfile', async () => {
+    const credsFromServer = await iosApi.getProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier
+    );
+    const credsFromMemory = await iosApi.getProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('deleteProvisioningProfile', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+    await iosApi.deleteProvisioningProfile(testExperienceName, testBundleIdentifier);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/delete`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      owner: jester2.username,
+    });
+  });
+});

--- a/packages/expo-cli/src/credentials/__tests__/api-basic-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-basic-test.ts
@@ -1,9 +1,8 @@
 import { IosApi } from '../api';
 import {
-  getApiV2Mock,
+  getApiV2MockCredentials,
   getCtxMock,
   jester,
-  jester2,
   testAllCredentials,
   testAppCredential,
   testAppleTeam,
@@ -27,15 +26,13 @@ afterAll(() => {
 });
 beforeEach(() => {});
 
-describe("IosApi - With Jester 2's Project Context", () => {
+describe('IosApi - Basic Tests', () => {
   let iosApi;
   let apiV2Mock;
-  let ctxMock;
 
   beforeEach(() => {
-    apiV2Mock = getApiV2Mock();
-    ctxMock = getCtxMock();
-    iosApi = new IosApi(jester).withApiClient(apiV2Mock).withProjectContext(ctxMock);
+    apiV2Mock = getApiV2MockCredentials();
+    iosApi = new IosApi(jester).withApiClient(apiV2Mock);
   });
   it('getAllCredentials', async () => {
     const credsFromServer = await iosApi.getAllCredentials();
@@ -44,7 +41,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     // expect to fetch from memory after 1st call
     expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
     expect(credsFromMemory).toMatchObject(credsFromServer);
-    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester.username });
   });
   it('getDistCert', async () => {
     const credsFromServer = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
@@ -53,20 +50,20 @@ describe("IosApi - With Jester 2's Project Context", () => {
     // expect to fetch from memory after 1st call
     expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
     expect(credsFromMemory).toMatchObject(credsFromServer);
-    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester.username });
   });
   it('createDistCert', async () => {
     const postAsync = jest.fn(() => {
       return { id: 666 };
     });
-    apiV2Mock = getApiV2Mock({ postAsync });
+    apiV2Mock = getApiV2MockCredentials({ postAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
     const newCred = await iosApi.createDistCert(testDistCert);
 
     expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
     expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/dist', {
       credentials: testDistCert,
-      owner: jester2.username,
+      owner: jester.username,
     });
     expect(newCred).toMatchObject({
       ...testDistCert,
@@ -78,14 +75,14 @@ describe("IosApi - With Jester 2's Project Context", () => {
     const putAsync = jest.fn(() => {
       return { id: credentialsId };
     });
-    apiV2Mock = getApiV2Mock({ putAsync });
+    apiV2Mock = getApiV2MockCredentials({ putAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
     const newCred = await iosApi.updateDistCert(credentialsId, testDistCert);
 
     expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
     expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
       credentials: testDistCert,
-      owner: jester2.username,
+      owner: jester.username,
     });
     expect(newCred).toMatchObject({
       ...testDistCert,
@@ -98,7 +95,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
 
     expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
     expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
-      owner: jester2.username,
+      owner: jester.username,
     });
   });
   it('useDistCert', async () => {
@@ -110,21 +107,21 @@ describe("IosApi - With Jester 2's Project Context", () => {
       experienceName: testExperienceName,
       bundleIdentifier: testBundleIdentifier,
       userCredentialsId: credentialsId,
-      owner: jester2.username,
+      owner: jester.username,
     });
   });
   it('createPushKey', async () => {
     const postAsync = jest.fn(() => {
       return { id: 666 };
     });
-    apiV2Mock = getApiV2Mock({ postAsync });
+    apiV2Mock = getApiV2MockCredentials({ postAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
     const newCred = await iosApi.createPushKey(testPushKey);
 
     expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
     expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/push', {
       credentials: testPushKey,
-      owner: jester2.username,
+      owner: jester.username,
     });
     expect(newCred).toMatchObject({
       ...testPushKey,
@@ -136,14 +133,14 @@ describe("IosApi - With Jester 2's Project Context", () => {
     const putAsync = jest.fn(() => {
       return { id: credentialsId };
     });
-    apiV2Mock = getApiV2Mock({ putAsync });
+    apiV2Mock = getApiV2MockCredentials({ putAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
     const newCred = await iosApi.updatePushKey(credentialsId, testPushKey);
 
     expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
     expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
       credentials: testPushKey,
-      owner: jester2.username,
+      owner: jester.username,
     });
     expect(newCred).toMatchObject({
       ...testPushKey,
@@ -156,7 +153,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
 
     expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
     expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
-      owner: jester2.username,
+      owner: jester.username,
     });
   });
   it('getPushKey', async () => {
@@ -166,7 +163,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     // expect to fetch from memory after 1st call
     expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
     expect(credsFromMemory).toMatchObject(credsFromServer);
-    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester.username });
   });
   it('usePushKey', async () => {
     const credentialsId = 666;
@@ -177,7 +174,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
       experienceName: testExperienceName,
       bundleIdentifier: testBundleIdentifier,
       userCredentialsId: credentialsId,
-      owner: jester2.username,
+      owner: jester.username,
     });
   });
   it('getPushCert', async () => {
@@ -190,7 +187,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     };
     testAllCredentialsWithLegacyCert.appCredentials = [testAppCredentialsWithLegacyCert];
     const getAsync = jest.fn(() => testAllCredentialsWithLegacyCert);
-    apiV2Mock = getApiV2Mock({ getAsync });
+    apiV2Mock = getApiV2MockCredentials({ getAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
 
     const credsFromServer = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
@@ -199,7 +196,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     // expect to fetch from memory after 1st call
     expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
     expect(credsFromMemory).toMatchObject(credsFromServer);
-    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester.username });
   });
   it('deletePushCert', async () => {
     // this call wont work unless we fetch credentials first
@@ -210,7 +207,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/pushCert/delete`, {
       experienceName: testExperienceName,
       bundleIdentifier: testBundleIdentifier,
-      owner: jester2.username,
+      owner: jester.username,
     });
   });
   it('updateProvisioningProfile', async () => {
@@ -230,7 +227,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
       experienceName: testExperienceName,
       bundleIdentifier: testBundleIdentifier,
       credentials: { ...testProvisioningProfile, teamId: testAppleTeam.id },
-      owner: jester2.username,
+      owner: jester.username,
     });
   });
   it('getAppCredentials', async () => {
@@ -246,7 +243,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     // expect to fetch from memory after 1st call
     expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
     expect(credsFromMemory).toMatchObject(credsFromServer);
-    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester.username });
   });
   it('getProvisioningProfile', async () => {
     const credsFromServer = await iosApi.getProvisioningProfile(
@@ -261,7 +258,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     // expect to fetch from memory after 1st call
     expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
     expect(credsFromMemory).toMatchObject(credsFromServer);
-    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester.username });
   });
   it('deleteProvisioningProfile', async () => {
     // this call wont work unless we fetch credentials first
@@ -272,7 +269,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/delete`, {
       experienceName: testExperienceName,
       bundleIdentifier: testBundleIdentifier,
-      owner: jester2.username,
+      owner: jester.username,
     });
   });
 });

--- a/packages/expo-cli/src/credentials/__tests__/api-project-context-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-project-context-test.ts
@@ -1,0 +1,278 @@
+import { IosApi } from '../api';
+import {
+  getApiV2Mock,
+  getCtxMock,
+  jester,
+  jester2,
+  testAllCredentials,
+  testAppCredential,
+  testAppleTeam,
+  testBundleIdentifier,
+  testDistCert,
+  testExperienceName,
+  testLegacyPushCert,
+  testProvisioningProfile,
+  testPushKey,
+} from '../test-fixtures/mocks';
+
+const originalWarn = console.warn;
+const originalLog = console.log;
+beforeAll(() => {
+  console.warn = jest.fn();
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.warn = originalWarn;
+  console.log = originalLog;
+});
+beforeEach(() => {});
+
+describe("IosApi - With Jester 2's Project Context", () => {
+  let iosApi;
+  let apiV2Mock;
+  let ctxMock;
+
+  beforeEach(() => {
+    apiV2Mock = getApiV2Mock();
+    ctxMock = getCtxMock();
+    iosApi = new IosApi(jester).withApiClient(apiV2Mock).withProjectContext(ctxMock);
+  });
+  it('getAllCredentials', async () => {
+    const credsFromServer = await iosApi.getAllCredentials();
+    const credsFromMemory = await iosApi.getAllCredentials();
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('getDistCert', async () => {
+    const credsFromServer = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('createDistCert', async () => {
+    const postAsync = jest.fn(() => {
+      return { id: 666 };
+    });
+    apiV2Mock = getApiV2Mock({ postAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.createDistCert(testDistCert);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/dist', {
+      credentials: testDistCert,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testDistCert,
+      id: 666,
+    });
+  });
+  it('updateDistCert', async () => {
+    const credentialsId = 666;
+    const putAsync = jest.fn(() => {
+      return { id: credentialsId };
+    });
+    apiV2Mock = getApiV2Mock({ putAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.updateDistCert(credentialsId, testDistCert);
+
+    expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
+      credentials: testDistCert,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testDistCert,
+      id: credentialsId,
+    });
+  });
+  it('deleteDistCert', async () => {
+    const credentialsId = 666;
+    await iosApi.deleteDistCert(credentialsId);
+
+    expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
+      owner: jester2.username,
+    });
+  });
+  it('useDistCert', async () => {
+    const credentialsId = 666;
+    await iosApi.useDistCert(testExperienceName, testBundleIdentifier, credentialsId);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/use/dist', {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      userCredentialsId: credentialsId,
+      owner: jester2.username,
+    });
+  });
+  it('createPushKey', async () => {
+    const postAsync = jest.fn(() => {
+      return { id: 666 };
+    });
+    apiV2Mock = getApiV2Mock({ postAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.createPushKey(testPushKey);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/push', {
+      credentials: testPushKey,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testPushKey,
+      id: 666,
+    });
+  });
+  it('updatePushKey', async () => {
+    const credentialsId = 666;
+    const putAsync = jest.fn(() => {
+      return { id: credentialsId };
+    });
+    apiV2Mock = getApiV2Mock({ putAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.updatePushKey(credentialsId, testPushKey);
+
+    expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
+      credentials: testPushKey,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testPushKey,
+      id: credentialsId,
+    });
+  });
+  it('deletePushKey', async () => {
+    const credentialsId = 666;
+    await iosApi.deletePushKey(credentialsId);
+
+    expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
+      owner: jester2.username,
+    });
+  });
+  it('getPushKey', async () => {
+    const credsFromServer = await iosApi.getPushKey(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getPushKey(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('usePushKey', async () => {
+    const credentialsId = 666;
+    await iosApi.usePushKey(testExperienceName, testBundleIdentifier, credentialsId);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/use/push', {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      userCredentialsId: credentialsId,
+      owner: jester2.username,
+    });
+  });
+  it('getPushCert', async () => {
+    const testAppCredentialsWithLegacyCert = {
+      ...testAppCredential,
+      credentials: testLegacyPushCert,
+    };
+    const testAllCredentialsWithLegacyCert = {
+      ...testAllCredentials,
+    };
+    testAllCredentialsWithLegacyCert.appCredentials = [testAppCredentialsWithLegacyCert];
+    const getAsync = jest.fn(() => testAllCredentialsWithLegacyCert);
+    apiV2Mock = getApiV2Mock({ getAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+
+    const credsFromServer = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('deletePushCert', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+    await iosApi.deletePushCert(testExperienceName, testBundleIdentifier);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/pushCert/delete`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      owner: jester2.username,
+    });
+  });
+  it('updateProvisioningProfile', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+
+    await iosApi.updateProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier,
+      testProvisioningProfile,
+      testAppleTeam
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/update`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      credentials: { ...testProvisioningProfile, teamId: testAppleTeam.id },
+      owner: jester2.username,
+    });
+  });
+  it('getAppCredentials', async () => {
+    const credsFromServer = await iosApi.getAppCredentials(
+      testExperienceName,
+      testBundleIdentifier
+    );
+    const credsFromMemory = await await iosApi.getAppCredentials(
+      testExperienceName,
+      testBundleIdentifier
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('getProvisioningProfile', async () => {
+    const credsFromServer = await iosApi.getProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier
+    );
+    const credsFromMemory = await iosApi.getProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('deleteProvisioningProfile', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+    await iosApi.deleteProvisioningProfile(testExperienceName, testBundleIdentifier);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/delete`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      owner: jester2.username,
+    });
+  });
+});

--- a/packages/expo-cli/src/credentials/__tests__/api-project-context-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-project-context-test.ts
@@ -1,11 +1,12 @@
 import { IosApi } from '../api';
 import {
-  getApiV2Mock,
+  getApiV2MockCredentials,
   getCtxMock,
   jester,
   jester2,
   testAllCredentials,
   testAppCredential,
+  testAppJsonWithDifferentOwner,
   testAppleTeam,
   testBundleIdentifier,
   testDistCert,
@@ -33,8 +34,8 @@ describe("IosApi - With Jester 2's Project Context", () => {
   let ctxMock;
 
   beforeEach(() => {
-    apiV2Mock = getApiV2Mock();
-    ctxMock = getCtxMock();
+    apiV2Mock = getApiV2MockCredentials();
+    ctxMock = getCtxMock({ manifest: testAppJsonWithDifferentOwner });
     iosApi = new IosApi(jester).withApiClient(apiV2Mock).withProjectContext(ctxMock);
   });
   it('getAllCredentials', async () => {
@@ -59,7 +60,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     const postAsync = jest.fn(() => {
       return { id: 666 };
     });
-    apiV2Mock = getApiV2Mock({ postAsync });
+    apiV2Mock = getApiV2MockCredentials({ postAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
     const newCred = await iosApi.createDistCert(testDistCert);
 
@@ -78,7 +79,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     const putAsync = jest.fn(() => {
       return { id: credentialsId };
     });
-    apiV2Mock = getApiV2Mock({ putAsync });
+    apiV2Mock = getApiV2MockCredentials({ putAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
     const newCred = await iosApi.updateDistCert(credentialsId, testDistCert);
 
@@ -117,7 +118,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     const postAsync = jest.fn(() => {
       return { id: 666 };
     });
-    apiV2Mock = getApiV2Mock({ postAsync });
+    apiV2Mock = getApiV2MockCredentials({ postAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
     const newCred = await iosApi.createPushKey(testPushKey);
 
@@ -136,7 +137,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     const putAsync = jest.fn(() => {
       return { id: credentialsId };
     });
-    apiV2Mock = getApiV2Mock({ putAsync });
+    apiV2Mock = getApiV2MockCredentials({ putAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
     const newCred = await iosApi.updatePushKey(credentialsId, testPushKey);
 
@@ -190,7 +191,7 @@ describe("IosApi - With Jester 2's Project Context", () => {
     };
     testAllCredentialsWithLegacyCert.appCredentials = [testAppCredentialsWithLegacyCert];
     const getAsync = jest.fn(() => testAllCredentialsWithLegacyCert);
-    apiV2Mock = getApiV2Mock({ getAsync });
+    apiV2Mock = getApiV2MockCredentials({ getAsync });
     iosApi = iosApi.withApiClient(apiV2Mock);
 
     const credsFromServer = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -64,14 +64,15 @@ export class Context {
   }
 
   async init(projectDir: string, options: CtxOptions = {}) {
+    // Check if we are in project context by looking for a manifest
     const status = await Doctor.validateWithoutNetworkAsync(projectDir);
     if (status !== Doctor.FATAL) {
-      /* This manager does not need to work in project context */
       const { exp } = getConfig(projectDir);
       this._manifest = exp;
       this._hasProjectContext = true;
       this._iosApiClient = new IosApi(this.user).withProjectContext(this);
     } else {
+      /* This manager does not need to work in project context */
       this._iosApiClient = new IosApi(this.user);
     }
 

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -64,6 +64,12 @@ export class Context {
   }
 
   async init(projectDir: string, options: CtxOptions = {}) {
+    if (options.allowAnonymous) {
+      this._user = (await UserManager.getCurrentUserAsync()) || undefined;
+    } else {
+      this._user = await UserManager.ensureLoggedInAsync();
+    }
+
     // Check if we are in project context by looking for a manifest
     const status = await Doctor.validateWithoutNetworkAsync(projectDir);
     if (status !== Doctor.FATAL) {
@@ -76,11 +82,6 @@ export class Context {
       this._iosApiClient = new IosApi(this.user);
     }
 
-    if (options.allowAnonymous) {
-      this._user = (await UserManager.getCurrentUserAsync()) || undefined;
-    } else {
-      this._user = await UserManager.ensureLoggedInAsync();
-    }
     this._apiClient = ApiV2.clientForUser(this.user);
   }
 }

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -3,6 +3,7 @@ import { ApiV2, Doctor, User, UserManager } from '@expo/xdl';
 
 import { AppleCtx, authenticate } from '../appleApi';
 import { IosApi } from './api';
+import log from '../log';
 
 export interface IView {
   open(ctx: Context): Promise<IView | null>;
@@ -77,6 +78,11 @@ export class Context {
       this._manifest = exp;
       this._hasProjectContext = true;
       this._iosApiClient = new IosApi(this.user).withProjectContext(this);
+      log(
+        `Configuring credentials for ${this.manifest.owner ?? this.user.username} in project ${
+          this.manifest.slug
+        }`
+      );
     } else {
       /* This manager does not need to work in project context */
       this._iosApiClient = new IosApi(this.user);

--- a/packages/expo-cli/src/credentials/test-fixtures/mocks.ts
+++ b/packages/expo-cli/src/credentials/test-fixtures/mocks.ts
@@ -1,68 +1,153 @@
+import { User } from '@expo/xdl';
+import merge from 'lodash/merge';
+import {
+  DistCert,
+  DistCertInfo,
+  ProvisioningProfile,
+  ProvisioningProfileInfo,
+  PushKey,
+  PushKeyInfo,
+  Team,
+} from '../../appleApi';
+import { IosDistCredentials, IosPushCredentials } from '../credentials';
 const today = new Date();
 const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-export const testProvisioningProfile = {
+export const testExperienceName = 'testApp';
+export const testBundleIdentifier = 'test.com.app';
+export const testAppleTeam: Team = {
+  id: 'test-team-id',
+};
+export const testProvisioningProfile: ProvisioningProfile = {
   provisioningProfileId: 'test-id',
+  provisioningProfile: 'test',
 };
 export const testProvisioningProfiles = [testProvisioningProfile];
-export const testProvisioningProfileFromApple = {
+export const testProvisioningProfileFromApple: ProvisioningProfileInfo = {
   name: 'test-name',
   status: 'Active',
-  expires: tomorrow,
+  expires: tomorrow.getTime(),
   distributionMethod: 'test',
   certificates: [],
   provisioningProfileId: testProvisioningProfile.provisioningProfileId,
+  provisioningProfile: testProvisioningProfile.provisioningProfile,
 };
 export const testProvisioningProfilesFromApple = [testProvisioningProfileFromApple];
 
-export const testDistCert = {
-  id: 1,
-  type: 'dist-cert',
+export const testDistCert: DistCert = {
   certP12: 'test-p12',
   certPassword: 'test-password',
   distCertSerialNumber: 'test-serial',
   teamId: 'test-team-id',
 };
-export const testDistCerts = [testDistCert];
-export const testDistCertFromApple = {
+export const testIosDistCredential: IosDistCredentials = {
+  id: 1,
+  type: 'dist-cert',
+  ...testDistCert,
+};
+export const testIosDistCredentials = [testIosDistCredential];
+export const testDistCertFromApple: DistCertInfo = {
   id: 'test-id',
+  name: 'test-name',
   status: 'Active',
   created: today.getTime(),
   expires: tomorrow.getTime(),
-  serialNumber: testDistCert.distCertSerialNumber,
+  ownerType: 'test-owner-type',
+  ownerName: 'test-owner',
+  ownerId: 'test-id',
+  serialNumber: testIosDistCredential.distCertSerialNumber as string,
 };
 export const testDistCertsFromApple = [testDistCertFromApple];
 
-export const testPushKey = {
-  id: 1,
-  type: 'push-key',
+export const testPushKey: PushKey = {
   apnsKeyP8: 'test-p8',
   apnsKeyId: 'test-key-id',
   teamId: 'test-team-id',
 };
-export const testPushKeys = [testPushKey];
-export const testPushKeyFromApple = {
-  id: testPushKey.apnsKeyId,
+export const testIosPushCredential: IosPushCredentials = {
+  id: 2,
+  type: 'push-key',
+  ...testPushKey,
+};
+export const testIosPushCredentials = [testIosPushCredential];
+export const testPushKeyFromApple: PushKeyInfo = {
+  id: testIosPushCredential.apnsKeyId,
   name: 'test-name',
 };
 export const testPushKeysFromApple = [testPushKeyFromApple];
+export const testLegacyPushCert = {
+  pushId: 'test-push-id',
+  pushP12: 'test-push-p12',
+  pushPassword: 'test-push-password',
+};
+export const testAppCredential = {
+  experienceName: testExperienceName,
+  bundleIdentifier: testBundleIdentifier,
+  distCredentialsId: testIosDistCredential.id,
+  pushCredentialsId: testIosPushCredential.id,
+  credentials: {
+    ...testProvisioningProfile,
+  },
+};
+export const testAppCredentials = [testAppCredential];
+export const testAllCredentials = {
+  userCredentials: [...testIosDistCredentials, ...testIosPushCredentials],
+  appCredentials: testAppCredentials,
+};
 
-export const testAppCredentials = [{ experienceName: 'testApp', bundleIdentifier: 'test.com.app' }];
+export const jester: User = {
+  kind: 'user',
+  username: 'jester',
+  nickname: 'jester',
+  userId: 'jester-id',
+  picture: 'jester-pic',
+  userMetadata: { onboarded: true },
+  currentConnection: 'Username-Password-Authentication',
+  sessionSecret: 'jester-secret',
+};
+
+export const jester2: User = {
+  kind: 'user',
+  username: 'jester2',
+  nickname: 'jester2',
+  userId: 'jester2-id',
+  picture: 'jester2-pic',
+  userMetadata: { onboarded: true },
+  currentConnection: 'Username-Password-Authentication',
+  sessionSecret: 'jester2-secret',
+};
+
+export function getApiV2Mock(overridenMock: { [key: string]: any } = {}) {
+  const defaultMock = {
+    sessionSecret: 'test-session',
+    getAsync: jest.fn(() => testAllCredentials),
+    postAsync: jest.fn(),
+    putAsync: jest.fn(),
+    deleteAsync: jest.fn(),
+    uploadFormDataAsync: jest.fn(),
+    _requestAsync: jest.fn(),
+  };
+  return merge(defaultMock, overridenMock);
+}
+export const testAppJson = {
+  name: 'testing 123',
+  version: '0.1.0',
+  slug: 'testing-123',
+  sdkVersion: '33.0.0',
+  owner: 'jester2',
+};
 export function getCtxMock() {
   return {
     ios: {
       getDistCert: jest.fn(),
-      createDistCert: jest.fn(() => testDistCert),
+      createDistCert: jest.fn(() => testIosDistCredential),
       useDistCert: jest.fn(),
       getPushKey: jest.fn(),
-      createPushKey: jest.fn(() => testPushKey),
+      createPushKey: jest.fn(() => testIosPushCredential),
       usePushKey: jest.fn(),
       updateProvisioningProfile: jest.fn(),
       getAppCredentials: jest.fn(() => testAppCredentials),
       getProvisioningProfile: jest.fn(),
-      credentials: {
-        userCredentials: [...testDistCerts, ...testPushKeys],
-        appCredentials: testAppCredentials,
-      },
+      credentials: testAllCredentials,
     },
     appleCtx: {
       appleId: 'test-id',
@@ -73,5 +158,7 @@ export function getCtxMock() {
     ensureAppleCtx: jest.fn(),
     user: jest.fn(),
     hasAppleCtx: jest.fn(() => true),
+    hasProjectContext: true,
+    manifest: testAppJson,
   };
 }

--- a/packages/expo-cli/src/credentials/test-fixtures/mocks.ts
+++ b/packages/expo-cli/src/credentials/test-fixtures/mocks.ts
@@ -10,9 +10,14 @@ import {
   Team,
 } from '../../appleApi';
 import { IosDistCredentials, IosPushCredentials } from '../credentials';
+
+/*
+Mock Credential objects for Jester 
+*/
 const today = new Date();
 const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-export const testExperienceName = 'testApp';
+export const testSlug = 'testApp';
+export const testExperienceName = `@jester/${testSlug}`;
 export const testBundleIdentifier = 'test.com.app';
 export const testAppleTeam: Team = {
   id: 'test-team-id',
@@ -116,6 +121,12 @@ export const jester2: User = {
   sessionSecret: 'jester2-secret',
 };
 
+export function getApiV2MockCredentials(overridenMock: { [key: string]: any } = {}) {
+  const defaultCredentialsApiV2Mock = {
+    getAsync: jest.fn(() => testAllCredentials),
+  };
+  return getApiV2Mock(merge(defaultCredentialsApiV2Mock, overridenMock));
+}
 export function getApiV2Mock(overridenMock: { [key: string]: any } = {}) {
   const defaultMock = {
     sessionSecret: 'test-session',
@@ -131,12 +142,17 @@ export function getApiV2Mock(overridenMock: { [key: string]: any } = {}) {
 export const testAppJson = {
   name: 'testing 123',
   version: '0.1.0',
-  slug: 'testing-123',
+  slug: testSlug,
   sdkVersion: '33.0.0',
-  owner: 'jester2',
+  ios: { bundleIdentifier: testBundleIdentifier },
 };
-export function getCtxMock() {
-  return {
+export const testAppJsonWithDifferentOwner = {
+  ...testAppJson,
+  owner: jester2.username,
+};
+
+export function getCtxMock(overridenMock: { [key: string]: any } = {}) {
+  const defaultMock = {
     ios: {
       getDistCert: jest.fn(),
       createDistCert: jest.fn(() => testIosDistCredential),
@@ -161,4 +177,5 @@ export function getCtxMock() {
     hasProjectContext: true,
     manifest: testAppJson,
   };
+  return merge(defaultMock, overridenMock);
 }

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import invariant from 'invariant';
 import prompt, { ChoiceType, Question } from '../../prompt';
 import log from '../../log';
 
@@ -125,7 +126,8 @@ export class SelectAndroidExperience implements IView {
         },
       ]);
       if (runProjectContext) {
-        const view = new androidView.ExperienceView(ctx.manifest.slug, null);
+        invariant(ctx.manifest.slug, 'app.json slug field must be set');
+        const view = new androidView.ExperienceView(ctx.manifest.slug as string, null);
         CredentialsManager.get().changeMainView(view);
         return view;
       }

--- a/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
@@ -1,8 +1,12 @@
 import { CreateIosDist, CreateOrReuseDistributionCert } from '../IosDistCert';
-import { getCtxMock, testDistCert, testDistCertsFromApple } from '../../test-fixtures/mocks';
+import {
+  getCtxMock,
+  testDistCertsFromApple,
+  testIosDistCredential,
+} from '../../test-fixtures/mocks';
 
 // these variables need to be prefixed with 'mock' if declared outside of the mock scope
-const mockDistCertManagerCreate = jest.fn(() => testDistCert);
+const mockDistCertManagerCreate = jest.fn(() => testIosDistCredential);
 const mockDistCertManagerList = jest.fn(() => testDistCertsFromApple);
 jest.mock('../../../appleApi', () => {
   return {

--- a/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
@@ -4,7 +4,7 @@ import {
 } from '../IosProvisioningProfile';
 import {
   getCtxMock,
-  testDistCert,
+  testIosDistCredential,
   testProvisioningProfiles,
   testProvisioningProfilesFromApple,
 } from '../../test-fixtures/mocks';
@@ -48,7 +48,7 @@ describe('IosProvisioningProfile', () => {
       const provProfOptions = {
         experienceName: 'testApp',
         bundleIdentifier: 'test.com.app',
-        distCert: testDistCert,
+        distCert: testIosDistCredential,
         nonInteractive: true,
       };
       const createProvisioningProfile = new CreateProvisioningProfile(provProfOptions);
@@ -67,7 +67,7 @@ describe('IosProvisioningProfile', () => {
       const provProfOptions = {
         experienceName: 'testApp',
         bundleIdentifier: 'test.com.app',
-        distCert: testDistCert,
+        distCert: testIosDistCredential,
         nonInteractive: true,
       };
       const createOrReuseProvisioningProfile = new CreateOrReuseProvisioningProfile(
@@ -92,7 +92,7 @@ describe('IosProvisioningProfile', () => {
       const provProfOptions = {
         experienceName: 'testApp',
         bundleIdentifier: 'test.com.app',
-        distCert: testDistCert,
+        distCert: testIosDistCredential,
         nonInteractive: true,
       };
       const createOrReuseProvisioningProfile = new CreateOrReuseProvisioningProfile(

--- a/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
@@ -1,8 +1,12 @@
 import { CreateIosPush, CreateOrReusePushKey } from '../IosPushCredentials';
-import { getCtxMock, testPushKey, testPushKeysFromApple } from '../../test-fixtures/mocks';
+import {
+  getCtxMock,
+  testIosPushCredential,
+  testPushKeysFromApple,
+} from '../../test-fixtures/mocks';
 
 // these variables need to be prefixed with 'mock' if declared outside of the mock scope
-const mockPushKeyManagerCreate = jest.fn(() => testPushKey);
+const mockPushKeyManagerCreate = jest.fn(() => testIosPushCredential);
 const mockPushKeyManagerList = jest.fn(() => testPushKeysFromApple);
 jest.mock('../../../appleApi', () => {
   return {

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
@@ -1,8 +1,12 @@
 import { SetupIosDist } from '../SetupIosDist';
-import { getCtxMock, testDistCert, testDistCertsFromApple } from '../../test-fixtures/mocks';
+import {
+  getCtxMock,
+  testDistCertsFromApple,
+  testIosDistCredential,
+} from '../../test-fixtures/mocks';
 
 // these variables need to be prefixed with 'mock' if declared outside of the mock scope
-const mockDistCertManagerCreate = jest.fn(() => testDistCert);
+const mockDistCertManagerCreate = jest.fn(() => testIosDistCredential);
 const mockDistCertManagerList = jest.fn(() => testDistCertsFromApple);
 jest.mock('../../../appleApi', () => {
   return {

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
@@ -1,8 +1,12 @@
 import { SetupIosPush } from '../SetupIosPush';
-import { getCtxMock, testPushKey, testPushKeysFromApple } from '../../test-fixtures/mocks';
+import {
+  getCtxMock,
+  testIosPushCredential,
+  testPushKeysFromApple,
+} from '../../test-fixtures/mocks';
 
 // these variables need to be prefixed with 'mock' if declared outside of the mock scope
-const mockPushKeyManagerCreate = jest.fn(() => testPushKey);
+const mockPushKeyManagerCreate = jest.fn(() => testIosPushCredential);
 const mockPushKeyManagerList = jest.fn(() => testPushKeysFromApple);
 jest.mock('../../../appleApi', () => {
   return {

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
@@ -1,6 +1,6 @@
 import {
   getCtxMock,
-  testDistCert,
+  testIosDistCredential,
   testProvisioningProfiles,
   testProvisioningProfilesFromApple,
 } from '../../test-fixtures/mocks';
@@ -45,7 +45,7 @@ describe('SetupProvisioningProfile', () => {
     const provProfOptions = {
       experienceName: 'testApp',
       bundleIdentifier: 'test.com.app',
-      distCert: testDistCert as IosDistCredentials,
+      distCert: testIosDistCredential as IosDistCredentials,
       nonInteractive: true,
     };
     const setupProvisioningProfile = new SetupIosProvisioningProfile(provProfOptions);

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -136,6 +136,7 @@ export default class ApiV2Client {
 
   async deleteAsync(
     methodName: string,
+    args: QueryParameters = {},
     extraOptions?: Partial<RequestOptions>,
     returnEntireResponse: boolean = false
   ) {
@@ -143,6 +144,7 @@ export default class ApiV2Client {
       methodName,
       {
         httpMethod: 'delete',
+        queryParameters: args,
       },
       extraOptions,
       returnEntireResponse


### PR DESCRIPTION
# why
We used to support builds where if User A gave User B permission to build their app, User B would be able to build User A's app. However, User B would need to specify `UserA` was the owner of the app in the owner field of the `app.json`.

When we moved to the new credential checker, we overlooked this use case. We add it back now by doing the following:

- Add `username` field to credential's IosApi
- Add `owner` in the api's request body or query parameter as appropriate

# todo
- [x] add tests
- [x] land https://github.com/expo/universe/pull/4807 
- [x] deploy https://github.com/expo/universe/pull/4807  to prod
- [x]  sanity test for User A with Developer role on User B's account
- [x] sanity test for regular users