### PR TITLE
fix: replace last instances of newestSdkVersion with newestReleasedSd…

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -71,7 +71,7 @@ export default class BaseBuilder {
     // Warn user if building a project using the next deprecated SDK version
     let oldestSupportedMajorVersion = await Versions.oldestSupportedMajorVersionAsync();
     if (semver.major(this.manifest.sdkVersion!) === oldestSupportedMajorVersion) {
-      let { version } = await Versions.newestSdkVersionAsync();
+      let { version } = await Versions.newestReleasedSdkVersionAsync();
       log.warn(
         `\nSDK${oldestSupportedMajorVersion} will be ${chalk.bold(
           'deprecated'

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -294,7 +294,7 @@ export default function (program: Command) {
       }
 
       const sdkVersions = await Versions.sdkVersionsAsync();
-      const latestSdk = await Versions.newestSdkVersionAsync();
+      const latestSdk = await Versions.newestReleasedSdkVersionAsync();
       const currentSdk = sdkVersions[currentSdkVersion!];
       const recommendedClient = currentSdk
         ? ClientUpgradeUtils.getClient(currentSdk, 'ios')
@@ -379,7 +379,7 @@ export default function (program: Command) {
       }
 
       const sdkVersions = await Versions.sdkVersionsAsync();
-      const latestSdk = await Versions.newestSdkVersionAsync();
+      const latestSdk = await Versions.newestReleasedSdkVersionAsync();
       const currentSdk = sdkVersions[currentSdkVersion!];
       const recommendedClient = currentSdk
         ? ClientUpgradeUtils.getClient(currentSdk, 'android')


### PR DESCRIPTION
…kVersionAsync

# why

When we pre-release a new SDK, the next version is available through the version endpoint. We should make sure that the release notes url has been added before using that version for anything