### PR TITLE
[expo-cli] Improve readability of asyncActionProjectDir

### DIFF
--- a/packages/expo-cli/src/commands/android.ts
+++ b/packages/expo-cli/src/commands/android.ts
@@ -8,21 +8,17 @@ export default function(program: Command) {
     .command('android [project-dir]')
     .description(chalk.yellow`Deprecated: Opens your app in Expo on a connected Android device`)
     .allowOffline()
-    .asyncActionProjectDir(
-      () => {
-        // Deprecate after July 24, 2020 (3 months)
-        console.log(
-          boxen(
-            chalk.yellow(
-              `${chalk.bold(
-                `expo android`
-              )} is deprecated. You can open your project by:\n- Pressing ${chalk.bold`a`} in the ${chalk.bold`expo start`} terminal UI\n- Or by running ${chalk.bold`expo start --android`}`
-            ),
-            { borderColor: 'yellow', padding: 1 }
-          )
-        );
-      },
-      /* skipProjectValidation: */ true,
-      /* skipAuthCheck: */ true
-    );
+    .asyncActionProjectDir(() => {
+      // Deprecate after July 24, 2020 (3 months)
+      console.log(
+        boxen(
+          chalk.yellow(
+            `${chalk.bold(
+              `expo android`
+            )} is deprecated. You can open your project by:\n- Pressing ${chalk.bold`a`} in the ${chalk.bold`expo start`} terminal UI\n- Or by running ${chalk.bold`expo start --android`}`
+          ),
+          { borderColor: 'yellow', padding: 1 }
+        )
+      );
+    });
 }

--- a/packages/expo-cli/src/commands/apply.ts
+++ b/packages/expo-cli/src/commands/apply.ts
@@ -16,19 +16,15 @@ export default function(program: Command) {
     .description(
       'Take the configuration from app.json or app.config.js and apply it to a native project.'
     )
-    .asyncActionProjectDir(
-      async (projectDir: string, options: Options) => {
-        if (!options.platform || options.platform === 'ios') {
-          await configureIOSProjectAsync(projectDir);
-          logConfigWarningsIOS();
-        }
+    .asyncActionProjectDir(async (projectDir: string, options: Options) => {
+      if (!options.platform || options.platform === 'ios') {
+        await configureIOSProjectAsync(projectDir);
+        logConfigWarningsIOS();
+      }
 
-        if (!options.platform || options.platform === 'android') {
-          await configureAndroidProjectAsync(projectDir);
-          logConfigWarningsAndroid();
-        }
-      },
-      /* skipProjectValidation: */ true,
-      /* skipAuthCheck: */ true
-    );
+      if (!options.platform || options.platform === 'android') {
+        await configureAndroidProjectAsync(projectDir);
+        logConfigWarningsAndroid();
+      }
+    });
 }

--- a/packages/expo-cli/src/commands/build-native/index.ts
+++ b/packages/expo-cli/src/commands/build-native/index.ts
@@ -30,10 +30,10 @@ export default function(program: Command) {
       'Build an app binary for your project, signed and ready for submission to the Google Play Store / App Store.'
     )
     .option('-p --platform <platform>', 'Platform: [android|ios]', /^(android|ios)$/i)
-    .asyncActionProjectDir(buildAction);
+    .asyncActionProjectDir(buildAction, { checkConfig: true });
 
   program
     .command('build:status')
     .description(`Get the status of the latest builds for your project.`)
-    .asyncAction(statusAction);
+    .asyncAction(statusAction, { checkConfig: true });
 }

