### PR TITLE
[expo-cli] simplify mocks for @expo/xdl and ora

### DIFF
--- a/packages/expo-cli/__mocks__/ora.js
+++ b/packages/expo-cli/__mocks__/ora.js
@@ -1,0 +1,9 @@
+const ora = jest.fn(() => {
+  return {
+    start: jest.fn(() => {
+      return { stop: jest.fn(), succeed: jest.fn(), fail: jest.fn() };
+    }),
+  };
+});
+
+module.exports = ora;

--- a/packages/expo-cli/src/__tests__/utils.ts
+++ b/packages/expo-cli/src/__tests__/utils.ts
@@ -1,0 +1,19 @@
+import * as xdl from '@expo/xdl';
+
+type MockedXDLModules = Partial<Record<keyof typeof xdl, object>>;
+
+function mockExpoXDL(mockedXDLModules: MockedXDLModules): void {
+  jest.mock('@expo/xdl', () => {
+    const pkg = jest.requireActual('@expo/xdl');
+    const xdlMock = { ...pkg };
+    for (const [name, value] of Object.entries(mockedXDLModules)) {
+      xdlMock[name] = {
+        ...pkg[name],
+        ...value,
+      };
+    }
+    return xdlMock;
+  });
+}
+
+export { mockExpoXDL };

--- a/packages/expo-cli/src/commands/__tests__/publish-info-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-info-test.ts
@@ -2,41 +2,20 @@ import { vol } from 'memfs';
 import { ApiV2 } from '@expo/xdl';
 
 import { getPublicationDetailAsync, getPublishHistoryAsync } from '../utils/PublishUtils';
+import { jester } from '../../credentials/test-fixtures/mocks';
+import { mockExpoXDL } from '../../__tests__/utils';
 
 jest.mock('fs');
 jest.mock('resolve-from');
