### PR TITLE
[config][expo-cli] add updates config to expo eject and expo apply

### DIFF
--- a/packages/config/src/android/Manifest.ts
+++ b/packages/config/src/android/Manifest.ts
@@ -99,3 +99,30 @@ export async function readAndroidManifestAsync(manifestPath: string): Promise<Do
 export async function getPackageAsync(manifest: Document): Promise<string | null> {
   return manifest.manifest?.['$']?.package ?? null;
 }
+
+export function addMetaDataItemToMainApplication(
+  mainApplication: any,
+  itemName: string,
+  itemValue: string
+) {
+  let existingMetaDataItem;
+  const newItem = {
+    $: {
+      'android:name': itemName,
+      'android:value': itemValue,
+    },
+  };
+  if (mainApplication.hasOwnProperty('meta-data')) {
+    existingMetaDataItem = mainApplication['meta-data'].filter(
+      (e: any) => e['$']['android:name'] === itemName
+    );
+    if (existingMetaDataItem.length) {
+      existingMetaDataItem[0]['$']['android:value'] = itemValue;
+    } else {
+      mainApplication['meta-data'].push(newItem);
+    }
+  } else {
+    mainApplication['meta-data'] = [newItem];
+  }
+  return mainApplication;
+}

--- a/packages/config/src/android/Updates.ts
+++ b/packages/config/src/android/Updates.ts
@@ -1,0 +1,103 @@
+import { ExpoConfig } from '../Config.types';
+import { Document } from './Manifest';
+
+export function getUpdateUrl(config: ExpoConfig, username: string | null) {
+  const user = typeof config.owner === 'string' ? config.owner : username;
+  if (!user) {
+    return null;
+  }
+  return `https://exp.host/@${user}/${config.slug}`;
+}
+
+export function getSDKVersion(config: ExpoConfig) {
+  return typeof config.sdkVersion === 'string' ? config.sdkVersion : null;
+}
+
+export function getUpdatesEnabled(config: ExpoConfig) {
+  return config.updates?.enabled !== false;
+}
+
+export function getUpdatesTimeout(config: ExpoConfig) {
+  return config.updates?.fallbackToCacheTimeout ?? 0;
+}
+
+export function getUpdatesCheckOnLaunch(config: ExpoConfig) {
+  if (config.updates?.checkAutomatically === 'ON_ERROR_RECOVERY') {
+    return 'NEVER';
+  } else if (config.updates?.checkAutomatically === 'ON_LOAD') {
+    return 'ALWAYS';
+  }
+  return 'ALWAYS';
+}
+
+export async function setUpdatesConfig(
+  config: ExpoConfig,
+  manifestDocument: Document,
+  username: string | null
+) {
+  let mainApplication = manifestDocument.manifest.application.filter(
+    (e: any) => e['$']['android:name'] === '.MainApplication'
+  )[0];
+
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    'expo.modules.updates.ENABLED',
+    `${getUpdatesEnabled(config)}`
+  );
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    'expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH',
+    getUpdatesCheckOnLaunch(config)
+  );
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    'expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS',
+    `${getUpdatesTimeout(config)}`
+  );
+
+  const updateUrl = getUpdateUrl(config, username);
+  if (updateUrl) {
+    addMetaDataItemToMainApplication(
+      mainApplication,
+      'expo.modules.updates.EXPO_UPDATE_URL',
+      updateUrl
+    );
+  }
+  const sdkVersion = getSDKVersion(config);
+  if (sdkVersion) {
+    addMetaDataItemToMainApplication(
+      mainApplication,
+      'expo.modules.updates.EXPO_SDK_VERSION',
+      sdkVersion
+    );
+  }
+
+  return manifestDocument;
+}
+
+function addMetaDataItemToMainApplication(
+  mainApplication: any,
+  itemName: string,
+  itemValue: string
+) {
+  let existingMetaDataItem;
+  const newItem = {
+    $: {
+      'android:name': itemName,
+      'android:value': itemValue,
+    },
+  };
+  if (mainApplication.hasOwnProperty('meta-data')) {
+    existingMetaDataItem = mainApplication['meta-data'].filter(
+      (e: any) => e['$']['android:name'] === itemName
+    );
+    if (existingMetaDataItem.length) {
+      existingMetaDataItem[0]['$']['android:value'] = itemValue;
+    } else {
+      mainApplication['meta-data'].push(newItem);
+    }
+  } else {
+    mainApplication['meta-data'] = [newItem];
+  }
+  return mainApplication;
+}

