### PR TITLE
@sviande/adb kill

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2416,7 +2416,6 @@ async function _stopInternalAsync(projectRoot: string): Promise<void> {
   await stopExpoServerAsync(projectRoot);
   ProjectUtils.logInfo(projectRoot, 'expo', '\u203A Stopping Metro bundler');
   await stopReactNativeServerAsync(projectRoot);
-  await Android.maybeStopAdbDaemonAsync();
   if (!Config.offline) {
     try {
       await stopTunnelsAsync(projectRoot);
@@ -2424,6 +2423,8 @@ async function _stopInternalAsync(projectRoot: string): Promise<void> {
       ProjectUtils.logDebug(projectRoot, 'expo', `Error stopping ngrok ${e.message}`);
     }
   }
+
+  await Android.maybeStopAdbDaemonAsync();
 }
 
 export async function stopWebOnlyAsync(projectDir: string): Promise<void> {


### PR DESCRIPTION
Stop ADB daemon only when expo launched it.

Fix a behavior introduce by #1876 it kills ADB daemon even if another process uses it.

Test 1
```
#ADB is not running
expo start
#ctrl-c expo
#adb is not running
```

Test 2
```
adb start-server
#use ADB (adb push, scrcpy....)
expo start
#ctrl-c expo
#ADB is always running
```