### PR TITLE
[expo-cli][xdl] Reduce warning messages when logged out. [closes:#1024]

### DIFF
--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -16,12 +16,7 @@ type CommandOptions = {
   };
 };
 
-export async function loginOrRegisterIfLoggedOut(): Promise<User> {
-  let user = await UserManager.getCurrentUserAsync();
-  if (user) {
-    return user;
-  }
-
+export async function loginOrRegisterAsync(): Promise<User> {
   log.warn('An Expo user account is required to proceed.');
 
   if (program.nonInteractive) {
@@ -60,6 +55,14 @@ export async function loginOrRegisterIfLoggedOut(): Promise<User> {
   } else {
     throw new CommandError('BAD_CHOICE', 'Not logged in.');
   }
+}
+
+export async function loginOrRegisterIfLoggedOutAsync(): Promise<User> {
+  let user = await UserManager.getCurrentUserAsync();
+  if (user) {
+    return user;
+  }
+  return await loginOrRegisterAsync();
 }
 
 export async function login(options: CommandOptions): Promise<User> {

--- a/packages/expo-cli/src/commands/eject/LegacyEject.ts
+++ b/packages/expo-cli/src/commands/eject/LegacyEject.ts
@@ -10,7 +10,7 @@ import semver from 'semver';
 import temporary from 'tempy';
 
 import * as PackageManager from '@expo/package-manager';
-import { loginOrRegisterIfLoggedOut } from '../../accounts';
+import { loginOrRegisterIfLoggedOutAsync } from '../../accounts';
 import log from '../../log';
 import prompt, { Question } from '../../prompt';
 import { validateGitStatusAsync } from '../utils/ProjectUtils';
@@ -131,7 +131,7 @@ export async function ejectAsync(projectRoot: string, options: EjectAsyncOptions
     log.nested(`  ${packageManager === 'npm' ? 'npm run ios' : 'yarn ios'}`);
     await warnIfDependenciesRequireAdditionalSetupAsync(projectRoot);
   } else if (ejectMethod === 'expokit') {
-    await loginOrRegisterIfLoggedOut();
+    await loginOrRegisterIfLoggedOutAsync();
     await Detach.detachAsync(projectRoot, options);
     log(chalk.green('Ejected successfully!'));
   } else if (ejectMethod === 'cancel') {

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -15,7 +15,7 @@ import trimStart from 'lodash/trimStart';
 import openBrowser from 'react-dev-utils/openBrowser';
 import readline from 'readline';
 import wordwrap from 'wordwrap';
-import { loginOrRegisterIfLoggedOut } from '../../accounts';
+import { loginOrRegisterIfLoggedOutAsync } from '../../accounts';
 import log from '../../log';
 import urlOpts from '../../urlOpts';
 import { startProjectInEditorAsync } from '../utils/EditorUtils';
@@ -57,17 +57,17 @@ const printUsage = async (projectDir: string, options: Pick<StartOptions, 'webOn
  \u203A Press ${platformInfo}.
  \u203A Press ${b`c`} to show info on ${u`c`}onnecting new devices.
  \u203A Press ${b`d`} to open DevTools in the default web browser.
- \u203A Press ${b`shift-d`} to ${openDevToolsAtStartup
-    ? 'disable'
-    : 'enable'} automatically opening ${u`D`}evTools at startup.${options.webOnly
-    ? ''
-    : `\n \u203A Press ${b`e`} to send an app link with ${u`e`}mail.`}
+ \u203A Press ${b`shift-d`} to ${
+    openDevToolsAtStartup ? 'disable' : 'enable'
+  } automatically opening ${u`D`}evTools at startup.${
+    options.webOnly ? '' : `\n \u203A Press ${b`e`} to send an app link with ${u`e`}mail.`
+  }
  \u203A Press ${b`p`} to toggle ${u`p`}roduction mode. (current mode: ${i(devMode)})
  \u203A Press ${b`r`} to ${u`r`}estart bundler, or ${b`shift-r`} to restart and clear cache.
  \u203A Press ${b`o`} to ${u`o`}pen the project in your editor.
- \u203A Press ${b`s`} to ${u`s`}ign ${username
-    ? `out. (Signed in as ${i('@' + username)}.)`
-    : 'in.'}
+ \u203A Press ${b`s`} to ${u`s`}ign ${
+    username ? `out. (Signed in as ${i('@' + username)}.)` : 'in.'
+  }
 `);
 };
 
@@ -132,7 +132,7 @@ export const startAsync = async (projectDir: string, options: StartOptions) => {
   UserManager.setInteractiveAuthenticationCallback(async () => {
     stopWaitingForCommand();
     try {
-      return await loginOrRegisterIfLoggedOut();
+      return await loginOrRegisterIfLoggedOutAsync();
     } finally {
       startWaitingForCommand();
     }
@@ -272,7 +272,7 @@ export const startAsync = async (projectDir: string, options: StartOptions) => {
       }
       case 'D': {
         clearConsole();
-        const enabled = !await UserSettings.getAsync('openDevToolsAtStartup', true);
+        const enabled = !(await UserSettings.getAsync('openDevToolsAtStartup', true));
         await UserSettings.setAsync('openDevToolsAtStartup', enabled);
         log(
           `Automatically opening DevTools ${b(
@@ -316,7 +316,7 @@ Please reload the project in the Expo app for the change to take effect.`
         } else {
           stopWaitingForCommand();
           try {
-            await loginOrRegisterIfLoggedOut();
+            await loginOrRegisterIfLoggedOutAsync();
           } catch (e) {
             log.error(e);
           } finally {

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -31,7 +31,7 @@ import {
 } from '@expo/xdl';
 import * as ConfigUtils from '@expo/config';
 
-import { loginOrRegisterIfLoggedOut } from './accounts';
+import { loginOrRegisterAsync } from './accounts';
 import log from './log';
 import update from './update';
 import urlOpts from './urlOpts';
@@ -327,7 +327,7 @@ function runAsync(programName: string) {
     Analytics.setVersionName(packageJSON.version);
     _registerLogs();
 
-    UserManager.setInteractiveAuthenticationCallback(loginOrRegisterIfLoggedOut);
+    UserManager.setInteractiveAuthenticationCallback(loginOrRegisterAsync);
 
     if (process.env.SERVER_URL) {
       let serverUrl = process.env.SERVER_URL;

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -156,7 +156,7 @@ export class UserManagerInstance {
       throw new XDLError('NETWORK_REQUIRED', "Can't verify user without network access");
     }
 
-    let user = await this.getCurrentUserAsync();
+    let user = await this.getCurrentUserAsync({ silent: true });
     if (!user && this._interactiveAuthenticationCallbackAsync) {
       user = await this._interactiveAuthenticationCallbackAsync();
     }


### PR DESCRIPTION
# why
https://github.com/expo/expo-cli/issues/1024

# how
Paired with @fson. 
Created a new callback function to remove the double call to the server.
Set the silent option to quiet the redundant error message.

# test
Log in to  cli, then log out of all other session with web ui.
`EXPO_STAGING=1 expod ph`
And check the error message.