--- a/packages/config/src/android/Updates.ts
+++ b/packages/config/src/android/Updates.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '../Config.types';
-import { Document } from './Manifest';
+import { Document, addMetaDataItemToMainApplication } from './Manifest';
 
 export function getUpdateUrl(config: ExpoConfig, username: string | null) {
   const user = typeof config.owner === 'string' ? config.owner : username;
@@ -73,31 +73,4 @@ export async function setUpdatesConfig(
   }
 
   return manifestDocument;
-}
-
-function addMetaDataItemToMainApplication(
-  mainApplication: any,
-  itemName: string,
-  itemValue: string
-) {
-  let existingMetaDataItem;
-  const newItem = {
-    $: {
-      'android:name': itemName,
-      'android:value': itemValue,
-    },
-  };
-  if (mainApplication.hasOwnProperty('meta-data')) {
-    existingMetaDataItem = mainApplication['meta-data'].filter(
-      (e: any) => e['$']['android:name'] === itemName
-    );
-    if (existingMetaDataItem.length) {
-      existingMetaDataItem[0]['$']['android:value'] = itemValue;
-    } else {
-      mainApplication['meta-data'].push(newItem);
-    }
-  } else {
-    mainApplication['meta-data'] = [newItem];
-  }
-  return mainApplication;
 }

--- a/packages/config/src/android/__tests__/Updates-test.js
+++ b/packages/config/src/android/__tests__/Updates-test.js
@@ -1,0 +1,80 @@
+import { resolve } from 'path';
+import * as Updates from '../Updates';
+import { readAndroidManifestAsync } from '../Manifest';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+
+describe('Android Updates config', () => {
+  it(`returns correct default values from all getters if no value provided`, () => {
+    expect(Updates.getSDKVersion({})).toBe(null);
+    expect(Updates.getUpdateUrl({}, null)).toBe(null);
+    expect(Updates.getUpdatesCheckOnLaunch({})).toBe('ALWAYS');
+    expect(Updates.getUpdatesEnabled({})).toBe(true);
+    expect(Updates.getUpdatesTimeout({})).toBe(0);
+  });
+
+  it(`returns correct value from all getters if value provided`, () => {
+    expect(Updates.getSDKVersion({ sdkVersion: '37.0.0' })).toBe('37.0.0');
+    expect(Updates.getUpdateUrl({ slug: 'my-app' }, 'user')).toBe('https://exp.host/@user/my-app');
+    expect(Updates.getUpdateUrl({ slug: 'my-app', owner: 'owner' }, 'user')).toBe(
+      'https://exp.host/@owner/my-app'
+    );
+    expect(
+      Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } })
+    ).toBe('NEVER');
+    expect(Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_LOAD' } })).toBe(
+      'ALWAYS'
+    );
+    expect(Updates.getUpdatesEnabled({ updates: { enabled: false } })).toBe(false);
+    expect(Updates.getUpdatesTimeout({ updates: { fallbackToCacheTimeout: 2000 } })).toBe(2000);
+  });
+
+  it('set correct values in AndroidManifest.xml', async () => {
+    let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+    const config = {
+      sdkVersion: '37.0.0',
+      slug: 'my-app',
+      owner: 'owner',
+      updates: {
+        enabled: false,
+        fallbackToCacheTimeout: 2000,
+        checkAutomatically: 'ON_ERROR_RECOVERY',
+      },
+    };
+    androidManifestJson = await Updates.setUpdatesConfig(config, androidManifestJson, 'user');
+    let mainApplication = androidManifestJson.manifest.application.filter(
+      e => e['$']['android:name'] === '.MainApplication'
+    )[0];
+
+    let updateUrl = mainApplication['meta-data'].filter(
+      e => e['$']['android:name'] === 'expo.modules.updates.EXPO_UPDATE_URL'
+    );
+    expect(updateUrl).toHaveLength(1);
+    expect(updateUrl[0]['$']['android:value']).toMatch('https://exp.host/@owner/my-app');
+
+    let sdkVersion = mainApplication['meta-data'].filter(
+      e => e['$']['android:name'] === 'expo.modules.updates.EXPO_SDK_VERSION'
+    );
+    expect(sdkVersion).toHaveLength(1);
+    expect(sdkVersion[0]['$']['android:value']).toMatch('37.0.0');
+
+    let enabled = mainApplication['meta-data'].filter(
+      e => e['$']['android:name'] === 'expo.modules.updates.ENABLED'
+    );
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0]['$']['android:value']).toMatch('false');
+
+    let checkOnLaunch = mainApplication['meta-data'].filter(
+      e => e['$']['android:name'] === 'expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH'
+    );
+    expect(checkOnLaunch).toHaveLength(1);
+    expect(checkOnLaunch[0]['$']['android:value']).toMatch('NEVER');
+
+    let timeout = mainApplication['meta-data'].filter(
+      e => e['$']['android:name'] === 'expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS'
+    );
+    expect(timeout).toHaveLength(1);
+    expect(timeout[0]['$']['android:value']).toMatch('2000');
+  });
+});

