### PR TITLE
Implement "useNextNotificationsApi" configuration SDK 38

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -199,6 +199,11 @@ export type AndroidPlatformConfig = {
    * @example https://play.google.com/store/apps/details?id=host.exp.exponent
    */
   playStoreUrl?: string;
+  
+  /**
+  * Configuration to select the handeling of notifications in android between the legacy notifications API and new notifications API (released with SKD 38)
+  */
+  useNextNotificationsApi?: boolean
 
   /**
    * List of permissions used by the standalone app. Remove the field to use the default list of permissions.\n\n  Example: `[ \"CAMERA\", \"ACCESS_FINE_LOCATION\" ]`.\n\n  You can specify the following permissions depending on what you need:\n\n- `ACCESS_COARSE_LOCATION`\n- `ACCESS_FINE_LOCATION`\n- `CAMERA`\n- `MANAGE_DOCUMENTS`\n- `READ_CONTACTS`\n- `READ_EXTERNAL_STORAGE`\n- `READ_INTERNAL_STORAGE`\n- `READ_PHONE_STATE`\n- `RECORD_AUDIO`\n- `USE_FINGERPRINT`\n- `VIBRATE`\n- `WAKE_LOCK`\n- `WRITE_EXTERNAL_STORAGE`\n- `com.anddoes.launcher.permission.UPDATE_COUNT`\n- `com.android.launcher.permission.INSTALL_SHORTCUT`\n- `com.google.android.c2dm.permission.RECEIVE`\n- `com.google.android.gms.permission.ACTIVITY_RECOGNITION`\n- `com.google.android.providers.gsf.permission.READ_GSERVICES`\n- `com.htc.launcher.permission.READ_SETTINGS`\n- `com.htc.launcher.permission.UPDATE_SHORTCUT`\n- `com.majeur.launcher.permission.UPDATE_BADGE`\n- `com.sec.android.provider.badge.permission.READ`\n- `com.sec.android.provider.badge.permission.WRITE`\n- `com.sonyericsson.home.permission.BROADCAST_BADGE`


### PR DESCRIPTION
With the release of SDK 38 the new notifications API "you’ll need to explicitly opt into the new API for now by setting android.useNextNotificationsApi to true in your app configuration". This change implements this value as detailed in the release notes found here - https://blog.expo.io/expo-sdk-38-is-now-available-ab6cd30ca2ee