### PR TITLE
Revert "[cli] Refactor Android keystore update test with prompts inject (#2290)"

### DIFF
--- a/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
@@ -4,6 +4,7 @@ import prompts from '../../../prompts';
 import { mockExpoXDL } from '../../../__tests__/mock-utils';
 
 jest.mock('../../actions/list');
+jest.mock('../../../prompts');
 jest.mock('fs-extra');
 mockExpoXDL({
   AndroidCredentials: {
@@ -21,20 +22,29 @@ afterAll(() => {
   console.warn = originalWarn;
   console.log = originalLog;
 });
+beforeEach(() => {
+  (prompts as any).mockReset();
+  (prompts as any).mockImplementation(() => {
+    throw new Error('Should not be called');
+  });
+});
 
 describe('UpdateKeystore', () => {
   describe('existing credentials', () => {
     it('should check credentials and generate new', async () => {
       const ctx = getCtxMock();
 
-      prompts.inject([
-        false, // Keystore source - Let Expo handle
-      ]);
+      (prompts as any)
+        .mockImplementationOnce(() => ({ answer: false })) // Let expo handle
+        .mockImplementation(() => {
+          throw new Error("shouldn't happen");
+        });
 
       const view = new UpdateKeystore(testExperienceName);
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
+      expect((prompts as any).mock.calls.length).toBe(1);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(1);
       expect(ctx.android.updateKeystore.mock.calls.length).toBe(1);
     });
@@ -42,15 +52,15 @@ describe('UpdateKeystore', () => {
     it('should check credentials and ask users for them', async () => {
       const ctx = getCtxMock();
 
-      prompts.inject([
-        true, // Keystore source - User provided
-        'test', // Keystore credentials
-      ]);
+      (prompts as any)
+        .mockImplementationOnce(() => ({ answer: true })) // user specified
+        .mockImplementation(() => ({ input: 'test' })); // keystore credentials
 
       const view = new UpdateKeystore(testExperienceName);
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
+      expect((prompts as any).mock.calls.length).toBe(5);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(1);
       expect(ctx.android.updateKeystore.mock.calls.length).toBe(1);
     });
@@ -63,14 +73,17 @@ describe('UpdateKeystore', () => {
         },
       });
 
-      prompts.inject([
-        false, // Keystore source - Let Expo handle
-      ]);
+      (prompts as any)
+        .mockImplementationOnce(() => ({ answer: false })) // Let expo handle
+        .mockImplementation(() => {
+          throw new Error("shouldn't happen");
+        });
 
       const view = new UpdateKeystore(testExperienceName);
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
+      expect((prompts as any).mock.calls.length).toBe(1);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(1);
       expect(ctx.android.updateKeystore.mock.calls.length).toBe(1);
     });
@@ -82,15 +95,15 @@ describe('UpdateKeystore', () => {
         },
       });
 
-      prompts.inject([
-        true, // Keystore source - User provided
-        'test', // Keystore credentials
-      ]);
+      (prompts as any)
+        .mockImplementationOnce(() => ({ answer: true })) // user specified
+        .mockImplementation(() => ({ input: 'test' })); // keystore credentials
 
       const view = new UpdateKeystore(testExperienceName);
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
+      expect((prompts as any).mock.calls.length).toBe(5);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(1);
       expect(ctx.android.updateKeystore.mock.calls.length).toBe(1);
     });

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -36,9 +36,3 @@ export default function prompt(
 // todo: replace this workaround, its still selectable by the cursor
 // see: https://github.com/terkelg/prompts/issues/254
 prompt.separator = (title: string): Choice => ({ title, disable: true, value: undefined });
-
-/**
- * Expose inject method to answering questions programatically, for testing purposes.
- * @see https://github.com/terkelg/prompts#injectvalues
- */
-prompt.inject = prompts.inject;


### PR DESCRIPTION
This reverts commit d338ab2cf46ada4b30f165b6e91d1ed3fac23a40.

inject does not handle all the cases the previous version did.
- if you inject to much or to many variables test won't fail
e.g instead of
```
      prompts.inject([
        true, // Keystore source - User provided
        'test', // Keystore credentials
      ]);
```
there should be 
```
      prompts.inject([
        true, // Keystore source - User provided
        'test','test','test','test', // Keystore credentials
      ]);
```
but tests are still passing
- if you inject too many variables next test will get values from the previous one and there is no way to reset state