### PR TITLE
Blacklist suspicious permissions

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -803,6 +803,10 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       'com.sec.android.provider.badge.permission.READ',
       'com.sec.android.provider.badge.permission.WRITE',
       'com.sonyericsson.home.permission.BROADCAST_BADGE',
+      'android.permission.REQUEST_INSTALL_PACKAGES',
+      'android.permission.STORAGE',
+      'android.permission.USE_BIOMETRIC',
+      'android.permission.SYSTEM_ALERT_WINDOW'
     ].filter(p => !whitelist.includes(p));
 
     await deleteLinesInFileAsync(

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -804,7 +804,6 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       'com.sec.android.provider.badge.permission.WRITE',
       'com.sonyericsson.home.permission.BROADCAST_BADGE',
       'android.permission.REQUEST_INSTALL_PACKAGES',
-      'android.permission.STORAGE',
       'android.permission.USE_BIOMETRIC',
       'android.permission.SYSTEM_ALERT_WINDOW'
     ].filter(p => !whitelist.includes(p));


### PR DESCRIPTION
Blacklist permissions that can be considered suspicious. Google may consider this to be bad enough to suspend an application from Google Play Store.

Fixes #8942