--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -49,24 +49,27 @@ export default function(program: Command) {
     .description(
       'Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.'
     )
-    .asyncActionProjectDir(async (projectDir: string, options: IosOptions) => {
-      if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
-        throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
-      }
-      let channelRe = new RegExp(/^[a-z\d][a-z\d._-]*$/);
-      if (!channelRe.test(options.releaseChannel)) {
-        log.error(
-          'Release channel name can only contain lowercase letters, numbers and special characters . _ and -'
-        );
-        process.exit(1);
-      }
-      options.type = await askBuildType(options.type, {
-        archive: 'Deploy the build to the store',
-        simulator: 'Run the build on a simulator',
-      });
-      const iosBuilder = new IOSBuilder(projectDir, options);
-      return iosBuilder.command();
-    });
+    .asyncActionProjectDir(
+      async (projectDir: string, options: IosOptions) => {
+        if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
+          throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
+        }
+        let channelRe = new RegExp(/^[a-z\d][a-z\d._-]*$/);
+        if (!channelRe.test(options.releaseChannel)) {
+          log.error(
+            'Release channel name can only contain lowercase letters, numbers and special characters . _ and -'
+          );
+          process.exit(1);
+        }
+        options.type = await askBuildType(options.type, {
+          archive: 'Deploy the build to the store',
+          simulator: 'Run the build on a simulator',
+        });
+        const iosBuilder = new IOSBuilder(projectDir, options);
+        return iosBuilder.command();
+      },
+      { checkConfig: true }
+    );
 
   program
     .command('build:android [project-dir]')
@@ -83,24 +86,27 @@ export default function(program: Command) {
     .description(
       'Build a standalone APK or App Bundle for your project, signed and ready for submission to the Google Play Store.'
     )
-    .asyncActionProjectDir(async (projectDir: string, options: AndroidOptions) => {
-      if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
-        throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
-      }
-      let channelRe = new RegExp(/^[a-z\d][a-z\d._-]*$/);
-      if (!channelRe.test(options.releaseChannel)) {
-        log.error(
-          'Release channel name can only contain lowercase letters, numbers and special characters . _ and -'
-        );
-        process.exit(1);
-      }
-      options.type = await askBuildType(options.type, {
-        apk: 'Build a package to deploy to the store or install directly on Android devices',
-        'app-bundle': 'Build an optimized bundle for the store',
-      });
-      const androidBuilder = new AndroidBuilder(projectDir, options);
-      return androidBuilder.command();
-    });
+    .asyncActionProjectDir(
+      async (projectDir: string, options: AndroidOptions) => {
+        if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
+          throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
+        }
+        let channelRe = new RegExp(/^[a-z\d][a-z\d._-]*$/);
+        if (!channelRe.test(options.releaseChannel)) {
+          log.error(
+            'Release channel name can only contain lowercase letters, numbers and special characters . _ and -'
+          );
+          process.exit(1);
+        }
+        options.type = await askBuildType(options.type, {
+          apk: 'Build a package to deploy to the store or install directly on Android devices',
+          'app-bundle': 'Build an optimized bundle for the store',
+        });
+        const androidBuilder = new AndroidBuilder(projectDir, options);
+        return androidBuilder.command();
+      },
+      { checkConfig: true }
+    );
 
   program
     .command('build:web [project-dir]')
@@ -117,9 +123,7 @@ export default function(program: Command) {
           ...options,
           dev: typeof options.dev === 'undefined' ? false : options.dev,
         });
-      },
-      /* skipProjectValidation: */ true,
-      /* skipAuthCheck: */ true
+      }
     );
 
   program
@@ -136,5 +140,5 @@ export default function(program: Command) {
       }
       const builder = new BaseBuilder(projectDir, options);
       return builder.commandCheckStatus();
-    }, /* skipProjectValidation: */ true);
+    });
 }

--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -118,7 +118,7 @@ export default function(program: Command) {
           dev: typeof options.dev === 'undefined' ? false : options.dev,
         });
       },
-      /* skipProjectValidation: */ false,
+      /* skipProjectValidation: */ true,
       /* skipAuthCheck: */ true
     );
 

--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -35,5 +35,5 @@ export default function(program: Command) {
     .description(
       'Bundles assets for a detached app. This command should be executed from xcode or gradle.'
     )
-    .asyncActionProjectDir(action, true);
+    .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -271,8 +271,7 @@ export default function(program: Command) {
           log(chalk.green(`${result.statusUrl}`));
         }
         log.newLine();
-      },
-      true
+      }
     );
 
   program
