### PR TITLE
fix(config): add postPublishHook type 

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -35,6 +35,24 @@ export type ProjectConfig = {
 };
 export type AppJSONConfig = { expo: ExpoConfig; [key: string]: any };
 export type BareAppConfig = { name: string; [key: string]: any };
+export type HookArguments = {
+  config: any;
+  url: any;
+  exp: ExpoConfig;
+  iosBundle: string;
+  iosSourceMap: string | null;
+  iosManifest: any;
+  androidBundle: string;
+  androidSourceMap: string | null;
+  androidManifest: any;
+  projectRoot: string;
+  log: (msg: any) => void;
+};
+export type PostPublishHook = {
+  file: string;
+  config: any;
+  _fn: (input: HookArguments) => any;
+};
 
 type ExpoOrientation = 'default' | 'portrait' | 'landscape';
 type ExpoPrivacy = 'public' | 'unlisted';
@@ -959,7 +977,7 @@ export type ExpoConfig = {
    * Configuration for scripts to run to hook into the publish process
    */
   hooks?: {
-    postPublish?: string[];
+    postPublish?: PostPublishHook[];
   };
   /**
    * An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.io/versions/latest/guides/offline-support.html)

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -51,7 +51,6 @@ export type HookArguments = {
 export type PostPublishHook = {
   file: string;
   config: any;
-  _fn: (input: HookArguments) => any;
 };
 
 type ExpoOrientation = 'default' | 'portrait' | 'landscape';

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1,5 +1,6 @@
 import {
   ExpoConfig,
+  HookArguments,
   PackageJSONConfig,
   Platform,
   PostPublishHook,
@@ -129,6 +130,10 @@ type PublicConfig = ExpoConfig & {
 
 type SelfHostedIndex = PublicConfig & {
   dependencies: string[];
+};
+
+type LoadedPostPublishHook = PostPublishHook & {
+  _fn: (input: HookArguments) => any;
 };
 
 export type StartOptions = {
@@ -762,7 +767,7 @@ export async function publishAsync(
   // TODO: refactor this out to a function, throw error if length doesn't match
   let { hooks } = exp;
   delete exp.hooks;
-  let validPostPublishHooks: PostPublishHook[] = [];
+  let validPostPublishHooks: LoadedPostPublishHook[] = [];
   if (hooks && hooks.postPublish) {
     hooks.postPublish.forEach((hook: any) => {
       let { file } = hook;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2,6 +2,7 @@ import {
   ExpoConfig,
   PackageJSONConfig,
   Platform,
+  PostPublishHook,
   ProjectTarget,
   configFilename,
   getConfig,
@@ -147,26 +148,6 @@ type PublishOptions = {
 type PackagerOptions = {
   dev: boolean;
   minify: boolean;
-};
-
-type HookArguments = {
-  config: any;
-  url: any;
-  exp: PublicConfig;
-  iosBundle: string;
-  iosSourceMap: string | null;
-  iosManifest: any;
-  androidBundle: string;
-  androidSourceMap: string | null;
-  androidManifest: any;
-  projectRoot: string;
-  log: (msg: any) => void;
-};
-
-type PostPublishHook = {
-  file: string;
-  config: any;
-  _fn: (input: HookArguments) => any;
 };
 
 type Release = {


### PR DESCRIPTION
`postPublishHook` aren't strings, just moving this type out of `xdl` and into `config`