### PR TITLE
fix: dead links & better android keystore logging

### DIFF
--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -44,7 +44,7 @@ export default class AndroidBuilder extends BaseBuilder {
     await utils.checkIfSdkIsSupported(this.manifest.sdkVersion!, ANDROID);
     if (!get(this.manifest, 'android.package')) {
       throw new BuildError(`Your project must have an Android package set in app.json
-See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#2-configure-appjson`);
+See https://docs.expo.io/distribution/building-standalone-apps/#2-configure-appjson`);
     }
     const androidPackage = get(this.manifest, 'android.package');
     if (!androidPackage) {
@@ -62,21 +62,25 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
       this.projectDir,
       ANDROID
     );
-
+    log.newLine();
     log.warn(
-      `Clearing your Android build credentials from our build servers is a ${chalk.red(
+      `⚠️  Clearing your Android build credentials from our build servers is a ${chalk.red(
         'PERMANENT and IRREVERSIBLE action.'
       )}`
     );
     log.warn(
-      'Android keystores must be identical to the one previously used to submit your app to the Google Play Store.'
+      chalk.bold(
+        'Android keystores must be identical to the one previously used to submit your app to the Google Play Store.'
+      )
     );
     log.warn(
-      'Please read https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#if-you-choose-to-build-for-android for more info before proceeding.'
+      'Please read https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android for more info before proceeding.'
     );
+    log.newLine();
     log.warn(
-      "We'll store a backup of your Android keystore in this directory in case you decide to delete it from our servers."
+      chalk.bold('Your keystore will be backed up to your current directory if you continue.')
     );
+    log.newLine();
     let questions: Question[] = [
       {
         type: 'confirm',
@@ -235,7 +239,7 @@ See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#
           '\tEXPO_ANDROID_KEYSTORE_PASSWORD\n' +
           '\tEXPO_ANDROID_KEY_PASSWORD\n' +
           'For details, see:\n' +
-          '\thttps://docs.expo.io/versions/latest/distribution/building-standalone-apps/#if-you-choose-to-build-for-android'
+          '\thttps://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android'
       );
     }
     return false;

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -159,7 +159,7 @@ export default class BaseBuilder {
     if (reuseStatus.canReuse) {
       log.warn(`Did you know that Expo provides over-the-air updates?
 Please see the docs (${chalk.underline(
-        'https://docs.expo.io/versions/latest/guides/configuring-ota-updates/'
+        'https://docs.expo.io/guides/configuring-ota-updates/'
       )}) and check if you can use them instead of building your app binaries again.`);
 
       log.warn(

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -68,7 +68,7 @@ class IOSBuilder extends BaseBuilder {
       throw new XDLError(
         'INVALID_OPTIONS',
         `Your project must have a bundleIdentifier set in app.json.
-See https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#2-configure-appjson`
+See https://docs.expo.io/distribution/building-standalone-apps/#2-configure-appjson`
       );
     }
     await utils.checkIfSdkIsSupported(sdkVersion!, PLATFORMS.IOS);

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -115,7 +115,6 @@ export async function validateWithSchema(
   exp: any,
   schema: any,
   configName: string,
-  sdkVersion: string,
   validateAssets: boolean
 ): Promise<{ schemaErrorMessage: string | undefined; assetsErrorMessage: string | undefined }> {
   let schemaErrorMessage;
@@ -129,7 +128,7 @@ export async function validateWithSchema(
     if (e instanceof SchemerError) {
       schemaErrorMessage = `Error: Problem${
         e.errors.length > 1 ? 's' : ''
-      } validating fields in ${configName}. See https://docs.expo.io/versions/v${sdkVersion}/workflow/configuration/`;
+      } validating fields in ${configName}. See https://docs.expo.io/workflow/configuration/`;
       schemaErrorMessage += e.errors.map(formatValidationError).join('');
     }
   }
@@ -224,7 +223,6 @@ async function _validateExpJsonAsync(
         exp,
         schema,
         configName,
-        sdkVersion,
         allowNetwork
       );
 


### PR DESCRIPTION
New docs don't have versioned guides anymore, so this fixes those links.

For android keystore logging-  saying “we’ll store a backup” implies that we keep a copy in case you screw up. The logging now is clear that the backup is in your possession, and the spacing makes that clearer