--- a/packages/config/src/android/index.ts
+++ b/packages/config/src/android/index.ts
@@ -19,6 +19,7 @@ import * as Scheme from './Scheme';
 import * as SplashScreen from './SplashScreen';
 import * as StatusBar from './StatusBar';
 import * as Styles from './Styles';
+import * as Updates from './Updates';
 import * as UserInterfaceStyle from './UserInterfaceStyle';
 import * as Version from './Version';
 
@@ -43,6 +44,7 @@ export {
   SplashScreen,
   StatusBar,
   Styles,
+  Updates,
   UserInterfaceStyle,
   Version,
 };

--- a/packages/config/src/ios/IosConfig.types.ts
+++ b/packages/config/src/ios/IosConfig.types.ts
@@ -25,3 +25,13 @@ export type InfoPlist = {
   UISupportedInterfaceOrientations?: Array<InterfaceOrientation>;
   GMSApiKey?: string;
 };
+
+export type ExpoPlist = {
+  EXUpdatesCheckOnLaunch?: string;
+  EXUpdatesEnabled?: boolean;
+  EXUpdatesLaunchWaitMs?: number;
+  EXUpdatesReleaseChannel?: string;
+  EXUpdatesRuntimeVersion?: string;
+  EXUpdatesSDKVersion?: string;
+  EXUpdatesURL?: string;
+};

--- a/packages/config/src/ios/Updates.ts
+++ b/packages/config/src/ios/Updates.ts
@@ -1,0 +1,63 @@
+import { ExpoPlist } from './IosConfig.types';
+import { ExpoConfig } from '../Config.types';
+
+export function getUpdateUrl(config: ExpoConfig, username: string | null) {
+  const user = typeof config.owner === 'string' ? config.owner : username;
+  if (!user) {
+    return null;
+  }
+  return `https://exp.host/@${user}/${config.slug}`;
+}
+
+export function getSDKVersion(config: ExpoConfig) {
+  return typeof config.sdkVersion === 'string' ? config.sdkVersion : null;
+}
+
+export function getUpdatesEnabled(config: ExpoConfig) {
+  return config.updates?.enabled !== false;
+}
+
+export function getUpdatesTimeout(config: ExpoConfig) {
+  return config.updates?.fallbackToCacheTimeout ?? 0;
+}
+
+export function getUpdatesCheckOnLaunch(config: ExpoConfig) {
+  if (config.updates?.checkAutomatically === 'ON_ERROR_RECOVERY') {
+    return 'NEVER';
+  } else if (config.updates?.checkAutomatically === 'ON_LOAD') {
+    return 'ALWAYS';
+  }
+  return 'ALWAYS';
+}
+
+export function setUpdatesConfig(
+  config: ExpoConfig,
+  expoPlist: ExpoPlist,
+  username: string | null
+) {
+  let newExpoPlist = {
+    ...expoPlist,
+    EXUpdatesEnabled: getUpdatesEnabled(config),
+    EXUpdatesURL: getUpdateUrl(config, username),
+    EXUpdatesCheckOnLaunch: getUpdatesCheckOnLaunch(config),
+    EXUpdatesLaunchWaitMs: getUpdatesTimeout(config),
+  };
+
+  const updateUrl = getUpdateUrl(config, username);
+  if (updateUrl) {
+    newExpoPlist = {
+      ...newExpoPlist,
+      EXUpdatesURL: updateUrl,
+    };
+  }
+
+  const sdkVersion = getSDKVersion(config);
+  if (sdkVersion) {
+    newExpoPlist = {
+      ...newExpoPlist,
+      EXUpdatesSDKVersion: sdkVersion,
+    };
+  }
+
+  return newExpoPlist;
+}