@@ -358,7 +357,7 @@ export default function(program: Command) {
       if (await Simulator.upgradeExpoAsync(targetClient.clientUrl)) {
         log('Done!');
       }
-    }, true);
+    });
 
   program
     .command('client:install:android')
@@ -443,5 +442,5 @@ export default function(program: Command) {
       if (await Android.upgradeExpoAsync(targetClient.clientUrl)) {
         log('Done!');
       }
-    }, true);
+    });
 }

--- a/packages/expo-cli/src/commands/doctor.ts
+++ b/packages/expo-cli/src/commands/doctor.ts
@@ -14,5 +14,5 @@ export default function(program: Command) {
   program
     .command('doctor [project-dir]')
     .description('Diagnoses issues with your Expo project.')
-    .asyncActionProjectDir(action, /* skipProjectValidation: */ true);
+    .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -52,5 +52,5 @@ export default function(program: Command) {
       '-f --force',
       'Will attempt to generate an iOS project even when the system is not running macOS. Unsafe and may fail.'
     )
-    .asyncActionProjectDir(action, /* skipProjectValidation: */ false, /* skipAuthCheck: */ true);
+    .asyncActionProjectDir(action, { checkConfig: true });
 }

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -222,5 +222,5 @@ export default function(program: Command) {
       []
     )
     .option('--max-workers [num]', 'Maximum number of tasks to allow Metro to spawn.')
-    .asyncActionProjectDir(action, false, true);
+    .asyncActionProjectDir(action, { checkConfig: true });
 }

--- a/packages/expo-cli/src/commands/fetch/index.ts
+++ b/packages/expo-cli/src/commands/fetch/index.ts
@@ -13,26 +13,26 @@ export default function(program: Command) {
     .description(
       `Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.`
     )
-    .asyncActionProjectDir(fetchIosCerts, true);
+    .asyncActionProjectDir(fetchIosCerts);
 
   program
     .command('fetch:android:keystore [project-dir]')
     .description(
       "Fetch this project's Android keystore. Writes keystore to PROJECT_DIR/PROJECT_NAME.jks and prints passwords to stdout."
     )
-    .asyncActionProjectDir(fetchAndroidKeystoreAsync, true);
+    .asyncActionProjectDir(fetchAndroidKeystoreAsync);
 
   program
     .command('fetch:android:hashes [project-dir]')
     .description(
       "Fetch this project's Android key hashes needed to set up Google/Facebook authentication. Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console."
     )
-    .asyncActionProjectDir(fetchAndroidHashesAsync, true);
+    .asyncActionProjectDir(fetchAndroidHashesAsync);
 
   program
     .command('fetch:android:upload-cert [project-dir]')
     .description(
       "Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate."
     )
-    .asyncActionProjectDir(fetchAndroidUploadCertAsync, true);
+    .asyncActionProjectDir(fetchAndroidUploadCertAsync);
 }

--- a/packages/expo-cli/src/commands/ios.ts
+++ b/packages/expo-cli/src/commands/ios.ts
@@ -9,21 +9,17 @@ export default function(program: Command) {
       chalk.yellow`Deprecated: Opens your app in Expo in an iOS simulator on your computer`
     )
     .allowOffline()
-    .asyncActionProjectDir(
-      () => {
-        // Deprecate after July 24, 2020 (3 months)
-        console.log(
-          boxen(
-            chalk.yellow(
-              `${chalk.bold(
-                `expo ios`
-              )} is deprecated. You can open your project by:\n- Pressing ${chalk.bold`i`} in the ${chalk.bold`expo start`} terminal UI\n- Or by running ${chalk.bold`expo start --ios`}`
-            ),
-            { borderColor: 'yellow', padding: 1 }
-          )
-        );
-      },
-      /* skipProjectValidation: */ true,
-      /* skipAuthCheck: */ true
-    );
+    .asyncActionProjectDir(() => {
+      // Deprecate after July 24, 2020 (3 months)
+      console.log(
+        boxen(
+          chalk.yellow(
+            `${chalk.bold(
+              `expo ios`
+            )} is deprecated. You can open your project by:\n- Pressing ${chalk.bold`i`} in the ${chalk.bold`expo start`} terminal UI\n- Or by running ${chalk.bold`expo start --ios`}`
+          ),
+          { borderColor: 'yellow', padding: 1 }
+        )
+      );
+    });
 }

