### PR TITLE
[cli] add owner support for push:android cmds

### DIFF
--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -79,9 +79,10 @@ export default function (program: Command) {
         `credentials/android/push/@${username}/${exp.slug}`
       );
       if (fcmApiKey) {
-        console.log(`FCM Api Key: ${fcmApiKey}`);
+        log(`FCM Api Key: ${fcmApiKey}`);
       } else {
-        console.log(`There is no FCM Api Key configured for this project`);
+        log(`There is no FCM Api Key configured for this project`);
+        process.exit(1);
       }
     });
 

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -21,21 +21,29 @@ export default function (program: Command) {
       if (!options.apiKey || options.apiKey.length === 0) {
         throw new Error('Must specify an API key to upload with --api-key.');
       }
-
-      log('Reading project configuration...');
-
-      const {
-        args: { remotePackageName },
-      } = await Exp.getPublishInfoAsync(projectDir);
-
       log('Logging in...');
 
       let user = await UserManager.getCurrentUserAsync();
+      if (!user) {
+        throw new Error('You must be logged in to proceed.');
+      }
       let apiClient = ApiV2.clientForUser(user);
 
-      log("Setting API key on Expo's servers...");
+      log('Reading project configuration...');
+      const { exp } = ConfigUtils.getConfig(projectDir, { skipSDKVersionRequirement: true });
+      let { username } = user;
+      if (exp.owner) {
+        username = exp.owner;
+      }
 
-      await apiClient.putAsync(`credentials/push/android/${remotePackageName}`, {
+      const isProxyUser = username !== user.username;
+      log(
+        `Setting API key on Expo's servers for project ${exp.slug}${
+          isProxyUser ? ` on behalf of ${username}` : ''
+        }...`
+      );
+
+      await apiClient.putAsync(`credentials/android/push/@${username}/${exp.slug}`, {
         fcmApiKey: options.apiKey,
       });
 
@@ -46,18 +54,34 @@ export default function (program: Command) {
     .command('push:android:show [project-dir]')
     .description('Print the value currently in use for FCM notifications for this project.')
     .asyncActionProjectDir(async (projectDir: string) => {
-      const {
-        args: { remotePackageName },
-      } = await Exp.getPublishInfoAsync(projectDir);
+      log('Logging in...');
+
       let user = await UserManager.getCurrentUserAsync();
+      if (!user) {
+        throw new Error('You must be logged in to proceed.');
+      }
+
+      log('Reading project configuration...');
+      const { exp } = ConfigUtils.getConfig(projectDir, { skipSDKVersionRequirement: true });
+      let { username } = user;
+      if (exp.owner) {
+        username = exp.owner;
+      }
+
+      const isProxyUser = username !== user.username;
+      log(
+        `Getting API key on Expo's servers for project ${exp.slug}${
+          isProxyUser ? ` on behalf of ${username}` : ''
+        }...`
+      );
       let apiClient = ApiV2.clientForUser(user);
-
-      let result = await apiClient.getAsync(`credentials/push/android/${remotePackageName}`);
-
-      if (result.status === 'ok' && result.fcmApiKey) {
-        console.log(JSON.stringify(result));
+      const { fcmApiKey } = await apiClient.getAsync(
+        `credentials/android/push/@${username}/${exp.slug}`
+      );
+      if (fcmApiKey) {
+        console.log(`FCM Api Key: ${fcmApiKey}`);
       } else {
-        throw new Error('Server returned an invalid result!');
+        console.log(`There is no FCM Api Key configured for this project`);
       }
     });
 
@@ -65,18 +89,28 @@ export default function (program: Command) {
     .command('push:android:clear [project-dir]')
     .description('Deletes a previously uploaded FCM credential.')
     .asyncActionProjectDir(async (projectDir: string) => {
-      log('Reading project configuration...');
-      const {
-        args: { remotePackageName },
-      } = await Exp.getPublishInfoAsync(projectDir);
-
       log('Logging in...');
       let user = await UserManager.getCurrentUserAsync();
+      if (!user) {
+        throw new Error('You must be logged in to proceed.');
+      }
+
+      log('Reading project configuration...');
+      const { exp } = ConfigUtils.getConfig(projectDir, { skipSDKVersionRequirement: true });
+      let { username } = user;
+      if (exp.owner) {
+        username = exp.owner;
+      }
       let apiClient = ApiV2.clientForUser(user);
 
-      log("Deleting API key from Expo's servers...");
+      const isProxyUser = username !== user.username;
+      log(
+        `Deleting API key on Expo's servers for project ${exp.slug}${
+          isProxyUser ? ` on behalf of ${username}` : ''
+        }...`
+      );
 
-      await apiClient.deleteAsync(`credentials/push/android/${remotePackageName}`);
+      await apiClient.deleteAsync(`credentials/android/push/@${username}/${exp.slug}`);
 
       log('All done!');
     });


### PR DESCRIPTION
# why
- add owner support for `expo push:android:{upload, show, clear}` commands
- umbrella issue tracked here: https://github.com/expo/expo-cli/issues/2150
- also added useful debug messages (show project and if you are a proxy user, show that you are working on a project on behalf of the main user)
fixes https://github.com/expo/expo-cli/issues/1294

# manual tests
### app.json with no owner field
- [x] `expo push:android:upload` works
- [x] `expo push:android:show` works
- [x] `expo push:android:clear` works

### app.json with owner field
- [x] `expo push:android:upload` works
- [x] `expo push:android:show` works
- [x] `expo push:android:clear` works

### proxy user (ADMIN privileges), app.json with owner field
- [x] `expo push:android:upload` works
- [x] `expo push:android:show` works
- [x] `expo push:android:clear` works
