### PR TITLE
[xdl] Get xdl-manifests from apiv2 endpoint

### DIFF
--- a/packages/xdl/gulp/build-tasks.js
+++ b/packages/xdl/gulp/build-tasks.js
@@ -59,7 +59,10 @@ const tasks = {
         fse.writeJsonSync(path.join(paths.caches, 'versions.json'), data);
 
         for (let version of Object.keys(data.sdkVersions)) {
-          const { data: release } = await axios.get(`https://exp.host/--/xdl-schema/${version}`);
+          const { data: schema } = await axios.get(
+            `https://exp.host/--/api/v2/project/configuration/schema/${version}`
+          );
+          const { release } = JSON.parse(schema);
 
           fse.writeJsonSync(path.join(paths.caches, `schema-${version}.json`), release);
         }

--- a/packages/xdl/gulp/build-tasks.js
+++ b/packages/xdl/gulp/build-tasks.js
@@ -60,9 +60,7 @@ const tasks = {
 
         for (let version of Object.keys(data.sdkVersions)) {
           const {
-            data: {
-              data: { schema },
-            },
+            data: { data: schema },
           } = await axios.get(`https://exp.host/--/api/v2/project/configuration/schema/${version}`);
 
           fse.writeJsonSync(path.join(paths.caches, `schema-${version}.json`), schema);

--- a/packages/xdl/gulp/build-tasks.js
+++ b/packages/xdl/gulp/build-tasks.js
@@ -59,12 +59,13 @@ const tasks = {
         fse.writeJsonSync(path.join(paths.caches, 'versions.json'), data);
 
         for (let version of Object.keys(data.sdkVersions)) {
-          const { data: schema } = await axios.get(
-            `https://exp.host/--/api/v2/project/configuration/schema/${version}`
-          );
-          const { release } = JSON.parse(schema);
+          const {
+            data: {
+              data: { schema },
+            },
+          } = await axios.get(`https://exp.host/--/api/v2/project/configuration/schema/${version}`);
 
-          fse.writeJsonSync(path.join(paths.caches, `schema-${version}.json`), release);
+          fse.writeJsonSync(path.join(paths.caches, `schema-${version}.json`), schema);
         }
       })
       .catch(error => done(error))

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -1,4 +1,3 @@
-import { JSONObject } from '@expo/json-file';
 import axios, { AxiosRequestConfig, Canceler } from 'axios';
 import concat from 'concat-stream';
 import ExtendableError from 'es6-error';
@@ -11,7 +10,6 @@ import Config from './Config';
 import * as ConnectionStatus from './ConnectionStatus';
 import * as Extract from './Extract';
 import * as Session from './Session';
-import { Cacher } from './tools/FsCache';
 import UserManager from './User';
 import UserSettings from './UserSettings';
 import XDLError from './XDLError';
@@ -207,8 +205,6 @@ export default class ApiClient {
   static host: string = Config.api.host;
   static port: number = Config.api.port || 80;
 
-  static _schemaCaches: { [version: string]: Cacher<JSONObject> } = {};
-
   static setClientName(name: string) {
     exponentClient = name;
   }
@@ -238,21 +234,6 @@ export default class ApiClient {
   ) {
     let url = _rootBaseUrl() + path;
     return _callMethodAsync(url, method, requestBody, requestOptions);
-  }
-
-  static async xdlSchemaAsync(sdkVersion: string): Promise<JSONObject> {
-    if (!ApiClient._schemaCaches.hasOwnProperty(sdkVersion)) {
-      ApiClient._schemaCaches[sdkVersion] = new Cacher(
-        async () => {
-          return await ApiClient.callPathAsync(`/--/xdl-schema/${sdkVersion}`);
-        },
-        `schema-${sdkVersion}.json`,
-        0,
-        path.join(__dirname, `../caches/schema-${sdkVersion}.json`)
-      );
-    }
-
-    return await ApiClient._schemaCaches[sdkVersion].getAsync();
   }
 
   static async downloadAsync(

--- a/packages/xdl/src/Utils.ts
+++ b/packages/xdl/src/Utils.ts
@@ -1,9 +1,4 @@
 import { ncp } from 'ncp';
-import path from 'path';
-import { JSONObject } from '@expo/json-file';
-import { Cacher } from './tools/FsCache';
-
-import { ApiV2 } from './xdl';
 
 export function ncpAsync(source: string, dest: string, options: any = {}) {
   return new Promise((resolve, reject) => {
@@ -47,24 +42,5 @@ export class Semaphore {
         nextResolver(true);
       }
     }
-  }
-}
-
-export class XdlSchemaClient {
-  static _schemaCaches: { [version: string]: Cacher<JSONObject> } = {};
-
-  static async getAsync(sdkVersion: string): Promise<JSONObject> {
-    if (!XdlSchemaClient._schemaCaches.hasOwnProperty(sdkVersion)) {
-      XdlSchemaClient._schemaCaches[sdkVersion] = new Cacher(
-        async () => {
-          return await new ApiV2().getAsync(`project/configuration/schema/${sdkVersion}`);
-        },
-        `schema-${sdkVersion}.json`,
-        0,
-        path.join(__dirname, `../caches/schema-${sdkVersion}.json`)
-      );
-    }
-
-    return await XdlSchemaClient._schemaCaches[sdkVersion].getAsync();
   }
 }

--- a/packages/xdl/src/Utils.ts
+++ b/packages/xdl/src/Utils.ts
@@ -57,7 +57,7 @@ export class XdlSchemaClient {
     if (!XdlSchemaClient._schemaCaches.hasOwnProperty(sdkVersion)) {
       XdlSchemaClient._schemaCaches[sdkVersion] = new Cacher(
         async () => {
-          return await new ApiV2().getAsync(`project/configuration/schema/${sdkVersion}`);
+          return (await new ApiV2().getAsync(`project/configuration/schema/${sdkVersion}`)).schema;
         },
         `schema-${sdkVersion}.json`,
         0,

--- a/packages/xdl/src/Utils.ts
+++ b/packages/xdl/src/Utils.ts
@@ -57,7 +57,7 @@ export class XdlSchemaClient {
     if (!XdlSchemaClient._schemaCaches.hasOwnProperty(sdkVersion)) {
       XdlSchemaClient._schemaCaches[sdkVersion] = new Cacher(
         async () => {
-          return (await new ApiV2().getAsync(`project/configuration/schema/${sdkVersion}`)).schema;
+          return await new ApiV2().getAsync(`project/configuration/schema/${sdkVersion}`);
         },
         `schema-${sdkVersion}.json`,
         0,

--- a/packages/xdl/src/project/ExpSchema.ts
+++ b/packages/xdl/src/project/ExpSchema.ts
@@ -1,14 +1,18 @@
+import path from 'path';
+import { JSONObject } from '@expo/json-file';
+
 import { getConfig } from '@expo/config';
 import Schemer from '@expo/schemer';
 import fs from 'fs';
-import path from 'path';
 
-import { XdlSchemaClient } from '../Utils';
+import ApiV2 from '../ApiV2';
+import { Cacher } from '../tools/FsCache';
 
 export type Schema = any;
 export type AssetSchema = { schema: Schema; fieldPath: string };
 
 let _xdlSchemaJson: { [sdkVersion: string]: Schema } = {};
+let _schemaCaches: { [version: string]: Cacher<JSONObject> } = {};
 
 export async function validatorFromProjectRoot(projectRoot: string): Promise<Schemer> {
   const { exp } = getConfig(projectRoot);
@@ -66,7 +70,7 @@ async function _getSchemaJSONAsync(sdkVersion: string): Promise<{ schema: Schema
 
   if (!_xdlSchemaJson[sdkVersion]) {
     try {
-      _xdlSchemaJson[sdkVersion] = await XdlSchemaClient.getAsync(sdkVersion);
+      _xdlSchemaJson[sdkVersion] = await getConfigurationSchemaAsync(sdkVersion);
     } catch (e) {
       if (e.code && e.code === 'INVALID_JSON') {
         throw new Error(`Couldn't read schema from server`);
@@ -77,4 +81,19 @@ async function _getSchemaJSONAsync(sdkVersion: string): Promise<{ schema: Schema
   }
 
   return _xdlSchemaJson[sdkVersion];
+}
+
+async function getConfigurationSchemaAsync(sdkVersion: string): Promise<JSONObject> {
+  if (!_schemaCaches.hasOwnProperty(sdkVersion)) {
+    _schemaCaches[sdkVersion] = new Cacher(
+      async () => {
+        return await new ApiV2().getAsync(`project/configuration/schema/${sdkVersion}`);
+      },
+      `schema-${sdkVersion}.json`,
+      0,
+      path.join(__dirname, `../caches/schema-${sdkVersion}.json`)
+    );
+  }
+
+  return await _schemaCaches[sdkVersion].getAsync();
 }

--- a/packages/xdl/src/project/ExpSchema.ts
+++ b/packages/xdl/src/project/ExpSchema.ts
@@ -3,7 +3,7 @@ import Schemer from '@expo/schemer';
 import fs from 'fs';
 import path from 'path';
 
-import Api from '../Api';
+import { XdlSchemaClient } from '../Utils';
 
 export type Schema = any;
 export type AssetSchema = { schema: Schema; fieldPath: string };
@@ -66,7 +66,7 @@ async function _getSchemaJSONAsync(sdkVersion: string): Promise<{ schema: Schema
 
   if (!_xdlSchemaJson[sdkVersion]) {
     try {
-      _xdlSchemaJson[sdkVersion] = await Api.xdlSchemaAsync(sdkVersion);
+      _xdlSchemaJson[sdkVersion] = await XdlSchemaClient.getAsync(sdkVersion);
     } catch (e) {
       if (e.code && e.code === 'INVALID_JSON') {
         throw new Error(`Couldn't read schema from server`);


### PR DESCRIPTION
# How

There are two locations xdl-manifests are fetched. For the first one in `packages/xdl/gulp/build-tasks.js` replaced the url. Confirmed this worked by repopulating the schema cache (git diff is empty):
```
cd ~/expo-cli/packages/xdl
rm caches/*
yarn prepack
git diff
```

For the second location, Line 69 in `packages/xdl/src/project/ExpSchema.ts`:
1) Refactored the Cache out of the Api v1 class and into its own: `XdlSchemaClient`. 
2) Checked it worked in a similar way to the first point, but this time checking that`~/.expo/caches/` was repopulated by running `expo start` in an expo project. (Note: you have to delete `~/expo-cli/packages/xdl/caches/*` before running this test to force the repopulation to happen from the endpoint instead of the local backup.)