--- a/packages/expo-cli/src/commands/opt-into-google-play-signing.ts
+++ b/packages/expo-cli/src/commands/opt-into-google-play-signing.ts
@@ -7,8 +7,11 @@ export default function(program: Command) {
     .description(
       'Switch from the old method of signing APKs to the new App Signing by Google Play. The APK will be signed with an upload key and after uploading it to the store, app will be re-signed with the key from the original keystore.'
     )
-    .asyncActionProjectDir(async (projectDir: string) => {
-      const optInProcess = new AppSigningOptInProcess(projectDir);
-      await optInProcess.run();
-    });
+    .asyncActionProjectDir(
+      async (projectDir: string) => {
+        const optInProcess = new AppSigningOptInProcess(projectDir);
+        await optInProcess.run();
+      },
+      { checkConfig: true }
+    );
 }

--- a/packages/expo-cli/src/commands/prepare-detached-build.ts
+++ b/packages/expo-cli/src/commands/prepare-detached-build.ts
@@ -16,5 +16,5 @@ export default function(program: Command) {
     .option('--platform [platform]', 'detached project platform')
     .option('--skipXcodeConfig [bool]', '[iOS only] if true, do not configure Xcode project')
     .description('Prepares a detached project for building')
-    .asyncActionProjectDir(action, true);
+    .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -29,70 +29,79 @@ export default (program: any) => {
       'Number of logs to view, maximum 100, default 5.',
       parseInt
     )
-    .option('-p, --platform <ios|android>', 'Filter by platform, android or ios. Defaults to both platforms.')
+    .option(
+      '-p, --platform <ios|android>',
+      'Filter by platform, android or ios. Defaults to both platforms.'
+    )
     .option('-s, --sdk-version <version>', 'Filter by SDK version e.g. 35.0.0')
     .option('-r, --raw', 'Produce some raw output.')
-    .asyncActionProjectDir(async (projectDir: string, options: HistoryOptions) => {
-      const result = await getPublishHistoryAsync(projectDir, options);
+    .asyncActionProjectDir(
+      async (projectDir: string, options: HistoryOptions) => {
+        const result = await getPublishHistoryAsync(projectDir, options);
 
-      if (options.raw) {
-        console.log(JSON.stringify(result));
-        return;
-      }
+        if (options.raw) {
+          console.log(JSON.stringify(result));
+          return;
+        }
 
-      if (result.queryResult && result.queryResult.length > 0) {
-        // Print general publication info
-        let sampleItem = result.queryResult[0]; // get a sample item
-        let generalTableString = table.printTableJson(
-          {
-            fullName: sampleItem.fullName,
-          },
-          'General Info'
-        );
-        console.log(generalTableString);
+        if (result.queryResult && result.queryResult.length > 0) {
+          // Print general publication info
+          let sampleItem = result.queryResult[0]; // get a sample item
+          let generalTableString = table.printTableJson(
+            {
+              fullName: sampleItem.fullName,
+            },
+            'General Info'
+          );
+          console.log(generalTableString);
 
-        // Print info specific to each publication
-        let headers = [
-          'publishedTime',
-          'appVersion',
-          'sdkVersion',
-          'platform',
-          'channel',
-          'publicationId',
-        ];
+          // Print info specific to each publication
+          let headers = [
+            'publishedTime',
+            'appVersion',
+            'sdkVersion',
+            'platform',
+            'channel',
+            'publicationId',
+          ];
 
-        // colWidths contains the cell size of each header
-        let colWidths: number[] = [];
-        let bigCells = new Set(['publicationId', 'publishedTime']);
-        headers.forEach(header => {
-          if (bigCells.has(header)) {
-            colWidths.push(HORIZ_CELL_WIDTH_BIG);
-          } else {
-            colWidths.push(HORIZ_CELL_WIDTH_SMALL);
-          }
-        });
-        const resultRows = result.queryResult.map((publication: Publication) => ({
-          ...publication,
-          publishedTime: dateFormat(publication.publishedTime, 'ddd mmm dd yyyy HH:MM:ss Z'),
-        }));
-        let tableString = table.printTableJsonArray(headers, resultRows, colWidths);
-        console.log(tableString);
-      } else {
-        throw new Error('No records found matching your query.');
-      }
-    });
+          // colWidths contains the cell size of each header
+          let colWidths: number[] = [];
+          let bigCells = new Set(['publicationId', 'publishedTime']);
+          headers.forEach(header => {
+            if (bigCells.has(header)) {
+              colWidths.push(HORIZ_CELL_WIDTH_BIG);
+            } else {
+              colWidths.push(HORIZ_CELL_WIDTH_SMALL);
+            }
+          });
+          const resultRows = result.queryResult.map((publication: Publication) => ({
+            ...publication,
+            publishedTime: dateFormat(publication.publishedTime, 'ddd mmm dd yyyy HH:MM:ss Z'),
+          }));
+          let tableString = table.printTableJsonArray(headers, resultRows, colWidths);
+          console.log(tableString);
+        } else {
+          throw new Error('No records found matching your query.');
+        }
+      },
+      { checkConfig: true }
+    );
   program
     .command('publish:details [project-dir]')
     .alias('pd')
     .description('View the details of a published release.')
     .option('--publish-id <publish-id>', 'Publication id. (Required)')
     .option('-r, --raw', 'Produce some raw output.')
-    .asyncActionProjectDir(async (projectDir: string, options: DetailOptions) => {
-      if (!options.publishId) {
-        throw new Error('--publish-id must be specified.');
-      }
+    .asyncActionProjectDir(
+      async (projectDir: string, options: DetailOptions) => {
+        if (!options.publishId) {
+          throw new Error('--publish-id must be specified.');
+        }
 
-      const detail = await getPublicationDetailAsync(projectDir, options);
-      await printPublicationDetailAsync(detail, options);
-    });
+        const detail = await getPublicationDetailAsync(projectDir, options);
+        await printPublicationDetailAsync(detail, options);
+      },
+      { checkConfig: true }
+    );
 };

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -49,7 +49,8 @@ export default function(program: Command) {
         } catch (e) {
           log.error(e);
         }
