### PR TITLE
[expo-cli] create app on expo servers before scheduling submission

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -56,8 +56,11 @@ export type Hook = {
 
 export type HookType = 'postPublish' | 'postExport';
 
+export enum ProjectPrivacy {
+  PUBLIC = 'public',
+  UNLISTED = 'unlisted',
+}
 type ExpoOrientation = 'default' | 'portrait' | 'landscape';
-type ExpoPrivacy = 'public' | 'unlisted';
 type SplashResizeMode = 'cover' | 'contain';
 
 /**
@@ -785,7 +788,7 @@ export type ExpoConfig = {
   /**
    * Either `public` or `unlisted`. If not provided, defaults to `unlisted`. In the future `private` will be supported. `unlisted` hides the experience from search results.
    */
-  privacy?: ExpoPrivacy;
+  privacy?: ProjectPrivacy;
   /**
    * The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.
    * @pattern ^(\\d+\\.\\d+\\.\\d+)|(UNVERSIONED)$

--- a/packages/expo-cli/src/__mocks__/projects.ts
+++ b/packages/expo-cli/src/__mocks__/projects.ts
@@ -1,0 +1,17 @@
+import { ProjectPrivacy } from '@expo/config';
+import { User } from '@expo/xdl';
+import { v4 as uuidv4 } from 'uuid';
+
+interface ProjectData {
+  accountName: string;
+  projectName: string;
+  privacy?: ProjectPrivacy;
+}
+
+async function _ensureProjectExistsAsync(_user: User, _data: ProjectData): Promise<string> {
+  return uuidv4();
+}
+
+const ensureProjectExistsAsync = jest.fn(_ensureProjectExistsAsync);
+
+export { ensureProjectExistsAsync };

--- a/packages/expo-cli/src/commands/upload/submission-service/SubmissionService.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/SubmissionService.ts
@@ -17,19 +17,22 @@ const DEFAULT_CHECK_INTERVAL_MS = 5 * 1000; // 5 secs
 
 async function startSubmissionAsync(
   platform: Platform,
+  projectId: string,
   config: SubmissionConfig
 ): Promise<StartSubmissionResult> {
   const api = await getApiClientForUser();
-  const { submissionId } = await api.postAsync('app-stores/submissions', {
+  const { submissionId } = await api.postAsync(`projects/${projectId}/app-store-submissions`, {
     platform,
     config: (config as unknown) as JSONObject,
   });
   return submissionId;
 }
 
-async function getSubmissionAsync(submissionId: string): Promise<Submission> {
+async function getSubmissionAsync(projectId: string, submissionId: string): Promise<Submission> {
   const api = await getApiClientForUser();
-  const result: Submission = await api.getAsync(`app-stores/submissions/${submissionId}`);
+  const result: Submission = await api.getAsync(
+    `projects/${projectId}/app-store-submissions/${submissionId}`
+  );
   return result;
 }
 

--- a/packages/expo-cli/src/commands/upload/submission-service/__mocks__/SubmissionService.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/__mocks__/SubmissionService.ts
@@ -19,6 +19,7 @@ const submissionStore: Record<string, Submission> = {};
 
 async function startSubmissionAsync(
   platform: Platform,
+  _projectId: string,
   _config: SubmissionConfig
 ): Promise<StartSubmissionResult> {
   const id = uuid();
@@ -35,7 +36,7 @@ async function startSubmissionAsync(
   return Promise.resolve(id);
 }
 
-async function getSubmissionAsync(submissionId: string): Promise<Submission> {
+async function getSubmissionAsync(_projectId: string, submissionId: string): Promise<Submission> {
   return submissionStore[submissionId];
 }
 

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
@@ -1,5 +1,6 @@
 import os from 'os';
 
+import { UserManager } from '@expo/xdl';
 import Table from 'cli-table3';
 import fs from 'fs-extra';
 import ora from 'ora';
@@ -23,8 +24,10 @@ import { Archive, ArchiveSource, getArchiveAsync } from '../archive-source';
 import { displayLogs } from '../utils/logs';
 import { runTravelingFastlaneAsync } from '../utils/travelingFastlane';
 import { SubmissionMode } from '../types';
+import { getExpoConfig } from '../utils/config';
 import { sleep } from '../../../utils/promise';
 import log from '../../../../log';
+import { ensureProjectExistsAsync } from '../../../../projects';
 
 export interface AndroidSubmissionOptions
   extends Pick<AndroidSubmissionConfig, 'track' | 'releaseStatus'> {
@@ -45,23 +48,37 @@ class AndroidSubmitter {
   async submitAsync(): Promise<void> {
     const resolvedSourceOptions = await this.resolveSourceOptions();
     if (this.ctx.mode === SubmissionMode.online) {
-      const submissionConfig = await AndroidOnlineSubmitter.formatSubmissionConfigAndPrintSummary(
-        this.options,
-        resolvedSourceOptions
-      );
-      const onlineSubmitter = new AndroidOnlineSubmitter(
-        submissionConfig,
-        this.ctx.commandOptions.verbose ?? false
-      );
-      await onlineSubmitter.submitAsync();
+      await this.submitOnlineAsync(resolvedSourceOptions);
     } else {
-      const submissionConfig = await AndroidOfflineSubmitter.formatSubmissionConfigAndPrintSummary(
-        this.options,
-        resolvedSourceOptions
-      );
-      const offlineSubmitter = new AndroidOfflineSubmitter(submissionConfig);
-      await offlineSubmitter.submitAsync();
+      await this.submitOfflineAsync(resolvedSourceOptions);
     }
+  }
+
+  private async submitOnlineAsync(resolvedSourceOptions: ResolvedSourceOptions): Promise<void> {
+    let user = await UserManager.ensureLoggedInAsync();
+    const exp = getExpoConfig(this.ctx.projectDir);
+    const projectId = await ensureProjectExistsAsync(user, {
+      accountName: exp.owner || user.username,
+      projectName: exp.slug,
+    });
+    const submissionConfig = await AndroidOnlineSubmitter.formatSubmissionConfigAndPrintSummary(
+      { ...this.options, projectId },
+      resolvedSourceOptions
+    );
+    const onlineSubmitter = new AndroidOnlineSubmitter(
+      submissionConfig,
+      this.ctx.commandOptions.verbose ?? false
+    );
+    await onlineSubmitter.submitAsync();
+  }
+
+  private async submitOfflineAsync(resolvedSourceOptions: ResolvedSourceOptions) {
+    const submissionConfig = await AndroidOfflineSubmitter.formatSubmissionConfigAndPrintSummary(
+      this.options,
+      resolvedSourceOptions
+    );
+    const offlineSubmitter = new AndroidOfflineSubmitter(submissionConfig);
+    await offlineSubmitter.submitAsync();
   }
 
   private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {
@@ -141,11 +158,14 @@ class AndroidOfflineSubmitter {
   }
 }
 
-type AndroidOnlineSubmissionConfig = AndroidSubmissionConfig;
+export type AndroidOnlineSubmissionConfig = AndroidSubmissionConfig & { projectId: string };
+interface AndroidOnlineSubmissionOptions extends AndroidSubmissionOptions {
+  projectId: string;
+}
 
 class AndroidOnlineSubmitter {
   static async formatSubmissionConfigAndPrintSummary(
-    options: AndroidSubmissionOptions,
+    options: AndroidOnlineSubmissionOptions,
     { archive, androidPackage, serviceAccountPath }: ResolvedSourceOptions
   ): Promise<AndroidOnlineSubmissionConfig> {
     const serviceAccount = await fs.readFile(serviceAccountPath, 'utf-8');
@@ -154,7 +174,7 @@ class AndroidOnlineSubmitter {
       archiveUrl: archive.location,
       archiveType: archive.type,
       serviceAccount,
-      ...pick(options, 'track', 'releaseStatus'),
+      ...pick(options, 'track', 'releaseStatus', 'projectId'),
     };
     printSummary({
       ...omit(submissionConfig, 'serviceAccount'),
@@ -175,6 +195,7 @@ class AndroidOnlineSubmitter {
     try {
       submissionId = await SubmissionService.startSubmissionAsync(
         Platform.ANDROID,
+        this.submissionConfig.projectId,
         this.submissionConfig
       );
       scheduleSpinner.succeed();
@@ -190,7 +211,10 @@ class AndroidOnlineSubmitter {
     try {
       while (!submissionCompleted) {
         await sleep(DEFAULT_CHECK_INTERVAL_MS);
-        submission = await SubmissionService.getSubmissionAsync(submissionId);
+        submission = await SubmissionService.getSubmissionAsync(
+          this.submissionConfig.projectId,
+          submissionId
+        );
         submissionSpinner.text = AndroidOnlineSubmitter.getStatusText(submission.status);
         submissionStatus = submission.status;
         if (submissionStatus === SubmissionStatus.ERRORED) {
@@ -233,6 +257,7 @@ interface Summary {
   track: ReleaseTrack;
   releaseStatus?: ReleaseStatus;
   mode: SubmissionMode;
+  projectId?: string;
 }
 
 const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
@@ -244,6 +269,7 @@ const SummaryHumanReadableKeys: Record<keyof Summary, string> = {
   track: 'Release track',
   releaseStatus: 'Release status',
   mode: 'Submission mode',
+  projectId: 'Project ID',
 };
 
 const SummaryHumanReadableValues: Partial<Record<keyof Summary, Function>> = {

--- a/packages/expo-cli/src/projects.ts
+++ b/packages/expo-cli/src/projects.ts
@@ -1,0 +1,53 @@
+import { ProjectPrivacy } from '@expo/config';
+import { ApiV2, User } from '@expo/xdl';
+import ora from 'ora';
+
+import log from './log';
+
+interface ProjectData {
+  accountName: string;
+  projectName: string;
+  privacy?: ProjectPrivacy;
+}
+
+async function ensureProjectExistsAsync(
+  user: User,
+  { accountName, projectName, privacy }: ProjectData
+): Promise<string> {
+  const projectFullName = `@${accountName}/${projectName}`;
+
+  const spinner = ora(
+    `Ensuring project ${log.chalk.bold(projectFullName)} is registered on Expo servers`
+  ).start();
+
+  const client = ApiV2.clientForUser(user);
+  try {
+    const [{ id }] = await client.getAsync('projects', { experienceName: projectFullName });
+    spinner.succeed();
+    return id;
+  } catch (err) {
+    if (err.code !== 'EXPERIENCE_NOT_FOUND') {
+      spinner.fail(
+        `Something went wrong when looking for project ${log.chalk.bold(
+          projectFullName
+        )} on Expo servers`
+      );
+      throw err;
+    }
+  }
+  try {
+    spinner.text = `Registering project ${log.chalk.bold(projectFullName)} on Expo servers`;
+    const { id } = await client.postAsync('projects', {
+      accountName,
+      projectName,
+      privacy: privacy || ProjectPrivacy.PUBLIC,
+    });
+    spinner.succeed();
+    return id;
+  } catch (err) {
+    spinner.fail();
+    throw err;
+  }
+}
+
+export { ensureProjectExistsAsync };


### PR DESCRIPTION
Once https://github.com/expo/universe/pull/5160 is merged, submissions will be associated with projects.
This PR makes sure the project exists on Expo servers before sending the submission request to Submission Service.