### PR TITLE
[webpack-config] Resolve babel preset expo from a global CLI

### DIFF
--- a/packages/webpack-config/src/loaders/createBabelLoader.ts
+++ b/packages/webpack-config/src/loaders/createBabelLoader.ts
@@ -151,11 +151,14 @@ export default function createBabelLoader({
     !fs.existsSync(path.join(projectRoot, 'babel.config.js')) &&
     !fs.existsSync(path.join(projectRoot, '.babelrc'))
   ) {
-    if (projectHasModule('babel-preset-expo', projectRoot, {})) {
+    // If no babel config exists then fallback on the default `babel-preset-expo`
+    // which is installed with `expo`.
+    const modulePath = projectHasModule('babel-preset-expo', projectRoot, {});
+    if (modulePath) {
       presetOptions = {
         babelrc: false,
         configFile: false,
-        presets: [require.resolve('babel-preset-expo')],
+        presets: [modulePath],
       };
     } else {
       console.log(chalk.yellow('\u203A Webpack failed to locate a valid Babel config'));


### PR DESCRIPTION
This fixes a bug where `babel-preset-expo` couldn't be resolved in a project unless the `webpack-config` package was installed in that project. We can now effectively remove the requirement for a local `babel.config.js` in the project root on web.