### PR TITLE
Make the Google Services prompt bold/use terminal link

### DIFF
--- a/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
@@ -1,3 +1,5 @@
+import terminalLink from 'terminal-link';
+import chalk from 'chalk';
 import prompt from '../../../../prompt';
 import { existingFile } from '../../../../validators';
 import log from '../../../../log';
@@ -51,8 +53,13 @@ async function handlePromptSourceAsync(_source: ServiceAccountPromptSource): Pro
 
 async function askForServiceAccountPathAsync(): Promise<string> {
   log(
-    'We need a Google Service Account JSON key to upload your app to Google Play Store.\n' +
-      "If you're not sure how to create one, learn more here: https://expo.fyi/creating-google-service-account"
+    `${chalk.bold(
+      'A Google Service Account JSON key is required to upload your app to Google Play Store'
+    )}.\n` +
+      `If you're not sure what this is or how to create one, learn more here: ${terminalLink(
+        'expo.fyi/creating-google-service-account',
+        'https://expo.fyi/creating-google-service-account'
+      )}`
   );
   const { filePath } = await prompt({
     name: 'filePath',


### PR DESCRIPTION
Use chalk to bold the first place where the user should read and use terminal link to remove https:// prefix and underline the link

<img width="1207" alt="Screen Shot 2020-05-24 at 7 47 26 PM" src="https://user-images.githubusercontent.com/90494/82773646-65e1c800-9df7-11ea-9781-0019f1c9e34c.png">

<hr />

In general I think we should try to call attention to where an important log message begins by using bolded text.

If there's an error that's followed by a bunch of text, we can prefix the error message with 🚨, and if it's a warning, we can prefix it with ⚠️. This is useful for people to quickly see what things they need to pay attention to in the scroll buffer. See the eject command for an example. (Note that we use red text for warning still here, this is because it's pretty hard to read yellow text).

<img width="1157" alt="Screen Shot 2020-05-24 at 7 54 16 PM" src="https://user-images.githubusercontent.com/90494/82773976-5adb6780-9df8-11ea-890e-71bd103340d9.png">

terminal-link is used elsewhere in the CLI (eg: eject) and lets us provide links in a more natural way when that is useful. Using it for all links helps us maintain consistency.

<img width="1064" alt="Screen Shot 2020-05-24 at 7 51 58 PM" src="https://user-images.githubusercontent.com/90494/82773881-0df79100-9df8-11ea-9717-530fa5eed9ce.png">
