### PR TITLE
[cli] Refactor Android keystore update test with prompt inject

### DIFF
--- a/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
@@ -4,7 +4,6 @@ import prompts from '../../../prompts';
 import { mockExpoXDL } from '../../../__tests__/mock-utils';
 
 jest.mock('../../actions/list');
-jest.mock('../../../prompts');
 jest.mock('fs-extra');
 mockExpoXDL({
   AndroidCredentials: {
@@ -22,29 +21,20 @@ afterAll(() => {
   console.warn = originalWarn;
   console.log = originalLog;
 });
-beforeEach(() => {
-  (prompts as any).mockReset();
-  (prompts as any).mockImplementation(() => {
-    throw new Error('Should not be called');
-  });
-});
 
 describe('UpdateKeystore', () => {
   describe('existing credentials', () => {
     it('should check credentials and generate new', async () => {
       const ctx = getCtxMock();
 
-      (prompts as any)
-        .mockImplementationOnce(() => ({ answer: false })) // Let expo handle
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
+      prompts.inject([
+        false, // Keystore source - Let Expo handle
+      ]);
 
       const view = new UpdateKeystore(testExperienceName);
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
-      expect((prompts as any).mock.calls.length).toBe(1);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(1);
       expect(ctx.android.updateKeystore.mock.calls.length).toBe(1);
     });
@@ -52,15 +42,15 @@ describe('UpdateKeystore', () => {
     it('should check credentials and ask users for them', async () => {
       const ctx = getCtxMock();
 
-      (prompts as any)
-        .mockImplementationOnce(() => ({ answer: true })) // user specified
-        .mockImplementation(() => ({ input: 'test' })); // keystore credentials
+      prompts.inject([
+        true, // Keystore source - User provided
+        'test', // Keystore credentials
+      ]);
 
       const view = new UpdateKeystore(testExperienceName);
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
-      expect((prompts as any).mock.calls.length).toBe(5);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(1);
       expect(ctx.android.updateKeystore.mock.calls.length).toBe(1);
     });
@@ -73,17 +63,14 @@ describe('UpdateKeystore', () => {
         },
       });
 
-      (prompts as any)
-        .mockImplementationOnce(() => ({ answer: false })) // Let expo handle
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
+      prompts.inject([
+        false, // Keystore source - Let Expo handle
+      ]);
 
       const view = new UpdateKeystore(testExperienceName);
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
-      expect((prompts as any).mock.calls.length).toBe(1);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(1);
       expect(ctx.android.updateKeystore.mock.calls.length).toBe(1);
     });
@@ -95,15 +82,15 @@ describe('UpdateKeystore', () => {
         },
       });
 
-      (prompts as any)
-        .mockImplementationOnce(() => ({ answer: true })) // user specified
-        .mockImplementation(() => ({ input: 'test' })); // keystore credentials
+      prompts.inject([
+        true, // Keystore source - User provided
+        'test', // Keystore credentials
+      ]);
 
       const view = new UpdateKeystore(testExperienceName);
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
-      expect((prompts as any).mock.calls.length).toBe(5);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(1);
       expect(ctx.android.updateKeystore.mock.calls.length).toBe(1);
     });

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -36,3 +36,9 @@ export default function prompt(
 // todo: replace this workaround, its still selectable by the cursor
 // see: https://github.com/terkelg/prompts/issues/254
 prompt.separator = (title: string): Choice => ({ title, disable: true, value: undefined });
+
+/**
+ * Expose inject method to answering questions programatically, for testing purposes.
+ * @see https://github.com/terkelg/prompts#injectvalues
+ */
+prompt.inject = prompts.inject;


### PR DESCRIPTION
This is a proposal to simplify testing without the need for mocking and typecasting in all tests.