### PR TITLE
Make clean scripts platform independent

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "lint": "eslint .",
     "test": "jest"
   },
@@ -64,7 +64,8 @@
     "@types/invariant": "^2.2.30",
     "@types/plist": "^3.0.1",
     "@types/xml2js": "^0.4.5",
-    "memfs": "^2.15.5"
+    "memfs": "^2.15.5",
+    "rimraf": "^3.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -8,7 +8,7 @@
     "build-client": "NODE_ENV=production next build && next export -o ./build/client",
     "build-server": "NODE_ENV=production tsc",
     "extract-fragment-types": "ts-node ./server/extract-fragment-types",
-    "clean": "rm -rf ./build",
+    "clean": "rimraf ./build",
     "prepare": "yarn run clean && yarn run build",
     "start": "yarn dev",
     "test": "jest --config jest.config.js"
@@ -63,6 +63,7 @@
     "react-redux": "^5.0.7",
     "react-textarea-autosize": "^6.1.0",
     "redux": "^3.7.2",
+    "rimraf": "^3.0.2",
     "slugify": "^1.0.2",
     "ts-node": "^8.6.2",
     "velocity-react": "^1.4.1"

--- a/packages/electron-adapter/package.json
+++ b/packages/electron-adapter/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "test": "cd example && yarn && yarn test:build",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf ./tsconfig.tsbuildinfo",
     "lint": "eslint ."
   },
   "bin": {
@@ -44,7 +44,8 @@
   ],
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.10",
-    "@expo/webpack-config": "0.12.2"
+    "@expo/webpack-config": "0.12.2",
+    "rimraf": "^3.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -13,7 +13,7 @@
     "build": "babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
     "watch": "tsc --watch",
     "prepare": "yarn run clean && yarn run build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "preversion": "node ./scripts/preversion.js",
     "pkg": "pkg .",
     "test": "jest",
@@ -74,7 +74,8 @@
     "@types/targz": "^1.0.0",
     "@types/untildify": "^3.0.0",
     "@types/wordwrap": "^1.0.0",
-    "pkg": "^4.2.1"
+    "pkg": "^4.2.1",
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
     "@expo/build-tools": "0.1.4",

--- a/packages/expo-codemod/package.json
+++ b/packages/expo-codemod/package.json
@@ -16,7 +16,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "test": "jest",
     "test:watch": "jest --watch"
   },
@@ -39,6 +39,7 @@
     "@types/globby": "^9.1.0",
     "@types/jscodeshift": "^0.6.0",
     "@types/multimatch": "^2.1.3",
-    "@types/yargs-parser": "^13.0.0"
+    "@types/yargs-parser": "^13.0.0",
+    "rimraf": "^3.0.2"
   }
 }

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo"
+    "clean": "rimraf build ./tsconfig.tsbuildinfo"
   },
   "repository": {
     "type": "git",
@@ -41,7 +41,8 @@
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.10",
-    "@types/semver": "^6.0.0"
+    "@types/semver": "^6.0.0",
+    "rimraf": "^3.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/json-file/package.json
+++ b/packages/json-file/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "lint": "eslint .",
     "test": "jest"
   },
@@ -41,7 +41,8 @@
     "@types/fs-extra": "^7.0.0",
     "@types/json5": "^0.0.30",
     "@types/lodash": "^4.14.135",
-    "@types/write-file-atomic": "^2.1.1"
+    "@types/write-file-atomic": "^2.1.1",
+    "rimraf": "^3.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "lint": "eslint .",
     "test": "jest"
   },
@@ -46,7 +46,8 @@
     "globby": "^11.0.0",
     "metro": "^0.59.0",
     "metro-config": "^0.59.0",
-    "react-native": "0.61.4"
+    "react-native": "0.61.4",
+    "rimraf": "^3.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/next-adapter/package.json
+++ b/packages/next-adapter/package.json
@@ -8,7 +8,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "lint": "eslint ."
   },
   "bin": {
@@ -44,7 +44,8 @@
   ],
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.10",
-    "@types/prompts": "^2.0.6"
+    "@types/prompts": "^2.0.6",
+    "rimraf": "^3.0.2"
   },
   "peerDependencies": {
     "next": "^9",

--- a/packages/osascript/package.json
+++ b/packages/osascript/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo"
+    "clean": "rimraf build ./tsconfig.tsbuildinfo"
   },
   "repository": {
     "type": "git",
@@ -34,7 +34,8 @@
     "exec-async": "^2.2.0"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.10"
+    "@expo/babel-preset-cli": "0.2.10",
+    "rimraf": "^3.0.2"
   },
   "files": [
     "lib/",

--- a/packages/package-manager/package.json
+++ b/packages/package-manager/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "lint": "eslint .",
     "test": "jest"
   },
@@ -46,7 +46,8 @@
     "sudo-prompt": "9.1.1"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.10"
+    "@expo/babel-preset-cli": "0.2.10",
+    "rimraf": "^3.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -29,10 +29,11 @@
     "lint": "eslint .",
     "watch": "tsc --watch",
     "build": "tsc",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo"
+    "clean": "rimraf build ./tsconfig.tsbuildinfo"
   },
   "devDependencies": {
-    "@types/node": "^12.6.8"
+    "@types/node": "^12.6.8",
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
     "@expo/babel-preset-cli": "0.2.10",

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -13,7 +13,7 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "lint": "eslint .",
-    "clean": "rm -rf ./webpack/ ./tsconfig.tsbuildinfo",
+    "clean": "rimraf ./webpack/ ./tsconfig.tsbuildinfo",
     "prepare": "yarn run clean && yarn run build",
     "test": "jest --config jest/unit-test-config.js",
     "test:e2e:start": "EXPO_E2E_COMMAND='start' jest --config jest/e2e-test-config.json --rootDir .",
@@ -83,6 +83,7 @@
     "jest-puppeteer": "^4.3.0",
     "prettier": "^1.16.4",
     "puppeteer": "^1.19.0",
+    "rimraf": "^3.0.2",
     "serve": "^11.1.0"
   },
   "gitHead": "613642fe06827cc231405784b099cf71c29072df",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -14,7 +14,7 @@
     "build": "tsc --emitDeclarationOnly && gulp build",
     "prepare": "yarn run clean && yarn run build",
     "prepack": "gulp caches",
