### PR TITLE
[xdl] Fix iOS shell app generation

### DIFF
--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -31,6 +31,8 @@ import * as Versions from '../Versions';
 import installPackagesAsync from './installPackagesAsync';
 import logger from './Logger';
 
+const SERVICE_CONTEXT_PROJECT_NAME = 'exponent-view-template';
+
 async function yesnoAsync(message) {
   const { ok } = await inquirer.prompt([
     {
@@ -360,7 +362,7 @@ async function readNullableConfigJsonAsync(projectDir) {
 
 async function prepareDetachedBuildIosAsync(projectDir, args) {
   const config = await readNullableConfigJsonAsync(projectDir);
-  if (config) {
+  if (config && config.exp.name !== SERVICE_CONTEXT_PROJECT_NAME) {
     return prepareDetachedUserContextIosAsync(projectDir, config.exp, args);
   } else {
     return prepareDetachedServiceContextIosAsync(projectDir, args);
@@ -513,7 +515,7 @@ export async function prepareDetachedBuildAsync(projectDir, args) {
 // `android/app/expo.gradle` for an example).
 export async function bundleAssetsAsync(projectDir, args) {
   const options = await readNullableConfigJsonAsync(projectDir);
-  if (!options) {
+  if (!options || options.exp.name === SERVICE_CONTEXT_PROJECT_NAME) {
     // Don't run assets bundling for the service context.
     return;
   }

--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -63,7 +63,7 @@ function _renderExpoKitDependency(options, sdkVersion) {
   let attributes;
   if (options.expoKitPath) {
     attributes = {
-      path: options.expoKitPath,
+      path: path.join(options.expoKitPath, 'ios'),
     };
   } else if (options.expoKitTag) {
     attributes = {

--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -206,9 +206,9 @@ async function _createStandaloneContextAsync(args) {
   }
 
   let bundleExecutable = args.type === 'client' ? EXPONENT_APP : EXPOKIT_APP;
-  if (manifest.ios && manifest.ios.infoPlist && manifest.ios.infoPlist.CFBundleExecutable) {
+  if (manifest?.ios?.infoPlist?.CFBundleExecutable) {
     bundleExecutable = manifest.ios.infoPlist.CFBundleExecutable;
-  } else if (privateConfig && privateConfig.bundleIdentifier) {
+  } else if (privateConfig?.bundleIdentifier) {
     bundleExecutable = pascalCase(privateConfig.bundleIdentifier);
   }
 

--- a/packages/xdl/src/detach/StandaloneContext.ts
+++ b/packages/xdl/src/detach/StandaloneContext.ts
@@ -137,6 +137,10 @@ export class StandaloneContextService extends StandaloneContext {
   ) {
     super();
   }
+
+  isAnonymous = () => {
+    return true;
+  };
 }
 
 export type AnyStandaloneContext = StandaloneContextUser | StandaloneContextService;

--- a/packages/xdl/src/detach/StandaloneContext.ts
+++ b/packages/xdl/src/detach/StandaloneContext.ts
@@ -104,11 +104,12 @@ class StandaloneContext {
 
   /**
    *  On iOS we begin configuring standalone apps before we have any information about the
-   *  project's manifest.
+   *  project's manifest. By default let's treat all contexts as non-anonymous and override
+   *  it in contexts that needs this to be different.
    */
-  isAnonymous = () => {
-    return this instanceof StandaloneContextService && !this.config;
-  };
+  isAnonymous() {
+    return false;
+  }
 }
 
 export class StandaloneContextUser extends StandaloneContext {
@@ -138,9 +139,13 @@ export class StandaloneContextService extends StandaloneContext {
     super();
   }
 
-  isAnonymous = () => {
+  /**
+   *  On iOS we begin configuring standalone apps before we have any information about the
+   *  project's manifest.
+   */
+  isAnonymous() {
     return true;
-  };
+  }
 }
 
 export type AnyStandaloneContext = StandaloneContextUser | StandaloneContextService;


### PR DESCRIPTION
# Why

Prerequisite to https://github.com/expo/expo/pull/8762

# How

- As per https://github.com/expo/expo/pull/8762, I changed the directory where `ExpoKit.podspec` is stored.
- Since `app.json` config is not required and partially autogenerated, two conditions checking if the config is present have been broken so I added temporary fix for them – this code will be removed soon anyway.
- Fixed broken condition introduced here https://github.com/expo/expo-cli/commit/6e8fbc4dec5c49eab347f9a0b5f7c4005b09356c#diff-b553f80c6b38ba687014b4801a75d808R209-R210 – `manifest` can be undefined at this place.

# Test Plan

Tested together with https://github.com/expo/expo/pull/8762