### PR TITLE
[xdl] don't log dots when downloading gradle

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1292,6 +1292,15 @@ async function buildShellAppAsync(context, sdkVersion, buildType, buildMode) {
         ANDROID_KEYSTORE_PATH: androidBuildConfiguration.keystore,
         ANDROID_KEYSTORE_PASSWORD: androidBuildConfiguration.keystorePassword,
       },
+      loggerLineTransformer: line => {
+        if (!line) {
+          return null;
+        } else if (line.match(/^\.+$/)) {
+          return null;
+        } else {
+          return line;
+        }
+      },
     });
 
     if (ExponentTools.parseSdkMajorVersion(sdkVersion) >= 32) {

--- a/packages/xdl/src/detach/ExponentTools.ts
+++ b/packages/xdl/src/detach/ExponentTools.ts
@@ -76,6 +76,7 @@ export type AsyncSpawnOptions = SpawnOptions & {
   loggerFields?: any;
   pipeToLogger?: boolean | { stdout?: boolean; stderr?: boolean };
   stdoutOnly?: boolean;
+  loggerLineTransformer?: (line: any) => any;
 };
 
 async function spawnAsyncThrowError(


### PR DESCRIPTION
# Why

From https://github.com/expo/turtle/issues/221:
> When running `turtle build:android` the logger outputs a lot of dots, which introduces noise for later analysis

# How

I added a logger line transformer which drops lines that only contain dots.

# Test Plan

- I yarn-linked `@expo/xdl` in my local `turtle-cli` repository.
- I ran an Android build and verified that no dots are displayed when Gradle Wrapper is downloading the appropriate Gradle version: <img width="1251" alt="Screenshot 2020-07-14 at 15 31 38" src="https://user-images.githubusercontent.com/5256730/87432541-6ec96b80-c5e8-11ea-9ce2-801d3aa5a4a1.png">
