### PR TITLE
fix: warn if no facebook config when building custom client

### DIFF
--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -61,7 +61,7 @@ export default function (program: Command) {
         }
         if (!exp.ios) exp.ios = {};
 
-        if (!(_.has(exp, 'facebookAppId') && _.has(exp, 'facebookScheme'))) {
+        if (!_.has(exp, 'facebookAppId') || !_.has(exp, 'facebookScheme')) {
           const disabledReason = exp
             ? `facebookAppId or facebookScheme are missing from app configuration. `
             : 'No custom configuration file could be found. You will need to provide a json file with valid facebookAppId and facebookScheme fields.';

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -24,7 +24,7 @@ import { CreateIosDist } from '../../credentials/views/IosDistCert';
 import { CreateOrReuseProvisioningProfileAdhoc } from '../../credentials/views/IosProvisioningProfileAdhoc';
 import { runCredentialsManager } from '../../credentials/route';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('client:ios [project-dir]')
     .option(
@@ -61,6 +61,12 @@ export default function (program: Command) {
         }
         if (!exp.ios) exp.ios = {};
 
+        if (!(_.has(exp, 'facebookAppId') && _.has(exp, 'facebookScheme'))) {
+          const disabledReason = exp
+            ? `facebookAppId or facebookScheme are missing from app configuration. `
+            : 'No custom configuration file could be found. You will need to provide a json file with valid facebookAppId and facebookScheme fields.';
+          disabledServices.googleMaps = { name: 'Facebook Login', reason: disabledReason };
+        }
         if (!_.has(exp, 'ios.config.googleMapsApiKey')) {
           const disabledReason = exp
             ? `ios.config.googleMapsApiKey does not exist in the app configuration.`

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -65,7 +65,7 @@ export default function (program: Command) {
           const disabledReason = exp
             ? `facebookAppId or facebookScheme are missing from app configuration. `
             : 'No custom configuration file could be found. You will need to provide a json file with valid facebookAppId and facebookScheme fields.';
-          disabledServices.googleMaps = { name: 'Facebook Login', reason: disabledReason };
+          disabledServices.facebookLogin = { name: 'Facebook Login', reason: disabledReason };
         }
         if (!_.has(exp, 'ios.config.googleMapsApiKey')) {
           const disabledReason = exp

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -24,7 +24,7 @@ import { CreateIosDist } from '../../credentials/views/IosDistCert';
 import { CreateOrReuseProvisioningProfileAdhoc } from '../../credentials/views/IosProvisioningProfileAdhoc';
 import { runCredentialsManager } from '../../credentials/route';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('client:ios [project-dir]')
     .option(


### PR DESCRIPTION
We warn for the other optional configs, so I'm adding the just-added Facebook config 