### PR TITLE
Print warning when running on newer version of Node.js

### DIFF
--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -23,7 +23,7 @@ const versionIsHigherThanSupported = semver.gtr(version, maxSupportedVersion.ran
 if (versionIsHigherThanSupported) {
   console.error(
     chalk.yellow(
-      `WARNING: Node.js version ${version} has not yet been tested.\n\n` +
+      `WARNING: expo-cli has not yet been tested against Node.js version ${version}. If you encounter any issues, please report them to https://github.com/expo/expo-cli/issues\n\n` +
         'expo-cli supports following Node.js versions:\n' +
         versionInfo
     )

--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -13,23 +13,29 @@ const isSupported = supportedVersions.some(function(supported) {
   return semver.satisfies(version, supported.range);
 });
 
-if (isSupported) {
+const versionInfo = supportedVersions
+  .map(supported => '* ' + supported.range + ' (' + supported.name + ')')
+  .join('\n');
+
+const maxSupportedVersion = supportedVersions[supportedVersions.length - 1];
+const versionIsHigherThanSupported = semver.gtr(version, maxSupportedVersion.range);
+
+if (versionIsHigherThanSupported) {
+  console.error(
+    chalk.yellow(
+      `WARNING: Node.js version ${version} has not yet been tested.\n\n` +
+        'expo-cli supports following Node.js versions:\n' +
+        versionInfo
+    )
+  );
+}
+
+if (isSupported || versionIsHigherThanSupported) {
   require('../build/exp.js').run('expo');
 } else {
-  const versionInfo = supportedVersions
-    .map(function(supported) {
-      return '* ' + supported.range + ' (' + supported.name + ')';
-    })
-    .join('\n');
-
-  const maxSupportedVersion = supportedVersions[supportedVersions.length - 1];
-  const versionIsHigherThanSupported = semver.gtr(version, maxSupportedVersion.range);
-
   console.error(
     chalk.red(
-      'ERROR: Node.js version ' +
-        version +
-        ` is ${versionIsHigherThanSupported ? 'not yet' : 'no longer'} supported.\n\n` +
+      `ERROR: Node.js version ${version} is no longer supported.\n\n` +
         'expo-cli supports following Node.js versions:\n' +
         versionInfo
     )


### PR DESCRIPTION
Right now, both Node.js 13 and 14 is "Current release"

<img width="771" alt="Screenshot 2020-04-25 at 13 25 13" src="https://user-images.githubusercontent.com/189580/80279893-348eb300-86f8-11ea-99ca-1406da9d0662.png">
