### PR TITLE
chore: fix type checking in CI, remove bootstrap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,10 @@ jobs:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
       - run:
-          name: Bootstrap (Link) Internal Dependencies
-          command: yarn bootstrap
+          name: Type Check and Build Packages
+          command: yarn build
       - persist_to_workspace:
-          root: '~'
+          root: "~"
           paths:
             - expo-cli
       - save_cache:
@@ -98,7 +98,7 @@ jobs:
     working_directory: ~/expo-cli/packages/dev-tools
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-expo-cli:
     parameters:
@@ -108,7 +108,7 @@ jobs:
     working_directory: ~/expo-cli/packages/expo-cli
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test
   test-webpack-config-e2e:
     parameters:
@@ -118,7 +118,7 @@ jobs:
     working_directory: ~/expo-cli/packages/webpack-config
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run:
           name: Install test project dependencies
           command: cd e2e/basic && yarn; cd ../..
@@ -131,7 +131,7 @@ jobs:
     working_directory: ~/expo-cli/packages/webpack-config
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run:
           name: Install test project dependencies
           command: cd e2e/nextjs && yarn; cd ../..
@@ -144,5 +144,5 @@ jobs:
     working_directory: ~/expo-cli/packages/electron-adapter
     steps:
       - attach_workspace:
-          at: '~'
+          at: "~"
       - run: yarn test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,9 @@ Keeping the `master` releasable means that changes merged to it need to be:
 ## Setting up the repository for development
 
 1. Clone the repository.
-2. Run `yarn run bootstrap`. (Installs dependencies, links and builds packages.)
+2. Run `yarn`. (Installs dependencies and links packages in the workspace.)
 3. Run `git config commit.template .github/.COMMIT_TEMPLATE` (Sets you up with our commit message template)
-
-You can then run `yarn start` in the root folder to start watching and automatically re-building packages when there are new changes.
+4. Run `yarn start` in the root folder. (Start watching and automatically re-building packages when there are new changes.)
 
 ## Submitting a pull request
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
     "packages/*"
   ],
   "scripts": {
-    "bootstrap": "lerna bootstrap",
-    "postbootstrap": "lerna run prepare --stream",
+    "build": "lerna run prepare --stream",
     "postinstall": "expo-yarn-workspaces check-workspace-dependencies",
     "publish": "echo \"This script is deprecated. Run \\\"node ./scripts/publish.js\\\" instead.\"; exit 1",
     "start": "lerna --ignore \"@expo/{dev-tools,next-adapter,electron-adapter}\" --ignore expo-optimize --ignore pod-install --ignore uri-scheme run watch --parallel",

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "yarn run prepare && yarn run watch",
-    "build": "babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
+    "build": "tsc --noEmit && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
     "watch": "tsc --watch",
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/expo-cli/tsconfig.json
+++ b/packages/expo-cli/tsconfig.json
@@ -2,9 +2,13 @@
   "extends": "@expo/babel-preset-cli/tsconfig.base",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "src",
+    "typeRoots": [
+      "../babel-preset-cli/ts-declarations",
+      "./node_modules/@types",
+      "../../node_modules/@types"
+    ]
   },
   "include": ["src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"],
-  "references": [{ "path": "../xdl" }]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }


### PR DESCRIPTION
This PR adds type checking with `tsc` to the `build` script in the `expo-cli` package to make sure any type errors are caught in CI. This is necessary because `expo-cli` is compiled with Babel (because [reasons](https://github.com/expo/expo-cli/pull/917)) and Babel doesn't do type checking for TypeScript.

The PR also:
- removes the `yarn bootstrap` script from the root `package.json`, because `lerna bootstrap` is not necessary in projects using Yarn Workspaces (Yarn handles linking and dependencies), and
- adds a `yarn build` script in the root for building all packages. This is mostly going to be used in CI: when developing it's often more convenient to just run `yarn start` to kick off the watcher.