### PR TITLE
chore: clean up lodash usage

### DIFF
--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -1,10 +1,9 @@
-import ora from 'ora';
 import chalk from 'chalk';
 import terminalLink from 'terminal-link';
 import wordwrap from 'wordwrap';
 
-import { every, some } from 'lodash';
-import invariant from 'invariant';
+import every from 'lodash/every';
+import some from 'lodash/some';
 import { runAction, travelingFastlane } from './fastlane';
 import { nonEmptyInput } from '../validators';
 import log from '../log';

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -2,8 +2,6 @@ import chalk from 'chalk';
 import terminalLink from 'terminal-link';
 import wordwrap from 'wordwrap';
 
-import every from 'lodash/every';
-import some from 'lodash/some';
 import { runAction, travelingFastlane } from './fastlane';
 import { nonEmptyInput } from '../validators';
 import log from '../log';
@@ -70,12 +68,12 @@ function _getAppleIdFromParams({ appleId, appleIdPassword }: Options): AppleCred
   const passedAppleIdPassword = appleIdPassword || process.env.EXPO_APPLE_PASSWORD;
 
   // none of the apple id params were set, assume user has no intention of passing it in
-  if (!some([appleId, passedAppleIdPassword])) {
+  if (!appleId && !passedAppleIdPassword) {
     return null;
   }
 
   // partial apple id params were set, assume user has intention of passing it in
-  if (!every([appleId, passedAppleIdPassword])) {
+  if (!(appleId && passedAppleIdPassword)) {
     throw new Error(
       'In order to provide your Apple ID credentials, you must set the --apple-id flag and set the EXPO_APPLE_PASSWORD environment variable.'
     );

--- a/packages/expo-cli/src/appleApi/distributionCert.ts
+++ b/packages/expo-cli/src/appleApi/distributionCert.ts
@@ -1,6 +1,5 @@
 import ora from 'ora';
 import dateformat from 'dateformat';
-import get from 'lodash/get';
 import chalk from 'chalk';
 
 import CommandError, { ErrorCodes } from '../CommandError';
@@ -86,7 +85,7 @@ export class DistCertManager {
       return result;
     } catch (err) {
       spinner.stop();
-      const resultString = get(err, 'rawDump.resultString');
+      const resultString = err.rawDump?.resultString;
       if (resultString && resultString.match(/Maximum number of certificates generated/)) {
         throw new CommandError(
           ErrorCodes.APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR,

--- a/packages/expo-cli/src/appleApi/pushKey.ts
+++ b/packages/expo-cli/src/appleApi/pushKey.ts
@@ -1,5 +1,4 @@
 import ora from 'ora';
-import get from 'lodash/get';
 import dateformat from 'dateformat';
 import chalk from 'chalk';
 import CommandError, { ErrorCodes } from '../CommandError';
@@ -66,7 +65,7 @@ export class PushKeyManager {
       };
     } catch (err) {
       spinner.stop();
-      const resultString = get(err, 'rawDump.resultString');
+      const resultString = err.rawDump?.resultString;
       if (resultString && resultString.match(/maximum allowed number of Keys/)) {
         throw new CommandError(
           ErrorCodes.APPLE_PUSH_KEYS_TOO_MANY_GENERATED_ERROR,

--- a/packages/expo-cli/src/commands/build-native/Builder.ts
+++ b/packages/expo-cli/src/commands/build-native/Builder.ts
@@ -7,7 +7,6 @@ import axios from 'axios';
 import concat from 'concat-stream';
 import fs from 'fs-extra';
 import md5File from 'md5-file/promise';
-import toPairs from 'lodash/toPairs';
 import ora from 'ora';
 import { v4 as uuid } from 'uuid';
 
@@ -77,7 +76,7 @@ async function uploadWithPresignedURL(presignedPost: PresignedPost, file: string
   const fileStream = fs.createReadStream(file);
 
   const form = new FormData();
-  for (const [fieldKey, fieldValue] of toPairs(presignedPost.fields)) {
+  for (const [fieldKey, fieldValue] of Object.entries(presignedPost.fields)) {
     form.append(fieldKey, fieldValue);
   }
   form.append('file', fileStream);

--- a/packages/expo-cli/src/commands/build-native/Builder.ts
+++ b/packages/expo-cli/src/commands/build-native/Builder.ts
@@ -1,8 +1,7 @@
 import os from 'os';
 import path from 'path';
 
-import { JSONObject } from '@expo/json-file';
-import { Android, Platform, prepareJob } from '@expo/build-tools';
+import { Platform, prepareJob } from '@expo/build-tools';
 import { ApiV2, FormData, User } from '@expo/xdl';
 import axios from 'axios';
 import concat from 'concat-stream';
@@ -13,7 +12,6 @@ import ora from 'ora';
 import { v4 as uuid } from 'uuid';
 
 import { makeProjectTarball, waitForBuildEnd } from './utils';
-import log from '../../log';
 
 export interface StatusResult {
   builds: BuildInfo[];

--- a/packages/expo-cli/src/commands/build-native/utils.ts
+++ b/packages/expo-cli/src/commands/build-native/utils.ts
@@ -1,7 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import { ApiV2 } from '@expo/xdl';
 import delayAsync from 'delay-async';
-import get from 'lodash/get';
 import ora from 'ora';
 
 import log from '../../log';
@@ -22,7 +21,7 @@ async function waitForBuildEnd(
     switch (buildInfo.status) {
       case 'finished':
         spinner.succeed('Build finished.');
-        return get(buildInfo, 'artifacts.buildUrl', '');
+        return buildInfo.artifacts?.buildUrl ?? '';
       case 'in-queue':
         spinner.text = 'Build queued...';
         break;

--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import untildify from 'untildify';
 import { Android, AndroidCredentials, Credentials } from '@expo/xdl';
 import chalk from 'chalk';
-import get from 'lodash/get';
 
 import invariant from 'invariant';
 import log from '../../log';
@@ -42,13 +41,10 @@ export default class AndroidBuilder extends BaseBuilder {
 
   async validateProject() {
     await utils.checkIfSdkIsSupported(this.manifest.sdkVersion!, ANDROID);
-    if (!get(this.manifest, 'android.package')) {
+    const androidPackage = this.manifest.android?.package;
+    if (!androidPackage) {
       throw new BuildError(`Your project must have an Android package set in app.json
 See https://docs.expo.io/distribution/building-standalone-apps/#2-configure-appjson`);
-    }
-    const androidPackage = get(this.manifest, 'android.package');
-    if (!androidPackage) {
-      throw new BuildError('Your project must have an Android package set in app.json.');
     }
     if (!/^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(androidPackage)) {
       throw new BuildError(

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -2,8 +2,6 @@ import { ExpoConfig, getConfig } from '@expo/config';
 import { Project, User, UserManager, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import delayAsync from 'delay-async';
-import fp from 'lodash/fp';
-import get from 'lodash/get';
 import ora from 'ora';
 import semver from 'semver';
 
@@ -304,22 +302,18 @@ ${job.id}
     while (true) {
       let res;
       if (process.env.EXPO_LEGACY_API === 'true') {
-        res = await Project.buildAsync(this.projectDir, {
+        res = (await Project.buildAsync(this.projectDir, {
           current: false,
           mode: 'status',
           ...(publicUrl ? { publicUrl } : {}),
-        });
+        })) as Project.BuildStatusResult;
       } else {
         res = await Project.getBuildStatusAsync(this.projectDir, {
           current: false,
           ...(publicUrl ? { publicUrl } : {}),
         });
       }
-      const job = fp.compose(
-        fp.head,
-        fp.filter(job => buildId && (job as any).id === buildId),
-        fp.getOr([], 'jobs')
-      )(res);
+      const job = res.jobs?.filter((job: Project.BuildJobFields) => job.id === buildId)[0];
 
       switch (job.status) {
         case 'finished':
@@ -347,7 +341,7 @@ ${job.id}
   async build(expIds?: Array<string>) {
     const { publicUrl } = this.options;
     const platform = this.platform();
-    const bundleIdentifier = get(this.manifest, 'ios.bundleIdentifier');
+    const bundleIdentifier = this.manifest.ios?.bundleIdentifier;
 
     let result: any;
     if (process.env.EXPO_LEGACY_API === 'true') {

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -339,7 +339,7 @@ class IOSBuilder extends BaseBuilder {
     }
   }
 
-  determineCredentialsToClear(): { [name: string]: boolean } {
+  determineCredentialsToClear(): Record<string, boolean> {
     const {
       clearCredentials,
       clearDistCert,

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -304,7 +304,7 @@ class IOSBuilder extends BaseBuilder {
     ctx: Context,
     experienceName: string,
     bundleIdentifier: string,
-    credsToClear: { [name: string]: boolean }
+    credsToClear: Record<string, boolean>
   ): Promise<void> {
     const shouldRevokeOnApple = this.options.revokeCredentials;
     const nonInteractive = this.options.parent && this.options.parent.nonInteractive;

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -2,7 +2,7 @@ import { Android, Simulator, UserManager, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import CliTable from 'cli-table3';
 import fs from 'fs-extra';
-import _ from 'lodash';
+import has from 'lodash/has';
 import ora from 'ora';
 import path from 'path';
 import { Command } from 'commander';
@@ -24,7 +24,7 @@ import { CreateIosDist } from '../../credentials/views/IosDistCert';
 import { CreateOrReuseProvisioningProfileAdhoc } from '../../credentials/views/IosProvisioningProfileAdhoc';
 import { runCredentialsManager } from '../../credentials/route';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('client:ios [project-dir]')
     .option(
@@ -61,19 +61,19 @@ export default function (program: Command) {
         }
         if (!exp.ios) exp.ios = {};
 
-        if (!_.has(exp, 'facebookAppId') || !_.has(exp, 'facebookScheme')) {
+        if (!has(exp, 'facebookAppId') || !has(exp, 'facebookScheme')) {
           const disabledReason = exp
             ? `facebookAppId or facebookScheme are missing from app configuration. `
             : 'No custom configuration file could be found. You will need to provide a json file with valid facebookAppId and facebookScheme fields.';
           disabledServices.facebookLogin = { name: 'Facebook Login', reason: disabledReason };
         }
-        if (!_.has(exp, 'ios.config.googleMapsApiKey')) {
+        if (!has(exp, 'ios.config.googleMapsApiKey')) {
           const disabledReason = exp
             ? `ios.config.googleMapsApiKey does not exist in the app configuration.`
             : 'No custom configuration file could be found. You will need to provide a json file with a valid ios.config.googleMapsApiKey field.';
           disabledServices.googleMaps = { name: 'Google Maps', reason: disabledReason };
         }
-        if (_.has(exp, 'ios.googleServicesFile')) {
+        if (has(exp, 'ios.googleServicesFile')) {
           const contents = await fs.readFile(
             path.resolve(projectDir, exp.ios.googleServicesFile!),
             'base64'

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -2,7 +2,6 @@ import { Android, Simulator, UserManager, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import CliTable from 'cli-table3';
 import fs from 'fs-extra';
-import has from 'lodash/has';
 import ora from 'ora';
 import path from 'path';
 import { Command } from 'commander';
@@ -24,7 +23,7 @@ import { CreateIosDist } from '../../credentials/views/IosDistCert';
 import { CreateOrReuseProvisioningProfileAdhoc } from '../../credentials/views/IosProvisioningProfileAdhoc';
 import { runCredentialsManager } from '../../credentials/route';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('client:ios [project-dir]')
     .option(
@@ -61,19 +60,19 @@ export default function(program: Command) {
         }
         if (!exp.ios) exp.ios = {};
 
-        if (!has(exp, 'facebookAppId') || !has(exp, 'facebookScheme')) {
+        if (!exp.facebookAppId || !exp.facebookScheme) {
           const disabledReason = exp
             ? `facebookAppId or facebookScheme are missing from app configuration. `
             : 'No custom configuration file could be found. You will need to provide a json file with valid facebookAppId and facebookScheme fields.';
           disabledServices.facebookLogin = { name: 'Facebook Login', reason: disabledReason };
         }
-        if (!has(exp, 'ios.config.googleMapsApiKey')) {
+        if (!exp.ios.config?.googleMapsApiKey) {
           const disabledReason = exp
             ? `ios.config.googleMapsApiKey does not exist in the app configuration.`
             : 'No custom configuration file could be found. You will need to provide a json file with a valid ios.config.googleMapsApiKey field.';
           disabledServices.googleMaps = { name: 'Google Maps', reason: disabledReason };
         }
-        if (has(exp, 'ios.googleServicesFile')) {
+        if (exp.ios.googleServicesFile) {
           const contents = await fs.readFile(
             path.resolve(projectDir, exp.ios.googleServicesFile!),
             'base64'

--- a/packages/expo-cli/src/commands/fetch/android.ts
+++ b/packages/expo-cli/src/commands/fetch/android.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs-extra';
-import get from 'lodash/get';
 
 import { AndroidCredentials } from '@expo/xdl';
 import invariant from 'invariant';
@@ -48,11 +47,12 @@ export async function fetchAndroidHashesAsync(projectDir: string): Promise<void>
     await view.fetch(ctx);
     await view.save(ctx, outputPath);
 
-    // @ts-ignore: keyPassword isn't defined
     await AndroidCredentials.logKeystoreHashes({
       keystorePath: outputPath,
-      keystorePassword: get(view, 'credentials.keystorePassword'),
-      keyAlias: get(view, 'credentials.keyAlias'),
+      // @ts-ignore keystorePassword can not be undefined
+      keystorePassword: view.credentials?.keystorePassword,
+      // @ts-ignore keyAlias can not be undefined
+      keyAlias: view.credentials?.keyAlias,
     });
     log(
       `\nNote: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console.`
@@ -88,8 +88,10 @@ export async function fetchAndroidUploadCertAsync(projectDir: string): Promise<v
     await AndroidCredentials.exportCertBase64(
       {
         keystorePath,
-        keystorePassword: get(view, 'credentials.keystorePassword'),
-        keyAlias: get(view, 'credentials.keyAlias'),
+        // @ts-ignore keystorePassword can not be undefined
+        keystorePassword: view.credentials?.keystorePassword,
+        // @ts-ignore keyAlias can not be undefined
+        keyAlias: view.credentials?.keyAlias,
       },
       uploadKeyPath
     );

--- a/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
+++ b/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
@@ -117,7 +117,8 @@ export default class AppSigningOptInProcess {
     log(`Saving upload keystore to ${this.uploadKeystore}...`);
     this.uploadKeystoreCredentials = await AndroidCredentials.generateUploadKeystore(
       this.uploadKeystore,
-      get(exp, 'android.package'),
+      // @ts-ignore android package might be undefined here
+      exp.android?.package,
       `@${username}/${exp.slug}`
     );
 

--- a/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
+++ b/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import get from 'lodash/get';
 
 import { AndroidCredentials, Credentials } from '@expo/xdl';
 import { ExpoConfig } from '@expo/config';
@@ -40,9 +39,12 @@ export default class AppSigningOptInProcess {
     await view.save(ctx, this.signKeystore, true);
 
     this.signKeystoreCredentials = {
-      keystorePassword: get(view, 'credentials.keystorePassword'),
-      keyAlias: get(view, 'credentials.keyAlias'),
-      keyPassword: get(view, 'credentials.keyPassword'),
+      // @ts-ignore possibly undefined
+      keystorePassword: view.credentials?.keystorePassword,
+      // @ts-ignore possibly undefined
+      keyAlias: view.credentials?.keyAlias,
+      // @ts-ignore possibly undefined
+      keyPassword: view.credentials?.keyPassword,
     };
 
     try {

--- a/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
+++ b/packages/expo-cli/src/commands/google-play/AppSigningOptIn.ts
@@ -115,10 +115,12 @@ export default class AppSigningOptInProcess {
 
   async prepareKeystores(username: string, exp: ExpoConfig): Promise<void> {
     log(`Saving upload keystore to ${this.uploadKeystore}...`);
+    if (!exp.android?.package) {
+      throw new Error('Missing android.package configuration.');
+    }
     this.uploadKeystoreCredentials = await AndroidCredentials.generateUploadKeystore(
       this.uploadKeystore,
-      // @ts-ignore android package might be undefined here
-      exp.android?.package,
+      exp.android.package,
       `@${username}/${exp.slug}`
     );
 

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import log from '../log';
 import * as table from '../commands/utils/cli-table';
 import {
@@ -11,7 +11,7 @@ import {
   setPublishToChannelAsync,
 } from './utils/PublishUtils';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('publish:set [project-dir]')
     .alias('ps')

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -1,17 +1,10 @@
-import {
-  ExpoConfig,
-  PackageJSONConfig,
-  getConfig,
-  resolveModule,
-} from '@expo/config';
+import { ExpoConfig, PackageJSONConfig, getConfig, projectHasModule } from '@expo/config';
 // @ts-ignore: not typed
 import { DevToolsServer } from '@expo/dev-tools';
 import JsonFile from '@expo/json-file';
 import { Project, ProjectSettings, UrlUtils, UserSettings, Versions } from '@expo/xdl';
 import chalk from 'chalk';
-import attempt from 'lodash/attempt';
 import intersection from 'lodash/intersection';
-import isError from 'lodash/isError';
 import path from 'path';
 import openBrowser from 'react-dev-utils/openBrowser';
 import semver from 'semver';
@@ -217,10 +210,12 @@ async function validateDependenciesVersions(
     return;
   }
 
-  const bundleNativeModulesPath = attempt(() =>
-    resolveModule('expo/bundledNativeModules.json', projectDir, exp)
+  const bundleNativeModulesPath = projectHasModule(
+    'expo/bundledNativeModules.json',
+    projectDir,
+    exp
   );
-  if (isError(bundleNativeModulesPath)) {
+  if (!bundleNativeModulesPath) {
     log.warn(
       `Your project is in SDK version >= 33.0.0, but the ${chalk.underline(
         'expo'

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -11,7 +11,6 @@ import {
   Webpack,
 } from '@expo/xdl';
 import chalk from 'chalk';
-import trimStart from 'lodash/trimStart';
 import openBrowser from 'react-dev-utils/openBrowser';
 import readline from 'readline';
 import wordwrap from 'wordwrap';
@@ -88,7 +87,7 @@ export const printServerInfo = async (
   urlOpts.printQRCode(url);
   const wrap = wordwrap(2, process.stdout.columns || 80);
   const wrapItem = wordwrap(4, process.stdout.columns || 80);
-  const item = (text: string): string => '  \u2022 ' + trimStart(wrapItem(text));
+  const item = (text: string): string => '  \u2022 ' + wrapItem(text).trimStart();
   const iosInfo = process.platform === 'darwin' ? `, or ${b('i')} for iOS simulator` : '';
   const webInfo = `${b`w`} to run on ${u`w`}eb`;
   log.nested(wrap(u('To run the app with live reloading, choose one of:')));

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -4,7 +4,9 @@ import * as PackageManager from '@expo/package-manager';
 import { Android, Project, Simulator, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import program, { Command } from 'commander';
-import _ from 'lodash';
+import pickBy from 'lodash/pickBy';
+import has from 'lodash/has';
+import difference from 'lodash/difference';
 import semver from 'semver';
 import ora from 'ora';
 import terminalLink from 'terminal-link';
@@ -494,11 +496,11 @@ export async function upgradeAsync(
   let updates = await getUpdatedDependenciesAsync(projectRoot, workflow, targetSdkVersion);
 
   // Split updated packages by dependencies and devDependencies
-  let devDependencies = _.pickBy(updates, (_version, name) => _.has(pkg.devDependencies, name));
+  let devDependencies = pickBy(updates, (_version, name) => has(pkg.devDependencies, name));
   let devDependenciesAsStringArray = Object.keys(devDependencies).map(
     name => `${name}@${updates[name]}`
   );
-  let dependencies = _.pickBy(updates, (_version, name) => _.has(pkg.dependencies, name));
+  let dependencies = pickBy(updates, (_version, name) => has(pkg.dependencies, name));
   let dependenciesAsStringArray = Object.keys(dependencies).map(name => `${name}@${updates[name]}`);
 
   // Install dev dependencies
@@ -557,7 +559,7 @@ export async function upgradeAsync(
 
   // List packages that were not updated
   let allDependencies = { ...pkg.dependencies, ...pkg.devDependencies };
-  let untouchedDependencies = _.difference(Object.keys(allDependencies), [
+  let untouchedDependencies = difference(Object.keys(allDependencies), [
     ...Object.keys(updates),
     'expo',
   ]);
@@ -598,7 +600,7 @@ export async function upgradeAsync(
     );
   }
 
-  let skippedSdkVersions = _.pickBy(sdkVersions, (_data, sdkVersionString) => {
+  let skippedSdkVersions = pickBy(sdkVersions, (_data, sdkVersionString) => {
     return (
       semver.lt(sdkVersionString, targetSdkVersionString) &&
       semver.gt(sdkVersionString, currentSdkVersionString)
@@ -667,7 +669,7 @@ async function maybeCleanNpmStateAsync(packageManager: any) {
   }
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('upgrade [targetSdkVersion]')
     .alias('update')

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -5,7 +5,6 @@ import { Android, Project, Simulator, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import program, { Command } from 'commander';
 import pickBy from 'lodash/pickBy';
-import has from 'lodash/has';
 import difference from 'lodash/difference';
 import semver from 'semver';
 import ora from 'ora';
@@ -496,11 +495,11 @@ export async function upgradeAsync(
   let updates = await getUpdatedDependenciesAsync(projectRoot, workflow, targetSdkVersion);
 
   // Split updated packages by dependencies and devDependencies
-  let devDependencies = pickBy(updates, (_version, name) => has(pkg.devDependencies, name));
+  let devDependencies = pickBy(updates, (_version, name) => pkg.devDependencies?.[name]);
   let devDependenciesAsStringArray = Object.keys(devDependencies).map(
     name => `${name}@${updates[name]}`
   );
-  let dependencies = pickBy(updates, (_version, name) => has(pkg.dependencies, name));
+  let dependencies = pickBy(updates, (_version, name) => pkg.dependencies?.[name]);
   let dependenciesAsStringArray = Object.keys(dependencies).map(name => `${name}@${updates[name]}`);
 
   // Install dev dependencies
@@ -669,7 +668,7 @@ async function maybeCleanNpmStateAsync(packageManager: any) {
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('upgrade [targetSdkVersion]')
     .alias('update')

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import pick from 'lodash/pick';
-import size from 'lodash/size';
 import { Command } from 'commander';
 
 import IOSUploader, { IosPlatformOptions, LANGUAGES } from './upload/IOSUploader';
@@ -112,7 +111,7 @@ export default function (program: Command) {
         checkRuntimePlatform('ios');
 
         const args = pick(options, SOURCE_OPTIONS);
-        if (size(args) > 1) {
+        if (Object.keys(args).length > 1) {
           throw new Error(`You have to choose only one of: --path, --id, --latest, --url`);
         }
         IOSUploader.validateOptions(options);

--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -2,7 +2,6 @@ import { Credentials, UrlUtils } from '@expo/xdl';
 import { ExpoConfig } from '@expo/config';
 import chalk from 'chalk';
 import has from 'lodash/has';
-import get from 'lodash/get';
 import pick from 'lodash/pick';
 import intersection from 'lodash/intersection';
 
@@ -133,7 +132,7 @@ export default class IOSUploader extends BaseUploader {
   async _getAppleTeamId(appleIdCrentials: AppleIdCredentials): Promise<string | undefined> {
     const credentialMetadata = await Credentials.getCredentialMetadataAsync(this.projectDir, 'ios');
     const credential = await Credentials.getCredentialsForPlatform(credentialMetadata);
-    let teamId = get(credential, 'teamId', undefined);
+    let teamId = credential?.teamId;
     if (teamId) {
       return teamId;
     } else {

--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -1,7 +1,6 @@
 import { Credentials, UrlUtils } from '@expo/xdl';
 import { ExpoConfig } from '@expo/config';
 import chalk from 'chalk';
-import has from 'lodash/has';
 import pick from 'lodash/pick';
 import intersection from 'lodash/intersection';
 
@@ -111,7 +110,7 @@ export default class IOSUploader extends BaseUploader {
   }
 
   _ensureExperienceIsValid(exp: ExpoConfig): void {
-    if (!has(exp, 'ios.bundleIdentifier')) {
+    if (!exp.ios?.bundleIdentifier) {
       throw new Error(`You must specify an iOS bundle identifier in app.json.`);
     }
   }

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
@@ -4,7 +4,6 @@ import Table from 'cli-table3';
 import fs from 'fs-extra';
 import ora from 'ora';
 import chunk from 'lodash/chunk';
-import curryRight from 'lodash/curryRight';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
@@ -255,8 +254,8 @@ const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {
       return 'Submitting the app from this computer';
     }
   },
-  archivePath: curryRight(breakWord)(50),
-  archiveUrl: curryRight(breakWord)(50),
+  archivePath: (path: string) => breakWord(path, 50),
+  archiveUrl: (url: string) => breakWord(url, 50),
 };
 
 function breakWord(word: string, chars: number): string {

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/logs.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/logs.ts
@@ -1,5 +1,3 @@
-import attempt from 'lodash/attempt';
-import isError from 'lodash/isError';
 import got from 'got';
 
 import log from '../../../../log';
@@ -49,8 +47,10 @@ function parseLogs(logs: string): Log[] {
   const lines = logs.split('\n');
   const result: Log[] = [];
   for (const line of lines) {
-    const parsedLine = attempt(() => JSON.parse(line));
-    if (isError(parsedLine)) {
+    let parsedLine;
+    try {
+      parsedLine = JSON.parse(line);
+    } catch (error) {
       continue;
     }
     let level: Log['level'];

--- a/packages/expo-cli/src/commands/upload/utils.ts
+++ b/packages/expo-cli/src/commands/upload/utils.ts
@@ -81,7 +81,7 @@ export async function runFastlaneAsync(
     let message =
       res.reason !== 'Unknown reason'
         ? res.reason
-        : get(res, 'rawDump.message', 'Unknown error when running fastlane');
+        : res.rawDump?.message ?? 'Unknown error when running fastlane';
     message = `${message}${
       res?.rawDump?.backtrace
         ? `\n${res.rawDump.backtrace.map((i: string) => `    ${i}`).join('\n')}`

--- a/packages/expo-cli/src/commands/upload/utils.ts
+++ b/packages/expo-cli/src/commands/upload/utils.ts
@@ -3,7 +3,6 @@ import { promisify } from 'util';
 
 import { ExponentTools } from '@expo/xdl';
 import fs from 'fs-extra';
-import get from 'lodash/get';
 import got from 'got';
 import ProgressBar from 'progress';
 

--- a/packages/expo-cli/src/credentials/actions/list.ts
+++ b/packages/expo-cli/src/credentials/actions/list.ts
@@ -1,8 +1,6 @@
 import chalk from 'chalk';
 import uniq from 'lodash/uniq';
-import isEmpty from 'lodash/isEmpty';
 import fs from 'fs-extra';
-import get from 'lodash/get';
 import { AndroidCredentials as Android } from '@expo/xdl';
 import {
   AndroidCredentials,
@@ -117,7 +115,7 @@ export function displayIosUserCredentials(
       )}`
     );
   } else {
-    log.warn(`  Unknown key type ${get(userCredentials, 'type')}`);
+    log.warn(`  Unknown key type ${(userCredentials as any).type}`);
   }
   log(
     `    Apple Team ID: ${chalk.green(
@@ -154,8 +152,8 @@ export async function displayAndroidAppCredentials(credentials: AndroidCredentia
 
     log(chalk.green(credentials.experienceName));
     log(chalk.bold('  Upload Keystore hashes'));
-    if (!isEmpty(credentials.keystore)) {
-      const storeBuf = Buffer.from(get(credentials, 'keystore.keystore'), 'base64');
+    if (credentials.keystore?.keystore) {
+      const storeBuf = Buffer.from(credentials.keystore.keystore, 'base64');
       await fs.writeFile(tmpFilename, storeBuf);
       await Android.logKeystoreHashes(
         {
@@ -168,10 +166,7 @@ export async function displayAndroidAppCredentials(credentials: AndroidCredentia
       log('    -----------------------');
     }
     log(chalk.bold('  Push Notifications credentials'));
-    log(
-      '    FCM Api Key: ',
-      get(credentials, 'pushCredentials.fcmApiKey', '---------------------')
-    );
+    log('    FCM Api Key: ', credentials.pushCredentials?.fcmApiKey, '---------------------');
     log('\n');
   } catch (error) {
     log.error('  Failed to parse the keystore', error);

--- a/packages/expo-cli/src/credentials/actions/list.ts
+++ b/packages/expo-cli/src/credentials/actions/list.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import uniq from 'lodash/uniq';
 import fs from 'fs-extra';
 import { AndroidCredentials as Android } from '@expo/xdl';
 import {
@@ -125,11 +124,13 @@ export function displayIosUserCredentials(
 
   if (credentials) {
     const field = userCredentials.type === 'push-key' ? 'pushCredentialsId' : 'distCredentialsId';
-    const usedByApps = uniq(
-      credentials.appCredentials
-        .filter(c => c[field] === userCredentials.id)
-        .map(c => `${c.experienceName} (${c.bundleIdentifier})`)
-    ).join(',\n      ');
+    const usedByApps = [
+      ...new Set(
+        credentials.appCredentials
+          .filter(c => c[field] === userCredentials.id)
+          .map(c => `${c.experienceName} (${c.bundleIdentifier})`)
+      ),
+    ].join(',\n      ');
     const usedByAppsText = usedByApps ? `used by\n      ${usedByApps}` : 'not used by any apps';
     log(`    ${chalk.gray(usedByAppsText)}`);
   }

--- a/packages/expo-cli/src/credentials/actions/promptForCredentials.ts
+++ b/packages/expo-cli/src/credentials/actions/promptForCredentials.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import untildify from 'untildify';
 import fs from 'fs-extra';
-import get from 'lodash/get';
 import once from 'lodash/once';
 
 import prompt, { Question as PromptQuestion } from '../../prompt';
@@ -24,7 +23,7 @@ export type CredentialSchema<T> = {
   dependsOn?: string;
   name: string;
   required: Array<string>;
-  questions?: {
+  questions: {
     [key: string]: Question;
   };
   deprecated?: boolean;
@@ -57,7 +56,7 @@ export async function getCredentialsFromUser<T extends Results>(
 ): Promise<T | null> {
   const results: Results = {};
   for (const field of credentialType.required) {
-    results[field] = await askQuestionAndProcessAnswer(get(credentialType, `questions.${field}`));
+    results[field] = await askQuestionAndProcessAnswer(credentialType?.questions?.[field]);
   }
   return results as T;
 }

--- a/packages/expo-cli/src/credentials/api.ts
+++ b/packages/expo-cli/src/credentials/api.ts
@@ -3,7 +3,6 @@ import findIndex from 'lodash/findIndex';
 import find from 'lodash/find';
 import omit from 'lodash/omit';
 import assign from 'lodash/assign';
-import get from 'lodash/get';
 import pick from 'lodash/pick';
 
 import invariant from 'invariant';
@@ -275,9 +274,9 @@ export class IosApi {
     bundleIdentifier: string
   ): Promise<{ pushId: string; pushP12: string; pushPassword: string } | null> {
     const appCredentials = await this.getAppCredentials(experienceName, bundleIdentifier);
-    const pushId = get(appCredentials, 'credentials.pushId');
-    const pushP12 = get(appCredentials, 'credentials.pushP12');
-    const pushPassword = get(appCredentials, 'credentials.pushPassword');
+    const pushId = appCredentials.credentials.pushId;
+    const pushP12 = appCredentials.credentials.pushP12;
+    const pushPassword = appCredentials.credentials.pushPassword;
     if (!pushId || !pushP12 || !pushPassword) {
       return null;
     }
@@ -350,7 +349,7 @@ export class IosApi {
     bundleIdentifier: string
   ): Promise<appleApi.ProvisioningProfile | null> {
     const appCredentials = await this.getAppCredentials(experienceName, bundleIdentifier);
-    const provisioningProfile = get(appCredentials, 'credentials.provisioningProfile');
+    const provisioningProfile = appCredentials.credentials.provisioningProfile;
     if (!provisioningProfile) {
       return null;
     }

--- a/packages/expo-cli/src/credentials/api.ts
+++ b/packages/expo-cli/src/credentials/api.ts
@@ -1,8 +1,5 @@
 import { ApiV2, User } from '@expo/xdl';
-import findIndex from 'lodash/findIndex';
-import find from 'lodash/find';
 import omit from 'lodash/omit';
-import assign from 'lodash/assign';
 import pick from 'lodash/pick';
 
 import invariant from 'invariant';
@@ -79,8 +76,7 @@ export class IosApi {
       await this._fetchAllCredentials();
     }
     this._ensureAppCredentials(experienceName, bundleIdentifier);
-    const credIndex = findIndex(
-      this.credentials.appCredentials,
+    const credIndex = this.credentials.appCredentials.findIndex(
       app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
     );
     const distCertExpoId = this.credentials.appCredentials[credIndex].distCredentialsId;
@@ -124,7 +120,7 @@ export class IosApi {
       owner: this.username,
     });
     const updatedDistCert: IosDistCredentials = { ...credentials, id, type: 'dist-cert' };
-    const credIndex = findIndex(this.credentials.userCredentials, ({ id }) => id === credentialsId);
+    const credIndex = this.credentials.userCredentials.findIndex(({ id }) => id === credentialsId);
     this.credentials.userCredentials[credIndex] = updatedDistCert;
     return updatedDistCert;
   }
@@ -164,8 +160,7 @@ export class IosApi {
       owner: this.username,
     });
     this._ensureAppCredentials(experienceName, bundleIdentifier);
-    const credIndex = findIndex(
-      this.credentials.appCredentials,
+    const credIndex = this.credentials.appCredentials.findIndex(
       app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
     );
     this.credentials.appCredentials[credIndex].distCredentialsId = userCredentialsId;
@@ -202,7 +197,7 @@ export class IosApi {
       owner: this.username,
     });
     const updatedPushKey: IosPushCredentials = { ...credentials, id, type: 'push-key' };
-    const credIndex = findIndex(this.credentials.userCredentials, ({ id }) => id === credentialsId);
+    const credIndex = this.credentials.userCredentials.findIndex(({ id }) => id === credentialsId);
     this.credentials.userCredentials[credIndex] = updatedPushKey;
     return updatedPushKey;
   }
@@ -233,8 +228,7 @@ export class IosApi {
       await this._fetchAllCredentials();
     }
     this._ensureAppCredentials(experienceName, bundleIdentifier);
-    const credIndex = findIndex(
-      this.credentials.appCredentials,
+    const credIndex = this.credentials.appCredentials.findIndex(
       app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
     );
     const pushKeyId = this.credentials.appCredentials[credIndex].pushCredentialsId;
@@ -263,8 +257,7 @@ export class IosApi {
       owner: this.username,
     });
     this._ensureAppCredentials(experienceName, bundleIdentifier);
-    const credIndex = findIndex(
-      this.credentials.appCredentials,
+    const credIndex = this.credentials.appCredentials.findIndex(
       app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
     );
     this.credentials.appCredentials[credIndex].pushCredentialsId = userCredentialsId;
@@ -292,8 +285,7 @@ export class IosApi {
       bundleIdentifier,
       owner: this.username,
     });
-    const credIndex = findIndex(
-      this.credentials.appCredentials,
+    const credIndex = this.credentials.appCredentials.findIndex(
       app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
     );
     this.credentials.appCredentials[credIndex].credentials = omit(
@@ -322,11 +314,10 @@ export class IosApi {
       credentials: { ...provisioningProfile, teamId: appleTeam.id },
       owner: this.username,
     });
-    const credIndex = findIndex(
-      this.credentials.appCredentials,
+    const credIndex = this.credentials.appCredentials.findIndex(
       app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
     );
-    assign(this.credentials.appCredentials[credIndex].credentials, provisioningProfile);
+    Object.assign(this.credentials.appCredentials[credIndex].credentials, provisioningProfile);
     return provisioningProfile;
   }
 
@@ -338,8 +329,7 @@ export class IosApi {
       await this._fetchAllCredentials();
     }
     this._ensureAppCredentials(experienceName, bundleIdentifier);
-    return find(
-      this.credentials.appCredentials,
+    return this.credentials.appCredentials.find(
       app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
     )!;
   }
@@ -368,8 +358,7 @@ export class IosApi {
       bundleIdentifier,
       owner: this.username,
     });
-    const credIndex = findIndex(
-      this.credentials.appCredentials,
+    const credIndex = this.credentials.appCredentials.findIndex(
       app => app.experienceName === experienceName && app.bundleIdentifier === bundleIdentifier
     );
     this.credentials.appCredentials[credIndex].credentials = omit(

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -1,5 +1,4 @@
 import { ApiV2, AndroidCredentials as Credentials } from '@expo/xdl';
-import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -34,9 +33,9 @@ export class ExperienceView implements IView {
       const appCredentials: AndroidCredentials = await ctx.api.getAsync(
         `credentials/android/@${ctx.user.username}/${this.experience}`
       );
-      this.experienceName = get(appCredentials, 'experienceName');
-      this.keystore = get(appCredentials, 'keystore');
-      this.pushCredentials = get(appCredentials, 'pushCredentials');
+      this.experienceName = appCredentials.experienceName;
+      this.keystore = appCredentials.keystore;
+      this.pushCredentials = appCredentials.pushCredentials;
     }
     if (!this.experienceName) {
       this.experienceName = `@${ctx.user.username}/${this.experience}`;

--- a/packages/expo-cli/src/credentials/views/IosAppCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosAppCredentials.ts
@@ -1,12 +1,4 @@
-import chalk from 'chalk';
-import get from 'lodash/get';
-
 import { Context, IView } from '../context';
-import { IosAppCredentials, IosCredentials, IosPushCredentials } from '../credentials';
-import { askForUserProvided } from '../actions/promptForCredentials';
-import { displayIosUserCredentials } from '../actions/list';
-import prompt from '../../prompt';
-import log from '../../log';
 
 export class CreateAppCredentialsIos implements IView {
   async open(context: Context): Promise<IView | null> {

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import dateformat from 'dateformat';
 import fs from 'fs-extra';
 import every from 'lodash/every';
-import get from 'lodash/get';
 import some from 'lodash/some';
 import ora from 'ora';
 import { IosCodeSigning } from '@expo/xdl';
@@ -340,12 +339,12 @@ export class CreateOrReuseDistributionCert implements IView {
 }
 
 function getOptionsFromProjectContext(ctx: Context): DistCertOptions | null {
-  const experience = get(ctx, 'manifest.slug');
-  const owner = get(ctx, 'manifest.owner');
+  const experience = ctx.manifest.slug;
+  const owner = ctx.manifest.owner;
   const experienceName = `@${owner || ctx.user.username}/${experience}`;
-  const bundleIdentifier = get(ctx, 'manifest.ios.bundleIdentifier');
+  const bundleIdentifier = ctx.manifest.ios?.bundleIdentifier;
   if (!experience || !bundleIdentifier) {
-    log.error(`slug and ios.bundleIdentifier needs to be defined`);
+    log.error(`slug and ios.bundleIdentifier need to be defined`);
     return null;
   }
 
@@ -483,9 +482,10 @@ function formatDistCert(
       "\n    ❓ Validity of this certificate on Apple's servers is unknown."
     );
   }
-  return `Distribution Certificate (Cert ID: ${
-    distCert.certId || '-----'
-  }, Serial number: ${serialNumber}, Team ID: ${distCert.teamId})${usedByString}${validityText}`;
+  return `Distribution Certificate (Cert ID: ${distCert.certId ||
+    '-----'}, Serial number: ${serialNumber}, Team ID: ${
+    distCert.teamId
+  })${usedByString}${validityText}`;
 }
 
 async function generateDistCert(ctx: Context): Promise<DistCert> {

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -1,8 +1,6 @@
 import chalk from 'chalk';
 import dateformat from 'dateformat';
 import fs from 'fs-extra';
-import every from 'lodash/every';
-import some from 'lodash/some';
 import ora from 'ora';
 import { IosCodeSigning } from '@expo/xdl';
 
@@ -482,10 +480,9 @@ function formatDistCert(
       "\n    ❓ Validity of this certificate on Apple's servers is unknown."
     );
   }
-  return `Distribution Certificate (Cert ID: ${distCert.certId ||
-    '-----'}, Serial number: ${serialNumber}, Team ID: ${
-    distCert.teamId
-  })${usedByString}${validityText}`;
+  return `Distribution Certificate (Cert ID: ${
+    distCert.certId || '-----'
+  }, Serial number: ${serialNumber}, Team ID: ${distCert.teamId})${usedByString}${validityText}`;
 }
 
 async function generateDistCert(ctx: Context): Promise<DistCert> {
@@ -655,12 +652,12 @@ export async function getDistCertFromParams(builderOptions: {
   const certPassword = process.env.EXPO_IOS_DIST_P12_PASSWORD;
 
   // none of the distCert params were set, assume user has no intention of passing it in
-  if (!some([distP12Path, certPassword])) {
+  if (!distP12Path && !certPassword) {
     return null;
   }
 
   // partial distCert params were set, assume user has intention of passing it in
-  if (!every([distP12Path, certPassword, teamId])) {
+  if (!(distP12Path && certPassword && teamId)) {
     throw new Error(
       'In order to provide a Distribution Certificate through the CLI parameters, you have to pass --dist-p12-path parameter, --team-id parameter and set EXPO_IOS_DIST_P12_PASSWORD environment variable.'
     );

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import find from 'lodash/find';
 import ora from 'ora';
-import every from 'lodash/every';
 import plist, { PlistObject } from '@expo/plist';
 import { IosCodeSigning, PKCS12Utils } from '@expo/xdl';
 import prompt, { Question } from '../../prompt';
@@ -474,12 +473,12 @@ export async function getProvisioningProfileFromParams(builderOptions: {
   const { provisioningProfilePath, teamId } = builderOptions;
 
   // none of the provisioningProfile params were set, assume user has no intention of passing it in
-  if (!provisioningProfilePath) {
+  if (!provisioningProfilePath && !teamId) {
     return null;
   }
 
   // partial provisioningProfile params were set, assume user has intention of passing it in
-  if (!every([provisioningProfilePath, teamId])) {
+  if (!(provisioningProfilePath && teamId)) {
     throw new Error(
       'In order to provide a Provisioning Profile through the CLI parameters, you have to pass --provisioning-profile-path and --team-id parameters.'
     );

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -113,8 +113,7 @@ export class CreateProvisioningProfile implements IView {
     await this.create(ctx);
 
     log(chalk.green('Successfully created Provisioning Profile\n'));
-    const appCredentials = find(
-      ctx.ios.credentials.appCredentials,
+    const appCredentials = ctx.ios.credentials.appCredentials.find(
       app =>
         app.experienceName === this._experienceName &&
         app.bundleIdentifier === this._bundleIdentifier

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import find from 'lodash/find';
 import ora from 'ora';
 import plist, { PlistObject } from '@expo/plist';
 import { IosCodeSigning, PKCS12Utils } from '@expo/xdl';

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -1,8 +1,6 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import every from 'lodash/every';
 import get from 'lodash/get';
-import some from 'lodash/some';
 import ora from 'ora';
 
 import terminalLink from 'terminal-link';
@@ -599,12 +597,12 @@ export async function getPushKeyFromParams(builderOptions: {
   const { pushId, pushP8Path, teamId } = builderOptions;
 
   // none of the pushKey params were set, assume user has no intention of passing it in
-  if (!some([pushId, pushP8Path])) {
+  if (!pushId && !pushP8Path) {
     return null;
   }
 
   // partial pushKey params were set, assume user has intention of passing it in
-  if (!every([pushId, pushP8Path, teamId])) {
+  if (!(pushId && pushP8Path && teamId)) {
     throw new Error(
       'In order to provide a Push Key through the CLI parameters, you have to pass --push-id, --push-p8-path and --team-id parameters.'
     );
@@ -612,7 +610,7 @@ export async function getPushKeyFromParams(builderOptions: {
 
   return {
     apnsKeyId: pushId,
-    apnsKeyP8: await fs.readFile(pushP8Path as string, 'base64'),
+    apnsKeyP8: await fs.readFile(pushP8Path, 'base64'),
     teamId,
   } as PushKey;
 }

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import get from 'lodash/get';
 import ora from 'ora';
 
 import terminalLink from 'terminal-link';
@@ -97,7 +96,7 @@ export class RemoveIosPush implements IView {
   async open(ctx: Context): Promise<IView | null> {
     const selected = await selectPushCredFromList(ctx);
     if (!selected) {
-    } else if (!get(selected, 'type')) {
+    } else if (!('type' in selected)) {
       await this.removePushCert(ctx, selected as IosAppCredentials);
       log(chalk.green('Successfully removed Push Certificate'));
     } else {
@@ -363,10 +362,10 @@ function getValidityStatus(
 }
 
 function getOptionsFromProjectContext(ctx: Context): PushKeyOptions | null {
-  const experience = get(ctx, 'manifest.slug');
-  const owner = get(ctx, 'manifest.owner');
+  const experience = ctx.manifest?.slug;
+  const owner = ctx.manifest?.owner;
   const experienceName = `@${owner || ctx.user.username}/${experience}`;
-  const bundleIdentifier = get(ctx, 'manifest.ios.bundleIdentifier');
+  const bundleIdentifier = ctx.manifest?.ios?.bundleIdentifier;
   if (!experience || !bundleIdentifier) {
     log.error(`slug and ios.bundleIdentifier needs to be defined`);
     return null;
@@ -409,7 +408,7 @@ async function selectPushCredFromList(
   }
 
   const getName = (pushCred: IosPushCredentials | IosAppCredentials) => {
-    if (get(pushCred, 'type') === 'push-key') {
+    if ('type' in pushCred) {
       return formatPushKey(
         pushCred as IosPushCredentials,
         iosCredentials,
@@ -440,11 +439,11 @@ function getAppsUsingPushCred(
   iosCredentials: IosCredentials,
   pushCred: IosPushCredentials | IosAppCredentials
 ): IosAppCredentials[] {
-  if (get(pushCred, 'type') === 'push-key') {
+  if ('type' in pushCred) {
     return iosCredentials.appCredentials.filter(
       cred => cred.pushCredentialsId === (pushCred as IosPushCredentials).id
     );
-  } else if (get(pushCred, 'credentials.pushP12') && get(pushCred, 'credentials.pushPassword')) {
+  } else if (pushCred.credentials?.pushP12 && pushCred.credentials?.pushPassword) {
     return [pushCred as IosAppCredentials];
   }
   return [];

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import invariant from 'invariant';
 import prompt, { ChoiceType, Question } from '../../prompt';
 import log from '../../log';
@@ -135,7 +134,7 @@ export class SelectAndroidExperience implements IView {
     this.askAboutProjectMode = false;
 
     if (this.androidCredentials.length === 0) {
-      this.androidCredentials = get(await ctx.api.getAsync('credentials/android'), 'credentials');
+      this.androidCredentials = (await ctx.api.getAsync('credentials/android')).credentials;
     }
     await displayAndroidCredentials(this.androidCredentials);
 

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -3,13 +3,12 @@ import prompt, { ChoiceType, Question } from '../../prompt';
 import log from '../../log';
 
 import * as androidView from './AndroidCredentials';
-import * as iosAppView from './IosAppCredentials';
 import * as iosPushView from './IosPushCredentials';
 import * as iosDistView from './IosDistCert';
 import * as iosProvisionigProfileView from './IosProvisioningProfile';
 
 import { Context, IView } from '../context';
-import { AndroidCredentials, IosCredentials } from '../credentials';
+import { AndroidCredentials } from '../credentials';
 import { CredentialsManager } from '../route';
 import { displayAndroidCredentials, displayIosCredentials } from '../actions/list';
 
@@ -134,7 +133,7 @@ export class SelectAndroidExperience implements IView {
     this.askAboutProjectMode = false;
 
     if (this.androidCredentials.length === 0) {
-      this.androidCredentials = (await ctx.api.getAsync('credentials/android')).credentials;
+      this.androidCredentials = (await ctx.api.getAsync('credentials/android'))?.credentials;
     }
     await displayAndroidCredentials(this.androidCredentials);
 

--- a/packages/expo-cli/src/credentials/views/SetupIosPush.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosPush.ts
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import { prompt } from 'inquirer';
 import * as iosPushView from './IosPushCredentials';
 
@@ -28,9 +27,9 @@ export class SetupIosPush implements IView {
       this._experienceName,
       this._bundleIdentifier
     );
-    const deprecatedPushId = get(appCredentials, 'credentials.pushId');
-    const deprecatedPushP12 = get(appCredentials, 'credentials.pushP12');
-    const deprecatedPushPassword = get(appCredentials, 'credentials.pushPassword');
+    const deprecatedPushId = appCredentials.credentials.pushId;
+    const deprecatedPushP12 = appCredentials.credentials.pushP12;
+    const deprecatedPushPassword = appCredentials.credentials.pushPassword;
     if (deprecatedPushId && deprecatedPushP12 && deprecatedPushPassword) {
       const confirmQuestion: Question = {
         type: 'confirm',

--- a/packages/expo-cli/src/credentials/views/SetupIosPush.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosPush.ts
@@ -27,9 +27,9 @@ export class SetupIosPush implements IView {
       this._experienceName,
       this._bundleIdentifier
     );
-    const deprecatedPushId = appCredentials.credentials.pushId;
-    const deprecatedPushP12 = appCredentials.credentials.pushP12;
-    const deprecatedPushPassword = appCredentials.credentials.pushPassword;
+    const deprecatedPushId = appCredentials?.credentials?.pushId;
+    const deprecatedPushP12 = appCredentials?.credentials?.pushP12;
+    const deprecatedPushPassword = appCredentials?.credentials?.pushPassword;
     if (deprecatedPushId && deprecatedPushP12 && deprecatedPushPassword) {
       const confirmQuestion: Question = {
         type: 'confirm',

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import url from 'url';
 
 import ProgressBar from 'progress';
-import last from 'lodash/last';
 import leven from 'leven';
 import compact from 'lodash/compact';
 import findLastIndex from 'lodash/findLastIndex';
@@ -74,7 +73,7 @@ Command.prototype.asyncAction = function (asyncFn: Action, skipUpdateCheck: bool
     }
 
     try {
-      let options = last(args);
+      let options = args[args.length - 1];
       if (options.offline) {
         Config.offline = true;
       }
@@ -361,7 +360,7 @@ function runAsync(programName: string) {
       process.exit(0);
     });
 
-    program.on('command:*', (subCommand) => {
+    program.on('command:*', subCommand => {
       let msg = `"${subCommand}" is not an expo command. See "expo --help" for the full list of commands.`;
       const availableCommands = program.commands.map((cmd: Command) => cmd._name);
       // finding the best match whose edit distance is less than 40% of their length.
@@ -559,7 +558,7 @@ export function run(programName: string) {
     } else {
       await Promise.all([writePathAsync(), runAsync(programName)]);
     }
-  })().catch((e) => {
+  })().catch(e => {
     console.error('Uncaught Error', e);
     process.exit(1);
   });

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -4,7 +4,6 @@ import url from 'url';
 
 import ProgressBar from 'progress';
 import leven from 'leven';
-import compact from 'lodash/compact';
 import findLastIndex from 'lodash/findLastIndex';
 import boxen from 'boxen';
 import bunyan from '@expo/bunyan';
@@ -162,7 +161,7 @@ Command.prototype.asyncActionProjectDir = function (
         return line.startsWith('node_modules');
       };
 
-      const stackFrames: string[] = compact(stack.split('\n'));
+      const stackFrames: string[] = stack.split('\n').filter((line: string) => line);
       let lastAppCodeFrameIndex = findLastIndex(stackFrames, (line: string) => {
         return !isLibraryFrame(line);
       });

--- a/packages/json-file/src/JsonFile.ts
+++ b/packages/json-file/src/JsonFile.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import { promisify } from 'util';
 
 import get from 'lodash/get';
-import has from 'lodash/has';
 import set from 'lodash/set';
 import JSON5 from 'json5';
 import writeFileAtomic from 'write-file-atomic';
@@ -196,7 +195,7 @@ async function getAsync<TJSONObject extends JSONObject, K extends keyof TJSONObj
   options?: Options<TJSONObject>
 ): Promise<any> {
   const object = await readAsync(file, options);
-  if (defaultValue === undefined && !has(object, key)) {
+  if (defaultValue === undefined && !(key in object)) {
     throw new JsonFileError(`No value at key path "${key}" in JSON object from: ${file}`);
   }
   return get(object, key, defaultValue);

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -3,7 +3,6 @@ import spawnAsync from '@expo/spawn-async';
 import child_process from 'child_process';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import some from 'lodash/some';
 import path from 'path';
 import ProgressBar from 'progress';
 
@@ -613,7 +612,7 @@ See https://docs.expo.io/guides/splash-screens/#splash-screen-api-limitations-on
     return;
   }
 
-  if (some(androidSplashImages, ({ sizeMatches }) => !sizeMatches)) {
+  if (androidSplashImages.some(({ sizeMatches }) => !sizeMatches)) {
     Logger.global
       .warn(`Splash resizeMode is set to 'native' and you've provided different images for different DPIs,
 but their sizes mismatch expected ones: [dpi: provided (expected)] ${androidSplashImages

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -3,7 +3,6 @@ import concat from 'concat-stream';
 import ExtendableError from 'es6-error';
 import FormData from 'form-data';
 import fs from 'fs-extra';
-import isString from 'lodash/isString';
 import path from 'path';
 
 import Config from './Config';
@@ -108,7 +107,7 @@ async function _callMethodAsync(
   }
   let responseBody = response.data;
   var responseObj;
-  if (isString(responseBody)) {
+  if (typeof responseBody === 'string') {
     try {
       responseObj = JSON.parse(responseBody);
     } catch (e) {

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -534,11 +534,17 @@ export async function exportForAppHosting(
   await fs.ensureDir(bundlesPathToWrite);
 
   const { iosBundle, androidBundle } = await _buildPublishBundlesAsync(projectRoot, packagerOpts);
-  const iosBundleHash = crypto.createHash('md5').update(iosBundle).digest('hex');
+  const iosBundleHash = crypto
+    .createHash('md5')
+    .update(iosBundle)
+    .digest('hex');
   const iosBundleUrl = `ios-${iosBundleHash}.js`;
   const iosJsPath = path.join(outputDir, 'bundles', iosBundleUrl);
 
-  const androidBundleHash = crypto.createHash('md5').update(androidBundle).digest('hex');
+  const androidBundleHash = crypto
+    .createHash('md5')
+    .update(androidBundle)
+    .digest('hex');
   const androidBundleUrl = `android-${androidBundleHash}.js`;
   const androidJsPath = path.join(outputDir, 'bundles', androidBundleUrl);
 
@@ -1338,11 +1344,46 @@ async function getConfigAsync(
   }
 }
 
-// TODO(ville): add the full type
-type BuildJob = unknown;
+type JobState = 'pending' | 'started' | 'in-progress' | 'finished' | 'errored' | 'sent-to-queue';
+
+export type TurtleMode = 'normal' | 'high' | 'high_only';
+
+// https://github.com/expo/universe/blob/283efaba3acfdefdc7db12f649516b6d6a94bec4/server/www/src/data/entities/builds/BuildJobEntity.ts#L25-L56
+export interface BuildJobFields {
+  id: string;
+  experienceName: string;
+  status: JobState;
+  platform: 'ios' | 'android';
+  userId: string | null;
+  experienceId: string;
+  artifactId: string | null;
+  nonce: string | null;
+  artifacts: {
+    url?: string;
+    manifestPlistUrl?: string;
+  } | null;
+  config: {
+    buildType?: string;
+    releaseChannel?: string;
+    bundleIdentifier?: string;
+  };
+  logs: object | null;
+  extraData: {
+    request_id?: string;
+    turtleMode?: TurtleMode;
+  } | null;
+  created: Date;
+  updated: Date;
+  expirationDate: Date;
+  sdkVersion: string | null;
+  turtleVersion: string | null;
+  buildDuration: number | null;
+  priority: string;
+  accountId: string | null;
+}
 
 export type BuildStatusResult = {
-  jobs: BuildJob[];
+  jobs: BuildJobFields[];
   err: null;
   userHasBuiltAppBefore: boolean;
   userHasBuiltExperienceBefore: boolean;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -31,7 +31,6 @@ import joi from 'joi';
 import chunk from 'lodash/chunk';
 import escapeRegExp from 'lodash/escapeRegExp';
 import get from 'lodash/get';
-import reduce from 'lodash/reduce';
 import set from 'lodash/set';
 import uniq from 'lodash/uniq';
 import md5hex from 'md5hex';
@@ -534,17 +533,11 @@ export async function exportForAppHosting(
   await fs.ensureDir(bundlesPathToWrite);
 
   const { iosBundle, androidBundle } = await _buildPublishBundlesAsync(projectRoot, packagerOpts);
-  const iosBundleHash = crypto
-    .createHash('md5')
-    .update(iosBundle)
-    .digest('hex');
+  const iosBundleHash = crypto.createHash('md5').update(iosBundle).digest('hex');
   const iosBundleUrl = `ios-${iosBundleHash}.js`;
   const iosJsPath = path.join(outputDir, 'bundles', iosBundleUrl);
 
-  const androidBundleHash = crypto
-    .createHash('md5')
-    .update(androidBundle)
-    .digest('hex');
+  const androidBundleHash = crypto.createHash('md5').update(androidBundle).digest('hex');
   const androidBundleUrl = `android-${androidBundleHash}.js`;
   const androidJsPath = path.join(outputDir, 'bundles', androidBundleUrl);
 
@@ -1800,9 +1793,8 @@ export async function startReactNativeServerAsync(
       packagerPort = userPackagerOpts.port;
     }
   }
-  let cliOpts = reduce(
-    packagerOpts,
-    (opts, val, key) => {
+  let cliOpts = packagerOpts.reduce(
+    (opts: any, val: any, key: string) => {
       // If the packager opt value is boolean, don't set
       // --[opt] [value], just set '--opt'
       if (val && typeof val === 'boolean') {

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -32,7 +32,6 @@ import chunk from 'lodash/chunk';
 import escapeRegExp from 'lodash/escapeRegExp';
 import get from 'lodash/get';
 import set from 'lodash/set';
-import uniq from 'lodash/uniq';
 import md5hex from 'md5hex';
 import minimatch from 'minimatch';
 import { AddressInfo } from 'net';
@@ -1786,7 +1785,7 @@ export async function startReactNativeServerAsync(
       ...userPackagerOpts,
       // In order to prevent people from forgetting to include the .expo extension or other things
       // NOTE(brentvatne): we should probably do away with packagerOpts soon in favor of @expo/metro-config!
-      sourceExts: uniq([...packagerOpts.sourceExts, ...(userPackagerOpts.sourceExts ?? [])]),
+      sourceExts: [...new Set([...packagerOpts.sourceExts, ...userPackagerOpts.sourceExts])],
     };
 
     if (userPackagerOpts.port !== undefined && userPackagerOpts.port !== null) {

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -1,7 +1,6 @@
 import JsonFile from '@expo/json-file';
 import { ProjectTarget } from '@expo/config';
 import fs from 'fs-extra';
-import defaults from 'lodash/defaults';
 import path from 'path';
 
 export type ProjectSettings = {
@@ -60,8 +59,7 @@ export async function readAsync(projectRoot: string): Promise<ProjectSettings> {
   }
   migrateDeprecatedSettings(projectSettings);
   // Set defaults for any missing fields
-  defaults(projectSettings, projectSettingsDefaults);
-  return projectSettings;
+  return { ...projectSettingsDefaults, ...projectSettings };
 }
 
 function migrateDeprecatedSettings(projectSettings: any): void {
@@ -90,9 +88,10 @@ export async function setAsync(
       cantReadFileDefault: projectSettingsDefaults,
     });
   } catch (e) {
-    return await projectSettingsJsonFile(projectRoot).writeAsync(
-      defaults(json, projectSettingsDefaults)
-    );
+    return await projectSettingsJsonFile(projectRoot).writeAsync({
+      ...projectSettingsDefaults,
+      ...json,
+    });
   }
 }
 

--- a/packages/xdl/src/Versions.ts
+++ b/packages/xdl/src/Versions.ts
@@ -1,7 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { JSONObject } from '@expo/json-file';
 import forEach from 'lodash/forEach';
-import get from 'lodash/get';
 import pickBy from 'lodash/pickBy';
 import path from 'path';
 import semver from 'semver';
@@ -245,7 +244,7 @@ export async function canTurtleBuildSdkVersion(
   }
 
   const supportedVersions = await getSdkVersionsSupportedByTurtle();
-  const supportedVersionsForPlatform = get(supportedVersions, platform, [] as string[]);
+  const supportedVersionsForPlatform: string[] = supportedVersions[platform] ?? [];
   return supportedVersionsForPlatform.indexOf(sdkVersion) !== -1;
 }
 

--- a/packages/xdl/src/Versions.ts
+++ b/packages/xdl/src/Versions.ts
@@ -1,6 +1,5 @@
 import { ExpoConfig } from '@expo/config';
 import { JSONObject } from '@expo/json-file';
-import forEach from 'lodash/forEach';
 import pickBy from 'lodash/pickBy';
 import path from 'path';
 import semver from 'semver';
@@ -143,17 +142,15 @@ export async function newestReleasedSdkVersionAsync(): Promise<{
   version: string;
   data: SDKVersion | null;
 }> {
-  let sdkVersions = await sdkVersionsAsync();
+  const sdkVersions = await sdkVersionsAsync();
   let result = null;
   let highestMajorVersion = '0.0.0';
-  forEach(sdkVersions, (value, key) => {
-    if (semver.major(key) > semver.major(highestMajorVersion)) {
-      if (value.releaseNoteUrl) {
-        highestMajorVersion = key;
-        result = value;
-      }
+  for (const [version, data] of Object.entries(sdkVersions)) {
+    if (semver.major(version) > semver.major(highestMajorVersion) && data.releaseNoteUrl) {
+      highestMajorVersion = version;
+      result = data;
     }
-  });
+  }
   return {
     version: highestMajorVersion,
     data: result,
@@ -164,15 +161,15 @@ export async function newestSdkVersionAsync(): Promise<{
   version: string;
   data: SDKVersion | null;
 }> {
-  let sdkVersions = await sdkVersionsAsync();
+  const sdkVersions = await sdkVersionsAsync();
   let result = null;
   let highestMajorVersion = '0.0.0';
-  forEach(sdkVersions, (value, key) => {
-    if (semver.major(key) > semver.major(highestMajorVersion)) {
-      highestMajorVersion = key;
-      result = value;
+  for (const [version, data] of Object.entries(sdkVersions)) {
+    if (semver.major(version) > semver.major(highestMajorVersion)) {
+      highestMajorVersion = version;
+      result = data;
     }
-  });
+  }
   return {
     version: highestMajorVersion,
     data: result,
@@ -182,23 +179,17 @@ export async function newestSdkVersionAsync(): Promise<{
 export async function oldestSupportedMajorVersionAsync(): Promise<number> {
   const sdkVersions = await sdkVersionsAsync();
   const supportedVersions = pickBy(sdkVersions, v => !v.isDeprecated);
-  let versionNumbers: number[] = [];
-  forEach(supportedVersions, (value, key) => {
-    versionNumbers.push(semver.major(key));
-  });
+  const versionNumbers = Object.keys(supportedVersions).map(version => semver.major(version));
   return Math.min(...versionNumbers);
 }
 
 export async function facebookReactNativeVersionsAsync(): Promise<string[]> {
-  let sdkVersions = await sdkVersionsAsync();
-  let facebookReactNativeVersions = new Set<string>();
-
-  forEach(sdkVersions, value => {
-    if (value.facebookReactNativeVersion) {
-      facebookReactNativeVersions.add(value.facebookReactNativeVersion);
-    }
-  });
-
+  const sdkVersions = await sdkVersionsAsync();
+  const facebookReactNativeVersions = new Set(
+    Object.values(sdkVersions)
+      .map(data => data.facebookReactNativeVersion)
+      .filter(version => version)
+  );
   return Array.from(facebookReactNativeVersions);
 }
 
@@ -212,18 +203,18 @@ export async function facebookReactNativeVersionToExpoVersionAsync(
     );
   }
 
-  let sdkVersions = await sdkVersionsAsync();
+  const sdkVersions = await sdkVersionsAsync();
   let currentSdkVersion: string | null = null;
 
-  forEach(sdkVersions, (value, key) => {
+  for (const [version, { facebookReactNativeVersion }] of Object.entries(sdkVersions)) {
     if (
-      semver.major(value.facebookReactNativeVersion) === semver.major(facebookReactNativeVersion) &&
-      semver.minor(value.facebookReactNativeVersion) === semver.minor(facebookReactNativeVersion) &&
-      (!currentSdkVersion || semver.gt(key, currentSdkVersion))
+      semver.major(facebookReactNativeVersion) === semver.major(facebookReactNativeVersion) &&
+      semver.minor(facebookReactNativeVersion) === semver.minor(facebookReactNativeVersion) &&
+      (!currentSdkVersion || semver.gt(version, currentSdkVersion))
     ) {
-      currentSdkVersion = key;
+      currentSdkVersion = version;
     }
-  });
+  }
 
   return currentSdkVersion;
 }

--- a/packages/xdl/src/detach/AndroidIntentFilters.ts
+++ b/packages/xdl/src/detach/AndroidIntentFilters.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import toPairs from 'lodash/toPairs';
 
 export default function renderIntentFilters(intentFilters: any) {
   // returns an array of <intent-filter> tags:
@@ -26,7 +26,7 @@ export default function renderIntentFilters(intentFilters: any) {
 }
 
 function renderIntentFilterDatumEntries(datum: any) {
-  return _.toPairs(datum)
+  return toPairs(datum)
     .map(entry => `android:${entry[0]}="${entry[1]}"`)
     .join(' ');
 }

--- a/packages/xdl/src/detach/AndroidIntentFilters.ts
+++ b/packages/xdl/src/detach/AndroidIntentFilters.ts
@@ -1,5 +1,3 @@
-import toPairs from 'lodash/toPairs';
-
 export default function renderIntentFilters(intentFilters: any) {
   // returns an array of <intent-filter> tags:
   // [
@@ -26,7 +24,7 @@ export default function renderIntentFilters(intentFilters: any) {
 }
 
 function renderIntentFilterDatumEntries(datum: any) {
-  return toPairs(datum)
+  return Object.entries(datum)
     .map(entry => `android:${entry[0]}="${entry[1]}"`)
     .join(' ');
 }

--- a/packages/xdl/src/detach/AssetBundle.ts
+++ b/packages/xdl/src/detach/AssetBundle.ts
@@ -2,7 +2,6 @@ import fs from 'fs-extra';
 import path from 'path';
 import url from 'url';
 
-import takeRight from 'lodash/takeRight';
 import pMap from 'p-map';
 import pRetry from 'p-retry';
 import urlJoin from 'url-join';
@@ -58,7 +57,7 @@ function createAssetsUrlResolver(
         `Could not resolve asset URLs relative to "${publishedUrl}". Published URL must be an absolute URL.`
       );
     }
-    const maybeExpoDomain = takeRight(hostname.split('.'), 2).join('.');
+    const maybeExpoDomain = hostname.split('.').slice(-2).join('.');
     if (!EXPO_DOMAINS.includes(maybeExpoDomain)) {
       assetsDirUrl = url.resolve(publishedUrl, assetUrlOverride);
     }

--- a/packages/xdl/src/detach/ExponentTools.ts
+++ b/packages/xdl/src/detach/ExponentTools.ts
@@ -1,7 +1,8 @@
 import { ExpoConfig, Platform } from '@expo/config';
 import spawnAsyncQuiet, { SpawnOptions, SpawnResult } from '@expo/spawn-async';
 import fs from 'fs-extra';
-import _ from 'lodash';
+import last from 'lodash/last';
+import isObject from 'lodash/isObject';
 import path from 'path';
 import axios from 'axios';
 import { Readable } from 'stream';
@@ -32,7 +33,7 @@ function parseSdkMajorVersion(expSdkVersion: string) {
 async function saveUrlToPathAsync(url: string, path: string, timeout = 20000) {
   const response = await axios.get(url, { responseType: 'stream', timeout });
 
-  return new Promise(function (resolve, reject) {
+  return new Promise(function(resolve, reject) {
     let stream = fs.createWriteStream(path);
     stream.on('close', resolve);
     stream.on('error', reject);
@@ -125,8 +126,8 @@ async function spawnAsync(
 
 function createSpawner(buildPhase: string, logger?: Logger) {
   return (command: string, ...args: any[]) => {
-    const lastArg = _.last(args);
-    const optionsFromArg = _.isObject(lastArg) ? args.pop() : {};
+    const lastArg = last(args);
+    const optionsFromArg = isObject(lastArg) ? args.pop() : {};
 
     const options = { ...optionsFromArg, pipeToLogger: true };
     if (buildPhase) {

--- a/packages/xdl/src/detach/ExponentTools.ts
+++ b/packages/xdl/src/detach/ExponentTools.ts
@@ -1,7 +1,6 @@
 import { ExpoConfig, Platform } from '@expo/config';
 import spawnAsyncQuiet, { SpawnOptions, SpawnResult } from '@expo/spawn-async';
 import fs from 'fs-extra';
-import last from 'lodash/last';
 import isObject from 'lodash/isObject';
 import path from 'path';
 import axios from 'axios';
@@ -33,7 +32,7 @@ function parseSdkMajorVersion(expSdkVersion: string) {
 async function saveUrlToPathAsync(url: string, path: string, timeout = 20000) {
   const response = await axios.get(url, { responseType: 'stream', timeout });
 
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     let stream = fs.createWriteStream(path);
     stream.on('close', resolve);
     stream.on('error', reject);
@@ -126,7 +125,7 @@ async function spawnAsync(
 
 function createSpawner(buildPhase: string, logger?: Logger) {
   return (command: string, ...args: any[]) => {
-    const lastArg = last(args);
+    const lastArg = args[args.length - 1];
     const optionsFromArg = isObject(lastArg) ? args.pop() : {};
 
     const options = { ...optionsFromArg, pipeToLogger: true };

--- a/packages/xdl/src/detach/IosCodeSigning.js
+++ b/packages/xdl/src/detach/IosCodeSigning.js
@@ -1,7 +1,9 @@
 import crypto from 'crypto';
 import path from 'path';
 
-import _ from 'lodash';
+import attempt from 'lodash/attempt';
+import isError from 'lodash/isError';
+import omit from 'lodash/omit';
 import fs from 'fs-extra';
 import glob from 'glob-promise';
 import minimatch from 'minimatch';
@@ -49,7 +51,11 @@ function _ensureDeveloperCertificateIsValid(plistData, distCertFingerprint) {
 
 function _genDerCertFingerprint(certBase64) {
   const certBuffer = Buffer.from(certBase64, 'base64');
-  return crypto.createHash('sha1').update(certBuffer).digest('hex').toUpperCase();
+  return crypto
+    .createHash('sha1')
+    .update(certBuffer)
+    .digest('hex')
+    .toUpperCase();
 }
 
 function _ensureBundleIdentifierIsValid(plistData, expectedBundleIdentifier) {
@@ -223,8 +229,8 @@ async function createEntitlementsFile({
   }
   const archiveEntitlementsPath = entitlementsPaths[0];
   const archiveEntitlementsRaw = await fs.readFile(archiveEntitlementsPath);
-  const archiveEntitlementsData = _.attempt(plist.parse, String(archiveEntitlementsRaw));
-  if (_.isError(archiveEntitlementsData)) {
+  const archiveEntitlementsData = attempt(plist.parse, String(archiveEntitlementsRaw));
+  if (isError(archiveEntitlementsData)) {
     throw new Error(`Error when parsing plist: ${archiveEntitlementsData.message}`);
   }
 
@@ -236,10 +242,10 @@ async function createEntitlementsFile({
     }
   });
 
-  let generatedEntitlements = _.omit(entitlements, blacklistedEntitlementKeys);
+  let generatedEntitlements = omit(entitlements, blacklistedEntitlementKeys);
 
   if (!manifest.ios.usesIcloudStorage) {
-    generatedEntitlements = _.omit(generatedEntitlements, blacklistedEntitlementKeysWithoutICloud);
+    generatedEntitlements = omit(generatedEntitlements, blacklistedEntitlementKeysWithoutICloud);
   } else {
     const ubiquityKvKey = 'com.apple.developer.ubiquity-kvstore-identifier';
     if (generatedEntitlements[ubiquityKvKey]) {
@@ -249,17 +255,17 @@ async function createEntitlementsFile({
     generatedEntitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
   }
   if (!manifest.ios.associatedDomains) {
-    generatedEntitlements = _.omit(generatedEntitlements, 'com.apple.developer.associated-domains');
+    generatedEntitlements = omit(generatedEntitlements, 'com.apple.developer.associated-domains');
   }
   if (!manifest.ios.usesAppleSignIn) {
-    generatedEntitlements = _.omit(generatedEntitlements, 'com.apple.developer.applesignin');
+    generatedEntitlements = omit(generatedEntitlements, 'com.apple.developer.applesignin');
   }
   if (generatedEntitlements[icloudContainerEnvKey]) {
     const envs = generatedEntitlements[icloudContainerEnvKey].filter(i => i === 'Production');
     generatedEntitlements[icloudContainerEnvKey] = envs;
   }
 
-  const generatedEntitlementsPlistData = _.attempt(plist.build, generatedEntitlements);
+  const generatedEntitlementsPlistData = attempt(plist.build, generatedEntitlements);
   await fs.writeFile(generatedEntitlementsPath, generatedEntitlementsPlistData, {
     mode: 0o755,
   });

--- a/packages/xdl/src/detach/IosIPABuilder.js
+++ b/packages/xdl/src/detach/IosIPABuilder.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import attempt from 'lodash/attempt';
+import isError from 'lodash/isError';
 import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
@@ -124,8 +125,8 @@ export default function createIPABuilder(buildParams) {
       }
     );
     const plistRaw = output.join('');
-    const plistData = _.attempt(plist.parse, plistRaw);
-    if (_.isError(plistData)) {
+    const plistData = attempt(plist.parse, plistRaw);
+    if (isError(plistData)) {
       throw new Error(`Error when parsing plist: ${plistData.message}`);
     }
     return plistData;

--- a/packages/xdl/src/detach/IosIPABuilder.js
+++ b/packages/xdl/src/detach/IosIPABuilder.js
@@ -1,5 +1,3 @@
-import attempt from 'lodash/attempt';
-import isError from 'lodash/isError';
 import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
@@ -125,11 +123,11 @@ export default function createIPABuilder(buildParams) {
       }
     );
     const plistRaw = output.join('');
-    const plistData = attempt(plist.parse, plistRaw);
-    if (isError(plistData)) {
-      throw new Error(`Error when parsing plist: ${plistData.message}`);
+    try {
+      return plist.parse(plistRaw);
+    } catch (error) {
+      throw new Error(`Error when parsing plist: ${error.message}`);
     }
-    return plistData;
   }
 
   const getProvisioningProfileDirPath = () =>

--- a/packages/xdl/src/detach/IosKeychain.ts
+++ b/packages/xdl/src/detach/IosKeychain.ts
@@ -1,5 +1,5 @@
 import uuidv1 from 'uuid/v1';
-import _ from 'lodash';
+import difference from 'lodash/difference';
 import fs from 'fs-extra';
 
 import _logger from './Logger';
@@ -103,7 +103,7 @@ export async function cleanUpKeychains() {
       }
 
       if (shouldCleanSearchList) {
-        const newSearchList = _.difference(allKeychainsList, turtleKeychainsList);
+        const newSearchList = difference(allKeychainsList, turtleKeychainsList);
         await spawnAsyncThrowError('security', ['list-keychains', '-s', ...newSearchList], {
           stdio: 'pipe',
         });

--- a/packages/xdl/src/detach/IosNSBundle.ts
+++ b/packages/xdl/src/detach/IosNSBundle.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-import get from 'lodash/get';
 import path from 'path';
 
 import { ExpoConfig } from '@expo/config';
@@ -79,7 +78,7 @@ async function _cleanPropertyListBackupsAsync(
   context: AnyStandaloneContext,
   backupPath: string
 ): Promise<void> {
-  if (get(context, 'build.ios.buildType') !== 'client') {
+  if (context.build?.ios?.buildType !== 'client') {
     await IosPlist.cleanBackupAsync(backupPath, 'EXShell', false);
   }
   await IosPlist.cleanBackupAsync(backupPath, 'Info', false);
@@ -510,11 +509,11 @@ async function _configureGoogleServicesPlistAsync(context: AnyStandaloneContext)
   if (context instanceof StandaloneContextUser) {
     return;
   }
-  if (get(context, 'data.manifest.ios.googleServicesFile')) {
+  if (context.data.manifest.ios?.googleServicesFile) {
     const { supportingDirectory } = IosWorkspace.getPaths(context);
     await fs.writeFile(
       path.join(supportingDirectory, 'GoogleService-Info.plist'),
-      get(context, 'data.manifest.ios.googleServicesFile'),
+      context.data.manifest.ios?.googleServicesFile,
       'base64'
     );
   }

--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -1,8 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
 import rimraf from 'rimraf';
-import get from 'lodash/get';
-import has from 'lodash/has';
 import pascalCase from 'pascal-case';
 
 import {
@@ -208,8 +206,8 @@ async function _createStandaloneContextAsync(args) {
   }
 
   let bundleExecutable = args.type === 'client' ? EXPONENT_APP : EXPOKIT_APP;
-  if (has(manifest, 'ios.infoPlist.CFBundleExecutable')) {
-    bundleExecutable = get(manifest, 'ios.infoPlist.CFBundleExecutable');
+  if (manifest.ios?.infoPlist?.CFBundleExecutable) {
+    bundleExecutable = manifest.ios.infoPlist.CFBundleExecutable;
   } else if (privateConfig && privateConfig.bundleIdentifier) {
     bundleExecutable = pascalCase(privateConfig.bundleIdentifier);
   }

--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -206,7 +206,7 @@ async function _createStandaloneContextAsync(args) {
   }
 
   let bundleExecutable = args.type === 'client' ? EXPONENT_APP : EXPOKIT_APP;
-  if (manifest.ios?.infoPlist?.CFBundleExecutable) {
+  if (manifest.ios && manifest.ios.infoPlist && manifest.ios.infoPlist.CFBundleExecutable) {
     bundleExecutable = manifest.ios.infoPlist.CFBundleExecutable;
   } else if (privateConfig && privateConfig.bundleIdentifier) {
     bundleExecutable = pascalCase(privateConfig.bundleIdentifier);

--- a/packages/xdl/src/detach/Logger.ts
+++ b/packages/xdl/src/detach/Logger.ts
@@ -1,5 +1,6 @@
 import bunyan from '@expo/bunyan';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isPlainObject from 'lodash/isPlainObject';
 import { Readable } from 'stream';
 
 export enum LogLevel {
@@ -54,13 +55,13 @@ export class Logger {
 
   logLine(level: LogLevel, ...args: any[]) {
     const argsToLog = [...args];
-    const extraFieldsFromArgsExist = _.isPlainObject(_.first(args));
+    const extraFieldsFromArgsExist = isPlainObject(args[0]);
     const extraFieldsFromArgs = extraFieldsFromArgsExist ? args[0] : {};
     if (extraFieldsFromArgsExist) {
       argsToLog.shift();
     }
     const extraFields = { ...extraFieldsFromArgs, ...this.extraFields };
-    if (!_.isEmpty(extraFields)) {
+    if (!isEmpty(extraFields)) {
       argsToLog.unshift(extraFields);
     }
 
@@ -101,7 +102,7 @@ function logMultiline(data: any, extraFields: any) {
   lines.forEach(line => {
     if (line) {
       const args = [line];
-      if (!_.isEmpty(extraFields)) {
+      if (!isEmpty(extraFields)) {
         args.unshift(extraFields);
       }
       LoggerDetach.info(...args);

--- a/packages/xdl/src/detach/PKCS12Utils.ts
+++ b/packages/xdl/src/detach/PKCS12Utils.ts
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import forge from 'node-forge';
 
 export function getP12CertFingerprint(
@@ -43,7 +42,7 @@ function _getCertData(p12Buffer: Buffer | string, passwordRaw: string | null) {
   const p12Asn1 = forge.asn1.fromDer(p12Der);
   const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password);
   const certBagType = forge.pki.oids.certBag;
-  const certData = get(p12.getBags({ bagType: certBagType }), [certBagType, 0, 'cert']);
+  const certData = p12.getBags({ bagType: certBagType })?.[certBagType]?.[0]?.cert;
   if (!certData) {
     throw new Error("_getCertData: couldn't find cert bag");
   }

--- a/packages/xdl/src/detach/StandaloneBuildFlags.ts
+++ b/packages/xdl/src/detach/StandaloneBuildFlags.ts
@@ -1,5 +1,3 @@
-import get from 'lodash/get';
-
 /*
  *  StandaloneBuildFlags is owned by a StandaloneContext and carries information about
  *  how to compile native code during the build step.
@@ -37,7 +35,7 @@ class StandaloneBuildFlags {
     let flags = new StandaloneBuildFlags();
     flags.configuration = configuration;
     flags.ios = ios;
-    flags.isExpoClientBuild = () => get(ios, 'buildType') === 'client';
+    flags.isExpoClientBuild = () => ios?.buildType === 'client';
     return flags;
   };
 

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -10,7 +10,6 @@ import Schemer, { SchemerError, ValidationError } from '@expo/schemer';
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import getenv from 'getenv';
-import _ from 'lodash';
 import path from 'path';
 import semver from 'semver';
 
@@ -32,7 +31,7 @@ const WARN_NPM_VERSION_RANGES = ['>= 5.0.0 < 5.7.0'];
 const BAD_NPM_VERSION_RANGES = ['>= 5.0.0 <= 5.0.3'];
 
 function _isNpmVersionWithinRanges(npmVersion: string, ranges: string[]) {
-  return _.some(ranges, range => semver.satisfies(npmVersion, range));
+  return ranges.some(range => semver.satisfies(npmVersion, range));
 }
 
 async function _checkNpmVersionAsync(projectRoot: string) {
@@ -45,7 +44,7 @@ async function _checkNpmVersionAsync(projectRoot: string) {
     } catch (e) {}
 
     let npmVersionResponse = await spawnAsync('npm', ['--version']);
-    let npmVersion = _.trim(npmVersionResponse.stdout);
+    let npmVersion = npmVersionResponse.stdout.trim();
 
     if (
       semver.lt(npmVersion, MIN_NPM_VERSION) ||
@@ -207,7 +206,7 @@ async function _validateExpJsonAsync(
     ProjectUtils.logError(
       projectRoot,
       'expo',
-      `Error: Invalid sdkVersion. Valid options are ${_.keys(sdkVersions).join(', ')}`,
+      `Error: Invalid sdkVersion. Valid options are ${Object.keys(sdkVersions).join(', ')}`,
       'doctor-invalid-sdk-version'
     );
     return ERROR;


### PR DESCRIPTION
- Removed every `import _ from 'lodash'` usage and replaced it with individual imports (which is the prevailing convention in this codebase). This way we don't end up bundling/parsing the whole library, when we only use a subset. This makes it also easier to later switch to individual `lodash.*` packages, in cases where doing that makes sense.
- Replaced most uses of `lodash/get` with plain TypeScript, because the return value of `get()` is `any`, which hides critical type errors. (Found a few potential errors this way.)
- Replaced `lodash/concat`, `lodash/every` etc, with plain TypeScript.