### PR TITLE
Enable setting the allowBackup attribute for the AndroidManifest

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -178,6 +178,13 @@ export type AndroidPlatformConfig = {
   versionCode?: number;
 
   /**
+   * Configure the `android:allowBackup` attribute in the AndroidManifest. Backups are enabled by default.
+   * If this is set to false, no backup or restore of the application will ever be performed, even by a full-system backup:
+   * https://developer.android.com/guide/topics/manifest/application-element#allowbackup
+   */
+  allowBackup?: boolean;
+
+  /**
    * The background color for your app, behind any of your React views. This is also known as the root view background color. This value should be a 6 character long hex color string, eg: '#000000'. Default is white — '#ffffff'.
    * Overrides the top-level `backgroundColor` key if it is present.
    */

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -388,6 +388,11 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
     versionCode = manifest.android.versionCode;
   }
 
+  let allowBackup = true;
+  if (manifest.android.allowBackup !== undefined) {
+    allowBackup = manifest.android.allowBackup;
+  }
+
   if (!javaPackage) {
     throw new Error(
       'Must specify androidPackage option (either from manifest or on command line).'
@@ -534,6 +539,15 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       /host\.exp\.exponent\.permission\.C2D_MESSAGE/g,
       `${javaPackage}.permission.C2D_MESSAGE`,
       path.join(shellPath, 'expoview', 'src', 'main', 'AndroidManifest.xml')
+    );
+  }
+
+  // Optionally disable backups. This flag is present by default in AndroidManifest.xml
+  if (!allowBackup) {
+    await regexFileAsync(
+      'android:allowBackup="true"',
+      'android:allowBackup="false"',
+      path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
     );
   }
 


### PR DESCRIPTION
Allows toggling the `android:allowBackup` attribute for standalone builds via app.json config.

Currently the allowBackup attribute is set to `true` for all expo [standalone builds](https://github.com/expo/expo/blob/master/template-files/android/AndroidManifest.xml#L50), and it's impossible to set to false without ejecting (where false is the default for the [bare android project](https://github.com/expo/expo/blob/master/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml#L28)). This leads to problems for apps which want to opt-out of system backups for security and other reasons, but don’t need to eject otherwise.

I've added the `allowBackup` flag in app.json to mirror the behaviour of the android attribute.
The value is true by default, which results in no change for current usage.
If the template sets `android:allowBackup` to false, or omits it entirely, then the config will have no effect (eject workflow).

## Testing

There’s no current testing in expo-cli for build file manipulation other than a minimal eject test. I checked this change has no effect on the AndroidManifest.xml generated in this test, as expected.

### Eject workflow

I tested by creating a minimal expo app, setting the new property, and then ejecting. The resulting project was unchanged, as expected.

### Standalone build

I tested by installing turtle, making it use the locally modified version of `@expo/xdl` and running an android build, verifying the resulting build had the allowBackup attribute as expected in the AndroidManifest.xml.

## Schemas

Note that the app.json schema validation needed disabling for expo-cli to publish with the added property -- these schemas appear to be downloaded, and I'm not sure how they are updated for new versions.