--- a/packages/config/src/ios/__tests__/Updates-test.ts
+++ b/packages/config/src/ios/__tests__/Updates-test.ts
@@ -1,0 +1,52 @@
+import * as Updates from '../Updates';
+
+describe('iOS Updates config', () => {
+  it(`returns correct default values from all getters if no value provided`, () => {
+    expect(Updates.getSDKVersion({})).toBe(null);
+    expect(Updates.getUpdateUrl({}, null)).toBe(null);
+    expect(Updates.getUpdatesCheckOnLaunch({})).toBe('ALWAYS');
+    expect(Updates.getUpdatesEnabled({})).toBe(true);
+    expect(Updates.getUpdatesTimeout({})).toBe(0);
+  });
+
+  it(`returns correct value from all getters if value provided`, () => {
+    expect(Updates.getSDKVersion({ sdkVersion: '37.0.0' })).toBe('37.0.0');
+    expect(Updates.getUpdateUrl({ slug: 'my-app' }, 'user')).toBe('https://exp.host/@user/my-app');
+    expect(Updates.getUpdateUrl({ slug: 'my-app', owner: 'owner' }, 'user')).toBe(
+      'https://exp.host/@owner/my-app'
+    );
+    expect(
+      Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } })
+    ).toBe('NEVER');
+    expect(Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_LOAD' } })).toBe(
+      'ALWAYS'
+    );
+    expect(Updates.getUpdatesEnabled({ updates: { enabled: false } })).toBe(false);
+    expect(Updates.getUpdatesTimeout({ updates: { fallbackToCacheTimeout: 2000 } })).toBe(2000);
+  });
+
+  it('sets the correct values in Expo.plist', () => {
+    expect(
+      Updates.setUpdatesConfig(
+        {
+          sdkVersion: '37.0.0',
+          slug: 'my-app',
+          owner: 'owner',
+          updates: {
+            enabled: false,
+            fallbackToCacheTimeout: 2000,
+            checkAutomatically: 'ON_ERROR_RECOVERY',
+          },
+        },
+        {},
+        'user'
+      )
+    ).toMatchObject({
+      EXUpdatesEnabled: false,
+      EXUpdatesURL: 'https://exp.host/@owner/my-app',
+      EXUpdatesCheckOnLaunch: 'NEVER',
+      EXUpdatesLaunchWaitMs: 2000,
+      EXUpdatesSDKVersion: '37.0.0',
+    });
+  });
+});

--- a/packages/config/src/ios/index.ts
+++ b/packages/config/src/ios/index.ts
@@ -12,6 +12,7 @@ import * as Entitlements from './Entitlements';
 import * as Facebook from './Facebook';
 import * as Google from './Google';
 import * as Orientation from './Orientation';
+import * as Updates from './Updates';
 
 // Placeholders
 import * as Icons from './Icons';
