### PR TITLE
[xdl] fix analytics for expo start

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2036,7 +2036,8 @@ export async function getSignedManifestStringAsync(
   if (_cachedSignedManifest.manifestString === manifestString) {
     return _cachedSignedManifest.signedManifest;
   }
-  const { response } = await ApiV2.clientForUser(currentSession).postAsync('manifest/sign', {
+  const user = await UserManager.ensureLoggedInAsync();
+  const { response } = await ApiV2.clientForUser(user).postAsync('manifest/sign', {
     args: {
       remoteUsername: manifest.owner ?? (await UserManager.getCurrentUsernameAsync()),
       remotePackageName: manifest.slug,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2036,6 +2036,8 @@ export async function getSignedManifestStringAsync(
   if (_cachedSignedManifest.manifestString === manifestString) {
     return _cachedSignedManifest.signedManifest;
   }
+  // WARNING: Removing the following line will regress analytics, see: https://github.com/expo/expo-cli/pull/2357
+  // TODO: make this more obvious from code
   const user = await UserManager.ensureLoggedInAsync();
   const { response } = await ApiV2.clientForUser(user).postAsync('manifest/sign', {
     args: {


### PR DESCRIPTION
This PR fixes an issue with expo-cli@3.22.x where the number of logged `Start Project` and `Serve Manifest` events are significantly lower than expected.

Paired with @animeeples to investigate and we found the root cause to be that by the time the `Serve Manifest` event should be sent, the `_userId` field in Analytics.ts is not set, meaning the following statement evaluates to false and the event is never sent to segment: 
https://github.com/expo/expo-cli/blob/d7e4d4d6440f8db81282c48ab11248d214f1ec49/packages/xdl/src/Analytics.ts#L41

Following the chain of methods that set the `_userId` field, it looks like this issue was introduced by https://github.com/expo/expo-cli/commit/553eb01540554070c2e8b3894dbb4314ba2cb484 which eliminated a call to `UserManager.ensureLoggedInAsync()` (https://github.com/expo/expo-cli/commit/553eb01540554070c2e8b3894dbb4314ba2cb484#diff-bf9f0db58154788a372e25a5c3898adbL2009). This method will set the `_userId` field on Analytics.ts if it is not already set.

This PR restores the previous functionality by adding a call to `UserManager.ensureLoggedInAsync()` in the analogous location, in order to keep these two metrics the same as before and preserve comparisons to historical data.

Looking further ahead, it would be good to
- refactor this code to be more intentional about when we set the `_userId` field in Analytics, so it's not such a hidden side effect
- reevaluate whether or not we want to track any/all segment events for users who are not logged in

But this PR is a first step/quick fix to get the metrics back to the place they were before 3.22.0.