### PR TITLE
[expo-cli] Wrap fastlane upload stderr JSON.parse in try/catch

### DIFF
--- a/packages/expo-cli/src/commands/upload/utils.ts
+++ b/packages/expo-cli/src/commands/upload/utils.ts
@@ -73,7 +73,13 @@ export async function runFastlaneAsync(
 
   const { stderr } = await spawnAsyncThrowError(program, args, spawnOptions);
 
-  const res = JSON.parse(stderr);
+  let res;
+  try {
+    res = JSON.parse(stderr);
+  } catch {
+    return stderr; // The error isn't parseable, but assume it was successful
+  }
+
   if (res.result !== 'failure') {
     return res;
   } else {


### PR DESCRIPTION
Assumes that the (un-parseable) string from fastlane was a success, since when used with github actions the process is successful. If it's not may have to take the issue up with fastlane?

For #2368 