### PR TITLE
Add CWD parameter to child process spawn

### DIFF
--- a/packages/config/src/getConfig.ts
+++ b/packages/config/src/getConfig.ts
@@ -58,7 +58,7 @@ function evalConfig(configFile: string, request: ConfigContext): DynamicConfigRe
       configFile,
       JSON.stringify({ ...request, config: serializeAndEvaluate(request.config) }),
     ],
-    {}
+    { cwd: request.projectRoot }
   );
 
   if (spawnResults.status === 0) {


### PR DESCRIPTION
Hello,
I am a maintainer of [React Native Tools](https://github.com/microsoft/vscode-react-native) VS Code extension. The extension is used for debugging React Native (including Expo) applications.
We faced [the issue](https://github.com/microsoft/vscode-react-native/issues/1302), when we were trying to use [dynamic project configuration](https://docs.expo.io/workflow/configuration/#typescript-config) and [babel-plugin-dotenv-import](https://github.com/tusbar/babel-plugin-dotenv-import). Our extension uses `@expo/xdl` package to start Expo server. But when the [`evalConfig`](https://github.com/expo/expo-cli/blob/master/packages/config/src/getConfig.ts#L52) method is being executed, we get an error that `@env` module doesn't exist. We found out that this happens due to incorrect CWD parameter in case of usage of this function within VS Code context. When we start the extension `process.cwd` isn't the same as the project root (on macOS it is `/`). But we found out that if we add correct CWD to spawn options, everything works fine.
This fix should increase the stability of `evalConfig` method work.