### PR TITLE
fix(expo-cli): add warning about damaged simulator builds catalina

### DIFF
--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import chalk from 'chalk';
 import pickBy from 'lodash/pickBy';
 import get from 'lodash/get';
@@ -5,6 +6,7 @@ import { XDLError } from '@expo/xdl';
 
 import { Dictionary } from 'lodash';
 import terminalLink from 'terminal-link';
+import semver from 'semver';
 import BaseBuilder from '../BaseBuilder';
 import { PLATFORMS } from '../constants';
 import * as utils from '../utils';
@@ -329,7 +331,11 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
   // warns for "damaged" builds when targeting simulator
   // see: https://github.com/expo/expo-cli/issues/1197
   maybeWarnDamagedSimulator() {
-    if (this.options.type === 'simulator') {
+    // see: https://en.wikipedia.org/wiki/Darwin_%28operating_system%29#Release_history
+    const isMacOsCatalinaOrLater =
+      os.platform() === 'darwin' && semver.satisfies(os.release(), '>=19.0.0');
+
+    if (isMacOsCatalinaOrLater && this.options.type === 'simulator') {
       log.newLine();
       log(
         chalk.bold(

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -41,6 +41,8 @@ class IOSBuilder extends BaseBuilder {
 
   async run(): Promise<void> {
     await this.validateProject();
+    this.maybeWarnDamagedSimulator();
+    log.addNewLineIfNone();
     await this.checkForBuildInProgress();
     if (this.options.type === 'archive') {
       await this.prepareCredentials();
@@ -50,6 +52,7 @@ class IOSBuilder extends BaseBuilder {
       await this.checkStatusBeforeBuild();
     }
     await this.build(publishedExpIds);
+    this.maybeWarnDamagedSimulator();
   }
 
   async validateProject() {
@@ -320,6 +323,22 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
       } else {
         // something weird happened, let's assume the icon is correct
       }
+    }
+  }
+
+  // warns for "damaged" builds when targeting simulator
+  // see: https://github.com/expo/expo-cli/issues/1197
+  maybeWarnDamagedSimulator() {
+    if (this.options.type === 'simulator') {
+      log.newLine();
+      log(
+        chalk.bold(
+          `🚨 If the build is not installable on your simulator because of "${chalk.underline(
+            `... is damaged and can't be opened.`
+          )}", please run:`
+        )
+      );
+      log(chalk.grey.bold('xattr -rd com.apple.quarantine /path/to/your.app'));
     }
   }
 }


### PR DESCRIPTION
Fixes #1197

It's just a warning, styled like the `expo upgrade` warnings, to tell the developer about possible damaged simulator builds. I put it in twice, so it's always visible when the user starts the build and when the build is completed (or sent, with `--no-wait`).

<details>
<summary>This is how it looks like when starting</summary>
<img src="https://user-images.githubusercontent.com/1203991/79881380-64d10b80-83f1-11ea-8634-be55e3123268.png" />
</details>

<details>
<summary>This is how it looks like at the end</summary>
<img src="https://user-images.githubusercontent.com/1203991/79883838-ac0ccb80-83f4-11ea-8ed9-5f128e7663dd.png" />
</details>