-      }
+      },
+      { checkConfig: true }
     );
   program
     .command('publish:rollback [project-dir]')
@@ -86,7 +87,8 @@ export default function(program: Command) {
           }
         }
         await rollbackPublicationFromChannelAsync(projectDir, options as RollbackOptions);
-      }
+      },
+      { checkConfig: true }
     );
 }
 async function getUsageAsync(projectDir: string): Promise<string> {

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -37,13 +37,19 @@ export async function action(projectDir: string, options: Options = {}) {
 
   if (pkg.dependencies['expo-updates'] && pkg.dependencies['expokit']) {
     log.warn(
-      `Warning: You have both the ${chalk.bold('expokit')} and ${chalk.bold('expo-updates')} packages installed in package.json.`
+      `Warning: You have both the ${chalk.bold('expokit')} and ${chalk.bold(
+        'expo-updates'
+      )} packages installed in package.json.`
     );
     log.warn(
-      `These two packages are incompatible and ${chalk.bold('publishing updates with expo-updates will not work if expokit is installed.')}`
+      `These two packages are incompatible and ${chalk.bold(
+        'publishing updates with expo-updates will not work if expokit is installed.'
+      )}`
     );
     log.warn(
-      `If you intent to use ${chalk.bold('expo-updates')}, please remove ${chalk.bold('expokit')} from your dependencies.`
+      `If you intent to use ${chalk.bold('expo-updates')}, please remove ${chalk.bold(
+        'expokit'
+      )} from your dependencies.`
     );
   }
 
@@ -238,5 +244,5 @@ export default function(program: Command) {
       "The release channel to publish to. Default is 'default'.",
       'default'
     )
-    .asyncActionProjectDir(action, true);
+    .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -47,7 +47,7 @@ export async function action(projectDir: string, options: Options = {}) {
       )}`
     );
     log.warn(
-      `If you intent to use ${chalk.bold('expo-updates')}, please remove ${chalk.bold(
+      `If you intend to use ${chalk.bold('expo-updates')}, please remove ${chalk.bold(
         'expokit'
       )} from your dependencies.`
     );

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -40,7 +40,7 @@ export default function(program: Command) {
       });
 
       log('All done!');
-    }, true);
+    });
 
   program
     .command('push:android:show [project-dir]')
