### PR TITLE
Prevent overwriting environment variables in Next.js

### DIFF
--- a/packages/next-adapter/src/withExpo.ts
+++ b/packages/next-adapter/src/withExpo.ts
@@ -8,6 +8,9 @@ export default function withExpo(nextConfig: NextConfig = {}): NextConfig {
     ...nextConfig,
     pageExtensions: getBareExtensions(['web']),
     webpack(config: AnyConfiguration, options: any): AnyConfiguration {
+      // Prevent define plugin from overwriting Next.js environment.
+      process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS = 'true';
+
       const expoConfig = withUnimodules(
         config,
         {

--- a/packages/next-adapter/src/withExpo.ts
+++ b/packages/next-adapter/src/withExpo.ts
@@ -9,7 +9,7 @@ export default function withExpo(nextConfig: NextConfig = {}): NextConfig {
     pageExtensions: getBareExtensions(['web']),
     webpack(config: AnyConfiguration, options: any): AnyConfiguration {
       // Prevent define plugin from overwriting Next.js environment.
-      process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS = 'true';
+      process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_AS_KEYS = 'true';
 
       const expoConfig = withUnimodules(
         config,

--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -351,7 +351,7 @@ module.exports = async function(env, argv) {
 
 ## Environment Variables
 
-- `EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS`: Should the define plugin explicitly set environment variables like `process.env.FOO` instead of creating an object like `proces.env: { FOO }`. Defaults to `false`. Next.js uses this to prevent overwriting injected environment variables.
+- `EXPO_WEBPACK_DEFINE_ENVIRONMENT_AS_KEYS`: Should the define plugin explicitly set environment variables like `process.env.FOO` instead of creating an object like `proces.env: { FOO }`. Defaults to `false`. Next.js uses this to prevent overwriting injected environment variables.
 
 ## Exports
 

--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -349,6 +349,10 @@ module.exports = async function(env, argv) {
 
 [workbox]: https://developers.google.com/web/tools/workbox
 
+## Environment Variables
+
+- `EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS`: Should the define plugin explicitly set environment variables like `process.env.FOO` instead of creating an object like `proces.env: { FOO }`. Defaults to `false`. Next.js uses this to prevent overwriting injected environment variables.
+
 ## Exports
 
 ### addons

--- a/packages/webpack-config/src/addons/withUnimodules.ts
+++ b/packages/webpack-config/src/addons/withUnimodules.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { getPossibleProjectRoot } from '@expo/config/paths';
-import { ExternalsFunctionElement, RuleSetRule } from 'webpack';
+import { ExternalsFunctionElement } from 'webpack';
 import {
   getAliases,
   getConfig,

--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { DefinePlugin as OriginalDefinePlugin } from 'webpack';
-
+import { boolish } from 'getenv';
 import { Environment, Mode } from '../types';
 import { getConfig, getMode, getPublicPaths } from '../env';
 
@@ -48,7 +48,7 @@ export interface ClientEnv {
  * @param nativeAppManifest public values to be used in `expo-constants`.
  * @internal
  */
-function createClientEnvironment(
+export function createClientEnvironment(
   mode: Mode,
   publicPath: string,
   nativeAppManifest: ExpoConfig
@@ -59,11 +59,15 @@ function createClientEnvironment(
   const ENV_VAR_REGEX = /^(EXPO_|REACT_NATIVE_|CI$)/i;
   const SECRET_REGEX = /(PASSWORD|SECRET|TOKEN)/i;
 
+  const shouldDefineKeys = boolish('EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS', false);
+
+  const prefix = shouldDefineKeys ? 'process.env.' : '';
+
   const processEnv = Object.keys(process.env)
     .filter(key => ENV_VAR_REGEX.test(key) && !SECRET_REGEX.test(key))
     .reduce(
       (env, key) => {
-        env[key] = JSON.stringify(process.env[key]);
+        env[`${prefix}${key}`] = JSON.stringify(process.env[key]);
         return env;
       },
       {
@@ -71,7 +75,7 @@ function createClientEnvironment(
          * Useful for determining whether we’re running in production mode.
          * Most importantly, it switches React into the correct mode.
          */
-        NODE_ENV: JSON.stringify(environment),
+        [`${prefix}NODE_ENV`]: JSON.stringify(environment),
 
         /**
          * Useful for resolving the correct path to static assets in `public`.
@@ -79,15 +83,23 @@ function createClientEnvironment(
          * This should only be used as an escape hatch. Normally you would put
          * images into the root folder and `import` them in code to get their paths.
          */
-        PUBLIC_URL: JSON.stringify(publicPath),
+        [`${prefix}PUBLIC_URL`]: JSON.stringify(publicPath),
 
         /**
          * Surfaces the `app.json` (config) as an environment variable which is then parsed by
          * `expo-constants` https://docs.expo.io/versions/latest/sdk/constants/
          */
-        APP_MANIFEST: JSON.stringify(nativeAppManifest),
-      } as { [key: string]: string }
+        [`${prefix}APP_MANIFEST`]: JSON.stringify(nativeAppManifest),
+      } as Record<string, string>
     );
+
+  if (shouldDefineKeys) {
+    return {
+      ...processEnv,
+      __DEV__,
+    };
+  }
+
   return {
     'process.env': processEnv,
     __DEV__,

--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -59,7 +59,7 @@ export function createClientEnvironment(
   const ENV_VAR_REGEX = /^(EXPO_|REACT_NATIVE_|CI$)/i;
   const SECRET_REGEX = /(PASSWORD|SECRET|TOKEN)/i;
 
-  const shouldDefineKeys = boolish('EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS', false);
+  const shouldDefineKeys = boolish('EXPO_WEBPACK_DEFINE_ENVIRONMENT_AS_KEYS', false);
 
   const prefix = shouldDefineKeys ? 'process.env.' : '';
 

--- a/packages/webpack-config/src/plugins/__tests__/ExpoDefinePlugin-test.ts
+++ b/packages/webpack-config/src/plugins/__tests__/ExpoDefinePlugin-test.ts
@@ -1,0 +1,24 @@
+import { createClientEnvironment } from '../ExpoDefinePlugin';
+
+beforeEach(() => {
+  delete process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS;
+});
+
+it(`defines process.env as an object by default`, () => {
+  const env = createClientEnvironment('development', '/', { foo: 'bar' });
+
+  expect(env.__DEV__).toBe(true);
+  // @ts-ignore
+  expect(env['process.env'].NODE_ENV).toBe('"development"');
+  expect(env['process.env.NODE_ENV']).not.toBeDefined();
+});
+
+it(`defines process.env explicitly as keys`, () => {
+  process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS = 'true';
+
+  const env = createClientEnvironment('development', '/', { foo: 'bar' });
+
+  expect(env.__DEV__).toBe(true);
+  expect(env['process.env']).not.toBeDefined();
+  expect(env['process.env.NODE_ENV']).toBe('"development"');
+});

--- a/packages/webpack-config/src/plugins/__tests__/ExpoDefinePlugin-test.ts
+++ b/packages/webpack-config/src/plugins/__tests__/ExpoDefinePlugin-test.ts
@@ -1,7 +1,7 @@
 import { createClientEnvironment } from '../ExpoDefinePlugin';
 
 beforeEach(() => {
-  delete process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS;
+  delete process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_AS_KEYS;
 });
 
 it(`defines process.env as an object by default`, () => {
@@ -14,7 +14,7 @@ it(`defines process.env as an object by default`, () => {
 });
 
 it(`defines process.env explicitly as keys`, () => {
-  process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_KEYS = 'true';
+  process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_AS_KEYS = 'true';
 
   const env = createClientEnvironment('development', '/', { foo: 'bar' });
 


### PR DESCRIPTION
fix #2156

Created an environment variable that changes the behavior of the Expo webpack-config's define plugin. This prevents `process.env` from being created in Next.js environments. 