### PR TITLE
[expo-cli][xdl] changes for expo-updates no-publish workflow

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -76,14 +76,6 @@ export async function ejectAsync(projectRoot: string, options: EjectAsyncOptions
       'expo fetch:android:keystore'
     )}`
   );
-  log.nested(
-    `- 🚀 ${terminalLink(
-      'expo-updates',
-      'https://github.com/expo/expo/blob/master/packages/expo-updates/README.md'
-    )} has been configured in your project. Before you do a release build, make sure you run ${chalk.bold(
-      'expo publish'
-    )}. ${terminalLink('Learn more.', 'https://expo.fyi/release-builds-with-expo-updates')}`
-  );
 
   log.newLine();
   log.nested(`☑️  ${chalk.bold('When you are ready to run your project')}`);

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -296,14 +296,6 @@ function logProjectReady({
         'android'
       )} directories with their respective IDEs.`
     );
-    log.nested(
-      `🚀 Please note that ${terminalLink(
-        'expo-updates',
-        'https://github.com/expo/expo/blob/master/packages/expo-updates/README.md'
-      )} has been configured in your project. Before you do a release build, make sure you run ${chalk.bold(
-        'expo publish'
-      )}. ${terminalLink('Learn more.', 'https://expo.fyi/release-builds-with-expo-updates')}`
-    );
     // TODO: add equivalent of this or some command to wrap it:
     // # ios
     // $ open -a Xcode ./ios/{PROJECT_NAME}.xcworkspace

--- a/packages/xdl/src/EmbeddedAssets.ts
+++ b/packages/xdl/src/EmbeddedAssets.ts
@@ -287,6 +287,8 @@ async function _maybeConfigureExpoUpdatesEmbeddedAssetsAsync(config: EmbeddedAss
     return;
   }
 
+  let isLikelyFirstPublish = false;
+
   const { projectRoot, exp, releaseChannel, iosManifestUrl, androidManifestUrl } = config;
 
   const { iosSupportingDirectory: supportingDirectory } = getIOSPaths(projectRoot);
@@ -295,6 +297,9 @@ async function _maybeConfigureExpoUpdatesEmbeddedAssetsAsync(config: EmbeddedAss
   if (fs.existsSync(path.join(supportingDirectory, 'Expo.plist'))) {
     // This is an app with expo-updates installed, set properties in Expo.plist
     await IosPlist.modifyAsync(supportingDirectory, 'Expo', (configPlist: any) => {
+      if (configPlist.EXUpdatesURL === 'YOUR-APP-URL-HERE') {
+        isLikelyFirstPublish = true;
+      }
       configPlist.EXUpdatesURL = iosManifestUrl;
       configPlist.EXUpdatesSDKVersion = exp.sdkVersion;
       if (releaseChannel) {
@@ -355,6 +360,15 @@ async function _maybeConfigureExpoUpdatesEmbeddedAssetsAsync(config: EmbeddedAss
       expoReleaseChannelRegex,
       expoReleaseChannelTag,
       androidManifestXmlPath
+    );
+  }
+
+  if (isLikelyFirstPublish) {
+    logger.global.warn(
+      '🚀 It looks like this your first publish for this project! ' +
+        "We've automatically set some configuration values in Expo.plist and AndroidManifest.xml. " +
+        "You'll need to make a new build with these changes before you can download the update " +
+        'you just published.'
     );
   }
 }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -842,7 +842,7 @@ export async function publishAsync(
     validPostPublishHooks.length ||
     (exp.ios && exp.ios.publishManifestPath) ||
     (exp.android && exp.android.publishManifestPath) ||
-    pkg.dependencies['expo-updates']
+    EmbeddedAssets.shouldEmbedAssetsForExpoUpdates(projectRoot, exp, pkg, target)
   ) {
     [androidManifest, iosManifest] = await Promise.all([
       ExponentTools.getManifestAsync(response.url, {


### PR DESCRIPTION
Depends on https://github.com/expo/expo/pull/8066 to land and be released

This PR removes warnings in expo-cli for expo-updates, regarding publishing before making release builds.

It also stops automatically embedding manifests + bundles in Xcode/Android projects on `expo publish` and `expo export`, except for those projects using expo-updates `0.1.x` or when the files already exist (to support developers who have upgraded to new expo-updates but have not switched over to the no-publish workflow).

Also added a new warning to mitigate the following confusing workflow:
- init new project
- make test release build
- publish OTA update (which automatically sets URL)
- previous build did not have URL yet --> cannot download update --> ???

# Test plan

- [x] `expo publish` with `expo-updates@0.1.2` in package.json embeds assets automatically
- [x] `expo publish` with `expo-updates@0.2.0` in package.json does not embed assets automatically
- [x] `expo publish` with `expo-updates@0.2.0` in package.json, but WITH app.manifest/app.bundle files already created, does embed assets automatically