### PR TITLE
[webpack-config] Interop assets like Metro bundler

### DIFF
--- a/packages/webpack-config/e2e/__tests__/basic-test.js
+++ b/packages/webpack-config/e2e/__tests__/basic-test.js
@@ -42,16 +42,23 @@ describe('Basic', () => {
 
   describe('Asset loader', () => {
     it(`should load an image as a string like Metro`, async () => {
-      const elementId = getTestIdQuery('expo-asset-raw-image');
+      const elementId = getTestIdQuery('asset-raw-image');
       await expect(page).toMatchElement(elementId, {
         text: 'data:image/png;base64',
       });
     });
 
     it(`should load a font as a string like Metro`, async () => {
-      const elementId = getTestIdQuery('expo-asset-raw-font');
+      const elementId = getTestIdQuery('asset-raw-font');
       await expect(page).toMatchElement(elementId, {
         text: 'data:font/ttf;base64,ZXhwbyBpcyB0aGUgYmVzdA==',
+      });
+    });
+
+    it(`should load a random file as a string like Metro`, async () => {
+      const elementId = getTestIdQuery('asset-raw-wildcard');
+      await expect(page).toMatchElement(elementId, {
+        text: 'string',
       });
     });
   });

--- a/packages/webpack-config/e2e/__tests__/basic-test.js
+++ b/packages/webpack-config/e2e/__tests__/basic-test.js
@@ -1,5 +1,6 @@
 /* global page */
 import getenv from 'getenv';
+
 import config from '../../jest-puppeteer.config';
 
 // We know that CI works in this process, but we want to test that it matches the process that our app runs in.
@@ -8,50 +9,79 @@ const type = getenv.string('EXPO_E2E_COMMAND');
 
 const isProduction = ['build'].includes(type);
 
+function getTestIdQuery(testId) {
+  return `div[data-testid="${testId}"]`;
+}
+
+// This needs to be evaluated to load the page
 let response;
 beforeEach(async () => {
   jest.setTimeout(60000);
   response = await page.goto(config.url);
 });
 
-it(`should match a text element`, async () => {
-  await expect(page).toMatchElement('div[data-testid="basic-text"]', {
-    text: 'Open up App.js to start working on your app!',
-  });
-});
+describe('Basic', () => {
+  it(`should match a text element`, async () => {
+    const elementId = getTestIdQuery('basic-text');
 
-if (isProduction) {
-  it(`should register expo service worker`, async () => {
-    const swID = 'div[data-testid="has-sw-text"]';
-
-    await expect(page).toMatchElement(swID, {
-      text: 'Has SW installed',
-      timeout: 2000,
+    await expect(page).toMatchElement(elementId, {
+      text: 'Open up App.js to start working on your app!',
     });
   });
-}
 
-it(`should have resize-observer polyfill added`, async () => {
-  const elementId = 'div[data-testid="has-resize-observer"]';
-  await expect(page).toMatchElement(elementId, {
-    text: 'Has ResizeObserver polyfill',
-  });
-});
+  if (isProduction) {
+    it(`should register expo service worker`, async () => {
+      const elementId = getTestIdQuery('has-sw-text');
 
-describe('DefinePlugin', () => {
-  it(`should be aware of process.env.CI`, async () => {
-    const ciID = 'div[data-testid="has-ci-text"]';
-    if (isInCI) {
-      await expect(page).toMatchElement(ciID, {
-        text: 'Has CI env',
+      await expect(page).toMatchElement(elementId, {
+        text: 'Has SW installed',
+        timeout: 2000,
       });
-    } else {
-      await expect(page).not.toMatchElement(ciID);
-    }
+    });
+  }
+
+  describe('Asset loader', () => {
+    it(`should load an image as a string like Metro`, async () => {
+      const elementId = getTestIdQuery('expo-asset-raw-image');
+      await expect(page).toMatchElement(elementId, {
+        text: 'data:image/png;base64',
+      });
+    });
+
+    it(`should load a font as a string like Metro`, async () => {
+      const elementId = getTestIdQuery('expo-asset-raw-font');
+      await expect(page).toMatchElement(elementId, {
+        text: 'data:font/ttf;base64,ZXhwbyBpcyB0aGUgYmVzdA==',
+      });
+    });
   });
-  it(`should have manifest from expo-constants`, async () => {
-    await expect(page).toMatchElement('div[data-testid="expo-constants-manifest"]', {
-      text: `A Neat Expo App`,
+
+  it(`should have resize-observer polyfill added`, async () => {
+    const elementId = getTestIdQuery('has-resize-observer');
+    await expect(page).toMatchElement(elementId, {
+      text: 'Has ResizeObserver polyfill',
+    });
+  });
+
+  describe('DefinePlugin', () => {
+    it(`should be aware of process.env.CI`, async () => {
+      const elementId = getTestIdQuery('has-ci-text');
+
+      if (isInCI) {
+        await expect(page).toMatchElement(elementId, {
+          text: 'Has CI env',
+        });
+      } else {
+        await expect(page).not.toMatchElement(elementId);
+      }
+    });
+
+    it(`should have manifest from expo-constants`, async () => {
+      const elementId = getTestIdQuery('expo-constants-manifest');
+
+      await expect(page).toMatchElement(elementId, {
+        text: `A Neat Expo App`,
+      });
     });
   });
 });

--- a/packages/webpack-config/e2e/basic/App.js
+++ b/packages/webpack-config/e2e/basic/App.js
@@ -24,6 +24,10 @@ function AspectView(props) {
   );
 }
 
+// These assets will be used to ensure that the file-loader and url-loader are loading the assets properly.
+const imageAsset = require('./img.png');
+const fontAsset = require('./font.ttf');
+
 export default function App() {
   // Test that the SW is registered
   const [isSWRegistered, setSW] = React.useState(null);
@@ -41,6 +45,8 @@ export default function App() {
       <AspectView style={{ aspectRatio: 1, backgroundColor: 'green', width: 40 }} />
       <Text testID="basic-text">Open up App.js to start working on your app!</Text>
       <Text testID="expo-constants-manifest">{JSON.stringify(Constants.manifest)}</Text>
+      <Text testID="expo-asset-raw-image">{imageAsset}</Text>
+      <Text testID="expo-asset-raw-font">{fontAsset}</Text>
       {boolish('CI', false) && <Text testID="has-ci-text">Has CI env</Text>}
       {isSWRegistered && <Text testID="has-sw-text">Has SW installed</Text>}
       {global.ResizeObserver && (

--- a/packages/webpack-config/e2e/basic/App.js
+++ b/packages/webpack-config/e2e/basic/App.js
@@ -27,6 +27,8 @@ function AspectView(props) {
 // These assets will be used to ensure that the file-loader and url-loader are loading the assets properly.
 const imageAsset = require('./img.png');
 const fontAsset = require('./font.ttf');
+// This tests that the wildcard (.*) loader is working properly.
+const randomAsset = require('./random.bacon');
 
 export default function App() {
   // Test that the SW is registered
@@ -45,8 +47,9 @@ export default function App() {
       <AspectView style={{ aspectRatio: 1, backgroundColor: 'green', width: 40 }} />
       <Text testID="basic-text">Open up App.js to start working on your app!</Text>
       <Text testID="expo-constants-manifest">{JSON.stringify(Constants.manifest)}</Text>
-      <Text testID="expo-asset-raw-image">{imageAsset}</Text>
-      <Text testID="expo-asset-raw-font">{fontAsset}</Text>
+      <Text testID="asset-raw-image">{imageAsset}</Text>
+      <Text testID="asset-raw-font">{fontAsset}</Text>
+      <Text testID="asset-raw-wildcard">{typeof randomAsset}</Text>
       {boolish('CI', false) && <Text testID="has-ci-text">Has CI env</Text>}
       {isSWRegistered && <Text testID="has-sw-text">Has SW installed</Text>}
       {global.ResizeObserver && (

--- a/packages/webpack-config/e2e/basic/font.ttf
+++ b/packages/webpack-config/e2e/basic/font.ttf
@@ -1,0 +1,1 @@
+expo is the best

--- a/packages/webpack-config/e2e/basic/random.bacon
+++ b/packages/webpack-config/e2e/basic/random.bacon
@@ -1,0 +1,1 @@
+bacon-file

--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -72,7 +72,8 @@ Object {
             "use": Object {
               "loader": "packages/webpack-config/node_modules/url-loader/dist/cjs.js",
               "options": Object {
-                "limit": 10000,
+                "esModule": false,
+                "limit": 1000,
                 "name": "static/media/[name].[hash:8].[ext]",
               },
             },
@@ -119,6 +120,7 @@ Object {
               Object {
                 "loader": "packages/webpack-config/node_modules/url-loader/dist/cjs.js",
                 "options": Object {
+                  "esModule": false,
                   "limit": 50000,
                   "name": "./fonts/[name].[ext]",
                 },
@@ -140,6 +142,7 @@ Object {
             ],
             "loader": "packages/webpack-config/node_modules/file-loader/dist/cjs.js",
             "options": Object {
+              "esModule": false,
               "name": "static/media/[name].[hash:8].[ext]",
             },
           },
@@ -245,7 +248,8 @@ Object {
             "use": Object {
               "loader": "packages/webpack-config/node_modules/url-loader/dist/cjs.js",
               "options": Object {
-                "limit": 10000,
+                "esModule": false,
+                "limit": 1000,
                 "name": "static/media/[name].[hash:8].[ext]",
               },
             },
@@ -292,6 +296,7 @@ Object {
               Object {
                 "loader": "packages/webpack-config/node_modules/url-loader/dist/cjs.js",
                 "options": Object {
+                  "esModule": false,
                   "limit": 50000,
                   "name": "./fonts/[name].[ext]",
                 },
@@ -313,6 +318,7 @@ Object {
             ],
             "loader": "packages/webpack-config/node_modules/file-loader/dist/cjs.js",
             "options": Object {
+              "esModule": false,
               "name": "static/media/[name].[hash:8].[ext]",
             },
           },
@@ -520,7 +526,8 @@ Object {
             "use": Object {
               "loader": "packages/webpack-config/node_modules/url-loader/dist/cjs.js",
               "options": Object {
-                "limit": 10000,
+                "esModule": false,
+                "limit": 1000,
                 "name": "static/media/[name].[hash:8].[ext]",
               },
             },
@@ -567,6 +574,7 @@ Object {
               Object {
                 "loader": "packages/webpack-config/node_modules/url-loader/dist/cjs.js",
                 "options": Object {
+                  "esModule": false,
                   "limit": 50000,
                   "name": "./fonts/[name].[ext]",
                 },
@@ -588,6 +596,7 @@ Object {
             ],
             "loader": "packages/webpack-config/node_modules/file-loader/dist/cjs.js",
             "options": Object {
+              "esModule": false,
               "name": "static/media/[name].[hash:8].[ext]",
             },
           },
@@ -705,7 +714,8 @@ Object {
             "use": Object {
               "loader": "packages/webpack-config/node_modules/url-loader/dist/cjs.js",
               "options": Object {
-                "limit": 10000,
+                "esModule": false,
+                "limit": 1000,
                 "name": "static/media/[name].[hash:8].[ext]",
               },
             },
@@ -752,6 +762,7 @@ Object {
               Object {
                 "loader": "packages/webpack-config/node_modules/url-loader/dist/cjs.js",
                 "options": Object {
+                  "esModule": false,
                   "limit": 50000,
                   "name": "./fonts/[name].[ext]",
                 },
@@ -773,6 +784,7 @@ Object {
             ],
             "loader": "packages/webpack-config/node_modules/file-loader/dist/cjs.js",
             "options": Object {
+              "esModule": false,
               "name": "static/media/[name].[hash:8].[ext]",
             },
           },

--- a/packages/webpack-config/src/loaders/createAllLoaders.ts
+++ b/packages/webpack-config/src/loaders/createAllLoaders.ts
@@ -14,7 +14,7 @@ import createWorkerLoader from './createWorkerLoader';
 // An Ethernet MTU is usually 1500. IP headers are 20 (v4) or 40 (v6) bytes and TCP
 // headers are 40 bytes. HTTP response headers vary and are around 400 bytes. This leaves
 // about 1000 bytes for content to fit in a packet.
-const imageInlineSizeLimit = parseInt(process.env.IMAGE_INLINE_SIZE_LIMIT || '10000');
+const imageInlineSizeLimit = parseInt(process.env.IMAGE_INLINE_SIZE_LIMIT || '1000');
 
 /**
  * This is needed for webpack to import static images in JavaScript files.

--- a/packages/webpack-config/src/loaders/createAllLoaders.ts
+++ b/packages/webpack-config/src/loaders/createAllLoaders.ts
@@ -31,6 +31,8 @@ export const imageLoaderRule: Rule = {
     loader: require.resolve('url-loader'),
     options: {
       limit: imageInlineSizeLimit,
+      // Interop assets like Metro bundler
+      esModule: false,
       name: 'static/media/[name].[hash:8].[ext]',
     },
   },
@@ -55,6 +57,8 @@ export const fallbackLoaderRule: Rule = {
   // Excludes: js, jsx, ts, tsx, html, json
   exclude: [/\.(mjs|[jt]sx?)$/, /\.html$/, /\.json$/],
   options: {
+    // Interop assets like Metro bundler
+    esModule: false,
     name: 'static/media/[name].[hash:8].[ext]',
   },
 };

--- a/packages/webpack-config/src/loaders/createFontLoader.ts
+++ b/packages/webpack-config/src/loaders/createFontLoader.ts
@@ -18,6 +18,8 @@ export default function createFontLoader(
       {
         loader: require.resolve('url-loader'),
         options: {
+          // Interop assets like Metro bundler
+          esModule: false,
           limit: 50000,
           name: './fonts/[name].[ext]',
         },


### PR DESCRIPTION
In the webpack upgrade the loaders started loading files as modules:
```js
const asset = require('img.png');
console.log(asset);
// Module {default: "data:image/png;base64,", __esModule: true, Symbol(Symbol.toStringTag): "Module"}
```
This PR changes all of the assets to load like metro bundler:

```js
const asset = require('img.png');
console.log(asset);
// data:image/png;base64,
```

I added E2E tests to ensure fonts, images, and wildcard files are loaded as expected.

fix https://github.com/expo/expo-cli/issues/2348