### PR TITLE
Adjust config types to take defaults in account

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -764,7 +764,7 @@ export type ExpoConfig = {
   /**
    * The name of your app as it appears both within Expo and on your home screen as a standalone app.
    */
-  name?: string;
+  name: string;
   /**
    * A short description of what your app is and why it is great.
    */
@@ -773,7 +773,7 @@ export type ExpoConfig = {
    * The friendly url name for publishing. eg: `expo.io/@your-username/slug`.
    * @pattern ^[a-zA-Z0-9_\\-]+$
    */
-  slug?: string;
+  slug: string;
   /**
    * The background color for your app, behind any of your React views. This is also known as the root view background color. This value should be a 6 character long hex color string, eg: '#000000'. Default is white — '#ffffff'.
    */
@@ -794,11 +794,11 @@ export type ExpoConfig = {
   /**
    * Your app version, use whatever versioning scheme that you like.
    */
-  version?: string;
+  version: string;
   /**
    * Platforms that your project explicitly supports. If not specified, it defaults to `[\"ios\", \"android\"]`.
    */
-  platforms?: Platform[];
+  platforms: Platform[];
   /**
    * If you would like to share the source code of your app on Github, enter the URL for the repository here and it will be linked to from your Expo project page.
    * @pattern ^https://github\\.com/

--- a/packages/config/src/ios/Scheme.ts
+++ b/packages/config/src/ios/Scheme.ts
@@ -1,11 +1,11 @@
 import { InfoPlist, URLScheme } from './IosConfig.types';
 import { ExpoConfig } from '../Config.types';
 
-export function getScheme(config: ExpoConfig): string | null {
+export function getScheme(config: Pick<ExpoConfig, 'scheme'>): string | null {
   return typeof config.scheme === 'string' ? config.scheme : null;
 }
 
-export function setScheme(config: ExpoConfig, infoPlist: InfoPlist): InfoPlist {
+export function setScheme(config: Pick<ExpoConfig, 'scheme'>, infoPlist: InfoPlist): InfoPlist {
   let scheme = getScheme(config);
   if (!scheme) {
     return infoPlist;

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -16,7 +16,7 @@ import { BuilderOptions } from './BaseBuilder.types';
 const secondsToMilliseconds = (seconds: number): number => seconds * 1000;
 
 export default class BaseBuilder {
-  manifest: ExpoConfig = {};
+  manifest: ExpoConfig = getConfig(this.projectDir).exp;
   user?: User;
 
   constructor(public projectDir: string, public options: BuilderOptions = {}) {}
@@ -54,9 +54,6 @@ export default class BaseBuilder {
   }
 
   async prepareProjectInfo(): Promise<void> {
-    // always use local json to unify behavior between regular apps and self hosted ones
-    const { exp } = getConfig(this.projectDir);
-    this.manifest = exp;
     this.user = await UserManager.ensureLoggedInAsync();
 
     await this.checkProjectConfig();

--- a/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
+++ b/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../credentials/test-fixtures/mocks-ios';
 import { mockExpoXDL } from '../../../__tests__/mock-utils';
 
-jest.setTimeout(10 * 1000); // 10s
+jest.setTimeout(30e3); // 30s
 
 jest.mock('fs');
 

--- a/packages/expo-cli/src/commands/client/clientBuildApi.ts
+++ b/packages/expo-cli/src/commands/client/clientBuildApi.ts
@@ -12,7 +12,7 @@ export type ClientBuildRequestOptions = {
   addUdid: any;
   email: any;
   bundleIdentifier: string;
-  customAppConfig: ExpoConfig;
+  customAppConfig: ExpoConfig | {};
 };
 
 export async function createClientBuildRequest({

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -447,7 +447,7 @@ async function promptForManagedConfig(
   parentDir: string,
   dirName: string | undefined,
   options: Options
-): Promise<AppJSONConfig> {
+): Promise<{ expo: Pick<ExpoConfig, 'name' | 'slug'> }> {
   let slug;
   if (dirName) {
     slug = dirName;
@@ -460,7 +460,7 @@ async function promptForManagedConfig(
       validate: (name: string) => validateName(parentDir, name),
     }));
   }
-  const expo: ExpoConfig = { name: slug, slug };
+  const expo = { name: slug, slug };
   if (options.name) {
     expo.name = options.name;
   }

--- a/packages/pwa/src/Manifest.ts
+++ b/packages/pwa/src/Manifest.ts
@@ -7,7 +7,7 @@ import {
   getWebOutputPath,
 } from '@expo/config';
 
-import { IconOptions, Manifest } from './Manifest.types';
+import { IconOptions, Manifest, PWAConfig } from './Manifest.types';
 
 // Use root to work better with create-react-app
 const DEFAULT_LANGUAGE_ISO_CODE = `en`;
@@ -37,12 +37,12 @@ function sanitizePublicPath(publicPath: unknown): string {
   return publicPath + '/';
 }
 
-export function getConfigForPWA(projectRoot: string) {
+export function getConfigForPWA(projectRoot: string): PWAConfig {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   return ensurePWAConfig(exp);
 }
 
-function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
+function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): PWAConfig {
   // For RN CLI support
   const appManifest = appJSON.expo || appJSON || {};
   const { web: webManifest = {}, splash = {}, ios = {}, android = {} } = appManifest;
@@ -260,7 +260,7 @@ export function getChromeIconConfig(config: ExpoConfig): IconOptions | null {
   return null;
 }
 
-function ensurePWAConfig(appJSON: AppJSONConfig | ExpoConfig): ExpoConfig {
+function ensurePWAConfig(appJSON: AppJSONConfig | ExpoConfig): PWAConfig {
   const config = applyWebDefaults(appJSON);
   return config;
 }

--- a/packages/pwa/src/Manifest.types.ts
+++ b/packages/pwa/src/Manifest.types.ts
@@ -1,4 +1,9 @@
+import { ExpoConfig, WebPlatformConfig } from '@expo/config';
 import { ImageOptions } from '@expo/image-utils';
+
+export type WebPlatformConfigWithDefaults = WebPlatformConfig &
+  Required<Pick<ExpoConfig, 'build' | 'lang' | 'meta'>>;
+export type PWAConfig = ExpoConfig & { web: WebPlatformConfigWithDefaults };
 
 export type Direction = 'ltr' | 'rtl' | 'auto';
 

--- a/packages/pwa/src/index.ts
+++ b/packages/pwa/src/index.ts
@@ -280,4 +280,4 @@ export {
   getChromeIconConfig,
 } from './Manifest';
 
-export { IconOptions, ProjectOptions, HTMLOutput } from './Manifest.types';
+export { IconOptions, ProjectOptions, HTMLOutput, PWAConfig } from './Manifest.types';

--- a/packages/webpack-config/src/env/getConfig.ts
+++ b/packages/webpack-config/src/env/getConfig.ts
@@ -1,5 +1,4 @@
-import { ExpoConfig } from '@expo/config';
-import { getConfigForPWA } from 'expo-pwa';
+import { PWAConfig, getConfigForPWA } from 'expo-pwa';
 
 import { Environment } from '../types';
 
@@ -9,7 +8,7 @@ import { Environment } from '../types';
  * @param env Environment properties used for getting the Expo project config.
  * @category env
  */
-function getConfig(env: Pick<Environment, 'projectRoot' | 'config'>): ExpoConfig {
+function getConfig(env: Pick<Environment, 'projectRoot' | 'config'>): PWAConfig {
   if (env.config) {
     return env.config;
   }

--- a/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoInterpolateHtmlPlugin.ts
@@ -17,12 +17,11 @@ export default class InterpolateHtmlPlugin extends OriginalInterpolateHtmlPlugin
     const config = env.config || getConfig(env);
     const { publicPath } = getPublicPaths(env);
 
-    const { lang } = config.web;
-
     return new InterpolateHtmlPlugin(HtmlWebpackPlugin, {
       WEB_PUBLIC_URL: publicPath,
-      WEB_TITLE: config.web.name,
-      LANG_ISO_CODE: lang,
+      // @ts-ignore Type 'string | undefined' is not assignable to type 'string'.
+      WEB_TITLE: config.web?.name,
+      LANG_ISO_CODE: config.web?.lang,
       // These are for legacy ejected web/index.html files
       NO_SCRIPT: `<form action="" style="background-color:#fff;position:fixed;top:0;left:0;right:0;bottom:0;z-index:9999;"><div style="font-size:18px;font-family:Helvetica,sans-serif;line-height:24px;margin:10%;width:80%;"> <p>Oh no! It looks like JavaScript is not enabled in your browser.</p> <p style="margin:20px 0;"> <button type="submit" style="background-color: #4630EB; border-radius: 100px; border: none; box-shadow: none; color: #fff; cursor: pointer; font-weight: bold; line-height: 20px; padding: 6px 16px;">Reload</button> </p> </div> </form>`,
       ROOT_ID: 'root',

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -4,6 +4,7 @@ import {
   ProxyConfigMap,
   Configuration as WebpackDevServerConfiguration,
 } from 'webpack-dev-server';
+import { PWAConfig } from 'expo-pwa';
 
 export interface DevConfiguration extends WebpackConfiguration {
   devServer?: WebpackDevServerConfiguration;
@@ -44,7 +45,7 @@ export type Environment = {
    *
    * @default undefined
    */
-  config: { [key: string]: any };
+  config: PWAConfig;
   /**
    * Paths used to locate where things are.
    */

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -354,7 +354,7 @@ export async function getProjectNameAsync(projectRoot: string): Promise<string> 
   const { exp } = ConfigUtils.getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
-  const { webName } = ConfigUtils.getNameFromConfig(exp);
+  const webName = ConfigUtils.getNameFromConfig(exp).webName ?? exp.name;
   return webName;
 }
 


### PR DESCRIPTION
Some fields (`name`, `slug`, `version`, `platforms`) are always set in `ExpoConfig` because they have default values.

Make sure the `ExpoConfig` type reflects these default and also rewrite `ensureConfigHasDefaultValues` to allow it to pass type checking.