### PR TITLE
fix(expo-cli): use user provided teamId, don't access appleCtx

### DIFF
--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -177,12 +177,7 @@ export class UpdateIosDist implements IView {
     }
 
     const newDistCert = await this.provideOrGenerate(ctx);
-    await ctx.ensureAppleCtx();
-    await ctx.ios.updateDistCert(selected.id, {
-      ...newDistCert,
-      teamId: ctx.appleCtx.team.id,
-      teamName: ctx.appleCtx.team.name,
-    });
+    await ctx.ios.updateDistCert(selected.id, newDistCert);
 
     for (const appCredentials of apps) {
       log(

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -186,12 +186,7 @@ export class UpdateIosPush implements IView {
     }
 
     const newPushKey = await this.provideOrGenerate(ctx);
-    const credentials = {
-      ...newPushKey,
-      teamId: ctx.appleCtx.team.id,
-      teamName: ctx.appleCtx.team.name,
-    };
-    await ctx.ios.updatePushKey(selected.id, credentials);
+    await ctx.ios.updatePushKey(selected.id, newPushKey);
   }
 
   async provideOrGenerate(ctx: Context): Promise<PushKey> {


### PR DESCRIPTION
fixes problem in credential manager when the user specifies push key manually and appleCtx is not intialized.

for distribution certificate this worked because there is `await ctx.ensureAppleCtx();`, but because adding teamId and teamName is obsolete(`newDistCert` and `newPushKey` have already teamId) I removed it. We don't need to force users to specify their credentials just for that.
