### PR TITLE
[xdl] set EXPO_TARGET to correct value when starting dev server

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2215,8 +2215,9 @@ async function startDevServerAsync(projectRoot: string, startOptions: StartOptio
   if (startOptions.target) {
     // EXPO_TARGET is used by @expo/metro-config to determine the target when getDefaultConfig is
     // called from metro.config.js and the --target option is used to override the default target.
-    process.env.EXPO_TARGET = options.target;
+    process.env.EXPO_TARGET = startOptions.target;
   }
+
   const { middleware } = await runMetroDevServerAsync(projectRoot, options);
   middleware.use(getManifestHandler(projectRoot));
 }


### PR DESCRIPTION
When trying to publish a project from inside expo/expo, I am getting the following error:

```
Error: Invalid target: 'undefined'. Debug info:
{
  "EXPO_TARGET": "undefined",
  "default": "managed"
}
    at getDefaultConfig (/Users/eric/.volta/tools/image/packages/expo-cli/3.21.5/node_modules/@expo/metro-config/src/ExpoMetroConfig.ts:45:11)
    at Object.loadAsync (/Users/eric/.volta/tools/image/packages/expo-cli/3.21.5/node_modules/@expo/metro-config/src/ExpoMetroConfig.ts:107:23)
    at runMetroDevServerAsync (/Users/eric/.volta/tools/image/packages/expo-cli/3.21.5/node_modules/@expo/dev-server/src/MetroDevServer.ts:17:45)
    at startDevServerAsync (/@expo/xdl@57.9.13/src/Project.ts:2166:32)
    at Object.startAsync (/@expo/xdl@57.9.13/src/Project.ts:2406:5)
    at action (/Users/eric/.volta/tools/image/packages/expo-cli/3.21.5/src/commands/publish.ts:103:5)
    at Command.<anonymous> (/Users/eric/.volta/tools/image/packages/expo-cli/3.21.5/src/exp.ts:80:7)
```

Digging in, it looks like this is caused by setting the `EXPO_TARGET` env var to a value that is always undefined -- which actually causes it to be read as the string `"undefined"` by @expo/metro-config. Changing this to the correct value fixed the issue and let the publish succeed.