-    "clean": "rm -rf build ./tsconfig.tsbuildinfo",
+    "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "watch": "concurrently \"tsc --emitDeclarationOnly --watch\" \"gulp watch\"",
     "test": "jest --config jest/unit-test-config.js",
     "integration-tests": "jest --config jest/integration-test-config.json --rootDir ."
@@ -140,7 +140,7 @@
     "gulplog": "^1.0.0",
     "mock-fs": "^3.12.1",
     "promise-print": "^2.3.0",
-    "rimraf": "^2.5.4"
+    "rimraf": "^3.0.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Currently, a lot of the cleaning scripts in many of the `package.json` do not work on Windows due to them running the `rm` command. This would work in PowerShell but not in `cmd` which is what Node seems to use to run scripts defined in `package.json`.

As an example, this leads to these errors when running the initial `yarn run bootstrap`:

### Before
```
expo-codemod: $ yarn run clean && yarn build
@expo/json-file: $ yarn run clean && yarn build
@expo/osascript: $ yarn run clean && yarn build
@expo/image-utils: $ yarn run clean && yarn build
@expo/package-manager: $ yarn run clean && yarn build
@expo/plist: $ yarn build
@expo/schemer: $ yarn build
expo-codemod: $ rm -rf build ./tsconfig.tsbuildinfo
@expo/json-file: $ rm -rf build ./tsconfig.tsbuildinfo
@expo/osascript: $ rm -rf build ./tsconfig.tsbuildinfo
@expo/image-utils: $ rm -rf build ./tsconfig.tsbuildinfo
expo-codemod: 'rm' is not recognized as an internal or external command,
expo-codemod: operable program or batch file.
@expo/osascript: 'rm' is not recognized as an internal or external command,
@expo/osascript: operable program or batch file.
@expo/json-file: 'rm' is not recognized as an internal or external command,
@expo/json-file: operable program or batch file.
@expo/plist: $ tsc
@expo/schemer: $ tsc
expo-codemod: error Command failed with exit code 1.
expo-codemod: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@expo/osascript: error Command failed with exit code 1.
@expo/osascript: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@expo/package-manager: $ rm -rf build ./tsconfig.tsbuildinfo
@expo/json-file: error Command failed with exit code 1.
@expo/json-file: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@expo/image-utils: 'rm' is not recognized as an internal or external command,
@expo/image-utils: operable program or batch file.
expo-codemod: error Command failed with exit code 1.
expo-codemod: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@expo/image-utils: error Command failed with exit code 1.
@expo/image-utils: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@expo/osascript: error Command failed with exit code 1.
@expo/osascript: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@expo/json-file: error Command failed with exit code 1.
@expo/json-file: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run prepare exited 1 in 'expo-codemod'
lerna WARN complete Waiting for 6 child processes to exit. CTRL-C to exit immediately.
error Command failed with exit code 1.
```
Notice all the `'rm' is not recognized as an internal or external command` lines leading to the commands returning error code 1.

I suggest using the [rimraf](https://github.com/isaacs/rimraf) package for these cleanups to render them platform independent.

With this change we get no errors when we run the clean scripts:

### After
```
@expo/image-utils: $ yarn run clean && yarn build
expo-codemod: $ yarn run clean && yarn build
@expo/json-file: $ yarn run clean && yarn build
@expo/osascript: $ yarn run clean && yarn build
@expo/package-manager: $ yarn run clean && yarn build
@expo/plist: $ yarn build
@expo/schemer: $ yarn build
expo-codemod: $ rimraf build ./tsconfig.tsbuildinfo
@expo/image-utils: $ rimraf build ./tsconfig.tsbuildinfo
@expo/json-file: $ rimraf build ./tsconfig.tsbuildinfo
@expo/plist: $ tsc
@expo/schemer: $ tsc
@expo/package-manager: $ rimraf build ./tsconfig.tsbuildinfo
@expo/osascript: $ rimraf build ./tsconfig.tsbuildinfo
expo-codemod: $ tsc
@expo/package-manager: $ tsc
@expo/osascript: $ tsc
@expo/json-file: $ tsc
@expo/image-utils: $ tsc
@expo/config: $ yarn run clean && yarn build
pod-install: $ yarn run clean && yarn run build:prod
@expo/config: $ rimraf build ./tsconfig.tsbuildinfo
pod-install: $ rimraf ./build/
@expo/config: $ tsc
pod-install: $ ncc build ./src/index.ts -o build/ --minify --no-cache --no-source-map-register
pod-install: ncc: Version 0.20.5
pod-install: ncc: Compiling file index.js
pod-install: ncc: Using typescript@3.7.3 (local user-provided)
expo-optimize: $ yarn run clean && yarn run build:prod
@expo/metro-config: $ yarn run clean && yarn build
expo-pwa: $ yarn run clean && yarn run build
uri-scheme: $ yarn run clean && yarn run build:prod
@expo/metro-config: $ rimraf build ./tsconfig.tsbuildinfo
uri-scheme: $ rimraf ./build/
expo-pwa: $ rimraf build ./tsconfig.tsbuildinfo
expo-optimize: $ rimraf ./build/
```