### PR TITLE
[package manager] Prompt the user to use sudo to install CocoaPods

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -7,6 +7,7 @@ import {
   readConfigJsonAsync,
   resolveModule,
 } from '@expo/config';
+import program from 'commander';
 import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
 import { Exp } from '@expo/xdl';
@@ -143,7 +144,10 @@ async function installPodsAsync(projectRoot: string) {
       // prompt user -- do you want to install cocoapods right now?
       step.text = 'CocoaPods CLI not found in your PATH, installing it now.';
       step.render();
-      await packageManager.installCLIAsync();
+      await PackageManager.CocoaPodsPackageManager.installCLIAsync({
+        nonInteractive: program.nonInteractive,
+        spawnOptions: packageManager.options,
+      });
       step.succeed('Installed CocoaPods CLI');
       step = logNewSection('Running `pod install` in the `ios` directory.');
     } catch (e) {

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import fs from 'fs';
-import { Command } from 'commander';
-import { AppJSONConfig, BareAppConfig, ExpoConfig } from '@expo/config';
+import program, { Command } from 'commander';
+import { BareAppConfig, ExpoConfig } from '@expo/config';
 import { Exp } from '@expo/xdl';
 import padEnd from 'lodash/padEnd';
 import npmPackageArg from 'npm-package-arg';
@@ -234,7 +234,7 @@ async function action(projectDir: string, command: Command) {
       workflow: 'bare',
       showPublishBeforeBuildWarning,
     });
-    if (!podsInstalled && process.platform === 'darwin') {
+    if (!podsInstalled && isMacOS) {
       log.newLine();
       log.nested(
         `⚠️  Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:`
@@ -326,7 +326,7 @@ function logProjectReadyAsync({
 
 async function installPodsAsync(projectRoot: string) {
   let step = logNewSection('Installing CocoaPods.');
-  if (process.platform !== 'darwin') {
+  if (!isMacOS) {
     step.succeed('Skipped installing CocoaPods because operating system is not on macOS.');
     return false;
   }
@@ -340,7 +340,10 @@ async function installPodsAsync(projectRoot: string) {
     try {
       step.text = 'CocoaPods CLI not found in your PATH, installing it now.';
       step.render();
-      await packageManager.installCLIAsync();
+      await PackageManager.CocoaPodsPackageManager.installCLIAsync({
+        nonInteractive: program.nonInteractive,
+        spawnOptions: packageManager.options,
+      });
       step.succeed('Installed CocoaPods CLI');
       step = logNewSection('Running `pod install` in the `ios` directory.');
     } catch (e) {

--- a/packages/package-manager/src/CocoaPodsPackageManager.ts
+++ b/packages/package-manager/src/CocoaPodsPackageManager.ts
@@ -28,14 +28,14 @@ export class CocoaPodsPackageManager implements PackageManager {
     const options = ['install', 'cocoapods', '--no-document'];
 
     try {
-      // Try the recommended way to install cocoapods first.
+      // In case the user has run sudo before running the command we can properly install CocoaPods without prompting for an interaction.
       await spawnAsync('gem', options, spawnOptions);
     } catch (error) {
       if (nonInteractive) {
         throw error;
       }
-      // If the default fails, it might be because sudo is required.
-      await spawnSudoAsync(`gem ${options.join(' ')}`);
+      // If the user doesn't have permission then we can prompt them to use sudo.
+      await spawnSudoAsync(['gem', ...options], spawnOptions);
     }
   }
 

--- a/packages/package-manager/src/CocoaPodsPackageManager.ts
+++ b/packages/package-manager/src/CocoaPodsPackageManager.ts
@@ -67,11 +67,12 @@ export class CocoaPodsPackageManager implements PackageManager {
       !silent && console.log(chalk.magenta(`\u203A Successfully installed CocoaPods with Gem`));
       return true;
     } catch (error) {
-      !silent && console.log(chalk.yellow(`\u203A Failed to install CocoaPods with Gem`));
-      !silent && console.log(chalk.black.bgRed(error.stderr));
+      if (!silent) {
+        console.log(chalk.yellow(`\u203A Failed to install CocoaPods with Gem`));
+        console.log(chalk.red(error.stderr ?? error.message));
+        console.log(chalk.magenta(`\u203A Attempting to install CocoaPods with Homebrew`));
+      }
       try {
-        !silent &&
-          console.log(chalk.magenta(`\u203A Attempting to install CocoaPods with Homebrew`));
         await CocoaPodsPackageManager.brewInstallCLIAsync(spawnOptions);
         if (!(await CocoaPodsPackageManager.isCLIInstalledAsync(spawnOptions))) {
           try {

--- a/packages/package-manager/src/PackageManager.ts
+++ b/packages/package-manager/src/PackageManager.ts
@@ -18,9 +18,8 @@ export function getPossibleProjectRoot(): string {
 }
 
 export function spawnSudoAsync(command: string): Promise<void> {
-  const packageJSON = require('../package.json');
   return new Promise((resolve, reject) => {
-    sudo.exec(command, { name: packageJSON.name }, error => {
+    sudo.exec(command, { name: 'pod install' }, error => {
       if (error) {
         reject(error);
       }

--- a/packages/package-manager/src/PackageManager.ts
+++ b/packages/package-manager/src/PackageManager.ts
@@ -1,5 +1,6 @@
 import { realpathSync } from 'fs';
 import sudo from 'sudo-prompt';
+import spawnAsync, { SpawnOptions } from '@expo/spawn-async';
 
 export type Logger = (...args: any[]) => void;
 
@@ -17,13 +18,20 @@ export function getPossibleProjectRoot(): string {
   return realpathSync(process.cwd());
 }
 
-export function spawnSudoAsync(command: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sudo.exec(command, { name: 'pod install' }, error => {
-      if (error) {
-        reject(error);
-      }
-      resolve();
+export async function spawnSudoAsync(command: string[], spawnOptions: SpawnOptions): Promise<void> {
+  // sudo prompt only seems to work on win32 machines.
+  if (process.platform === 'win32') {
+    return new Promise((resolve, reject) => {
+      sudo.exec(command.join(' '), { name: 'pod install' }, error => {
+        if (error) {
+          reject(error);
+        }
+        resolve();
+      });
     });
-  });
+  } else {
+    // Attempt to use sudo to run the command on Mac and Linux.
+    // TODO(Bacon): Make a v of sudo-prompt that's win32 only for better bundle size.
+    await spawnAsync('sudo', command, spawnOptions);
+  }
 }

--- a/packages/package-manager/src/PackageManager.ts
+++ b/packages/package-manager/src/PackageManager.ts
@@ -32,6 +32,9 @@ export async function spawnSudoAsync(command: string[], spawnOptions: SpawnOptio
   } else {
     // Attempt to use sudo to run the command on Mac and Linux.
     // TODO(Bacon): Make a v of sudo-prompt that's win32 only for better bundle size.
+    console.log(
+      'Your password might be needed to install CocoaPods CLI: https://guides.cocoapods.org/using/getting-started.html#installation'
+    );
     await spawnAsync('sudo', command, spawnOptions);
   }
 }


### PR DESCRIPTION
## Why 

The recommended way to install cocoapods is with `sudo gem install`, but more often than not they're installing with homebrew on mac. This PR attempts to address this issue by prompting the user to enter their password in interactive mode.

## How 

- Fix sudo-prompt integration - not tested as I don't have a win32 machine. We also often skip pod install on non-darwin machines.
- Use sudo on mac and linux - tested and works.
- `pod-install --non-interactive` will skip prompts.