### PR TITLE
doc: expo-splash-screen: fix a command instrution

### DIFF
--- a/packages/configure-splash-screen/README.md
+++ b/packages/configure-splash-screen/README.md
@@ -38,7 +38,7 @@ You can use it to configure your native iOS and Android project according to you
 Command syntax:
 
 ```
-yarn run @expo/configure-splash-screen [options] <backgroundColor> [imagePathOrDarkModeBackgroundColor] [imagePath] [darkModeImagePath]
+yarn run configure-splash-screen [options] <backgroundColor> [imagePathOrDarkModeBackgroundColor] [imagePath] [darkModeImagePath]
 ```
 
 ### Arguments


### PR DESCRIPTION
when running 
```
yarn run @expo/configure-splash-screen [options] <backgroundColor> [imagePathOrDarkModeBackgroundColor] [imagePath] [darkModeImagePath]
```

It says command not found.

Changing command to 

```yarn run configure-splash-screen [options] <backgroundColor> [imagePathOrDarkModeBackgroundColor] [imagePath] [darkModeImagePath]```

works fine.



