### PR TITLE
Make Node.js version gate work on older versions

### DIFF
--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -1,44 +1,36 @@
 #!/usr/bin/env node
-const chalk = require('chalk');
-const semver = require('semver');
-const version = process.versions.node;
 
-const supportedVersions = [
-  { range: semver.validRange('^10.13.0'), name: 'Active LTS' },
-  { range: semver.validRange('^12.0.0'), name: 'Active LTS' },
-  { range: semver.validRange('^13.0.0'), name: 'Current Release' },
-];
+var match = process.version.match(/v(\d+)\.(\d+)/);
+var major = parseInt(match[1], 10);
+var minor = parseInt(match[2], 10);
 
-const isSupported = supportedVersions.some(function(supported) {
-  return semver.satisfies(version, supported.range);
-});
-
-const versionInfo = supportedVersions
-  .map(supported => '* ' + supported.range + ' (' + supported.name + ')')
-  .join('\n');
-
-const maxSupportedVersion = supportedVersions[supportedVersions.length - 1];
-const versionIsHigherThanSupported = semver.gtr(version, maxSupportedVersion.range);
-
-if (versionIsHigherThanSupported) {
+// If older than 10.13, or if 11.x
+if (major < 10 || (major === 10 && minor < 13) || major === 11) {
   console.error(
-    chalk.yellow(
-      `WARNING: expo-cli has not yet been tested against Node.js version ${version}. If you encounter any issues, please report them to https://github.com/expo/expo-cli/issues\n\n` +
-        'expo-cli supports following Node.js versions:\n' +
-        versionInfo
-    )
-  );
-}
-
-if (isSupported || versionIsHigherThanSupported) {
-  require('../build/exp.js').run('expo');
-} else {
-  console.error(
-    chalk.red(
-      `ERROR: Node.js version ${version} is no longer supported.\n\n` +
-        'expo-cli supports following Node.js versions:\n' +
-        versionInfo
-    )
+    '\x1B[31mERROR: Node.js ' +
+      process.version +
+      ' is no longer supported.\x1B[39m\n' +
+      '\x1B[31m\x1B[39m\n' +
+      '\x1B[31mexpo-cli supports following Node.js versions:\x1B[39m\n' +
+      '\x1B[31m* >=10.13.0 <11.0.0 (Active LTS)\x1B[39m\n' +
+      '\x1B[31m* >=12.0.0 <13.0.0 (Active LTS)\x1B[39m\n' +
+      '\x1B[31m* >=13.0.0 <14.0.0 (Current Release)\x1B[39m'
   );
   process.exit(1);
 }
+
+// If newer than, or equal to, 14.x
+if (major >= 14) {
+  console.error(
+    '\x1B[33mWARNING: expo-cli has not yet been tested against Node.js ' +
+      process.version +
+      '. If you encounter any issues, please report them to https://github.com/expo/expo-cli/issues\x1B[39m\n' +
+      '\x1B[33m\x1B[39m\n' +
+      '\x1B[33mexpo-cli supports following Node.js versions:\x1B[39m\n' +
+      '\x1B[33m* >=10.13.0 <11.0.0 (Active LTS)\x1B[39m\n' +
+      '\x1B[33m* >=12.0.0 <13.0.0 (Active LTS)\x1B[39m\n' +
+      '\x1B[33m* >=13.0.0 <14.0.0 (Current Release)\x1B[39m'
+  );
+}
+
+require('../build/exp.js').run('expo');


### PR DESCRIPTION
Follow up to #1992, this makes the guard that prints a nice error when using an older version of Node.js work on older versions of Node.js.

It even supports 0.10 now 😄 

<img width="303" alt="Screenshot 2020-04-28 at 21 11 58" src="https://user-images.githubusercontent.com/189580/80533371-6b352980-8995-11ea-8941-2d34d15ee4dd.png">

(ping @brentvatne)