### PR TITLE
[scripts] add publish support for alpha tags

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,6 +3,15 @@ let path = require('path');
 let spawnAsync = require('@expo/spawn-async');
 
 let lerna = path.join(__dirname, '../node_modules/.bin/lerna');
+const shouldPrerelease = isPrelease();
+
+function isPrelease() {
+  const bumpFlagIndex = process.argv.findIndex(arg => arg === '--bump');
+  const prereleaseArgIndex = process.argv.findIndex(arg => arg === 'prerelease');
+  return (
+    bumpFlagIndex !== -1 && prereleaseArgIndex !== -1 && bumpFlagIndex + 1 === prereleaseArgIndex
+  );
+}
 
 async function run() {
   await spawnAsync(lerna, ['version', '--exact', ...process.argv.slice(2)], { stdio: 'inherit' });
@@ -52,6 +61,9 @@ async function run() {
     console.log();
     console.log('🚢 Publishing', name);
     const args = ['publish', '--access', 'public'];
+    if (shouldPrerelease) {
+      args.push('--tag', 'alpha');
+    }
     if (name === 'expo-cli') {
       args.push('--tag', 'next');
       console.log(`  using dist-tag 'next', run 'npm dist-tag add ${name}@${version} latest'`);

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,9 +3,9 @@ let path = require('path');
 let spawnAsync = require('@expo/spawn-async');
 
 let lerna = path.join(__dirname, '../node_modules/.bin/lerna');
-const shouldPrerelease = isPrelease();
+const shouldPrerelease = isPrerelease();
 
-function isPrelease() {
+function isPrerelease() {
   const bumpFlagIndex = process.argv.findIndex(arg => arg === '--bump');
   const prereleaseArgIndex = process.argv.findIndex(arg => arg === 'prerelease');
   return (


### PR DESCRIPTION
# why
when someone runs `./scripts/publish.js --bump prerelease`, add an alpha tag so we do `npm publish --tag alpha`. We want to do this because otherwise, npm will mark the prerelease as `latest`

# testing

- [ ] manually tested `isPrelease` function

