### PR TITLE
[xdl] clean up *.bak files when building ipa

### DIFF
--- a/packages/xdl/src/detach/IosNSBundle.ts
+++ b/packages/xdl/src/detach/IosNSBundle.ts
@@ -80,6 +80,8 @@ async function _cleanPropertyListBackupsAsync(
 ): Promise<void> {
   if (context.build?.ios?.buildType !== 'client') {
     await IosPlist.cleanBackupAsync(backupPath, 'EXShell', false);
+    await IosPlist.cleanBackupAsync(backupPath, 'EXSDKVersions', false);
+    await IosPlist.cleanBackupAsync(backupPath, 'EXBuildConstants', false);
   }
   await IosPlist.cleanBackupAsync(backupPath, 'Info', false);
   // TODO: support this in user contexts as well

--- a/packages/xdl/src/detach/IosNSBundle.ts
+++ b/packages/xdl/src/detach/IosNSBundle.ts
@@ -80,6 +80,7 @@ async function _cleanPropertyListBackupsAsync(
 ): Promise<void> {
   if (context.build?.ios?.buildType !== 'client') {
     await IosPlist.cleanBackupAsync(backupPath, 'EXShell', false);
+    // [dsokal] it's probably ok to clean up those two for client but no one knows if it's true for sure
     await IosPlist.cleanBackupAsync(backupPath, 'EXSDKVersions', false);
     await IosPlist.cleanBackupAsync(backupPath, 'EXBuildConstants', false);
   }


### PR DESCRIPTION
Once deployed to Turtle, it should fix https://github.com/expo/turtle/issues/219.

The generated IPA file contains two backup files:
- Payload/ExpoKitApp.app/EXBuildConstants.plist.bak
- Payload/ExpoKitApp.app/EXSDKVersions.plist.bak

I added a clean-up of these in the case when we're building a standalone app.

The way I tested it:
- I built an `.ipa` with Turtle, unpacked it with `unzip`, and noticed the two abovementioned .bak files.
- I made the changes in xdl and yarn-linked it in the local Turtle setup.
- I built another `.ipa`, unpacked it with `unzip`, and noticed the .bak files are gone.

I'm a little terrified of moving those two lines outside of the `if`. Per discussion with @tsapeta - it should be probably safe to do that but I think it's not worth the risk of breaking things.