### PR TITLE
[expo-cli] consolidate env variables.

### DIFF
--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -9,7 +9,7 @@ import { SubmissionMode } from './upload/submission-service/types';
 
 const SOURCE_OPTIONS = ['id', 'latest', 'path', 'url'];
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('upload:android [projectDir]')
     .alias('ua')
@@ -76,7 +76,7 @@ export default function (program: Command) {
     )
     .option(
       '--apple-id-password <apple-id-password>',
-      'your Apple ID password (you can also set EXPO_APPLE_ID_PASSWORD env variable)'
+      'your Apple ID password (you can also set EXPO_APPLE_PASSWORD env variable)'
     )
     .option(
       '--app-name <app-name>',
@@ -99,7 +99,7 @@ export default function (program: Command) {
     .description(
       'Uploads a standalone app to Apple TestFlight (works on macOS only). Uploads the latest build by default.'
     )
-    .on('--help', function () {
+    .on('--help', function() {
       console.log('Available languages:');
       console.log(`  ${LANGUAGES.join(', ')}`);
       console.log();

--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -144,14 +144,16 @@ export default class IOSUploader extends BaseUploader {
     const appleCredsKeys = ['appleId', 'appleIdPassword'];
     const result: AppleCreds = pick(this.options, appleCredsKeys);
 
-    if (process.env.EXPO_APPLE_ID) {
-      result.appleId = process.env.EXPO_APPLE_ID;
-    }
+    const appleId = result.appleId ?? process.env.EXPO_APPLE_ID;
+    const appleIdPassword =
+      result.appleIdPassword ??
+      process.env.EXPO_APPLE_PASSWORD ??
+      process.env.EXPO_APPLE_ID_PASSWORD;
+
     if (process.env.EXPO_APPLE_ID_PASSWORD) {
-      result.appleIdPassword = process.env.EXPO_APPLE_ID_PASSWORD;
+      log.error('EXPO_APPLE_ID_PASSWORD is deprecated, please use EXPO_APPLE_PASSWORD instead!');
     }
 
-    const { appleId, appleIdPassword } = result;
     if (appleId && appleIdPassword) {
       return {
         appleId,

--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -144,6 +144,16 @@ export default class IOSUploader extends BaseUploader {
     const appleCredsKeys = ['appleId', 'appleIdPassword'];
     const result: AppleCreds = pick(this.options, appleCredsKeys);
 
+    if (result.appleId && process.env.EXPO_APPLE_ID) {
+      log.warn(
+        `You've provided contradictory Apple IDs. You should provide either the EXPO_APPLE_ID env or the --apple-id flag, not both. Falling back to --apple-id.`
+      );
+    }
+    if (result.appleIdPassword && process.env.EXPO_APPLE_PASSWORD) {
+      log.warn(
+        `You've provided contradictory Apple IDs. You should provide either the EXPO_APPLE_PASSWORD env or the --apple-id-password flag, not both. Falling back to --apple-id-password.`
+      );
+    }
     const appleId = result.appleId ?? process.env.EXPO_APPLE_ID;
     const appleIdPassword =
       result.appleIdPassword ??

--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -151,7 +151,7 @@ export default class IOSUploader extends BaseUploader {
     }
     if (result.appleIdPassword && process.env.EXPO_APPLE_PASSWORD) {
       log.warn(
-        `You've provided contradictory Apple IDs. You should provide either the EXPO_APPLE_PASSWORD env or the --apple-id-password flag, not both. Falling back to --apple-id-password.`
+        `You've provided contradictory Apple passwords. You should provide either the EXPO_APPLE_PASSWORD env or the --apple-id-password flag, not both. Falling back to --apple-id-password.`
       );
     }
     const appleId = result.appleId ?? process.env.EXPO_APPLE_ID;


### PR DESCRIPTION
This fixes https://github.com/expo/expo-cli/issues/2280.

NB: in case of conflict we chose to prioritize the flag over the env variable.

Joint with @quinlanj 

# tests

- [x] manually tested `expo upload:ios` with flags and env var