### PR TITLE
chore: upgrade to TypeScript 3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jest": "^25.2.6",
     "lerna": "3.4.1",
     "lint-staged": "^8.0.4",
-    "prettier": "^1.19.0"
+    "prettier": "^2.0.5"
   },
   "resolutions": {
     "@types/webpack": "4.41.8"

--- a/packages/babel-preset-cli/package.json
+++ b/packages/babel-preset-cli/package.json
@@ -28,7 +28,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.5.0",
     "@babel/preset-env": "^7.4.4",
     "@babel/preset-typescript": "^7.3.3",
-    "typescript": "3.7.3"
+    "typescript": "^3.8.3"
   },
   "devDependencies": {
     "jest-snapshot-serializer-raw": "^1.1.0"

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "yarn run prepare && yarn run watch",
-    "build": "tsc --noEmit && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
+    "build": "tsc --emitDeclarationOnly && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
     "watch": "tsc --watch",
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/next-adapter/src/customize/index.ts
+++ b/packages/next-adapter/src/customize/index.ts
@@ -44,7 +44,7 @@ export async function runAsync({
   for (const customization of manifest) {
     const enabled = await customization.onEnabledAsync({ projectRoot, force });
     values.push({
-      name: customization.name,
+      title: customization.name,
       value: customization.name,
       // @ts-ignore: broken types
       disabled: !force && !enabled,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18413,10 +18413,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.16.4, prettier@^1.19.0:
+prettier@^1.16.4:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-bytes@5.2.0:
   version "5.2.0"
@@ -21929,10 +21934,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
Upgrade TypeScript to 3.8.x. Also Prettier had to be updated to 2.0.x ([TS 3.8 support was introduced in Prettier 2.0](https://prettier.io/blog/2020/03/21/2.0.0.html#typescript)).