### PR TITLE
[expo-cli] Wrap fastlane upload stderr JSON.parse in try/catch

### DIFF
--- a/packages/expo-cli/src/commands/upload/utils.ts
+++ b/packages/expo-cli/src/commands/upload/utils.ts
@@ -6,6 +6,8 @@ import fs from 'fs-extra';
 import got from 'got';
 import ProgressBar from 'progress';
 
+import log from '../../log';
+
 const { spawnAsyncThrowError } = ExponentTools;
 const pipeline = promisify(stream.pipeline);
 
@@ -73,7 +75,15 @@ export async function runFastlaneAsync(
 
   const { stderr } = await spawnAsyncThrowError(program, args, spawnOptions);
 
-  const res = JSON.parse(stderr);
+  let res;
+  try {
+    res = JSON.parse(stderr);
+  } catch {
+    // Log unparseable stderr message, but consider it a success
+    log(`Unexpected fastlane message: ${stderr}`);
+    return { result: 'success', rawDump: { message: stderr } };
+  }
+
   if (res.result !== 'failure') {
     return res;
   } else {


### PR DESCRIPTION
Assumes that the (un-parseable) string from fastlane was a success, since when used with github actions the process is successful. If it's not may have to take the issue up with fastlane?

I can switch it to produce an error message, but my current experience is the fastlane upload is successful?

For #2368