### PR TITLE
Mark functions as deprecated

### DIFF
--- a/packages/expo-cli/src/prompt.ts
+++ b/packages/expo-cli/src/prompt.ts
@@ -6,7 +6,7 @@ export { Question, ChoiceType };
 
 type CliQuestions = Question | Question[];
 
-// note(cedric): this prompt is now deprecated in favor of ./prompts
+/** @deprecated this prompt is now deprecated in favor of ./prompts */
 export default function prompt(
   questions: CliQuestions,
   { nonInteractiveHelp }: { nonInteractiveHelp?: string } = {}

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -200,6 +200,7 @@ async function _downloadAsync(
   await fs.rename(tmpPath, outputPath);
 }
 
+/** @deprecated use ApiV2, got or GraphQL depending on use case. */
 export default class ApiClient {
   static host: string = Config.api.host;
   static port: number = Config.api.port || 80;

--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -14,7 +14,6 @@ import yaml from 'js-yaml';
 
 import { NpmPackageManager, YarnPackageManager } from '@expo/package-manager';
 import semver from 'semver';
-import Api from './Api';
 import ApiV2 from './ApiV2';
 import Logger from './Logger';
 import NotificationCode from './NotificationCode';
@@ -28,6 +27,7 @@ type TemplateConfig = { name: string };
 
 const supportedPlatforms = ['ios', 'android', 'web'];
 
+/** @deprecated use getEntryPoint from @expo/config/paths */
 export function determineEntryPoint(projectRoot: string, platform?: string): string {
   if (platform && !supportedPlatforms.includes(platform)) {
     throw new Error(
@@ -313,6 +313,7 @@ type PublishInfo = {
 };
 
 // TODO: remove / change, no longer publishInfo, this is just used for signing
+/** @deprecated use getConfig from @expo/config */
 export async function getPublishInfoAsync(root: string): Promise<PublishInfo> {
   const user = await UserManager.ensureLoggedInAsync();
 

--- a/packages/xdl/src/credentials/Credentials.ts
+++ b/packages/xdl/src/credentials/Credentials.ts
@@ -18,6 +18,7 @@ export type CredentialMetadata = {
 
 export { Ios };
 
+/** @deprecated */
 export async function getCredentialMetadataAsync(
   projectRoot: string,
   platform: Platform
@@ -40,6 +41,7 @@ export async function getCredentialMetadataAsync(
   };
 }
 
+/** @deprecated */
 export async function credentialsExistForPlatformAsync(
   metadata: CredentialMetadata
 ): Promise<boolean> {
@@ -47,18 +49,21 @@ export async function credentialsExistForPlatformAsync(
   return !!credentials;
 }
 
+/** @deprecated */
 export async function getEncryptedCredentialsForPlatformAsync(
   metadata: CredentialMetadata
 ): Promise<Credentials | undefined | null> {
   return fetchCredentials(metadata, false);
 }
 
+/** @deprecated */
 export async function getCredentialsForPlatform(
   metadata: CredentialMetadata
 ): Promise<Credentials | undefined | null> {
   return fetchCredentials(metadata, true);
 }
 
+/** @deprecated use expo-cli/src/credentials/api */
 async function fetchCredentials(
   { username, experienceName, bundleIdentifier, platform }: CredentialMetadata,
   decrypt: boolean
@@ -108,6 +113,7 @@ async function fetchCredentials(
   return credentials;
 }
 
+/** @deprecated use expo-cli/src/credentials/api */
 export async function updateCredentialsForPlatform(
   platform: 'android',
   newCredentials: Keystore,

--- a/packages/xdl/src/tools/ModuleVersion.ts
+++ b/packages/xdl/src/tools/ModuleVersion.ts
@@ -5,6 +5,7 @@ import semver from 'semver';
 
 import { Cacher } from './FsCache';
 
+/** @deprecated just use the update-check npm package */
 function createModuleVersionChecker(name: string, currentVersion: string) {
   const UpdateCacher = new Cacher(
     async () => {


### PR DESCRIPTION
I imagine we could do a separate cleanup to get rid of these a bit later, but for now I just want to make it clearer that new code should not depend on these as they are going away eventually.

- xdl.Api
- xdl.Exp.determineEntryPoint
- xdl.Exp.getPublishInfoAsync
- xdl.Credentials
- xdl.ModuleVersion
- expo-cli/src/prompt.ts
  (was already deprecated, but add the JSDoc tag to make it more prominent)

Also related: https://github.com/expo/expo-cli/issues/2282