@@ -39,6 +40,7 @@ export {
   Orientation,
   RequiresFullScreen,
   Scheme,
+  Updates,
   UserInterfaceStyle,
   UsesNonExemptEncryption,
   Version,

--- a/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
@@ -2,6 +2,7 @@ import { AndroidConfig, getConfig } from '@expo/config';
 import { sync as globSync } from 'glob';
 import fs from 'fs-extra';
 import path from 'path';
+import { UserManager } from '@expo/xdl';
 
 async function modifyBuildGradleAsync(
   projectRoot: string,
@@ -54,6 +55,7 @@ async function modifyMainActivityJavaAsync(
 
 export default async function configureAndroidProjectAsync(projectRoot: string) {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const username = await UserManager.getCurrentUsernameAsync();
 
   await modifyBuildGradleAsync(projectRoot, (buildGradle: string) => {
     buildGradle = AndroidConfig.GoogleServices.setClassPath(exp, buildGradle);
@@ -93,6 +95,8 @@ export default async function configureAndroidProjectAsync(projectRoot: string) 
       exp,
       androidManifest
     );
+
+    androidManifest = await AndroidConfig.Updates.setUpdatesConfig(exp, androidManifest, username);
 
     return androidManifest;
   });

--- a/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
@@ -74,13 +74,14 @@ async function modifyExpoPlistAsync(projectRoot: string, callback: (plist: any) 
   const supportingDirectory = path.join(iosProjectDirectory, 'Supporting');
   try {
     await IosPlist.modifyAsync(supportingDirectory, 'Expo', callback);
-    await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
   } catch (error) {
     WarningAggregator.addWarningIOS(
       'updates',
       'Expo.plist configuration could not be applied. You will need to create Expo.plist if it does not exist and add Updates configuration manually.',
       'https://docs.expo.io/bare/updating-your-app/#configuration-options'
     );
+  } finally {
+    await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
   }
 }
 

--- a/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
@@ -1,9 +1,10 @@
-import { IosPlist } from '@expo/xdl';
-import { IOSConfig, getConfig } from '@expo/config';
+import { IosPlist, UserManager } from '@expo/xdl';
+import { IOSConfig, WarningAggregator, getConfig } from '@expo/config';
 import path from 'path';
 
 export default async function configureIOSProjectAsync(projectRoot: string) {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const username = await UserManager.getCurrentUsernameAsync();
 
   IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(projectRoot, exp.ios!.bundleIdentifier!);
   IOSConfig.Google.setGoogleServicesFile(exp, projectRoot);
@@ -25,6 +26,12 @@ export default async function configureIOSProjectAsync(projectRoot: string) {
     infoPlist = IOSConfig.Version.setVersion(exp, infoPlist);
 
     return infoPlist;
+  });
+
+  // Configure Expo.plist
+  await modifyExpoPlistAsync(projectRoot, expoPlist => {
+    expoPlist = IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, username);
+    return expoPlist;
   });
 
   // Configure entitlements/capabilities
@@ -60,6 +67,21 @@ async function modifyInfoPlistAsync(projectRoot: string, callback: (plist: any) 
   const { iosProjectDirectory } = getIOSPaths(projectRoot);
   await IosPlist.modifyAsync(iosProjectDirectory, 'Info', callback);
   await IosPlist.cleanBackupAsync(iosProjectDirectory, 'Info', false);
+}
+
+async function modifyExpoPlistAsync(projectRoot: string, callback: (plist: any) => any) {
+  const { iosProjectDirectory } = getIOSPaths(projectRoot);
+  const supportingDirectory = path.join(iosProjectDirectory, 'Supporting');
+  try {
+    await IosPlist.modifyAsync(supportingDirectory, 'Expo', callback);
+    await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
+  } catch (error) {
+    WarningAggregator.addWarningIOS(
+      'updates',
+      'Expo.plist configuration could not be applied. You will need to create Expo.plist if it does not exist and add Updates configuration manually.',
+      'https://docs.expo.io/bare/updating-your-app/#configuration-options'
+    );
+  }
 }
 
 // TODO: come up with a better solution for using app.json expo.name in various places


### PR DESCRIPTION
Follow up to #2249, partial step of #1494. 

Adds Updates configuration (both the properties set in app.json, and other properties like the update URL) to the `configureAndroidProjectAsync` and `configureIOSProjectAsync` steps of `expo eject`.

This allows workflows like 

- expo eject
- make release build
- publish update
- get update in app right away

without having to set configuration options (like the URL) manually before making a release build.

Tested manually with defaults and with each of the app.json fields set manually (including owner) and verified that the resulting fields in Expo.plist and AndroidManifest.xml were correct in all cases.

- [x] TODO: add unit tests for these config methods