### PR TITLE
[cli] Replace inquirer with prompts in the AndroidBuilder

### DIFF
--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -1,5 +1,4 @@
 import { Android } from '@expo/xdl';
-import pick from 'lodash/pick';
 
 import { Context } from '../../credentials';
 import { runCredentialsManager } from '../../credentials/route';
@@ -11,8 +10,6 @@ import {
 import { SetupAndroidKeystore } from '../../credentials/views/SetupAndroidKeystore';
 import BuildError from './BuildError';
 import BaseBuilder from './BaseBuilder';
-import prompt, { Question } from '../../prompt';
-import log from '../../log';
 import * as utils from './utils';
 import { PLATFORMS, Platform } from './constants';
 

--- a/packages/expo-cli/src/commands/build/utils.ts
+++ b/packages/expo-cli/src/commands/build/utils.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import program from 'commander';
 
 import log from '../../log';
-import prompt from '../../prompt';
+import prompts from '../../prompts';
 
 export async function checkIfSdkIsSupported(
   sdkVersion: string,
@@ -50,14 +50,14 @@ export async function askBuildType<T extends string>(
     return allowedTypes[0];
   }
 
-  const { answer } = await prompt({
-    type: 'list',
+  const { answer } = await prompts({
+    type: 'select',
     name: 'answer',
     message: 'Choose the build type you would like:',
     choices: allowedTypes.map(type => ({
+      title: type,
       value: type,
-      short: type,
-      name: `${type} ${chalk.gray(`- ${availableTypes[type]}`)}`,
+      description: availableTypes[type],
     })),
   });
 

--- a/packages/expo-cli/src/credentials/actions/promptForCredentials.ts
+++ b/packages/expo-cli/src/credentials/actions/promptForCredentials.ts
@@ -3,7 +3,7 @@ import untildify from 'untildify';
 import fs from 'fs-extra';
 import once from 'lodash/once';
 
-import prompt, { Question as PromptQuestion } from '../../prompt';
+import prompts, { Question as PromptQuestion } from '../../prompts';
 import log from '../../log';
 import * as validators from '../../validators';
 
@@ -67,17 +67,17 @@ export async function getCredentialsFromUser<T extends Results>(
 }
 
 async function willUserProvideCredentialsType<T>(schema: CredentialSchema<T>) {
-  const { answer } = await prompt({
-    type: 'list',
+  const { answer } = await prompts({
+    type: 'select',
     name: 'answer',
     message: schema?.provideMethodQuestion?.question ?? `Will you provide your own ${schema.name}?`,
     choices: [
       {
-        name: schema?.provideMethodQuestion?.expoGenerated ?? 'Let Expo handle the process',
+        title: schema?.provideMethodQuestion?.expoGenerated ?? 'Let Expo handle the process',
         value: false,
       },
       {
-        name: schema?.provideMethodQuestion?.userProvided ?? 'I want to upload my own file',
+        title: schema?.provideMethodQuestion?.userProvided ?? 'I want to upload my own file',
         value: true,
       },
     ],
@@ -87,7 +87,7 @@ async function willUserProvideCredentialsType<T>(schema: CredentialSchema<T>) {
 
 async function askQuestionAndProcessAnswer(definition: Question): Promise<string> {
   const questionObject = buildQuestionObject(definition);
-  const { input } = await prompt(questionObject);
+  const { input } = await prompts(questionObject);
   return await processAnswer(definition, input);
 }
 
@@ -95,24 +95,24 @@ function buildQuestionObject({ type, question }: Question): PromptQuestion {
   switch (type) {
     case 'string':
       return {
-        type: 'input',
+        type: 'text',
         name: 'input',
         message: question,
       };
     case 'file':
       return {
-        type: 'input',
+        type: 'text',
         name: 'input',
         message: question,
-        filter: produceAbsolutePath,
-        validate: validators.existingFile,
+        format: produceAbsolutePath,
+        validate: validators.promptsExistingFile,
       } as PromptQuestion;
     case 'password':
       return {
         type: 'password',
         name: 'input',
         message: question,
-        validate: validators.nonEmptyInput,
+        validate: validators.promptsNonEmptyInput,
       };
   }
 }

--- a/packages/expo-cli/src/prompt.ts
+++ b/packages/expo-cli/src/prompt.ts
@@ -6,6 +6,7 @@ export { Question, ChoiceType };
 
 type CliQuestions = Question | Question[];
 
+// note(cedric): this prompt is now deprecated in favor of ./prompts
 export default function prompt(
   questions: CliQuestions,
   { nonInteractiveHelp }: { nonInteractiveHelp?: string } = {}

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -1,5 +1,5 @@
 import program from 'commander';
-import prompts, { Choice, PromptType, PromptObject as Question } from 'prompts';
+import prompts, { Choice, Options, PromptType, PromptObject as Question } from 'prompts';
 
 import CommandError from './CommandError';
 
@@ -7,7 +7,7 @@ export { PromptType, Question };
 
 export default function prompt(
   questions: Question | Question[],
-  { nonInteractiveHelp }: { nonInteractiveHelp?: string } = {}
+  { nonInteractiveHelp, ...options }: { nonInteractiveHelp?: string } & Options = {}
 ) {
   questions = Array.isArray(questions) ? questions : [questions];
   if (program.nonInteractive && questions.length !== 0) {
@@ -29,6 +29,7 @@ export default function prompt(
     onCancel() {
       throw new CommandError('ABORTED');
     },
+    ...options,
   });
 }
 

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -1,0 +1,34 @@
+import program from 'commander';
+import prompts, { Choice, PromptObject, PromptType } from 'prompts';
+
+import CommandError from './CommandError';
+
+export { PromptType, PromptObject };
+
+type CliPrompts = PromptObject | PromptObject[];
+
+export default function prompt(
+  cliPrompts: CliPrompts,
+  { nonInteractiveHelp }: { nonInteractiveHelp?: string } = {}
+) {
+  const nPrompts = Array.isArray(cliPrompts) ? cliPrompts.length : 1;
+  if (program.nonInteractive && nPrompts !== 0) {
+    let message = `Input is required, but Expo CLI is in non-interactive mode.\n`;
+    if (nonInteractiveHelp) {
+      message += nonInteractiveHelp;
+    } else {
+      const question: any = Array.isArray(cliPrompts) ? cliPrompts[0] : cliPrompts;
+      message += `Required input:\n${(question.message || '').trim().replace(/^/gm, '> ')}`;
+    }
+    throw new CommandError('NON_INTERACTIVE', message);
+  }
+  return prompts(cliPrompts, {
+    onCancel() {
+      throw new CommandError('ABORTED');
+    },
+  });
+}
+
+// todo: replace this workaround, its still selectable by the cursor
+// see: https://github.com/terkelg/prompts/issues/254
+prompt.separator = (title: string): Choice => ({ title, disable: true, value: undefined });

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -1,28 +1,31 @@
 import program from 'commander';
-import prompts, { Choice, PromptObject, PromptType } from 'prompts';
+import prompts, { Choice, PromptType, PromptObject as Question } from 'prompts';
 
 import CommandError from './CommandError';
 
-export { PromptType, PromptObject as Question };
-
-type CliPrompts = PromptObject | PromptObject[];
+export { PromptType, Question };
 
 export default function prompt(
   questions: Question | Question[],
   { nonInteractiveHelp }: { nonInteractiveHelp?: string } = {}
 ) {
   questions = Array.isArray(questions) ? questions : [questions];
-  if (program.nonInteractive && nPrompts !== 0) {
+  if (program.nonInteractive && questions.length !== 0) {
     let message = `Input is required, but Expo CLI is in non-interactive mode.\n`;
     if (nonInteractiveHelp) {
       message += nonInteractiveHelp;
     } else {
       const question = questions[0];
-      message += `Required input:\n${(question.message || '').trim().replace(/^/gm, '> ')}`;
+      const questionMessage =
+        typeof question.message === 'function'
+          ? question.message(undefined, {}, question)
+          : question.message;
+
+      message += `Required input:\n${(questionMessage || '').trim().replace(/^/gm, '> ')}`;
     }
     throw new CommandError('NON_INTERACTIVE', message);
   }
-  return prompts(cliPrompts, {
+  return prompts(questions, {
     onCancel() {
       throw new CommandError('ABORTED');
     },

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -8,16 +8,16 @@ export { PromptType, PromptObject };
 type CliPrompts = PromptObject | PromptObject[];
 
 export default function prompt(
-  cliPrompts: CliPrompts,
+  questions: Question | Question[],
   { nonInteractiveHelp }: { nonInteractiveHelp?: string } = {}
 ) {
-  const nPrompts = Array.isArray(cliPrompts) ? cliPrompts.length : 1;
+  questions = Array.isArray(questions) ? questions : [questions];
   if (program.nonInteractive && nPrompts !== 0) {
     let message = `Input is required, but Expo CLI is in non-interactive mode.\n`;
     if (nonInteractiveHelp) {
       message += nonInteractiveHelp;
     } else {
-      const question: any = Array.isArray(cliPrompts) ? cliPrompts[0] : cliPrompts;
+      const question = questions[0];
       message += `Required input:\n${(question.message || '').trim().replace(/^/gm, '> ')}`;
     }
     throw new CommandError('NON_INTERACTIVE', message);

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -3,7 +3,7 @@ import prompts, { Choice, PromptObject, PromptType } from 'prompts';
 
 import CommandError from './CommandError';
 
-export { PromptType, PromptObject };
+export { PromptType, PromptObject as Question };
 
 type CliPrompts = PromptObject | PromptObject[];
 

--- a/packages/expo-cli/src/validators.ts
+++ b/packages/expo-cli/src/validators.ts
@@ -16,4 +16,19 @@ const existingFile = async (filePath: string, verbose = true) => {
   }
 };
 
-export { nonEmptyInput, existingFile };
+// note(cedric): export prompts-compatible validators,
+// refactor when prompt is replaced with prompts
+const promptsNonEmptyInput = nonEmptyInput;
+const promptsExistingFile = async (filePath: string) => {
+  try {
+    const stats = await fs.stat(filePath);
+    if (stats.isFile()) {
+      return true;
+    }
+    return 'Input is not a file.';
+  } catch {
+    return 'File does not exist.';
+  }
+};
+
+export { nonEmptyInput, existingFile, promptsNonEmptyInput, promptsExistingFile };


### PR DESCRIPTION
~~If you use the `rawlist`, name or short names aren't displayed. Instead, it uses the value of the question. In this case, it would be either `true` or `false`, which is not a clear definition of what's chosen. This switches to the `list` to show the user what his selection is, without modifying the actual returned value. I double-checked if there weren't any other `rawlist`-questions, but there aren't~~ 😄

~~See https://github.com/SBoudrias/Inquirer.js/issues/889~~

See comments 😄 