@@ -59,7 +59,7 @@ export default function(program: Command) {
       } else {
         throw new Error('Server returned an invalid result!');
       }
-    }, true);
+    });
 
   program
     .command('push:android:clear [project-dir]')
@@ -79,7 +79,7 @@ export default function(program: Command) {
       await apiClient.deleteAsync(`credentials/push/android/${remotePackageName}`);
 
       log('All done!');
-    }, true);
+    });
 
   const vapidSubjectDescription =
     'URL or `mailto:` URL which provides a point of contact in case the push service needs to contact the message sender.';
@@ -98,7 +98,7 @@ export default function(program: Command) {
       }
 
       await _uploadWebPushCredientials(projectDir, options);
-    }, true);
+    });
 
   program
     .command('push:web:generate [project-dir]')
@@ -112,7 +112,7 @@ export default function(program: Command) {
       const results = await _uploadWebPushCredientials(projectDir, options);
       log(chalk.green(`Your VAPID public key is: ${results.vapidPublicKey}`));
       log(chalk.green(`Your VAPID private key is: ${results.vapidPrivateKey}`));
-    }, true);
+    });
 
   program
     .command('push:web:show [project-dir]')
@@ -140,7 +140,7 @@ export default function(program: Command) {
       } else {
         throw new Error('Server returned an invalid result!');
       }
-    }, true);
+    });
 
   program
     .command('push:web:clear [project-dir]')
@@ -160,7 +160,7 @@ export default function(program: Command) {
       log("Deleting API key from Expo's servers...");
 
       await apiClient.deleteAsync(`credentials/push/web/${remotePackageName}`);
-    }, true);
+    });
 }
 
 async function _uploadWebPushCredientials(projectDir: string, options: VapidData) {

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -51,5 +51,5 @@ export default function(program: Command) {
     //.help('You must have the server running for this command to work')
     .option('-s, --send-to  [dest]', 'Specifies the email address to send this URL to')
     .urlOpts()
-    .asyncActionProjectDir(action);
+    .asyncActionProjectDir(action, true);
 }

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -51,5 +51,5 @@ export default function(program: Command) {
     //.help('You must have the server running for this command to work')
     .option('-s, --send-to  [dest]', 'Specifies the email address to send this URL to')
     .urlOpts()
-    .asyncActionProjectDir(action, true);
+    .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -332,9 +332,7 @@ export default (program: any) => {
           return await startWebAction(projectDir, normalizedOptions);
         }
         return await action(projectDir, normalizedOptions);
-      },
-      /* skipProjectValidation: */ true,
-      /* skipAuthCheck: */ true
+      }
     );
 
   program
@@ -355,8 +353,6 @@ export default (program: any) => {
           projectDir,
           await normalizeOptionsAsync(projectDir, { ...options, webOnly: true })
         );
