### PR TITLE
Add a default project root for easier use with Webpack CLI

### DIFF
--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -1,9 +1,10 @@
+import { getPossibleProjectRoot } from '@expo/config/paths';
 import { Configuration } from 'webpack';
 
-import { Arguments, DevConfiguration, Environment, InputEnvironment } from './types';
-import { getPublicPaths, validateEnvironment } from './env';
-import webpackConfig from './webpack.config';
 import { withWorkbox } from './addons';
+import { getPublicPaths, validateEnvironment } from './env';
+import { Arguments, DevConfiguration, Environment, InputEnvironment } from './types';
+import webpackConfig from './webpack.config';
 
 /**
  * Create the official Webpack config for loading Expo web apps.
@@ -13,9 +14,13 @@ import { withWorkbox } from './addons';
  * @category default
  */
 export default async function createWebpackConfigAsync(
-  env: InputEnvironment,
+  env: InputEnvironment = {},
   argv: Arguments = {}
 ): Promise<Configuration | DevConfiguration> {
+  if (!env.projectRoot) {
+    env.projectRoot = getPossibleProjectRoot();
+  }
+
   const environment: Environment = validateEnvironment(env);
 
   const config: Configuration | DevConfiguration = await webpackConfig(environment, argv);


### PR DESCRIPTION
Make it easier for people to use react-native-web without Expo CLI.

- `yarn add -D @expo/webpack-config webpack webpack-cli webpack-dev-server`
- `touch webpack.config.js`
```js
const createConfig = require("@expo/webpack-config");

module.exports = () => {
  return createConfig();
};
```
- Run `npx webpack-dev-server`
- Build `npx webpack`

This isn't optimal in a lot of ways but it gives people who don't like Expo an alternative way to use ... expo web

