### PR TITLE
[expo-cli] configure expo-updates plist/xml values in expo init

### DIFF
--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -386,16 +386,14 @@ async function configureUpdatesProjectFilesAsync(
   const result = await AndroidConfig.Updates.setUpdatesConfig(exp, androidManifestJSON, username);
   await AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, result);
 
-  // apply iOS config if on macOS
-  if (process.platform === 'darwin') {
-    const supportingDirectory = path.join(projectRoot, 'ios', initialConfig.name, 'Supporting');
-    try {
-      await IosPlist.modifyAsync(supportingDirectory, 'Expo', expoPlist => {
-        return IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, username);
-      });
-    } finally {
-      await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
-    }
+  // apply iOS config
+  const supportingDirectory = path.join(projectRoot, 'ios', initialConfig.name, 'Supporting');
+  try {
+    await IosPlist.modifyAsync(supportingDirectory, 'Expo', expoPlist => {
+      return IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, username);
+    });
+  } finally {
+    await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
   }
 }
 

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -372,15 +372,8 @@ async function configureUpdatesProjectFilesAsync(
   username: string
 ) {
   const { exp } = await getConfig(projectRoot);
-  const supportingDirectory = path.join(projectRoot, 'ios', initialConfig.name, 'Supporting');
-  try {
-    await IosPlist.modifyAsync(supportingDirectory, 'Expo', expoPlist => {
-      return IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, username);
-    });
-  } finally {
-    await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
-  }
 
+  // apply Android config
   const androidManifestPath = await AndroidConfig.Manifest.getProjectAndroidManifestPathAsync(
     projectRoot
   );
@@ -392,6 +385,18 @@ async function configureUpdatesProjectFilesAsync(
   );
   const result = await AndroidConfig.Updates.setUpdatesConfig(exp, androidManifestJSON, username);
   await AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, result);
+
+  // apply iOS config if on macOS
+  if (process.platform === 'darwin') {
+    const supportingDirectory = path.join(projectRoot, 'ios', initialConfig.name, 'Supporting');
+    try {
+      await IosPlist.modifyAsync(supportingDirectory, 'Expo', expoPlist => {
+        return IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, username);
+      });
+    } finally {
+      await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
+    }
+  }
 }
 
 async function installPodsAsync(projectRoot: string) {


### PR DESCRIPTION
Currently if you want to try out OTA updates in a new bare project, this is what likely happens

- expo init bare
- make release build
- expo publish
- relaunch app, OTA update doesn't load ???

This is because expo-updates depends on some native configuration values in Expo.plist/AndroidManifest.xml. `expo publish` sets these values automatically, but in the flow above, by the time the user runs `expo publish` they have already made a release build without the necessary values.

This PR adds configuring these fields with best-guess values on `expo init`. We need the SDK version and project URL; we can get the SDK version from the project config, and we can make a best guess of the URL by combining the project slug with the logged-in user's username. We also show a message warning the user they'll need to change these values if they publish under a different user (although `expo publish` will do this automatically), or letting them know if we can't configure these values at all for some reason.

Todo next:
- same thing in eject
- configure more values from app.json `updates` field in eject, if they exist