-      },
-      /* skipProjectValidation: */ true,
-      /* skipAuthCheck: */ true
+      }
     );
 };

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -23,7 +23,9 @@ export default function(program: Command) {
     .description(
       'Uploads a standalone Android app to Google Play (works on macOS only). Uploads the latest build by default.'
     )
-    .asyncActionProjectDir(createUploadAction(AndroidUploader, ANDROID_OPTIONS));
+    .asyncActionProjectDir(createUploadAction(AndroidUploader, ANDROID_OPTIONS), {
+      checkConfig: true,
+    });
 
   const IOS_OPTIONS = [
     ...COMMON_OPTIONS,
@@ -79,7 +81,7 @@ export default function(program: Command) {
       console.log(`  ${LANGUAGES.join(', ')}`);
       console.log();
     })
-    .asyncActionProjectDir(createUploadAction(IOSUploader, IOS_OPTIONS));
+    .asyncActionProjectDir(createUploadAction(IOSUploader, IOS_OPTIONS), { checkConfig: true });
 }
 
 function setCommonOptions(command: Command, fileExtension: string) {

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -96,13 +96,13 @@ export default function(program: Command) {
     .description('Displays the URL you can use to view your project in Expo')
     .urlOpts()
     .allowOffline()
-    .asyncActionProjectDir(action, /* skipProjectValidation: */ true, /* skipAuthCheck: */ true);
+    .asyncActionProjectDir(action);
 
   program
     .command('url:ipa [project-dir]')
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     .description('Displays the standalone iOS binary URL you can use to download your app binary')
-    .asyncActionProjectDir(logArtifactUrl('ios'), true);
+    .asyncActionProjectDir(logArtifactUrl('ios'));
 
   program
     .command('url:apk [project-dir]')
@@ -110,5 +110,5 @@ export default function(program: Command) {
     .description(
       'Displays the standalone Android binary URL you can use to download your app binary'
     )
-    .asyncActionProjectDir(logArtifactUrl('android'), true);
+    .asyncActionProjectDir(logArtifactUrl('android'));
 }

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -36,7 +36,7 @@ export default function(program: Command) {
       }
 
       log('All done!');
-    }, true);
+    });
 
   program
     .command('webhooks:show [project-dir]')
@@ -65,7 +65,7 @@ export default function(program: Command) {
         log.error(e);
         throw new Error('Unable to fetch webhooks for this project.');
       }
-    }, true);
+    });
 
   program
     .command('webhooks:clear [project-dir]')
@@ -86,7 +86,7 @@ export default function(program: Command) {
         throw new Error('Unable to clear webhook and secret for this project.');
       }
       log('All done!');
-    }, true);
+    });
 }
 
 async function _sanitizeOptions(options: Options): Promise<Webhooks.WebhookData> {

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -115,10 +115,9 @@ Command.prototype.asyncAction = function(asyncFn: Action, skipUpdateCheck: boole
 // - Runs AsyncAction with the projectDir as an argument
 Command.prototype.asyncActionProjectDir = function(
   asyncFn: Action,
-  skipProjectValidation: boolean,
-  skipAuthCheck: boolean
+  options: { checkConfig?: boolean } = {}
 ) {
-  this.option('--config [file]', 'Specify a path to app.json');
+  this.option('--config [file]', 'Specify a path to app.json or app.config.js');
   return this.asyncAction(async (projectDir: string, ...args: any[]) => {
     const opts = args[0];
 
@@ -300,7 +299,7 @@ Command.prototype.asyncActionProjectDir = function(
     // If the packager/manifest server is running and healthy, there is no need
     // to rerun Doctor because the directory was already checked previously
     // This is relevant for command such as `send`
-    if (!skipProjectValidation && (await Project.currentStatus(projectDir)) !== 'running') {
+    if (options.checkConfig && (await Project.currentStatus(projectDir)) !== 'running') {
       let spinner = ora('Making sure project is set up correctly...').start();
       log.setSpinner(spinner);
       // validate that this is a good projectDir before we try anything else


### PR DESCRIPTION
- `asyncActionProjectDir` accepts three parameters, we've been adding comment blocks to tell what those parameters do. This is bad practice.
- Mostly we disable the validation checks that are done, so I've flipped the condition where you enable the check instead of disabling it.
- Auth check wasn't being used so I removed it.