### PR TITLE
Update Node.js version check, drop Node v13 support

### DIFF
--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -1,36 +1,39 @@
 #!/usr/bin/env node
 
-var match = process.version.match(/v(\d+)\.(\d+)/);
+function red(text) {
+  return '\u001b[31m' + text + '\u001b[39m';
+}
+function yellow(text) {
+  return '\u001b[33m' + text + '\u001b[39m';
+}
+
+var match = /v(\d+)\.(\d+)/.exec(process.version);
 var major = parseInt(match[1], 10);
 var minor = parseInt(match[2], 10);
 
-// If older than 10.13, or if 11.x
-if (major < 10 || (major === 10 && minor < 13) || major === 11) {
-  console.error(
-    '\x1B[31mERROR: Node.js ' +
-      process.version +
-      ' is no longer supported.\x1B[39m\n' +
-      '\x1B[31m\x1B[39m\n' +
-      '\x1B[31mexpo-cli supports following Node.js versions:\x1B[39m\n' +
-      '\x1B[31m* >=10.13.0 <11.0.0 (Active LTS)\x1B[39m\n' +
-      '\x1B[31m* >=12.0.0 <13.0.0 (Active LTS)\x1B[39m\n' +
-      '\x1B[31m* >=13.0.0 <14.0.0 (Current Release)\x1B[39m'
-  );
-  process.exit(1);
-}
+var supportedVersions =
+  'expo-cli supports following Node.js versions:\n' +
+  '* >=10.13.0 <11.0.0 (Maintenance LTS)\n' +
+  '* >=12.13.0 <13.0.0 (Active LTS)\n' +
+  '* >=14.0.0  <15.0.0 (Current Release)\n';
 
 // If newer than the current release
 if (major > 14) {
-  console.error(
-    '\x1B[33mWARNING: expo-cli has not yet been tested against Node.js ' +
-      process.version +
-      '. If you encounter any issues, please report them to https://github.com/expo/expo-cli/issues\x1B[39m\n' +
-      '\x1B[33m\x1B[39m\n' +
-      '\x1B[33mexpo-cli supports following Node.js versions:\x1B[39m\n' +
-      '\x1B[33m* >=10.13.0 <11.0.0 (Active LTS)\x1B[39m\n' +
-      '\x1B[33m* >=12.0.0 <13.0.0 (Active LTS)\x1B[39m\n' +
-      '\x1B[33m* >=13.0.0 <14.0.0 (Current Release)\x1B[39m'
+  console.warn(
+    yellow(
+      'WARNING: expo-cli has not yet been tested against Node.js ' +
+        process.version +
+        '.\n' +
+        'If you encounter any issues, please report them to https://github.com/expo/expo-cli/issues\n' +
+        '\n' +
+        supportedVersions
+    )
   );
+} else if (!((major === 10 && minor >= 13) || (major === 12 && minor >= 13) || major === 14)) {
+  console.error(
+    red('ERROR: Node.js ' + process.version + ' is no longer supported.\n\n' + supportedVersions)
+  );
+  process.exit(1);
 }
 
 require('../build/exp.js').run('expo');


### PR DESCRIPTION
- Drop support for Node 13 ([end-of-life 2020-06-01](https://github.com/nodejs/Release#end-of-life-releases))
- Drop support for Node 12.0.0-12.13.0. ([LTS started from 12.13.0](https://nodejs.org/en/blog/release/v12.13.0/))
- Node 14 is now "current release", adjust the text accordingly
- Node 10 is now "maintenance LTS", adjust the text accordingly
- Clean up the entry point file to make it easier to edit.