### PR TITLE
chore: disable codecov comments on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,4 @@ coverage:
     patch: yes
     project: no
 
-comment:
-  behavior: default
-  require_changes: false
-  layout: 'header, flags, diff'
+comment: false


### PR DESCRIPTION
## What?

Codecov is pretty cool and it's nice to have it checking pull requests and notifying through the Commit Status API:
<img width="719" alt="Screen Shot 2020-05-27 at 17 32 22" src="https://user-images.githubusercontent.com/497214/83033660-0f1aff00-a040-11ea-9ddb-c1f27b768d59.png">

This PR disables the commenting from the codecov bot. Commit status is still updated as before and will show if the PR changes the test coverage.

## Why?

But the comment that @codecov posts to every PR is too distracting:
- it shows up one the list of PRs as a comment, making you think there's a new comment to your PR from a human being: 

  
  <img width="525" alt="Screen Shot 2020-05-27 at 17 37 06" src="https://user-images.githubusercontent.com/497214/83034242-b6983180-a040-11ea-9740-c1eccbe42bc7.png">

  _Both my PRs have comments! I'll go have a look! ...Oh, it's just the bot._ ☠️ 

- it takes more than one screenful of space, so you need to scroll a lot to see the actual comments (if any):
  
  <img width="257" alt="Screen Shot 2020-05-27 at 17 39 33" src="https://user-images.githubusercontent.com/497214/83034719-3cb47800-a041-11ea-9d42-cc42bc8c2123.png">

