### PR TITLE
fix: resolve and import metro-config from the project

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -37,10 +37,6 @@
     "@expo/config": "3.2.0",
     "metro-react-native-babel-transformer": "^0.58.0"
   },
-  "peerDependencies": {
-    "metro": "^0.56.0",
-    "metro-config": "^0.56.0"
-  },
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.11",
     "expo": "37",

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { ProjectTarget, getConfig, getDefaultTarget, resolveModule } from '@expo/config';
 import { getBareExtensions, getManagedExtensions } from '@expo/config/paths';
 import { Reporter } from 'metro';
-import { ConfigT, InputConfigT, loadConfig } from 'metro-config';
+import { ConfigT, InputConfigT } from 'metro-config';
 
 const INTERNAL_CALLSITES_REGEX = new RegExp(
   [
@@ -96,5 +96,7 @@ export async function loadAsync(
   if (reporter) {
     defaultConfig = { ...defaultConfig, reporter };
   }
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const { loadConfig } = require(resolveModule('metro-config', projectRoot, exp));
   return await loadConfig({ cwd: projectRoot, projectRoot, ...metroOptions }, defaultConfig);
 }


### PR DESCRIPTION
Fixes "Error: Cannot find module 'metro-config'" when running
```
EXPO_USE_DEV_SERVER=true expo start
```