### PR TITLE
[expo-cli] increase timeout for build-ios-test.ts

### DIFF
--- a/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
+++ b/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
@@ -9,6 +9,8 @@ import {
 } from '../../../credentials/test-fixtures/mocks';
 import { mockExpoXDL } from '../../../__tests__/utils';
 
+jest.setTimeout(10 * 1000); // 10s
+
 jest.mock('fs');
 
 jest.mock('@expo/plist', () => {


### PR DESCRIPTION
I've noticed that test cases from this test suite are failing on master occasionally. They exceed the default 5s timeout. I increased it to 10s.