### PR TITLE
[xdl] Deprecate Web module in favor of Webpack module

### DIFF
--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -8,7 +8,7 @@ import {
 // @ts-ignore: not typed
 import { DevToolsServer } from '@expo/dev-tools';
 import JsonFile from '@expo/json-file';
-import { Project, ProjectSettings, UrlUtils, UserSettings, Versions, Web } from '@expo/xdl';
+import { Project, ProjectSettings, UrlUtils, UserSettings, Versions, Webpack } from '@expo/xdl';
 import chalk from 'chalk';
 import attempt from 'lodash/attempt';
 import intersection from 'lodash/intersection';
@@ -60,6 +60,25 @@ function getBooleanArg(rawArgs: string[], argName: string): boolean {
   }
 }
 
+/**
+ * If the project config `platforms` only contains the "web" field.
+ * If no `platforms` array is defined this could still resolve true because platforms
+ * will be inferred from the existence of `react-native-web` and `react-native`.
+ *
+ * @param projectRoot
+ */
+function isWebOnly(projectRoot: string): boolean {
+  // TODO(Bacon): Limit the amount of times that the config is evaluated
+  // currently we read it the first time without the SDK version then later read it with the SDK version if react-native is installed.
+  const { exp } = getConfig(projectRoot, {
+    skipSDKVersionRequirement: true,
+  });
+  if (Array.isArray(exp.platforms) && exp.platforms.length === 1) {
+    return exp.platforms[0] === 'web';
+  }
+  return false;
+}
+
 // The main purpose of this function is to take existing options object and
 // support boolean args with as defined in the hasBooleanArg and getBooleanArg
 // functions.
