### PR TITLE
[xdl] Fix jest typescript line number reporting

### DIFF
--- a/packages/xdl/src/xdl.ts
+++ b/packages/xdl/src/xdl.ts
@@ -91,7 +91,7 @@ import * as Webpack from './Webpack';
 import XDLError from './XDLError';
 export { ConnectionStatus };
 
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   installSourceMapSupport();
 }
 export { Analytics };


### PR DESCRIPTION
`source-map-support` causes issues with line numbers when using typescript and jest.

Brief mentions of the issue at:
https://github.com/kulshekhar/ts-jest/issues/727
https://github.com/celo-org/ganache-core/pull/21

It seems the only fix is not to register it when in tests.

This was added a while back in https://github.com/expo/expo-cli/commit/5204b12a83fe59eec2ee7550123d9623c1c4dec2 without much context (or context was lost in phabricator) so I can't really assess whether this is going to break something else, but I think it should be okay.

Test Plan:
- Patch into www in combination with https://github.com/expo/universe/pull/5373 and cause a test to fail, ensure the correct line numbers are reported.