### PR TITLE
[xdl] prefer expo-updates version from template when ejecting

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -335,6 +335,8 @@ async function createNativeProjectsFromTemplateAsync(projectRoot: string): Promi
    *   for example RNGH and Reanimated. We should prefer the version that is already being used
    *   in the project for those, but swap the react/react-native/react-native-unimodules versions
    *   with the ones in the template.
+   * - The same applies to expo-updates -- since some native project configuration may depend on the
+   *   version, we should always use the version of expo-updates in the template.
    */
 
   const combinedDependencies: DependenciesMap = createDependenciesMap({
@@ -342,7 +344,12 @@ async function createNativeProjectsFromTemplateAsync(projectRoot: string): Promi
     ...pkg.dependencies,
   });
 
-  for (const dependenciesKey of ['react', 'react-native-unimodules', 'react-native']) {
+  for (const dependenciesKey of [
+    'react',
+    'react-native-unimodules',
+    'react-native',
+    'expo-updates',
+  ]) {
     combinedDependencies[dependenciesKey] = defaultDependencies[dependenciesKey];
   }
   const combinedDevDependencies: DependenciesMap = createDependenciesMap({


### PR DESCRIPTION
Since the native project configuration can change between expo-updates versions, when ejecting we should prefer the expo-updates version in the template project rather than the version the project already has installed (if any).

Otherwise we can end up in a situation where we eject a project with `expo-updates@0.1.2` installed, but the resulting project has the native configuration for `0.2.0` which will make the build fail.

The only time this could be an issue is if we change the JS API, but as long as we don't do this within a single SDK version this won't be an issue.

Tested by: expo init EjectTest -> expo install expo-updates (0.1.3) -> expo eject -> verify 0.2.1 installed.