### PR TITLE
fix(config): use basename to avoid mixed path separators from glob

### DIFF
--- a/packages/config/src/ios/utils/Xcodeproj.ts
+++ b/packages/config/src/ios/utils/Xcodeproj.ts
@@ -7,8 +7,7 @@ import path from 'path';
 
 export function getProjectName(projectRoot: string) {
   const sourceRoot = getSourceRoot(projectRoot);
-  const sourceRootParts = sourceRoot.split(path.sep);
-  return sourceRootParts[sourceRootParts.length - 1];
+  return path.basename(sourceRoot);
 }
 
 export function getSourceRoot(projectRoot: string) {


### PR DESCRIPTION
Fixes #2312
Fixes #2326

I noticed `glob` returning paths with the forward-slash on Windows environments, even though the `path.sep` correctly returns a backslash. This uses the `path.basename` to resolve the last folder, regardless of the platform separator. 

To outline the issue, here is a log that I used in `getProjectName` to log the exact output of the `projectRoot`, `sourceRoot`, `sourceRootParts`, `path.sep`, the bad result (old implementation), and the good result (new implementation):

```
getProjectName {
  projectRoot: 'C:\\Users\\cedri\\Desktop\\expo-cli\\test-project',
  sourceRoot: 'C:/Users/cedri/Desktop/expo-cli/test-project/ios/testproject',
  sourceRootParts: [ 'C:/Users/cedri/Desktop/expo-cli/test-project/ios/testproject' ],
  resultBad: 'C:/Users/cedri/Desktop/expo-cli/test-project/ios/testproject',
  resultGood: 'testproject',
  pathsep: '\\'
}
```