### PR TITLE
fix: Rewrite ProjectUtils.findProjectRootAsync to use @expo/config

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.types.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.types.ts
@@ -6,6 +6,7 @@ export type CommonOptions = {
   wait: boolean;
   skipWorkflowCheck?: boolean;
   parent?: { nonInteractive: boolean };
+  config?: string;
 };
 
 export type IosOptions = CommonOptions & {

--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -95,10 +95,6 @@ export default function (program: Command) {
     )
     .asyncActionProjectDir(
       async (projectDir: string, options: IosOptions) => {
-        if (options.config) {
-          setCustomConfigPath(projectDir, options.config);
-        }
-
         if (!options.skipWorkflowCheck) {
           if (
             await maybeBailOnWorkflowWarning({
@@ -149,10 +145,6 @@ export default function (program: Command) {
     )
     .asyncActionProjectDir(
       async (projectDir: string, options: AndroidOptions) => {
-        if (options.config) {
-          setCustomConfigPath(projectDir, options.config);
-        }
-
         if (!options.skipWorkflowCheck) {
           if (
             await maybeBailOnWorkflowWarning({

--- a/packages/expo-cli/src/commands/utils/__tests__/ProjectUtils-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/ProjectUtils-test.ts
@@ -1,0 +1,107 @@
+import { vol } from 'memfs';
+import { setCustomConfigPath } from '@expo/config';
+import { findProjectRootAsync } from '../ProjectUtils';
+
+jest.mock('fs');
+
+const basicPackageJson = {
+  name: 'testing123',
+  version: '0.1.0',
+  description: 'fake description',
+  main: 'index.js',
+  dependencies: {},
+};
+
+const basicAppJson = {};
+const exampleProjectPath = '/project';
+
+describe('findProjectRootAsync', () => {
+  describe('valid managed app.json and package.json in project', () => {
+    beforeAll(() => {
+      vol.fromJSON({
+        [`${exampleProjectPath}/package.json`]: JSON.stringify(basicPackageJson),
+        [`${exampleProjectPath}/app.json`]: JSON.stringify(basicAppJson),
+      });
+    });
+
+    afterAll(() => {
+      vol.reset();
+    });
+
+    it('returns the project path and workflow as managed', async () => {
+      const { projectRoot, workflow } = await findProjectRootAsync(exampleProjectPath);
+      expect(projectRoot).toEqual(exampleProjectPath);
+      expect(workflow).toEqual('managed');
+    });
+  });
+
+  describe('package.json with react-native-unimodules', () => {
+    beforeAll(() => {
+      const barePackageJson = {
+        ...basicPackageJson,
+        dependencies: { 'react-native-unimodules': '0.0.0' },
+      };
+
+      vol.fromJSON({
+        [`${exampleProjectPath}/package.json`]: JSON.stringify(barePackageJson),
+        [`${exampleProjectPath}/app.json`]: JSON.stringify(basicAppJson),
+      });
+    });
+
+    afterAll(() => {
+      vol.reset();
+    });
+
+    it('returns bare workflow', async () => {
+      const { projectRoot, workflow } = await findProjectRootAsync(exampleProjectPath);
+      expect(projectRoot).toEqual(exampleProjectPath);
+      expect(workflow).toEqual('bare');
+    });
+  });
+
+  describe('no app.json, no react-native-unimodules', () => {
+    beforeAll(() => {
+      vol.fromJSON({
+        [`${exampleProjectPath}/package.json`]: JSON.stringify(basicPackageJson),
+      });
+    });
+
+    afterAll(() => {
+      vol.reset();
+    });
+
+    it('returns the project path and bare workflow', async () => {
+      const { projectRoot, workflow } = await findProjectRootAsync(exampleProjectPath);
+      expect(projectRoot).toEqual(exampleProjectPath);
+      expect(workflow).toEqual('bare');
+    });
+  });
+
+  describe('app.json in separate config path parent directory', () => {
+    beforeAll(() => {
+      vol.fromJSON({
+        [`${exampleProjectPath}/config/app.json`]: JSON.stringify(basicAppJson),
+        [`${exampleProjectPath}/package.json`]: JSON.stringify(basicPackageJson),
+      });
+    });
+
+    afterAll(() => {
+      vol.reset();
+    });
+
+    it('returns the project path and managed workflow', async () => {
+      setCustomConfigPath(exampleProjectPath, `${exampleProjectPath}/config/app.json`);
+      const { projectRoot, workflow } = await findProjectRootAsync(exampleProjectPath);
+      expect(projectRoot).toEqual(exampleProjectPath);
+      expect(workflow).toEqual('managed');
+    });
+  });
+
+  describe('no valid project', () => {
+    it('throws an error if no package.json in directory or its parents', async () => {
+      expect(findProjectRootAsync(exampleProjectPath)).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"No managed or bare projects found. Please make sure you are inside a project folder."`
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/expo/expo-cli/issues/2109

`findProjectRootAsync` was not respecting the config and `build:*` was not calling `setCustomConfigPath` with the value of the `--config` flag. This resolves both of those issues.

Note: there are other places where we call `findProjectRootAsync`: `install` and `upgrade`. I didn't think it made sense to support the config flag in these places, but I am open to being convinced.

### TODO

- [x] Add test coverage for `findProjectRootAsync`