### PR TITLE
[xdl] add sdkVersion to Start Project and Serve Manifest events

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2013,6 +2013,7 @@ function getManifestHandler(projectRoot: string) {
       Analytics.logEvent('Serve Manifest', {
         projectRoot,
         developerTool: Config.developerTool,
+        sdkVersion: manifest.sdkVersion ?? null,
       });
     } catch (e) {
       ProjectUtils.logError(projectRoot, 'expo', e.stack);
@@ -2375,12 +2376,13 @@ export async function startAsync(
   verbose: boolean = true
 ): Promise<ExpoConfig> {
   _assertValidProjectRoot(projectRoot);
+  let { exp } = getConfig(projectRoot);
   Analytics.logEvent('Start Project', {
     projectRoot,
     developerTool: Config.developerTool,
+    sdkVersion: exp.sdkVersion ?? null,
   });
 
-  let { exp } = getConfig(projectRoot);
   if (options.webOnly) {
     await Webpack.restartAsync(projectRoot, options);
     DevSession.startSession(projectRoot, exp, 'web');


### PR DESCRIPTION
Following up on some internal discussions, we'd like to start tracking the SDK version of projects that send `Start Project` and `Serve Manifest` events to segment so that we can get an idea of the distribution of development usage across supported SDK versions over time.

I added `sdkVersion` as an extra property when these two events are logged. Ran a project without any issues. @tcdavis does `sdkVersion` need to be added to a table somewhere in our analytics, or will it start being saved automatically?

Did not make a changelog entry as this is not a user-facing change (but let me know if I should anyway).