### PR TITLE
[expo-cli] client:ios -- default to using Apple ID email address

### DIFF
--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -199,6 +199,7 @@ export default function(program: Command) {
           ({ email } = await prompt({
             name: 'email',
             message: 'Please enter an email address to notify, when the build is completed:',
+            default: context.user.email,
             filter: value => value.trim(),
             validate: (value: string) =>
               /.+@.+/.test(value) ? true : "That doesn't look like a valid email.",


### PR DESCRIPTION
resolve https://github.com/expo/expo-cli/issues/2002