### PR TITLE
Get the public exported url set by expo export from the manifest and pass in to bundleAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix bundling assets in bare apps that are using `expo-updates` and `expo export` for self hosting. ([#1999](https://github.com/expo/expo-cli/pull/1999) by [@brentvatne](https://github.com/brentvatne)).
 - Use UIStatusBarStyleDefault in standalone apps unless otherwise specified. This fixes a longstanding issue where the status bar style is different between Expo client and standalone apps (https://github.com/expo/expo-cli/commit/474a56e863a16228a641c58f31f3f5c9f3c2d9e8 by [@brentvatne](https://github.com/brentvatne)).
 
 ### 🤷‍♂️ Chores

--- a/packages/xdl/src/detach/AssetBundle.ts
+++ b/packages/xdl/src/detach/AssetBundle.ts
@@ -11,18 +11,24 @@ import { AnyStandaloneContext } from './StandaloneContext';
 import { saveUrlToPathAsync } from './ExponentTools';
 
 const EXPO_DOMAINS = ['expo.io', 'exp.host', 'expo.test', 'localhost'];
-const ASSETS_DIR_DEFAULT_URL = 'https://d1wp6m56sqw74a.cloudfront.net/~assets';
+export const DEFAULT_CDN_HOST = 'https://d1wp6m56sqw74a.cloudfront.net';
+export const ASSETS_DIR_DEFAULT_URL = `${DEFAULT_CDN_HOST}/~assets`;
 
 type UrlResolver = (hash: string) => string;
 
-export async function bundleAsync(context: any, assets: string[], dest: string) {
+export async function bundleAsync(
+  context: any,
+  assets: string[],
+  dest: string,
+  exportUrl?: string | null
+) {
   if (!assets) {
     return;
   }
 
   await fs.ensureDir(dest);
 
-  const urlResolver = createAssetsUrlResolver(context);
+  const urlResolver = createAssetsUrlResolver(context, exportUrl);
   await pMap(assets, asset => downloadAssetAsync(urlResolver, dest, asset), { concurrency: 5 });
 }
 
@@ -33,11 +39,16 @@ async function downloadAssetAsync(urlResolver: UrlResolver, dest: string, asset:
     extensionIndex >= 0
       ? asset.substring(prefixLength, extensionIndex)
       : asset.substring(prefixLength);
+  console.log(urlResolver(hash));
   await pRetry(() => saveUrlToPathAsync(urlResolver(hash), path.join(dest, asset)), { retries: 3 });
 }
 
-function createAssetsUrlResolver(context: AnyStandaloneContext): UrlResolver {
-  let assetsDirUrl = ASSETS_DIR_DEFAULT_URL;
+function createAssetsUrlResolver(
+  context: AnyStandaloneContext,
+  exportUrl?: string | null
+): UrlResolver {
+  let assetsDirUrl = exportUrl ? `${exportUrl}/assets` : ASSETS_DIR_DEFAULT_URL;
+
   if (context && context.published && context.published.url) {
     const { assetUrlOverride = './assets' } = context.config;
     const publishedUrl = context.published.url;
@@ -52,5 +63,6 @@ function createAssetsUrlResolver(context: AnyStandaloneContext): UrlResolver {
       assetsDirUrl = url.resolve(publishedUrl, assetUrlOverride);
     }
   }
+
   return hash => urlJoin(assetsDirUrl, hash);
 }


### PR DESCRIPTION
This is a hotfix for the issue discussed in https://forums.expo.io/t/ios-bundle-assets-error-when-building-release-403/36616/9

We should follow up with a better solution and write tests. I don't like that we are depending on the hardcoded Cloudfront URL to determine whether the app was exported or not, there should probably be a field in manifest that gives us this information.