### PR TITLE
Update "googleMobileAdsAutoInit" to be optional

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -267,7 +267,7 @@ export type AndroidPlatformConfig = {
      *  Sets the opposite of the given value to the following tag in AndroidManifest.xml:
      *  https://developers.google.com/admob/android/eu-consent#delay_app_measurement_optional
      */
-    googleMobileAdsAutoInit: boolean;
+    googleMobileAdsAutoInit?: boolean;
     /**
      * [Google Sign-In Android SDK](https://developers.google.com/identity/sign-in/android/start-integrating) keys for your standalone app.
      */


### PR DESCRIPTION
Following the information provided both in this file and on the docs (found here: https://docs.expo.io/workflow/configuration/#android) - "The default in Expo (Client and in standalone apps) is `false`". Drawing from this I have concluded that this value is not actually required, hence updating the type declaration to reflect this.