### PR TITLE
Add a deprecation notice for expo generate-module

### DIFF
--- a/packages/expo-cli/src/commands/generate-module.ts
+++ b/packages/expo-cli/src/commands/generate-module.ts
@@ -1,8 +1,10 @@
-import { Command } from 'commander';
+import { Command, CommandOptions } from 'commander';
+import chalk from 'chalk';
+import boxen from 'boxen';
 
 import generateModuleAsync from './generate-module/generateModuleAsync';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('generate-module [new-module-project]')
     .option(
@@ -10,7 +12,22 @@ export default function (program: Command) {
       'Local directory or npm package containing template for universal Expo module'
     )
     .description(
-      'Generate a universal module for Expo from a template in [new-module-project] directory.'
+      chalk.yellow`Generate a universal module for Expo from a template in [new-module-project] directory.`
     )
-    .asyncAction(generateModuleAsync);
+    .asyncAction((newModuleProjectDir: string, options: CommandOptions & { template?: string }) => {
+      // Deprecate after September 2, 2020 (3 months)
+      console.log(
+        boxen(
+          chalk.yellow(
+            `${chalk.bold(
+              `expo generate-module`
+            )} is deprecated and will be removed after ${chalk.bold(
+              `September 2, 2020`
+            )}.\nYou can create a module using expo-tools in the expo/expo repo or with expo-module-scripts`
+          ),
+          { borderColor: 'yellow', padding: 1 }
+        )
+      );
+      return generateModuleAsync(newModuleProjectDir, options);
+    });
 }


### PR DESCRIPTION
We discussed this internally on slack. This will help make the `--help` command more readable, and generally make expo-cli lighter.

<img width="864" alt="Screen Shot 2020-06-02 at 2 15 24 PM" src="https://user-images.githubusercontent.com/9664363/83570802-8be42800-a4db-11ea-9d9d-0da3b304263d.png">
