### PR TITLE
chore(configure-splash-screen): remove unused package inquirer

### DIFF
--- a/packages/configure-splash-screen/package.json
+++ b/packages/configure-splash-screen/package.json
@@ -43,7 +43,6 @@
     "commander": "^5.1.0",
     "core-js": "^3.6.5",
     "fs-extra": "^9.0.0",
-    "inquirer": "^7.1.0",
     "pngjs": "^5.0.0",
     "xcode": "^3.0.0",
     "xml-js": "^1.6.11"
@@ -55,7 +54,6 @@
     "@expo/babel-preset-cli": "0.2.16",
     "@types/color-string": "^1.5.0",
     "@types/fs-extra": "^8.1.0",
-    "@types/inquirer": "^6.5.0",
     "@types/jest": "^25.2.1",
     "babel-jest": "^26.0.1",
     "eslint": "^6.8.0",


### PR DESCRIPTION
`inquirer` adds more than 20 MB to the installation size of the package, even though it's not used in the package.