@@ -69,7 +88,7 @@ async function normalizeOptionsAsync(
 ): Promise<NormalizedOptions> {
   const opts: NormalizedOptions = {
     ...options, // This is necessary to ensure we don't drop any options
-    webOnly: options.webOnly ?? (await Web.onlySupportsWebAsync(projectDir)),
+    webOnly: options.webOnly ?? isWebOnly(projectDir),
     nonInteractive: options.parent?.nonInteractive,
   };
 

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -2,7 +2,6 @@ import {
   ExpoConfig,
   PackageJSONConfig,
   getConfig,
-  // getProjectConfigDescription,
   resolveModule,
 } from '@expo/config';
 // @ts-ignore: not typed

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -2,13 +2,13 @@ import {
   ExpoConfig,
   PackageJSONConfig,
   getConfig,
-  getProjectConfigDescription,
+  // getProjectConfigDescription,
   resolveModule,
 } from '@expo/config';
 // @ts-ignore: not typed
 import { DevToolsServer } from '@expo/dev-tools';
 import JsonFile from '@expo/json-file';
-import { Project, ProjectSettings, UrlUtils, UserSettings, Versions, Webpack } from '@expo/xdl';
+import { Project, ProjectSettings, UrlUtils, UserSettings, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import attempt from 'lodash/attempt';
 import intersection from 'lodash/intersection';

--- a/packages/xdl/src/Web.ts
+++ b/packages/xdl/src/Web.ts
@@ -1,145 +1,39 @@
-import chalk from 'chalk';
-import fs from 'fs-extra';
-import getenv from 'getenv';
 import { getConfig } from '@expo/config';
-import path from 'path';
-import openBrowser from 'react-dev-utils/openBrowser';
-import webpack from 'webpack';
-import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
-
-import Logger from './Logger';
-import { LogTag, logWarning } from './project/ProjectUtils';
-import * as UrlUtils from './UrlUtils';
-
-export type WebpackConfiguration = webpack.Configuration;
-
-export type WebEnvironment = {
-  projectRoot: string;
-  isImageEditingEnabled: boolean;
-  // deprecated
-  pwa: boolean;
-  mode: 'development' | 'production' | 'test' | 'none';
-  https: boolean;
-};
-
-// When you have errors in the production build that aren't present in the development build you can use `EXPO_WEB_DEBUG=true expo start --no-dev` to debug those errors.
-// - Prevent the production build from being minified
-// - Include file path info comments in the bundle
-export function isDebugModeEnabled(): boolean {
-  return getenv.boolish('EXPO_WEB_DEBUG', false);
-}
-
-export function isInfoEnabled(): boolean {
-  return getenv.boolish('EXPO_WEB_INFO', false);
-}
-
-export function shouldWebpackClearLogs(): boolean {
-  return !isDebugModeEnabled() && !isInfoEnabled() && !getenv.boolish('EXPO_DEBUG', false);
-}
-
-export function logEnvironmentInfo(
-  projectRoot: string,
-  tag: LogTag,
-  config: webpack.Configuration
-): void {
-  if (isDebugModeEnabled() && config.mode === 'production') {
-    logWarning(
-      projectRoot,
-      tag,
-      `Webpack is bundling your project in \`production\` mode with the ${chalk.bold(
-        '`EXPO_WEB_DEBUG`'
-      )} environment variable enabled. You should toggle it off before building for production.`
-    );
-  }
-}
-
-function applyEnvironmentVariables(config: WebpackConfiguration): WebpackConfiguration {
-  // Use EXPO_DEBUG_WEB=true to enable debugging features for cases where the prod build
-  // has errors that aren't caught in development mode.
-  // Related: https://github.com/expo/expo-cli/issues/614
-  if (isDebugModeEnabled() && config.mode === 'production') {
-    console.log(chalk.bgYellow.black('Bundling the project in debug mode.'));
-
-    const output = config.output || {};
-    const optimization = config.optimization || {};
-
-    // Enable line to line mapped mode for all/specified modules.
-    // Line to line mapped mode uses a simple SourceMap where each line of the generated source is mapped to the same line of the original source.
-    // It’s a performance optimization. Only use it if your performance need to be better and you are sure that input lines match which generated lines.
-    // true enables it for all modules (not recommended)
-    output.devtoolLineToLine = true;
-
-    // Add comments that describe the file import/exports.
-    // This will make it easier to debug.
-    output.pathinfo = true;
-    // Instead of numeric ids, give modules readable names for better debugging.
-    optimization.namedModules = true;
-    // Instead of numeric ids, give chunks readable names for better debugging.
-    optimization.namedChunks = true;
-    // Readable ids for better debugging.
-    // @ts-ignore Property 'moduleIds' does not exist.
-    optimization.moduleIds = 'named';
-    // if optimization.namedChunks is enabled optimization.chunkIds is set to 'named'.
-    // This will manually enable it just to be safe.
-    // @ts-ignore Property 'chunkIds' does not exist.
-    optimization.chunkIds = 'named';
-
-    if (optimization.splitChunks) {
-      optimization.splitChunks.name = true;
-    }
-
-    Object.assign(config, { output, optimization });
-  }
-
-  return config;
-}
-
-export async function invokeWebpackConfigAsync(
-  env: WebEnvironment,
-  argv?: string[]
-): Promise<WebpackConfiguration> {
-  // Check if the project has a webpack.config.js in the root.
-  const projectWebpackConfig = path.resolve(env.projectRoot, 'webpack.config.js');
-  let config: WebpackConfiguration;
-  if (fs.existsSync(projectWebpackConfig)) {
-    const webpackConfig = require(projectWebpackConfig);
-    if (typeof webpackConfig === 'function') {
-      config = await webpackConfig(env, argv);
-    } else {
-      config = webpackConfig;
-    }
-  } else {
-    // Fallback to the default expo webpack config.
-    const createExpoWebpackConfigAsync = require('@expo/webpack-config');
-    config = await createExpoWebpackConfigAsync(env, argv);
-  }
-  return applyEnvironmentVariables(config);
-}
-
-export async function openProjectAsync(
-  projectRoot: string
-): Promise<{ success: true; url: string } | { success: false; error: Error }> {
-  try {
-    let url = await UrlUtils.constructWebAppUrlAsync(projectRoot, { hostType: 'localhost' });
-    if (!url) {
-      throw new Error('Webpack Dev Server is not running');
-    }
-    openBrowser(url);
-    return { success: true, url };
-  } catch (e) {
-    Logger.global.error(`Couldn't start project on web: ${e.message}`);
-    return { success: false, error: e };
-  }
-}
+import * as Webpack from './Webpack';
+/**
+ * @deprecated use Webpack.isDebugModeEnabled() instead
+ */
+export const isDebugModeEnabled = Webpack.isDebugModeEnabled;
 
 /**
- * If the project config `platforms` only contains the "web" field.
- * If no `platforms` array is defined this could still resolve true because platforms
- * will be inferred from the existence of `react-native-web` and `react-native`.
- *
- * @param projectRoot
+ * @deprecated use Webpack.isInfoEnabled() instead
  */
-export async function onlySupportsWebAsync(projectRoot: string): Promise<boolean> {
+export const isInfoEnabled = Webpack.isInfoEnabled;
+
+/**
+ * @deprecated use Webpack.shouldWebpackClearLogs() instead
+ */
+export const shouldWebpackClearLogs = Webpack.shouldWebpackClearLogs;
+
+/**
+ * @deprecated use Webpack.logEnvironmentInfo() instead
+ */
+export const logEnvironmentInfo = Webpack.logEnvironmentInfo;
+
+/**
+ * @deprecated use Webpack.invokeWebpackConfigAsync() instead
+ */
+export const invokeWebpackConfigAsync = Webpack.invokeWebpackConfigAsync;
+
+/**
+ * @deprecated use Webpack.openProjectAsync() instead
+ */
+export const openProjectAsync = Webpack.openProjectAsync;
+
+/**
+ * @deprecated use Webpack.onlySupportsWebAsync() instead
+ */
+export const onlySupportsWebAsync = (projectRoot: string): boolean => {
   const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
@@ -147,4 +41,4 @@ export async function onlySupportsWebAsync(projectRoot: string): Promise<boolean
     return exp.platforms[0] === 'web';
   }
   return false;
-}
+};

--- a/packages/xdl/src/Web.ts
+++ b/packages/xdl/src/Web.ts
@@ -1,24 +1,20 @@
 import { getConfig } from '@expo/config';
 import * as Webpack from './Webpack';
+import * as WebpackEnvironment from './webpack-utils/WebpackEnvironment';
 /**
- * @deprecated use Webpack.isDebugModeEnabled() instead
+ * @deprecated this is not publicly exposed anymore.
  */
-export const isDebugModeEnabled = Webpack.isDebugModeEnabled;
+export const isDebugModeEnabled = WebpackEnvironment.isDebugModeEnabled;
 
 /**
- * @deprecated use Webpack.isInfoEnabled() instead
+ * @deprecated this is not publicly exposed anymore.
  */
-export const isInfoEnabled = Webpack.isInfoEnabled;
+export const isInfoEnabled = WebpackEnvironment.isInfoEnabled;
 
 /**
- * @deprecated use Webpack.shouldWebpackClearLogs() instead
+ * @deprecated this is not publicly exposed anymore.
  */
-export const shouldWebpackClearLogs = Webpack.shouldWebpackClearLogs;
-
-/**
- * @deprecated use Webpack.logEnvironmentInfo() instead
- */
-export const logEnvironmentInfo = Webpack.logEnvironmentInfo;
+export const shouldWebpackClearLogs = WebpackEnvironment.shouldWebpackClearLogs;
 
 /**
  * @deprecated use Webpack.invokeWebpackConfigAsync() instead

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -1,4 +1,5 @@
 import * as ConfigUtils from '@expo/config';
+import { isUsingYarn } from '@expo/package-manager';
 import chalk from 'chalk';
 import * as devcert from 'devcert';
 import fs from 'fs-extra';
@@ -6,15 +7,17 @@ import getenv from 'getenv';
 import http from 'http';
 import * as path from 'path';
 import formatWebpackMessages from 'react-dev-utils/formatWebpackMessages';
+import openBrowser from 'react-dev-utils/openBrowser';
 import { Urls, choosePort, prepareUrls } from 'react-dev-utils/WebpackDevServerUtils';
 import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import { isUsingYarn } from '@expo/package-manager';
+
 import createWebpackCompiler, { printInstructions } from './createWebpackCompiler';
 import ip from './ip';
+import Logger from './Logger';
 import * as ProjectUtils from './project/ProjectUtils';
 import * as ProjectSettings from './ProjectSettings';
-import * as Web from './Web';
+import * as UrlUtils from './UrlUtils';
 import XDLError from './XDLError';
 
 export const HOST = getenv.string('WEB_HOST', '0.0.0.0');
@@ -232,7 +235,7 @@ export async function openAsync(projectRoot: string, options?: BundlingOptions):
   if (!webpackDevServerInstance) {
     await startAsync(projectRoot, options);
   }
-  await Web.openProjectAsync(projectRoot);
+  await openProjectAsync(projectRoot);
 }
 
 export async function compileWebAppAsync(
@@ -292,7 +295,7 @@ export async function compileWebAppAsync(
   return { warnings };
 }
 
-export async function bundleWebAppAsync(projectRoot: string, config: Web.WebpackConfiguration) {
+export async function bundleWebAppAsync(projectRoot: string, config: WebpackConfiguration) {
   const compiler = webpack(config);
 
   try {
@@ -419,9 +422,9 @@ function transformCLIOptions(options: CLIWebOptions): BundlingOptions {
 }
 
 async function createWebpackConfigAsync(
-  env: Web.WebEnvironment,
+  env: WebEnvironment,
   options: CLIWebOptions = {}
-): Promise<Web.WebpackConfiguration> {
+): Promise<WebpackConfiguration> {
   setMode(env.mode);
 
   let config;
@@ -429,7 +432,7 @@ async function createWebpackConfigAsync(
     const { withUnimodules } = require('@expo/webpack-config/addons');
     config = withUnimodules({}, env);
   } else {
-    config = await Web.invokeWebpackConfigAsync(env);
+    config = await invokeWebpackConfigAsync(env);
   }
 
   return config;
@@ -455,7 +458,7 @@ async function applyOptionsToProjectSettingsAsync(
 async function getWebpackConfigEnvFromBundlingOptionsAsync(
   projectRoot: string,
   options: BundlingOptions
-): Promise<Web.WebEnvironment> {
+): Promise<WebEnvironment> {
   let { dev, https } = await applyOptionsToProjectSettingsAsync(projectRoot, options);
 
   const mode = typeof options.mode === 'string' ? options.mode : dev ? 'development' : 'production';
@@ -510,4 +513,125 @@ async function getSSLCertAsync({
   }
 
   return false;
+}
+
+export type WebpackConfiguration = webpack.Configuration;
+
+export type WebEnvironment = {
+  projectRoot: string;
+  isImageEditingEnabled: boolean;
+  // deprecated
+  pwa: boolean;
+  mode: 'development' | 'production' | 'test' | 'none';
+  https: boolean;
+};
+
+// When you have errors in the production build that aren't present in the development build you can use `EXPO_WEB_DEBUG=true expo start --no-dev` to debug those errors.
+// - Prevent the production build from being minified
+// - Include file path info comments in the bundle
+export function isDebugModeEnabled(): boolean {
+  return getenv.boolish('EXPO_WEB_DEBUG', false);
+}
+
+export function isInfoEnabled(): boolean {
+  return getenv.boolish('EXPO_WEB_INFO', false);
+}
+
+export function shouldWebpackClearLogs(): boolean {
+  return !isDebugModeEnabled() && !isInfoEnabled() && !getenv.boolish('EXPO_DEBUG', false);
+}
+
+export function logEnvironmentInfo(
+  projectRoot: string,
+  tag: ProjectUtils.LogTag,
+  config: webpack.Configuration
+): void {
+  if (isDebugModeEnabled() && config.mode === 'production') {
+    ProjectUtils.logWarning(
+      projectRoot,
+      tag,
+      `Webpack is bundling your project in \`production\` mode with the ${chalk.bold(
+        '`EXPO_WEB_DEBUG`'
+      )} environment variable enabled. You should toggle it off before building for production.`
+    );
+  }
+}
+
+function applyEnvironmentVariables(config: WebpackConfiguration): WebpackConfiguration {
+  // Use EXPO_DEBUG_WEB=true to enable debugging features for cases where the prod build
+  // has errors that aren't caught in development mode.
+  // Related: https://github.com/expo/expo-cli/issues/614
+  if (isDebugModeEnabled() && config.mode === 'production') {
+    console.log(chalk.bgYellow.black('Bundling the project in debug mode.'));
+
+    const output = config.output || {};
+    const optimization = config.optimization || {};
+
+    // Enable line to line mapped mode for all/specified modules.
+    // Line to line mapped mode uses a simple SourceMap where each line of the generated source is mapped to the same line of the original source.
+    // It’s a performance optimization. Only use it if your performance need to be better and you are sure that input lines match which generated lines.
+    // true enables it for all modules (not recommended)
+    output.devtoolLineToLine = true;
+
+    // Add comments that describe the file import/exports.
+    // This will make it easier to debug.
+    output.pathinfo = true;
+    // Instead of numeric ids, give modules readable names for better debugging.
+    optimization.namedModules = true;
+    // Instead of numeric ids, give chunks readable names for better debugging.
+    optimization.namedChunks = true;
+    // Readable ids for better debugging.
+    // @ts-ignore Property 'moduleIds' does not exist.
+    optimization.moduleIds = 'named';
+    // if optimization.namedChunks is enabled optimization.chunkIds is set to 'named'.
+    // This will manually enable it just to be safe.
+    // @ts-ignore Property 'chunkIds' does not exist.
+    optimization.chunkIds = 'named';
+
+    if (optimization.splitChunks) {
+      optimization.splitChunks.name = true;
+    }
+
+    Object.assign(config, { output, optimization });
+  }
+
+  return config;
+}
+
+export async function invokeWebpackConfigAsync(
+  env: WebEnvironment,
+  argv?: string[]
+): Promise<WebpackConfiguration> {
+  // Check if the project has a webpack.config.js in the root.
+  const projectWebpackConfig = path.resolve(env.projectRoot, 'webpack.config.js');
+  let config: WebpackConfiguration;
+  if (fs.existsSync(projectWebpackConfig)) {
+    const webpackConfig = require(projectWebpackConfig);
+    if (typeof webpackConfig === 'function') {
+      config = await webpackConfig(env, argv);
+    } else {
+      config = webpackConfig;
+    }
+  } else {
+    // Fallback to the default expo webpack config.
+    const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+    config = await createExpoWebpackConfigAsync(env, argv);
+  }
+  return applyEnvironmentVariables(config);
+}
+
+export async function openProjectAsync(
+  projectRoot: string
+): Promise<{ success: true; url: string } | { success: false; error: Error }> {
+  try {
+    let url = await UrlUtils.constructWebAppUrlAsync(projectRoot, { hostType: 'localhost' });
+    if (!url) {
+      throw new Error('Webpack Dev Server is not running');
+    }
+    openBrowser(url);
+    return { success: true, url };
+  } catch (e) {
+    Logger.global.error(`Couldn't start project on web: ${e.message}`);
+    return { success: false, error: e };
+  }
 }

--- a/packages/xdl/src/webpack-utils/WebpackEnvironment.ts
+++ b/packages/xdl/src/webpack-utils/WebpackEnvironment.ts
@@ -1,0 +1,36 @@
+import getenv from 'getenv';
+import { Configuration } from 'webpack';
+import chalk from 'chalk';
+
+import { LogTag, logWarning } from '../project/ProjectUtils';
+
+export const HOST = getenv.string('WEB_HOST', '0.0.0.0');
+
+export const DEFAULT_PORT = getenv.int('WEB_PORT', 19006);
+
+// When you have errors in the production build that aren't present in the development build you can use `EXPO_WEB_DEBUG=true expo start --no-dev` to debug those errors.
+// - Prevent the production build from being minified
+// - Include file path info comments in the bundle
+export function isDebugModeEnabled(): boolean {
+  return getenv.boolish('EXPO_WEB_DEBUG', false);
+}
+
+export function isInfoEnabled(): boolean {
+  return getenv.boolish('EXPO_WEB_INFO', false);
+}
+
+export function shouldWebpackClearLogs(): boolean {
+  return !isDebugModeEnabled() && !isInfoEnabled() && !getenv.boolish('EXPO_DEBUG', false);
+}
+
+export function logEnvironmentInfo(projectRoot: string, tag: LogTag, config: Configuration): void {
+  if (isDebugModeEnabled() && config.mode === 'production') {
+    logWarning(
+      projectRoot,
+      tag,
+      `Webpack is bundling your project in \`production\` mode with the ${chalk.bold(
+        '`EXPO_WEB_DEBUG`'
+      )} environment variable enabled. You should toggle it off before building for production.`
+    );
+  }
+}

--- a/packages/xdl/src/webpack-utils/createWebpackCompiler.ts
+++ b/packages/xdl/src/webpack-utils/createWebpackCompiler.ts
@@ -11,8 +11,8 @@ import boxen from 'boxen';
 import { Urls } from 'react-dev-utils/WebpackDevServerUtils';
 import webpack from 'webpack';
 
-import * as ProjectUtils from './project/ProjectUtils';
-import { logEnvironmentInfo, shouldWebpackClearLogs } from './Web';
+import * as ProjectUtils from '../project/ProjectUtils';
+import { logEnvironmentInfo, shouldWebpackClearLogs } from './WebpackEnvironment';
 
 const CONSOLE_TAG = 'expo';
 


### PR DESCRIPTION
- Don't need two modules that basically do the same stuff. 
- Merge into one and simplify the exports of the remaining one.