### PR TITLE
Remove unused legacy API code

### DIFF
--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -111,23 +111,12 @@ export async function action(projectDir: string, options: Options = {}) {
     args: { sdkVersion },
   } = await Exp.getPublishInfoAsync(projectDir);
 
-  let buildStatus;
-  if (process.env.EXPO_LEGACY_API === 'true') {
-    buildStatus = await Project.buildAsync(projectDir, {
-      mode: 'status',
-      platform: 'all',
-      current: true,
-      releaseChannel: options.releaseChannel,
-      sdkVersion,
-    });
-  } else {
-    buildStatus = await Project.getBuildStatusAsync(projectDir, {
-      platform: 'all',
-      current: true,
-      releaseChannel: options.releaseChannel,
-      sdkVersion,
-    });
-  }
+  const buildStatus = await Project.getBuildStatusAsync(projectDir, {
+    platform: 'all',
+    current: true,
+    releaseChannel: options.releaseChannel,
+    sdkVersion,
+  });
 
   if (
     'userHasBuiltExperienceBefore' in buildStatus &&

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -23,20 +23,12 @@ const logArtifactUrl = (platform: 'ios' | 'android') => async (
     throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
   }
 
-  let res;
-  if (process.env.EXPO_LEGACY_API === 'true') {
-    res = (await Project.buildAsync(projectDir, {
-      current: false,
-      mode: 'status',
-      ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
-    })) as Project.BuildStatusResult;
-  } else {
-    res = await Project.getBuildStatusAsync(projectDir, {
-      current: false,
-      ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
-    });
-  }
-  const url = res.jobs?.filter((job: Project.BuildJobFields) => job.platform === platform)[0]
+  const result = await Project.getBuildStatusAsync(projectDir, {
+    current: false,
+    ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
+  });
+
+  const url = result.jobs?.filter((job: Project.BuildJobFields) => job.platform === platform)[0]
     ?.artifacts?.url;
   if (url) {
     log.nested(url);

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -76,45 +76,16 @@ export async function getPublishHistoryAsync(
     skipSDKVersionRequirement: true,
   });
 
-  let result: any;
-  if (process.env.EXPO_LEGACY_API === 'true') {
-    // TODO(ville): move request from multipart/form-data to JSON once supported by the endpoint.
-    let formData = new FormData();
-    formData.append('queryType', 'history');
-    if (exp.owner) {
-      formData.append('owner', exp.owner);
-    }
-    formData.append('slug', await Project.getSlugAsync(projectDir));
-    formData.append('version', VERSION);
-    if (options.releaseChannel) {
-      formData.append('releaseChannel', options.releaseChannel);
-    }
-    if (options.count) {
-      formData.append('count', options.count);
-    }
-    if (options.platform) {
-      formData.append('platform', options.platform);
-    }
-    if (options.sdkVersion) {
-      formData.append('sdkVersion', options.sdkVersion);
-    }
-
-    result = await Api.callMethodAsync('publishInfo', [], 'post', null, {
-      formData,
-    });
-  } else {
-    const api = ApiV2.clientForUser(user);
-    result = await api.postAsync('publish/history', {
-      owner: exp.owner,
-      slug: await Project.getSlugAsync(projectDir),
-      version: VERSION,
-      releaseChannel: options.releaseChannel,
-      count: options.count,
-      platform: options.platform,
-      sdkVersion: options.sdkVersion,
-    });
-  }
-  return result;
+  const api = ApiV2.clientForUser(user);
+  return await api.postAsync('publish/history', {
+    owner: exp.owner,
+    slug: await Project.getSlugAsync(projectDir),
+    version: VERSION,
+    releaseChannel: options.releaseChannel,
+    count: options.count,
+    platform: options.platform,
+    sdkVersion: options.sdkVersion,
+  });
 }
 
 export async function setPublishToChannelAsync(
@@ -253,28 +224,13 @@ export async function getPublicationDetailAsync(
     skipSDKVersionRequirement: true,
   });
   const slug = await Project.getSlugAsync(projectDir);
-  let result: any;
-  if (process.env.EXPO_LEGACY_API === 'true') {
-    let formData = new FormData();
-    formData.append('queryType', 'details');
 
-    if (exp.owner) {
-      formData.append('owner', exp.owner);
-    }
-    formData.append('publishId', options.publishId);
-    formData.append('slug', slug);
-
-    result = await Api.callMethodAsync('publishInfo', null, 'post', null, {
-      formData,
-    });
-  } else {
-    const api = ApiV2.clientForUser(user);
-    result = await api.postAsync('publish/details', {
-      owner: exp.owner,
-      publishId: options.publishId,
-      slug,
-    });
-  }
+  const api = ApiV2.clientForUser(user);
+  const result = await api.postAsync('publish/details', {
+    owner: exp.owner,
+    publishId: options.publishId,
+    slug,
+  });
 
   if (!result.queryResult) {
     throw new Error('No records found matching your query.');

--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -361,19 +361,13 @@ export async function getPublishInfoAsync(root: string): Promise<PublishInfo> {
 }
 
 export async function sendAsync(recipient: string, url_: string, allowUnauthed: boolean = true) {
-  let result;
-  if (process.env.EXPO_LEGACY_API === 'true') {
-    result = await Api.callMethodAsync('send', [recipient, url_, allowUnauthed]);
-  } else {
-    const user = await UserManager.ensureLoggedInAsync();
-    const api = ApiV2.clientForUser(user);
-    result = await api.postAsync('send-project', {
-      emailOrPhone: recipient,
-      url: url_,
-      includeExpoLinks: allowUnauthed,
-    });
-  }
-  return result;
+  const user = await UserManager.ensureLoggedInAsync();
+  const api = ApiV2.clientForUser(user);
+  return await api.postAsync('send-project', {
+    emailOrPhone: recipient,
+    url: url_,
+    includeExpoLinks: allowUnauthed,
+  });
 }
 
 // TODO: figure out where these functions should live

--- a/packages/xdl/src/__integration_tests__/UserSessions-test.js
+++ b/packages/xdl/src/__integration_tests__/UserSessions-test.js
@@ -92,30 +92,6 @@ describe('User Sessions', () => {
     expect(sessionSecret).toBe(undefined);
   });
 
-  it('should use the token in apiv1', async () => {
-    const UserManager = _newTestUserManager();
-    await UserManager.loginAsync('user-pass', {
-      username: userForTest.username,
-      password: userForTestPassword,
-    });
-
-    let formData = new FormData();
-    formData.append('queryType', 'history');
-    formData.append('slug', 'foobar');
-
-    let response = await Api.callMethodAsync(
-      'publishInfo',
-      [],
-      'post',
-      null,
-      {
-        formData,
-      },
-      true
-    );
-    expect(response.status).toBe(200);
-  });
-
   it('should use the token in apiv2', async () => {
     const UserManager = _newTestUserManager();
     await UserManager.loginAsync('user-pass', {


### PR DESCRIPTION
These API calls have been using APIv2 by default since March (https://github.com/expo/expo-cli/pull/1537, https://github.com/expo/expo-cli/pull/1660). The old APIv1 code has been available under the special `EXPO_LEGACY_API` environment variable.

This PR removes these old code paths that are no longer used. This should make it easier to do upcoming changes related to authentication (service accounts), as there will be less code branches to update.