### PR TITLE
Use ES2017

### DIFF
--- a/packages/babel-preset-cli/tsconfig.base.json
+++ b/packages/babel-preset-cli/tsconfig.base.json
@@ -4,14 +4,14 @@
     "composite": true,
     "esModuleInterop": true,
     "inlineSources": true,
-    "lib": ["ES2016"],
+    "lib": ["ES2017"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2016",
+    "target": "ES2017",
     "skipLibCheck": true,
     "typeRoots": ["./ts-declarations", "node_modules/@types", "../../node_modules/@types"]
   }


### PR DESCRIPTION
I noticed that in Expo CLI (which we compile with babel) we ship await/async, whereas all other packages that are build with TS create an awaiter method. Using ES2017 reduces bundle size. 
Ex `@expo/json-file`

### Before
```
npm notice === Tarball Details === 
npm notice name:          @expo/json-file                         
npm notice version:       8.2.11                                  
npm notice filename:      expo-json-file-8.2.11.tgz               
npm notice package size:  7.9 kB                                  
npm notice unpacked size: 36.4 kB                                 
npm notice shasum:        611d7d915e018737e6ab1328d81558637f54a6b8
npm notice integrity:     sha512-xoGaG04Afl6+0[...]PlAOMyrjl+AYg==
npm notice total files:   9  
```

### After

```
npm notice === Tarball Details === 
npm notice name:          @expo/json-file                         
npm notice version:       8.2.11                                  
npm notice filename:      expo-json-file-8.2.11.tgz               
npm notice package size:  7.6 kB                                  
npm notice unpacked size: 34.4 kB                                 
npm notice shasum:        f8d62a94ebd72a86ec19c61c7eed93cd53f4ace8
npm notice integrity:     sha512-4e3r8tnI/2WyG[...]XZ0Frj2xkNfyw==
npm notice total files:   9   
```