### PR TITLE
Add imports to fix ejecting on Android with userInterfaceStyle set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Add necessary imports for onConfigurationChanged updates to MainActivity when ejecting. ([#2001](https://github.com/expo/expo-cli/pull/2001) by [@brentvatne](https://github.com/brentvatne)).
+
 ### 🤷‍♂️ Chores
 
 ## [Sat Apr 25 16:26:28 2020 -0700](https://github.com/expo/expo-cli/commit/8a805d)

--- a/packages/config/src/android/UserInterfaceStyle.ts
+++ b/packages/config/src/android/UserInterfaceStyle.ts
@@ -49,6 +49,25 @@ export function addOnConfigurationChangedMainActivity(
   if (MainActivity.match(`onConfigurationChanged`)?.length) {
     return MainActivity;
   }
+
+  let MainActivityWithImports = addJavaImports(MainActivity, [
+    'android.content.Intent',
+    'android.content.res.Configuration',
+  ]);
+
   let pattern = new RegExp(`public class MainActivity extends ReactActivity {`);
-  return MainActivity.replace(pattern, ON_CONFIGURATION_CHANGED);
+  return MainActivityWithImports.replace(pattern, ON_CONFIGURATION_CHANGED);
+}
+
+// TODO: we should have a generic utility for doing this
+function addJavaImports(javaSource: string, javaImports: string[]): string {
+  const lines = javaSource.split('\n');
+  const lineIndexWithPackageDeclaration = lines.findIndex(line => line.match(/^package .*;$/));
+  for (let javaImport of javaImports) {
+    if (!javaSource.includes(javaImport)) {
+      const importStatement = `import ${javaImport};`;
+      lines.splice(lineIndexWithPackageDeclaration + 1, 0, importStatement);
+    }
+  }
+  return lines.join('\n');
 }

--- a/packages/config/src/android/__tests__/UserInterfaceStyle-test.js
+++ b/packages/config/src/android/__tests__/UserInterfaceStyle-test.js
@@ -10,8 +10,7 @@ import { readAndroidManifestAsync } from '../Manifest';
 const fixturesPath = resolve(__dirname, 'fixtures');
 const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
 
-const EXAMPLE_MAIN_ACTIVITY_BEFORE = `
-package com.helloworld;
+const EXAMPLE_MAIN_ACTIVITY_BEFORE = `package com.helloworld;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
@@ -57,6 +56,17 @@ describe('User interface style', () => {
         android: { userInterfaceStyle: 'light' },
       })
     ).toBe('light');
+  });
+
+  it(`adds the require imports if needed`, () => {
+    let result = addOnConfigurationChangedMainActivity(
+      { userInterfaceStyle: 'light' },
+      EXAMPLE_MAIN_ACTIVITY_BEFORE
+    );
+
+    expect(result.split('\n')[0]).toMatch('package com.helloworld;');
+    expect(result).toMatch('import android.content.Intent;');
+    expect(result).toMatch('import android.content.res.Configuration');
   });
 
   it(`adds the onConfigurationChanged method in MainActivity.java if userInterfaceStyle is given`, () => {


### PR DESCRIPTION
If you eject an app on Android with `userInterfaceStyle` set to `automatic` then we will add some code to MainActivity that will not work because it depends on classes that haven't been imported. This adds those imports.