### PR TITLE
Adjusted check for newer versions on Node

### DIFF
--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -18,7 +18,7 @@ var supportedVersions =
   '* >=14.0.0  <15.0.0 (Current Release)\n';
 
 // If newer than the current release
-if (major > 14) {
+if (major >= 14) {
   console.warn(
     yellow(
       'WARNING: expo-cli has not yet been tested against Node.js ' +
@@ -29,7 +29,7 @@ if (major > 14) {
         supportedVersions
     )
   );
-} else if (!((major === 10 && minor >= 13) || (major === 12 && minor >= 13) || major === 14)) {
+} else if (!((major === 10 && minor >= 13) || (major === 12 && minor >= 13))) {
   console.error(
     red('ERROR: Node.js ' + process.version + ' is no longer supported.\n\n' + supportedVersions)
   );


### PR DESCRIPTION
updated packages/expo-cli/bin/expo.js for Node vesion 14 by removing major === 14 from conditional in the else if, 
the else if was checking if major version was === to 14 and exiting the program.

Fixes #1955 & the update from #1957 