-jest.mock('ora', () =>
-  jest.fn(() => {
-    return {
-      start: jest.fn(() => {
-        return { stop: jest.fn(), succeed: jest.fn() };
-      }),
-    };
-  })
-);
-jest.mock('@expo/xdl', () => {
-  const user = {
-    kind: 'user',
-    username: 'test-username',
-    nickname: 'test-nickname',
-    userId: 'test-id',
-    picture: 'test-pic',
-    currentConnection: 'Username-Password-Authentication',
-    sessionSecret: 'test-session-secret',
-  };
-  const pkg = jest.requireActual('@expo/xdl');
-  return {
-    ...pkg,
-    UserManager: {
-      ...pkg.UserManager,
-      ensureLoggedInAsync: jest.fn(() => user),
-      getCurrentUserAsync: jest.fn(() => user),
-    },
-    ApiV2: {
-      ...pkg.clientForUser,
-      clientForUser: jest.fn(),
-    },
-  };
+
+mockExpoXDL({
+  UserManager: {
+    ensureLoggedInAsync: jest.fn(() => jester),
+    getCurrentUserAsync: jest.fn(() => jester),
+  },
+  ApiV2: {
+    clientForUser: jest.fn(),
+  },
 });
 
 describe('publish details', () => {
@@ -56,7 +35,7 @@ describe('publish details', () => {
     version: '0.1.0',
     slug: 'testing-123',
     sdkVersion: '33.0.0',
-    owner: 'test-user',
+    owner: jester.username,
   });
 
   beforeAll(() => {
@@ -94,7 +73,7 @@ describe('publish details', () => {
 
     expect(postAsync.mock.calls.length).toBe(1);
     expect(postAsync).toHaveBeenCalledWith('publish/details', {
-      owner: 'test-user',
+      owner: jester.username,
       publishId: 'test-uuid',
       slug: 'testing-123',
     });
@@ -120,7 +99,7 @@ describe('publish details', () => {
       platform: 'ios',
       releaseChannel: 'test-channel',
       sdkVersion: '35.0.0',
-      owner: 'test-user',
+      owner: jester.username,
       slug: 'testing-123',
       version: 2,
     });

--- a/packages/expo-cli/src/commands/__tests__/publish-modify-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-modify-test.ts
@@ -5,41 +5,20 @@ import {
   rollbackPublicationFromChannelAsync,
   setPublishToChannelAsync,
 } from '../utils/PublishUtils';
+import { jester } from '../../credentials/test-fixtures/mocks';
+import { mockExpoXDL } from '../../__tests__/utils';
 
 jest.mock('fs');
 jest.mock('resolve-from');
-jest.mock('ora', () =>
-  jest.fn(() => {
-    return {
-      start: jest.fn(() => {
-        return { stop: jest.fn(), succeed: jest.fn() };
-      }),
-    };
-  })
-);
-jest.mock('@expo/xdl', () => {
-  const user = {
-    kind: 'user',
-    username: 'test-username',
-    nickname: 'test-nickname',
-    userId: 'test-id',
-    picture: 'test-pic',
-    currentConnection: 'Username-Password-Authentication',
-    sessionSecret: 'test-session-secret',
-  };
-  const pkg = jest.requireActual('@expo/xdl');
-  return {
-    ...pkg,
-    UserManager: {
-      ...pkg.UserManager,
-      ensureLoggedInAsync: jest.fn(() => user),
-      getCurrentUserAsync: jest.fn(() => user),
-    },
-    ApiV2: {
-      ...pkg.clientForUser,
-      clientForUser: jest.fn(),
-    },
-  };
+
+mockExpoXDL({
+  UserManager: {
+    ensureLoggedInAsync: jest.fn(() => jester),
+    getCurrentUserAsync: jest.fn(() => jester),
+  },
+  ApiV2: {
+    clientForUser: jest.fn(),
+  },
 });
 
 describe('publish details', () => {
@@ -59,7 +38,7 @@ describe('publish details', () => {
     version: '0.1.0',
     slug: 'testing-123',
     sdkVersion: '33.0.0',
-    owner: 'test-user',
+    owner: jester.username,
   });
 
   beforeAll(() => {
@@ -133,7 +112,7 @@ describe('publish details', () => {
       releaseChannel: 'test-channel',
       slug: 'testing-123',
       count: 2,
-      owner: 'test-user',
+      owner: jester.username,
       platform: 'ios',
       sdkVersion: '35.0.0',
       version: 2,
@@ -176,7 +155,7 @@ describe('publish details', () => {
       releaseChannel: 'test-channel',
       slug: 'testing-123',
       count: 2,
-      owner: 'test-user',
+      owner: jester.username,
       platform: 'ios',
       sdkVersion: '35.0.0',
       version: 2,
@@ -221,7 +200,7 @@ describe('publish details', () => {
       releaseChannel: 'test-channel',
       slug: 'testing-123',
       count: 2,
-      owner: 'test-user',
+      owner: jester.username,
       platform: 'ios',
       sdkVersion: '35.0.0',
       version: 2,
@@ -229,7 +208,7 @@ describe('publish details', () => {
     expect(postAsync).toHaveBeenCalledWith('publish/details', {
       slug: 'testing-123',
       publishId: 'test-publication-uuid-1',
-      owner: 'test-user',
+      owner: jester.username,
     });
     expect(postAsync).toHaveBeenCalledWith('publish/set', {
       slug: 'testing-123',
@@ -275,7 +254,7 @@ describe('publish details', () => {
       releaseChannel: 'test-channel',
       slug: 'testing-123',
       count: 2,
-      owner: 'test-user',
+      owner: jester.username,
       platform: 'ios',
       sdkVersion: '35.0.0',
       version: 2,
@@ -284,7 +263,7 @@ describe('publish details', () => {
       releaseChannel: 'test-channel',
       slug: 'testing-123',
       count: 2,
-      owner: 'test-user',
+      owner: jester.username,
       platform: 'android',
       sdkVersion: '35.0.0',
       version: 2,
@@ -292,12 +271,12 @@ describe('publish details', () => {
     expect(postAsync).toHaveBeenCalledWith('publish/details', {
       slug: 'testing-123',
       publishId: 'test-publication-uuid-ios-1',
-      owner: 'test-user',
+      owner: jester.username,
     });
     expect(postAsync).toHaveBeenCalledWith('publish/details', {
       slug: 'testing-123',
       publishId: 'test-publication-uuid-android-1',
-      owner: 'test-user',
+      owner: jester.username,
     });
     expect(postAsync).toHaveBeenCalledWith('publish/set', {
       slug: 'testing-123',

--- a/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
@@ -5,6 +5,7 @@ import {
   maybeFormatSdkVersion,
   upgradeAsync,
 } from '../upgrade';
+import { mockExpoXDL } from '../../__tests__/utils';
 
 jest.mock('fs');
 jest.mock('resolve-from');
@@ -179,16 +180,11 @@ xdescribe('upgradeAsync', () => {
         },
       };
     });
-    jest.mock('@expo/xdl', () => {
-      const pkg = jest.requireActual('@expo/xdl');
-      return {
-        ...pkg,
-        Project: {
-          ...pkg.Project,
-          startReactNativeServerAsync: jest.fn(),
-          stopReactNativeServerAsync: jest.fn(),
-        },
-      };
+    mockExpoXDL({
+      Project: {
+        startReactNativeServerAsync: jest.fn(),
+        stopReactNativeServerAsync: jest.fn(),
+      },
     });
     jest.mock('@expo/config', () => {
       const config = jest.requireActual('@expo/config');
@@ -256,10 +252,10 @@ xdescribe('upgradeAsync', () => {
       '/from-app-config-js/app.json': JSON.stringify({
         expo: { ...appJson, sdkVersion: undefined },
       }),
-      '/from-app-config-js/app.config.js': `module.exports=({config}) => ({ 
-          ...config, 
-          androidNavigationBar: {visible: false}, 
-          sdkVersion: '34.0.0' 
+      '/from-app-config-js/app.config.js': `module.exports=({config}) => ({
+          ...config,
+          androidNavigationBar: {visible: false},
+          sdkVersion: '34.0.0'
         })`,
       '/from-app-config-js/node_modules/expo/package.json': expoPackageJson,
       '/from-app-config-js/node_modules/expo/bundledNativeModules.json': JSON.stringify({}),

--- a/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
+++ b/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
@@ -7,17 +7,10 @@ import {
   jester,
   testAppJson,
 } from '../../../credentials/test-fixtures/mocks';
+import { mockExpoXDL } from '../../../__tests__/utils';
 
 jest.mock('fs');
-jest.mock('ora', () =>
-  jest.fn(() => {
-    return {
-      start: jest.fn(() => {
-        return { stop: jest.fn(), succeed: jest.fn(), fail: jest.fn() };
-      }),
-    };
-  })
-);
+
 jest.mock('@expo/plist', () => {
   const plistModule = jest.requireActual('@expo/plist');
   return {
@@ -40,13 +33,12 @@ jest.mock('commander', () => {
   };
 });
 
-const mockUser = jester;
 const mockApiV2 = getApiV2MockCredentials();
 const mockedXDLModules = {
   UserManager: {
-    ensureLoggedInAsync: jest.fn(() => mockUser),
-    getCurrentUserAsync: jest.fn(() => mockUser),
-    getCurrentUsernameAsync: jest.fn(() => mockUser.username),
+    ensureLoggedInAsync: jest.fn(() => jester),
+    getCurrentUserAsync: jest.fn(() => jester),
+    getCurrentUsernameAsync: jest.fn(() => jester.username),
   },
   ApiV2: {
     clientForUser: jest.fn(() => mockApiV2),
@@ -62,20 +54,7 @@ const mockedXDLModules = {
   },
   PKCS12Utils: { getP12CertFingerprint: jest.fn(), findP12CertSerialNumber: jest.fn() },
 };
-
-jest.mock('@expo/xdl', () => {
-  const pkg = jest.requireActual('@expo/xdl');
-  const xdlMock = {
-    ...pkg,
-  };
-  for (const xdlModuleName of Object.keys(mockedXDLModules)) {
-    xdlMock[xdlModuleName] = {
-      ...pkg[xdlModuleName],
-      ...mockedXDLModules[xdlModuleName],
-    };
-  }
-  return xdlMock;
-});
+mockExpoXDL(mockedXDLModules);
 
 describe('build ios', () => {
   const projectRoot = '/test-project';


### PR DESCRIPTION
I need to mock `@expo/xdl` and `ora` in tests for my other PR. I saw that we're already mocking these modules in few places. I wanted to simplify mocking them so it requires less boilerplate in each test suite.

- I added a global mock for `ora`.
- I added a utility function for mocking `@expo/xdl` (it's type-safe).