### PR TITLE
[xdl] add allowBackup customization feature for android

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -217,7 +217,7 @@ export type AndroidPlatformConfig = {
   userInterfaceStyle?: 'light' | 'dark' | 'automatic';
 
   /**
-   * Whether to allow the application to participate in the backup and restore infrastructure. If this attribute is set to false, no backup or restore of the application will ever be performed. Defaults to the Android default, which is true.
+   * Allows your user's app data to be automatically backed up to their Google Drive. If this is set to false, no backup or restore of the application will ever be performed (this is useful if your app deals with sensitive information). Defaults to the Android default, which is true.
    * @fallback true
    */
   allowBackup?: boolean;

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -216,6 +216,12 @@ export type AndroidPlatformConfig = {
    */
   userInterfaceStyle?: 'light' | 'dark' | 'automatic';
 
+  /**
+   * Whether to allow the application to participate in the backup and restore infrastructure. If this attribute is set to false, no backup or restore of the application will ever be performed. Defaults to the Android default, which is true.
+   * @fallback true
+   */
+  allowBackup?: boolean;
+
   config?: {
     /**
      * [Branch](https://branch.io/) key to hook up Branch linking services.

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -754,6 +754,14 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
     );
   }
 
+  if (manifest.android && manifest.android.allowBackup === false) {
+    await regexFileAsync(
+      `android:allowBackup="true"`,
+      `android:allowBackup="false"`,
+      path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
+    );
+  }
+
   // Add permissions
   if (manifest.android && manifest.android.permissions) {
     const whitelist = [];


### PR DESCRIPTION
This will allow users to set whether or not the app data can be backed up. We've gotten this request from a few partners (specifically for security reasons), so I'd like to add it in. + it would close a couple canny requests: 
- https://expo.canny.io/feature-requests/p/set-allowbackup-for-android-in-appjson
- https://expo.canny.io/feature-requests/p/disable-back-up-on-android

I tested this with some local turtle builds, setting `android.allowBackup=false` resulted in the proper outcome in androidmanifest, and leaving it out did nothing ✅ 

Before I move forward and open PRs for:
- [x] documentation
- [x] xdl schemas
- [ ] `expo/config`

I'd like to get feedback on whether we should control this and other settings like it ([list of potential settings here](https://developer.android.com/guide/topics/manifest/application-element)) via an `android.application` key or something like that? Or are we okay with just keeping it in `android`?