### PR TITLE
[cli] tests for credentials api with project context

### DIFF
--- a/packages/expo-cli/src/credentials/__tests__/api-basic-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-basic-test.ts
@@ -1,0 +1,278 @@
+import { IosApi } from '../api';
+import {
+  getApiV2Mock,
+  getCtxMock,
+  jester,
+  jester2,
+  testAllCredentials,
+  testAppCredential,
+  testAppleTeam,
+  testBundleIdentifier,
+  testDistCert,
+  testExperienceName,
+  testLegacyPushCert,
+  testProvisioningProfile,
+  testPushKey,
+} from '../test-fixtures/mocks';
+
+const originalWarn = console.warn;
+const originalLog = console.log;
+beforeAll(() => {
+  console.warn = jest.fn();
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.warn = originalWarn;
+  console.log = originalLog;
+});
+beforeEach(() => {});
+
+describe("IosApi - With Jester 2's Project Context", () => {
+  let iosApi;
+  let apiV2Mock;
+  let ctxMock;
+
+  beforeEach(() => {
+    apiV2Mock = getApiV2Mock();
+    ctxMock = getCtxMock();
+    iosApi = new IosApi(jester).withApiClient(apiV2Mock).withProjectContext(ctxMock);
+  });
+  it('getAllCredentials', async () => {
+    const credsFromServer = await iosApi.getAllCredentials();
+    const credsFromMemory = await iosApi.getAllCredentials();
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('getDistCert', async () => {
+    const credsFromServer = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('createDistCert', async () => {
+    const postAsync = jest.fn(() => {
+      return { id: 666 };
+    });
+    apiV2Mock = getApiV2Mock({ postAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.createDistCert(testDistCert);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/dist', {
+      credentials: testDistCert,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testDistCert,
+      id: 666,
+    });
+  });
+  it('updateDistCert', async () => {
+    const credentialsId = 666;
+    const putAsync = jest.fn(() => {
+      return { id: credentialsId };
+    });
+    apiV2Mock = getApiV2Mock({ putAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.updateDistCert(credentialsId, testDistCert);
+
+    expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
+      credentials: testDistCert,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testDistCert,
+      id: credentialsId,
+    });
+  });
+  it('deleteDistCert', async () => {
+    const credentialsId = 666;
+    await iosApi.deleteDistCert(credentialsId);
+
+    expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
+      owner: jester2.username,
+    });
+  });
+  it('useDistCert', async () => {
+    const credentialsId = 666;
+    await iosApi.useDistCert(testExperienceName, testBundleIdentifier, credentialsId);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/use/dist', {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      userCredentialsId: credentialsId,
+      owner: jester2.username,
+    });
+  });
+  it('createPushKey', async () => {
+    const postAsync = jest.fn(() => {
+      return { id: 666 };
+    });
+    apiV2Mock = getApiV2Mock({ postAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.createPushKey(testPushKey);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/push', {
+      credentials: testPushKey,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testPushKey,
+      id: 666,
+    });
+  });
+  it('updatePushKey', async () => {
+    const credentialsId = 666;
+    const putAsync = jest.fn(() => {
+      return { id: credentialsId };
+    });
+    apiV2Mock = getApiV2Mock({ putAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.updatePushKey(credentialsId, testPushKey);
+
+    expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
+      credentials: testPushKey,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testPushKey,
+      id: credentialsId,
+    });
+  });
+  it('deletePushKey', async () => {
+    const credentialsId = 666;
+    await iosApi.deletePushKey(credentialsId);
+
+    expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
+      owner: jester2.username,
+    });
+  });
+  it('getPushKey', async () => {
+    const credsFromServer = await iosApi.getPushKey(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getPushKey(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('usePushKey', async () => {
+    const credentialsId = 666;
+    await iosApi.usePushKey(testExperienceName, testBundleIdentifier, credentialsId);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/use/push', {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      userCredentialsId: credentialsId,
+      owner: jester2.username,
+    });
+  });
+  it('getPushCert', async () => {
+    const testAppCredentialsWithLegacyCert = {
+      ...testAppCredential,
+      credentials: testLegacyPushCert,
+    };
+    const testAllCredentialsWithLegacyCert = {
+      ...testAllCredentials,
+    };
+    testAllCredentialsWithLegacyCert.appCredentials = [testAppCredentialsWithLegacyCert];
+    const getAsync = jest.fn(() => testAllCredentialsWithLegacyCert);
+    apiV2Mock = getApiV2Mock({ getAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+
+    const credsFromServer = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('deletePushCert', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+    await iosApi.deletePushCert(testExperienceName, testBundleIdentifier);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/pushCert/delete`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      owner: jester2.username,
+    });
+  });
+  it('updateProvisioningProfile', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+
+    await iosApi.updateProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier,
+      testProvisioningProfile,
+      testAppleTeam
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/update`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      credentials: { ...testProvisioningProfile, teamId: testAppleTeam.id },
+      owner: jester2.username,
+    });
+  });
+  it('getAppCredentials', async () => {
+    const credsFromServer = await iosApi.getAppCredentials(
+      testExperienceName,
+      testBundleIdentifier
+    );
+    const credsFromMemory = await await iosApi.getAppCredentials(
+      testExperienceName,
+      testBundleIdentifier
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('getProvisioningProfile', async () => {
+    const credsFromServer = await iosApi.getProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier
+    );
+    const credsFromMemory = await iosApi.getProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('deleteProvisioningProfile', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+    await iosApi.deleteProvisioningProfile(testExperienceName, testBundleIdentifier);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/delete`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      owner: jester2.username,
+    });
+  });
+});

--- a/packages/expo-cli/src/credentials/__tests__/api-project-context-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-project-context-test.ts
@@ -1,0 +1,278 @@
+import { IosApi } from '../api';
+import {
+  getApiV2Mock,
+  getCtxMock,
+  jester,
+  jester2,
+  testAllCredentials,
+  testAppCredential,
+  testAppleTeam,
+  testBundleIdentifier,
+  testDistCert,
+  testExperienceName,
+  testLegacyPushCert,
+  testProvisioningProfile,
+  testPushKey,
+} from '../test-fixtures/mocks';
+
+const originalWarn = console.warn;
+const originalLog = console.log;
+beforeAll(() => {
+  console.warn = jest.fn();
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.warn = originalWarn;
+  console.log = originalLog;
+});
+beforeEach(() => {});
+
+describe("IosApi - With Jester 2's Project Context", () => {
+  let iosApi;
+  let apiV2Mock;
+  let ctxMock;
+
+  beforeEach(() => {
+    apiV2Mock = getApiV2Mock();
+    ctxMock = getCtxMock();
+    iosApi = new IosApi(jester).withApiClient(apiV2Mock).withProjectContext(ctxMock);
+  });
+  it('getAllCredentials', async () => {
+    const credsFromServer = await iosApi.getAllCredentials();
+    const credsFromMemory = await iosApi.getAllCredentials();
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('getDistCert', async () => {
+    const credsFromServer = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getDistCert(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('createDistCert', async () => {
+    const postAsync = jest.fn(() => {
+      return { id: 666 };
+    });
+    apiV2Mock = getApiV2Mock({ postAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.createDistCert(testDistCert);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/dist', {
+      credentials: testDistCert,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testDistCert,
+      id: 666,
+    });
+  });
+  it('updateDistCert', async () => {
+    const credentialsId = 666;
+    const putAsync = jest.fn(() => {
+      return { id: credentialsId };
+    });
+    apiV2Mock = getApiV2Mock({ putAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.updateDistCert(credentialsId, testDistCert);
+
+    expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
+      credentials: testDistCert,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testDistCert,
+      id: credentialsId,
+    });
+  });
+  it('deleteDistCert', async () => {
+    const credentialsId = 666;
+    await iosApi.deleteDistCert(credentialsId);
+
+    expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/dist/${credentialsId}`, {
+      owner: jester2.username,
+    });
+  });
+  it('useDistCert', async () => {
+    const credentialsId = 666;
+    await iosApi.useDistCert(testExperienceName, testBundleIdentifier, credentialsId);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/use/dist', {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      userCredentialsId: credentialsId,
+      owner: jester2.username,
+    });
+  });
+  it('createPushKey', async () => {
+    const postAsync = jest.fn(() => {
+      return { id: 666 };
+    });
+    apiV2Mock = getApiV2Mock({ postAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.createPushKey(testPushKey);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/push', {
+      credentials: testPushKey,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testPushKey,
+      id: 666,
+    });
+  });
+  it('updatePushKey', async () => {
+    const credentialsId = 666;
+    const putAsync = jest.fn(() => {
+      return { id: credentialsId };
+    });
+    apiV2Mock = getApiV2Mock({ putAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+    const newCred = await iosApi.updatePushKey(credentialsId, testPushKey);
+
+    expect(apiV2Mock.putAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.putAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
+      credentials: testPushKey,
+      owner: jester2.username,
+    });
+    expect(newCred).toMatchObject({
+      ...testPushKey,
+      id: credentialsId,
+    });
+  });
+  it('deletePushKey', async () => {
+    const credentialsId = 666;
+    await iosApi.deletePushKey(credentialsId);
+
+    expect(apiV2Mock.deleteAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.deleteAsync).toBeCalledWith(`credentials/ios/push/${credentialsId}`, {
+      owner: jester2.username,
+    });
+  });
+  it('getPushKey', async () => {
+    const credsFromServer = await iosApi.getPushKey(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getPushKey(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('usePushKey', async () => {
+    const credentialsId = 666;
+    await iosApi.usePushKey(testExperienceName, testBundleIdentifier, credentialsId);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith('credentials/ios/use/push', {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      userCredentialsId: credentialsId,
+      owner: jester2.username,
+    });
+  });
+  it('getPushCert', async () => {
+    const testAppCredentialsWithLegacyCert = {
+      ...testAppCredential,
+      credentials: testLegacyPushCert,
+    };
+    const testAllCredentialsWithLegacyCert = {
+      ...testAllCredentials,
+    };
+    testAllCredentialsWithLegacyCert.appCredentials = [testAppCredentialsWithLegacyCert];
+    const getAsync = jest.fn(() => testAllCredentialsWithLegacyCert);
+    apiV2Mock = getApiV2Mock({ getAsync });
+    iosApi = iosApi.withApiClient(apiV2Mock);
+
+    const credsFromServer = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
+    const credsFromMemory = await iosApi.getPushCert(testExperienceName, testBundleIdentifier);
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('deletePushCert', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+    await iosApi.deletePushCert(testExperienceName, testBundleIdentifier);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/pushCert/delete`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      owner: jester2.username,
+    });
+  });
+  it('updateProvisioningProfile', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+
+    await iosApi.updateProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier,
+      testProvisioningProfile,
+      testAppleTeam
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/update`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      credentials: { ...testProvisioningProfile, teamId: testAppleTeam.id },
+      owner: jester2.username,
+    });
+  });
+  it('getAppCredentials', async () => {
+    const credsFromServer = await iosApi.getAppCredentials(
+      testExperienceName,
+      testBundleIdentifier
+    );
+    const credsFromMemory = await await iosApi.getAppCredentials(
+      testExperienceName,
+      testBundleIdentifier
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('getProvisioningProfile', async () => {
+    const credsFromServer = await iosApi.getProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier
+    );
+    const credsFromMemory = await iosApi.getProvisioningProfile(
+      testExperienceName,
+      testBundleIdentifier
+    );
+
+    // expect to fetch from memory after 1st call
+    expect(apiV2Mock.getAsync.mock.calls.length).toBe(1);
+    expect(credsFromMemory).toMatchObject(credsFromServer);
+    expect(apiV2Mock.getAsync).toBeCalledWith('credentials/ios', { owner: jester2.username });
+  });
+  it('deleteProvisioningProfile', async () => {
+    // this call wont work unless we fetch credentials first
+    await iosApi.getAllCredentials();
+    await iosApi.deleteProvisioningProfile(testExperienceName, testBundleIdentifier);
+
+    expect(apiV2Mock.postAsync.mock.calls.length).toBe(1);
+    expect(apiV2Mock.postAsync).toBeCalledWith(`credentials/ios/provisioningProfile/delete`, {
+      experienceName: testExperienceName,
+      bundleIdentifier: testBundleIdentifier,
+      owner: jester2.username,
+    });
+  });
+});

--- a/packages/expo-cli/src/credentials/test-fixtures/mocks.ts
+++ b/packages/expo-cli/src/credentials/test-fixtures/mocks.ts
@@ -1,68 +1,153 @@
+import { User } from '@expo/xdl';
+import merge from 'lodash/merge';
+import {
+  DistCert,
+  DistCertInfo,
+  ProvisioningProfile,
+  ProvisioningProfileInfo,
+  PushKey,
+  PushKeyInfo,
+  Team,
+} from '../../appleApi';
+import { IosDistCredentials, IosPushCredentials } from '../credentials';
 const today = new Date();
 const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-export const testProvisioningProfile = {
+export const testExperienceName = 'testApp';
+export const testBundleIdentifier = 'test.com.app';
+export const testAppleTeam: Team = {
+  id: 'test-team-id',
+};
+export const testProvisioningProfile: ProvisioningProfile = {
   provisioningProfileId: 'test-id',
+  provisioningProfile: 'test',
 };
 export const testProvisioningProfiles = [testProvisioningProfile];
-export const testProvisioningProfileFromApple = {
+export const testProvisioningProfileFromApple: ProvisioningProfileInfo = {
   name: 'test-name',
   status: 'Active',
-  expires: tomorrow,
+  expires: tomorrow.getTime(),
   distributionMethod: 'test',
   certificates: [],
   provisioningProfileId: testProvisioningProfile.provisioningProfileId,
+  provisioningProfile: testProvisioningProfile.provisioningProfile,
 };
 export const testProvisioningProfilesFromApple = [testProvisioningProfileFromApple];
 
-export const testDistCert = {
-  id: 1,
-  type: 'dist-cert',
+export const testDistCert: DistCert = {
   certP12: 'test-p12',
   certPassword: 'test-password',
   distCertSerialNumber: 'test-serial',
   teamId: 'test-team-id',
 };
-export const testDistCerts = [testDistCert];
-export const testDistCertFromApple = {
+export const testIosDistCredential: IosDistCredentials = {
+  id: 1,
+  type: 'dist-cert',
+  ...testDistCert,
+};
+export const testIosDistCredentials = [testIosDistCredential];
+export const testDistCertFromApple: DistCertInfo = {
   id: 'test-id',
+  name: 'test-name',
   status: 'Active',
   created: today.getTime(),
   expires: tomorrow.getTime(),
-  serialNumber: testDistCert.distCertSerialNumber,
+  ownerType: 'test-owner-type',
+  ownerName: 'test-owner',
+  ownerId: 'test-id',
+  serialNumber: testIosDistCredential.distCertSerialNumber as string,
 };
 export const testDistCertsFromApple = [testDistCertFromApple];
 
-export const testPushKey = {
-  id: 1,
-  type: 'push-key',
+export const testPushKey: PushKey = {
   apnsKeyP8: 'test-p8',
   apnsKeyId: 'test-key-id',
   teamId: 'test-team-id',
 };
-export const testPushKeys = [testPushKey];
-export const testPushKeyFromApple = {
-  id: testPushKey.apnsKeyId,
+export const testIosPushCredential: IosPushCredentials = {
+  id: 2,
+  type: 'push-key',
+  ...testPushKey,
+};
+export const testIosPushCredentials = [testIosPushCredential];
+export const testPushKeyFromApple: PushKeyInfo = {
+  id: testIosPushCredential.apnsKeyId,
   name: 'test-name',
 };
 export const testPushKeysFromApple = [testPushKeyFromApple];
+export const testLegacyPushCert = {
+  pushId: 'test-push-id',
+  pushP12: 'test-push-p12',
+  pushPassword: 'test-push-password',
+};
+export const testAppCredential = {
+  experienceName: testExperienceName,
+  bundleIdentifier: testBundleIdentifier,
+  distCredentialsId: testIosDistCredential.id,
+  pushCredentialsId: testIosPushCredential.id,
+  credentials: {
+    ...testProvisioningProfile,
+  },
+};
+export const testAppCredentials = [testAppCredential];
+export const testAllCredentials = {
+  userCredentials: [...testIosDistCredentials, ...testIosPushCredentials],
+  appCredentials: testAppCredentials,
+};
 
-export const testAppCredentials = [{ experienceName: 'testApp', bundleIdentifier: 'test.com.app' }];
+export const jester: User = {
+  kind: 'user',
+  username: 'jester',
+  nickname: 'jester',
+  userId: 'jester-id',
+  picture: 'jester-pic',
+  userMetadata: { onboarded: true },
+  currentConnection: 'Username-Password-Authentication',
+  sessionSecret: 'jester-secret',
+};
+
+export const jester2: User = {
+  kind: 'user',
+  username: 'jester2',
+  nickname: 'jester2',
+  userId: 'jester2-id',
+  picture: 'jester2-pic',
+  userMetadata: { onboarded: true },
+  currentConnection: 'Username-Password-Authentication',
+  sessionSecret: 'jester2-secret',
+};
+
+export function getApiV2Mock(overridenMock: { [key: string]: any } = {}) {
+  const defaultMock = {
+    sessionSecret: 'test-session',
+    getAsync: jest.fn(() => testAllCredentials),
+    postAsync: jest.fn(),
+    putAsync: jest.fn(),
+    deleteAsync: jest.fn(),
+    uploadFormDataAsync: jest.fn(),
+    _requestAsync: jest.fn(),
+  };
+  return merge(defaultMock, overridenMock);
+}
+export const testAppJson = {
+  name: 'testing 123',
+  version: '0.1.0',
+  slug: 'testing-123',
+  sdkVersion: '33.0.0',
+  owner: 'jester2',
+};
 export function getCtxMock() {
   return {
     ios: {
       getDistCert: jest.fn(),
-      createDistCert: jest.fn(() => testDistCert),
+      createDistCert: jest.fn(() => testIosDistCredential),
       useDistCert: jest.fn(),
       getPushKey: jest.fn(),
-      createPushKey: jest.fn(() => testPushKey),
+      createPushKey: jest.fn(() => testIosPushCredential),
       usePushKey: jest.fn(),
       updateProvisioningProfile: jest.fn(),
       getAppCredentials: jest.fn(() => testAppCredentials),
       getProvisioningProfile: jest.fn(),
-      credentials: {
-        userCredentials: [...testDistCerts, ...testPushKeys],
-        appCredentials: testAppCredentials,
-      },
+      credentials: testAllCredentials,
     },
     appleCtx: {
       appleId: 'test-id',
@@ -73,5 +158,7 @@ export function getCtxMock() {
     ensureAppleCtx: jest.fn(),
     user: jest.fn(),
     hasAppleCtx: jest.fn(() => true),
+    hasProjectContext: true,
+    manifest: testAppJson,
   };
 }

--- a/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
@@ -1,8 +1,12 @@
 import { CreateIosDist, CreateOrReuseDistributionCert } from '../IosDistCert';
-import { getCtxMock, testDistCert, testDistCertsFromApple } from '../../test-fixtures/mocks';
+import {
+  getCtxMock,
+  testDistCertsFromApple,
+  testIosDistCredential,
+} from '../../test-fixtures/mocks';
 
 // these variables need to be prefixed with 'mock' if declared outside of the mock scope
-const mockDistCertManagerCreate = jest.fn(() => testDistCert);
+const mockDistCertManagerCreate = jest.fn(() => testIosDistCredential);
 const mockDistCertManagerList = jest.fn(() => testDistCertsFromApple);
 jest.mock('../../../appleApi', () => {
   return {

--- a/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
@@ -4,7 +4,7 @@ import {
 } from '../IosProvisioningProfile';
 import {
   getCtxMock,
-  testDistCert,
+  testIosDistCredential,
   testProvisioningProfiles,
   testProvisioningProfilesFromApple,
 } from '../../test-fixtures/mocks';
@@ -48,7 +48,7 @@ describe('IosProvisioningProfile', () => {
       const provProfOptions = {
         experienceName: 'testApp',
         bundleIdentifier: 'test.com.app',
-        distCert: testDistCert,
+        distCert: testIosDistCredential,
         nonInteractive: true,
       };
       const createProvisioningProfile = new CreateProvisioningProfile(provProfOptions);
@@ -67,7 +67,7 @@ describe('IosProvisioningProfile', () => {
       const provProfOptions = {
         experienceName: 'testApp',
         bundleIdentifier: 'test.com.app',
-        distCert: testDistCert,
+        distCert: testIosDistCredential,
         nonInteractive: true,
       };
       const createOrReuseProvisioningProfile = new CreateOrReuseProvisioningProfile(
@@ -92,7 +92,7 @@ describe('IosProvisioningProfile', () => {
       const provProfOptions = {
         experienceName: 'testApp',
         bundleIdentifier: 'test.com.app',
-        distCert: testDistCert,
+        distCert: testIosDistCredential,
         nonInteractive: true,
       };
       const createOrReuseProvisioningProfile = new CreateOrReuseProvisioningProfile(

--- a/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
@@ -1,8 +1,12 @@
 import { CreateIosPush, CreateOrReusePushKey } from '../IosPushCredentials';
-import { getCtxMock, testPushKey, testPushKeysFromApple } from '../../test-fixtures/mocks';
+import {
+  getCtxMock,
+  testIosPushCredential,
+  testPushKeysFromApple,
+} from '../../test-fixtures/mocks';
 
 // these variables need to be prefixed with 'mock' if declared outside of the mock scope
-const mockPushKeyManagerCreate = jest.fn(() => testPushKey);
+const mockPushKeyManagerCreate = jest.fn(() => testIosPushCredential);
 const mockPushKeyManagerList = jest.fn(() => testPushKeysFromApple);
 jest.mock('../../../appleApi', () => {
   return {

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
@@ -1,8 +1,12 @@
 import { SetupIosDist } from '../SetupIosDist';
-import { getCtxMock, testDistCert, testDistCertsFromApple } from '../../test-fixtures/mocks';
+import {
+  getCtxMock,
+  testDistCertsFromApple,
+  testIosDistCredential,
+} from '../../test-fixtures/mocks';
 
 // these variables need to be prefixed with 'mock' if declared outside of the mock scope
-const mockDistCertManagerCreate = jest.fn(() => testDistCert);
+const mockDistCertManagerCreate = jest.fn(() => testIosDistCredential);
 const mockDistCertManagerList = jest.fn(() => testDistCertsFromApple);
 jest.mock('../../../appleApi', () => {
   return {

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
@@ -1,8 +1,12 @@
 import { SetupIosPush } from '../SetupIosPush';
-import { getCtxMock, testPushKey, testPushKeysFromApple } from '../../test-fixtures/mocks';
+import {
+  getCtxMock,
+  testIosPushCredential,
+  testPushKeysFromApple,
+} from '../../test-fixtures/mocks';
 
 // these variables need to be prefixed with 'mock' if declared outside of the mock scope
-const mockPushKeyManagerCreate = jest.fn(() => testPushKey);
+const mockPushKeyManagerCreate = jest.fn(() => testIosPushCredential);
 const mockPushKeyManagerList = jest.fn(() => testPushKeysFromApple);
 jest.mock('../../../appleApi', () => {
   return {

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
@@ -1,6 +1,6 @@
 import {
   getCtxMock,
-  testDistCert,
+  testIosDistCredential,
   testProvisioningProfiles,
   testProvisioningProfilesFromApple,
 } from '../../test-fixtures/mocks';
@@ -45,7 +45,7 @@ describe('SetupProvisioningProfile', () => {
     const provProfOptions = {
       experienceName: 'testApp',
       bundleIdentifier: 'test.com.app',
-      distCert: testDistCert as IosDistCredentials,
+      distCert: testIosDistCredential as IosDistCredentials,
       nonInteractive: true,
     };
     const setupProvisioningProfile = new SetupIosProvisioningProfile(provProfOptions);


### PR DESCRIPTION
tests for https://github.com/expo/expo-cli/pull/1941

includes:

- regular tests for credentials api class
- project context tests for credentials api class
- more mocks + such for credentials 