### PR TITLE
[xdl] Only update root client urls when sdk is latest and released

### DIFF
--- a/packages/xdl/src/tools/UpdateVersions.ts
+++ b/packages/xdl/src/tools/UpdateVersions.ts
@@ -96,8 +96,11 @@ async function updateClientUrlAndVersionAsync(
     versions.sdkVersions[sdkVersion] = {};
   }
 
+  const isReleased = sdkVersion && !!versions.sdkVersions[sdkVersion].releaseNoteUrl;
+  const isLatest = sdkVersion === Object.keys(versions.sdkVersions).sort(semver.rcompare)[0];
+
   // For compatibility reasons we have to maintain that global config, but only when we're updating the most recent SDK.
-  if (!sdkVersion || Object.keys(versions.sdkVersions).sort(semver.rcompare)[0] === sdkVersion) {
+  if (isReleased && isLatest) {
     versions[`${platform}Version`] = appVersion;
     versions[`${platform}Url`] = clientUrl;
   }

--- a/packages/xdl/src/tools/UpdateVersions.ts
+++ b/packages/xdl/src/tools/UpdateVersions.ts
@@ -100,7 +100,7 @@ async function updateClientUrlAndVersionAsync(
   const isLatest = sdkVersion === Object.keys(versions.sdkVersions).sort(semver.rcompare)[0];
 
   // For compatibility reasons we have to maintain that global config, but only when we're updating the most recent SDK.
-  if (isReleased && isLatest) {
+  if (!sdkVersion || (isReleased && isLatest)) {
     versions[`${platform}Version`] = appVersion;
     versions[`${platform}Url`] = clientUrl;
   }


### PR DESCRIPTION
This prevents the root client urls being updated if an SDK version is not yet released. It avoids marking this as "latest" by default in the CLI.