### PR TITLE
[cli] upgrade fastlane

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -115,8 +115,8 @@
     "wordwrap": "1.0.0"
   },
   "optionalDependencies": {
-    "@expo/traveling-fastlane-darwin": "1.14.0",
-    "@expo/traveling-fastlane-linux": "1.14.0"
+    "@expo/traveling-fastlane-darwin": "1.15.1",
+    "@expo/traveling-fastlane-linux": "1.15.1"
   },
   "gitHead": "613642fe06827cc231405784b099cf71c29072df"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,15 +1476,15 @@
     fs-extra "^8.1.0"
     lodash "^4.17.15"
 
-"@expo/traveling-fastlane-darwin@1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.14.0.tgz#3732f042923f43b162caf2b0fff75964f248dca0"
-  integrity sha512-66OW6sjF8POHr0uZmWFH7Aoo/hbBk3CFcfmfc0STZRumpseFLh3ir3wajejZl0FSHnQvtXLEWO5aya6QTYoPmQ==
+"@expo/traveling-fastlane-darwin@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.15.1.tgz#87b34e39a91377044070a55f3b03c575d00be39e"
+  integrity sha512-7sjG83+o9BT4MVPNq2UVqy1Oyg3n47FpEIDxc0M9CQvbC1WgYsAKloOJ85g5GRXZAjqzPOPUZF+lBhGbOwmQvg==
 
-"@expo/traveling-fastlane-linux@1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.14.0.tgz#1dc065d6a385913af4bad1c320dc3b3ff47fc3a3"
-  integrity sha512-8rcwcZrd0LiD5guGPc6GzZFihFFabnh/BtXKL/HyXOtki0gMa1WrR3RL2S++2H9zeLB6BVsOV7lttGpvl7JBoA==
+"@expo/traveling-fastlane-linux@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.15.1.tgz#3b77e3a3d490cbe59fbcffd155068e267c2e95c8"
+  integrity sha512-YaFAYYOOxImYNx9s6X3tY6fC1y6rka0KXstrs2zrS+vHyyBD8IOhNtIUvybHScM3jUL+qukgKElAb+7gzlF6Eg==
 
 "@expo/turtle-spawn@0.0.10":
   version "0.0.10"


### PR DESCRIPTION
# why
- upgrade cli to use traveling fastlane with the latest fixes. In particular, there are promising fixes to potentially solve https://github.com/expo/expo-cli/issues/1631
- Upgrades to `traveling-fastlane-linux/darwin` version 1.15.1. We originally had problems in `1.15.0` from the large bundle sizes, and after cleanup, we've got it down to an unpacked size of 107.8MB for darwin and 107.6 MB for linux, a slight increase from 1.14.0.

# testing

- [x] ran `expo build:ios` and made all credentials from scratch. This runs through a bunch of fastlane commands. 

