### PR TITLE
chore: add --quiet to the pod-install README

### DIFF
--- a/packages/pod-install/README.md
+++ b/packages/pod-install/README.md
@@ -54,6 +54,7 @@ For more information run `npx pod-install --help` (or `-h`)
 | Flag                | Input       | Description                                   | Default                |
 | ------------------- | ----------- | --------------------------------------------- | ---------------------- |
 | `--non-interactive` | `[boolean]` | Skip prompting to install CocoaPods with sudo | `process.stdout.isTTY` |
+| `--quiet`           | `[boolean]` | Only print errors                             | `false`                |
 
 ## License
 


### PR DESCRIPTION
This small PR adds `--quiet` option description to the `pod-install` README file. Refs #2102.