### PR TITLE
fix(dev-tools): add clean up to avoid inflating package size

### DIFF
--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -8,7 +8,7 @@
     "build-client": "NODE_ENV=production next build && next export -o ./build/client",
     "build-server": "NODE_ENV=production tsc",
     "extract-fragment-types": "ts-node ./server/extract-fragment-types",
-    "clean": "rimraf ./build",
+    "clean": "rimraf .next build",
     "prepare": "yarn run clean && yarn run build",
     "start": "yarn dev",
     "test": "jest --config jest.config.js"


### PR DESCRIPTION
Clean up the `.next` folder before building Dev Tools to avoid inflating the package size.

In `@expo/dev-tools@0.13.6`, the unzipped size of the `build/client/_next/static` was 70M and it included 130 folders. It turns out these folders are copied from the `.next` folder when `next export` is run, and the size of the folder grew with every build.

## Testing

Ran `yarn run prepare && ls build/client/_next/static|wc -l` a bunch of times in a row and verified that the number of folders remained constant `3`.