### PR TITLE
[traveling-fastlane] undocumented timeout flag

### DIFF
--- a/packages/traveling-fastlane/Rakefile
+++ b/packages/traveling-fastlane/Rakefile
@@ -151,12 +151,12 @@ def create_package target
   if target == "osx"
     sh "mv #{PACKAGE_NAME}-#{VERSION}-osx publishing/darwin/dist"
     if !ENV['NO_PUBLISH']
-      sh "cd publishing/darwin; npm publish --access=public"
+      sh "cd publishing/darwin; npm publish --access=public -timeout=9999999"
     end
   else
     sh "mv #{PACKAGE_NAME}-#{VERSION}-linux-x86_64 publishing/linux/dist"
     if !ENV['NO_PUBLISH']
-      sh "cd publishing/linux; npm publish --access=public"
+      sh "cd publishing/linux; npm publish --access=public -timeout=9999999"
     end
   end
 end


### PR DESCRIPTION
# why
when i tried publishing traveling fastlane today, I kept getting a timeout message. I figured the package could be too large and my upload speeds not fast enough to put everything to npm before a default timeout. Someone on Stackoverflow suggested this [undocumented timeout flag](https://stackoverflow.com/a/61488783/8611543). It's not in any of the `npm publish` docs, but when i used it, my publish went through successfully. Could be helpful to others in the future!

# error msg
```
npm notice === Tarball Details === 
npm notice name:          @expo/traveling-fastlane-linux          
npm notice version:       1.15.0                                  
npm notice package size:  24.4 MB                                 
npm notice unpacked size: 173.2 MB                                
npm notice shasum:        7baef947b6b6140ce2624d30009f0c986ad2aca5
npm notice integrity:     sha512-YRowzGwJSpRQn[...]M8VLUmwps7x2A==
npm notice total files:   10401                                   
npm notice 
npm ERR! network timeout at: https://registry.npmjs.org/@expo%2ftraveling-fastlane-linux

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/quin/.npm/_logs/2020-06-17T17_42_14_717Z-debug.log
rake aborted!
```