### PR TITLE
[cli] change ordering of android credential questions

### DIFF
--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -153,17 +153,17 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
           when: (answers: Record<string, Question>) => answers.uploadKeystore,
         },
         {
-          type: 'input',
-          name: 'keystoreAlias',
-          message: `Keystore Alias:`,
+          type: 'password',
+          name: 'keystorePassword',
+          message: `Keystore Password:`,
           validate: (val: string): boolean => val !== '',
           // @ts-ignore: The expected type comes from property 'when' which is declared here on type 'Question<Record<string, any>>'
           when: (answers: Record<string, Question>) => answers.uploadKeystore,
         },
         {
-          type: 'password',
-          name: 'keystorePassword',
-          message: `Keystore Password:`,
+          type: 'input',
+          name: 'keystoreAlias',
+          message: `Keystore Alias:`,
           validate: (val: string): boolean => val !== '',
           // @ts-ignore: The expected type comes from property 'when' which is declared here on type 'Question<Record<string, any>>'
           when: (answers: Record<string, Question>) => answers.uploadKeystore,


### PR DESCRIPTION
fixes https://github.com/expo/expo-cli/issues/356

# some background
- There are 4 relevant android credential values we track: {`keystore`, `keystore password`, `keystore alias`, `key password`}
- Android Keystore contains a set of keys. This keystore is accessed with a keystore password.
You can index into each value (a key or certificate) in this keystore with a string alias. Each key in the keystore has a key password. 
- When a user asks to upload their own android credentials, the most intuitive order to ask the questions in are 1. keystore path, 2. keystore password, 3. keystore alias and 4. key password.
- The current order is 1. keystore path, 2. keystore alias, 3. keystore password and 4. key password.

# testing

- [x] manual sanity checked to make sure `answers` are the same before and after