### PR TITLE
Allow providing a postExport hook

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -48,10 +48,15 @@ export type HookArguments = {
   projectRoot: string;
   log: (msg: any) => void;
 };
-export type PostPublishHook = {
+
+type BaseHook = {
   file: string;
   config: any;
 };
+
+export type PostPublishHook = BaseHook;
+export type PostExportHook = BaseHook;
+export type HookType = 'postPublish' | 'postExport';
 
 type ExpoOrientation = 'default' | 'portrait' | 'landscape';
 type ExpoPrivacy = 'public' | 'unlisted';
@@ -977,6 +982,7 @@ export type ExpoConfig = {
    */
   hooks?: {
     postPublish?: PostPublishHook[];
+    postExport?: PostExportHook[];
   };
   /**
    * An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.io/guides/offline-support/)

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -49,13 +49,11 @@ export type HookArguments = {
   log: (msg: any) => void;
 };
 
-type BaseHook = {
+export type Hook = {
   file: string;
   config: any;
 };
 
-export type PostPublishHook = BaseHook;
-export type PostExportHook = BaseHook;
 export type HookType = 'postPublish' | 'postExport';
 
 type ExpoOrientation = 'default' | 'portrait' | 'landscape';
@@ -981,9 +979,9 @@ export type ExpoConfig = {
    * Configuration for scripts to run to hook into the publish process
    */
   hooks?: {
-    postPublish?: PostPublishHook[];
-    postExport?: PostExportHook[];
+    [key in HookType]?: Hook[];
   };
+
   /**
    * An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.io/guides/offline-support/)
    */

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1,11 +1,10 @@
 import {
   ExpoConfig,
+  Hook,
   HookArguments,
   HookType,
   PackageJSONConfig,
   Platform,
-  PostExportHook,
-  PostPublishHook,
   ProjectTarget,
   configFilename,
   getConfig,
@@ -132,7 +131,7 @@ type SelfHostedIndex = PublicConfig & {
   dependencies: string[];
 };
 
-type LoadedHook = PostPublishHook & {
+type LoadedHook = BaseHook & {
   _fn: (input: HookArguments) => any;
 };
 

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -725,29 +725,28 @@ export async function exportForAppHosting(
     );
   }
 
-    const hookOptions = {
-      url: null,
-      exp,
-      iosBundle,
-      iosSourceMap,
-      iosManifest,
-      androidBundle,
-      androidSourceMap,
-      androidManifest,
-      projectRoot,
-      log: (msg: any) => {
-        logger.global.info({ quiet: true }, msg);
-      },
-    };
+  const hookOptions = {
+    url: null,
+    exp,
+    iosBundle,
+    iosSourceMap,
+    iosManifest,
+    androidBundle,
+    androidSourceMap,
+    androidManifest,
+    projectRoot,
+    log: (msg: any) => {
+      logger.global.info({ quiet: true }, msg);
+    },
+  };
 
-    for (let hook of validPostExportHooks) {
-      logger.global.info(`Running postExport hook: ${hook.file}`);
+  for (let hook of validPostExportHooks) {
+    logger.global.info(`Running postExport hook: ${hook.file}`);
 
-      try {
-        runHook(hook, hookOptions);
-      } catch (e) {
-        logger.global.warn(`Warning: postExport hook '${hook.file}' failed: ${e.stack}`);
-      }
+    try {
+      runHook(hook, hookOptions);
+    } catch (e) {
+      logger.global.warn(`Warning: postExport hook '${hook.file}' failed: ${e.stack}`);
     }
   }
 

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -131,7 +131,7 @@ type SelfHostedIndex = PublicConfig & {
   dependencies: string[];
 };
 
-type LoadedHook = BaseHook & {
+type LoadedHook = Hook & {
   _fn: (input: HookArguments) => any;
 };
 

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -517,8 +517,6 @@ function prepareHooks(
     });
 
     if (hooks[hookType] !== undefined && validHooks.length !== hooks[hookType]?.length) {
-      logger.global.error();
-
       throw new XDLError(
         'HOOK_INITIALIZATION_ERROR',
         `Please fix your ${hookType} hook configuration`

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -508,7 +508,7 @@ function prepareHooks(
       let fn = _requireFromProject(file, projectRoot, exp);
       if (typeof fn !== 'function') {
         logger.global.error(
-          `Unable to load ${hookType}Hook: '${file}'. The module does not export a function.`
+          `Unable to load ${hookType} hook: '${file}'. The module does not export a function.`
         );
       } else {
         hook._fn = fn;
@@ -516,12 +516,12 @@ function prepareHooks(
       }
     });
 
-    if (validHooks.length !== hooks[hookType]?.length) {
+    if (hooks[hookType] !== undefined && validHooks.length !== hooks[hookType]?.length) {
       logger.global.error();
 
       throw new XDLError(
         'HOOK_INITIALIZATION_ERROR',
-        `Please fix your ${hookType} hook configuration.`
+        `Please fix your ${hookType} hook configuration`
       );
     }
   }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -687,10 +687,10 @@ export async function exportForAppHosting(
   let iosSourceMap = null;
   let androidSourceMap = null;
 
-  // build source maps
-  if (options.dumpSourcemap) {
+  // Build sourcemaps when `postExport` hook is set up or when `dumpSourcemap` argument is passed
+  if (options.dumpSourcemap || (hooks?.postExport && hooks.postExport?.length > 0)) {
     ({ iosSourceMap, androidSourceMap } = await _buildSourceMapsAsync(projectRoot));
-    // write the sourcemap files
+    // Write the sourcemap files
     const iosMapName = `ios-${iosBundleHash}.map`;
     const iosMapPath = path.join(outputDir, 'bundles', iosMapName);
     await writeArtifactSafelyAsync(projectRoot, null, iosMapPath, iosSourceMap);

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -503,8 +503,8 @@ function prepareHooks(
 ) {
   const validHooks: LoadedHook[] = [];
 
-  if (hooks !== undefined && hooks[hookType]) {
-    hooks[hookType].forEach((hook: any) => {
+  if (hooks) {
+    hooks[hookType]?.forEach((hook: any) => {
       let { file } = hook;
       let fn = _requireFromProject(file, projectRoot, exp);
       if (typeof fn !== 'function') {
@@ -517,7 +517,7 @@ function prepareHooks(
       }
     });
 
-    if (validHooks.length !== hooks[hookType].length) {
+    if (validHooks.length !== hooks[hookType]?.length) {
       logger.global.error();
 
       throw new XDLError(

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -727,12 +727,6 @@ export async function exportForAppHosting(
     );
   }
 
-  if (
-    validPostExportHooks.length ||
-    (exp.ios && exp.ios.publishManifestPath) ||
-    (exp.android && exp.android.publishManifestPath) ||
-    EmbeddedAssets.shouldEmbedAssetsForExpoUpdates(projectRoot, exp, pkg, target)
-  ) {
     const hookOptions = {
       url: null,
       exp,


### PR DESCRIPTION
We would like to upload our sourcemaps to Sentry after creating an export. Since we don't publish our assets to Expo (we just create a local CDN, export our assets and then generate a build using Turtle), we cannot rely on the existing `postPublish` hook.

As @fson mentioned in https://github.com/expo/expo-cli/issues/298#issuecomment-454192941, it would be nice to have a `postExport` hook.

## Testing

I tested this locally by running:

```
/Users/vernondegoede/Sites/expo-cli/packages/expo-cli/bin/expo.js export --dump-sourcemap --public-url=https://localhost:3000
```

Outcome (left some stuff out intentionally):

```
[...]
Saving blah.png
Saving foo.png
Files successfully saved.
Processing asset bundle patterns:
- /Users/vernondegoede/Sites/mollie-mobile/**/*
Building sourcemaps
Configuring sourcemaps
Preparing additional debugging files
Running postExport hook: sentry-expo/upload-sourcemaps
Export was successful. Your exported files can be found in dist
Created release WZxxxxxxx.

> Analyzing 4 sources
> Rewriting sources
> Adding source map references
> Bundled 4 files for upload
> Uploaded release files to Sentry
> File processing complete

Source Map Upload Report
  Minified Scripts
    ~/main.android.bundle (sourcemap at main.android.map)
    ~/main.ios.bundle (sourcemap at main.ios.map)
  Source Maps
    ~/main.android.map
    ~/main.ios.map
[...]
```