### PR TITLE
[xdl] clean up Expo.plist artifacts left behind by IosPlist util

### DIFF
--- a/packages/xdl/src/EmbeddedAssets.ts
+++ b/packages/xdl/src/EmbeddedAssets.ts
@@ -272,6 +272,7 @@ async function _maybeConfigureExpoUpdatesEmbeddedAssetsAsync(config: EmbeddedAss
       }
       return configPlist;
     });
+    await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
   }
 
   // Android expo-updates


### PR DESCRIPTION
The `IosPlist` util leaves behind some artifacts (`*.json`, `*.plist.bak`) which may be confusing to users who aren't expecting them.

In particular, users running `expo publish` in a bare workflow project with `expo-updates` may find these extra files (which come from modifying the data in the Expo.plist config file) confusing. Their utility is limited -- since most people are using version control there's no need to have separate backup files in the same folder. So in this case we should just delete those files after the `IosPlist.modifyAsync` operation completes successfully.

## Test plan

`expo init`, bare-minimum template, `expo publish`

- [x] latest expo-cli `expo publish` produces `Expo.json` and `Expo.plist.bak` files in the Supporting dir
- [x] after this change, `expo publish` no longer produces those files
- [x] deleting files that don't exist with `fs.removeSync` is a no-op