### PR TITLE
[expo-cli] configure jest with jest.config not with package.json

### DIFF
--- a/packages/expo-cli/jest.config.js
+++ b/packages/expo-cli/jest.config.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  rootDir: path.resolve(__dirname),
+  displayName: require('expo-cli/package.json').name,
+  testRegex: '/__tests__/.*(test|spec)\\.(j|t)s$',
+  testEnvironment: 'node',
+  resetModules: false,
+};

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -18,19 +18,6 @@
     "test": "jest",
     "test:watch": "jest --watch"
   },
-  "jest": {
-    "testEnvironment": "node",
-    "roots": [
-      "__mocks__",
-      "src"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "ts",
-      "json"
-    ],
-    "resetModules": false
-  },
   "bin": {
     "expo": "./bin/expo.js",
     "expo-cli": "./bin/expo.js"


### PR DESCRIPTION
Just a simple change. I think it's better to keep `package.json` as simple as possible.