### PR TITLE
fix(expo-cli): credentials:manager read credentials fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix `expo credentials:manager` listing all credentials on android and respect owner field` ([#2311](https://github.com/expo/expo-cli/pull/2311) by [@wkozyra95](https://github.com/wkozyra95)).
+
 ### 📦 Packages updated
 
 ## [Tue Jun 23 17:55:00 2020 -0700](https://github.com/expo/expo-cli/commit/4bc73721d5a46fcac35096a0e86a1ceaa333b459)

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -110,12 +110,11 @@ export class SelectIosExperience implements IView {
 }
 
 export class SelectAndroidExperience implements IView {
-  private androidCredentials: AndroidCredentials[] = [];
   private askAboutProjectMode = true;
 
   async open(ctx: Context): Promise<IView | null> {
     if (ctx.hasProjectContext && this.askAboutProjectMode) {
-      const experienceName = `@${ctx.user.username}/${ctx.manifest.slug}`;
+      const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
       const { runProjectContext } = await prompt([
         {
           type: 'confirm',
@@ -133,15 +132,15 @@ export class SelectAndroidExperience implements IView {
     this.askAboutProjectMode = false;
 
     const credentials = await ctx.android.fetchAll();
-    await displayAndroidCredentials(this.androidCredentials);
+    await displayAndroidCredentials(Object.values(credentials));
 
     const question: Question = {
       type: 'list',
       name: 'experienceName',
       message: 'Select application',
-      choices: this.androidCredentials.map((cred, index) => ({
+      choices: Object.values(credentials).map(cred => ({
         name: cred.experienceName,
-        value: index,
+        value: cred.experienceName,
       })),
       pageSize: Infinity,
     };


### PR DESCRIPTION
- fix reading list of apps
- read owner field when selecting experience from current directory