### PR TITLE
[expo-cli] submission service: fix passing archive type from command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🐛 Bug fixes
 
 - [xdl] Fix incorrect check of the packager port in the "setOptionsAsync" function [#2270](https://github.com/expo/expo-cli/issues/2270)
+- [expo-cli] expo upload:android - Fix passing archive type from command line [#2383](https://github.com/expo/expo-cli/pull/2383)
 
 ### 📦 Packages updated
 

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 
 import IOSUploader, { IosPlatformOptions, LANGUAGES } from './upload/IOSUploader';
 import AndroidSubmitCommand from './upload/submission-service/android/AndroidSubmitCommand';
+import { AndroidSubmitCommandOptions } from './upload/submission-service/android/types';
 import log from '../log';
 import { SubmissionMode } from './upload/submission-service/types';
 
@@ -42,7 +43,7 @@ export default function (program: Command) {
     .option('--verbose', 'Always print logs from Submission Service')
     .description('Uploads an Android standalone app to Google Play Store.')
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
-    .asyncActionProjectDir(async (projectDir: string, options: any) => {
+    .asyncActionProjectDir(async (projectDir: string, options: AndroidSubmitCommandOptions) => {
       // TODO: remove this once we verify `fastlane supply` works on linux / windows
       if (!options.useSubmissionService) {
         checkRuntimePlatform('android');

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitCommand.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitCommand.ts
@@ -183,7 +183,7 @@ class AndroidSubmitCommand {
   }
 
   private resolveArchiveTypeSource(): ArchiveTypeSource {
-    const { archiveType: rawArchiveType } = this.ctx.commandOptions;
+    const { type: rawArchiveType } = this.ctx.commandOptions;
     if (rawArchiveType) {
       if (!(rawArchiveType in ArchiveType)) {
         throw new Error(

--- a/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
@@ -4,12 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { AndroidSubmitCommandOptions } from '../types';
 import { SubmissionMode } from '../../types';
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
-import {
-  AndroidSubmissionConfig,
-  ArchiveType,
-  ReleaseStatus,
-  ReleaseTrack,
-} from '../AndroidSubmissionConfig';
+import { ArchiveType, ReleaseStatus, ReleaseTrack } from '../AndroidSubmissionConfig';
 import { mockExpoXDL } from '../../../../../__tests__/mock-utils';
 import { createTestProject } from '../../../../../__tests__/project-utils';
 import { jester } from '../../../../../__tests__/user-fixtures';
@@ -78,8 +73,8 @@ describe(AndroidSubmitCommand, () => {
     it('sends a request to Submission Service', async () => {
       const projectId = uuidv4();
       (SubmissionService.getSubmissionAsync as jest.Mock).mockImplementationOnce(
-        async (id: string): Promise<Submission> => {
-          const actualSubmission = await originalGetSubmissionAsync(id);
+        async (projectId: string, submissionId: string): Promise<Submission> => {
+          const actualSubmission = await originalGetSubmissionAsync(projectId, submissionId);
           return {
             ...actualSubmission,
             status: SubmissionStatus.FINISHED,
@@ -90,7 +85,7 @@ describe(AndroidSubmitCommand, () => {
 
       const options: AndroidSubmitCommandOptions = {
         url: 'http://expo.io/fake.apk',
-        archiveType: 'apk',
+        type: 'apk',
         key: '/google-service-account.json',
         track: 'internal',
         releaseStatus: 'draft',
@@ -129,7 +124,7 @@ describe(AndroidSubmitCommand, () => {
     it('executes supply_android from traveling-fastlane', async () => {
       const options: AndroidSubmitCommandOptions = {
         path: '/apks/fake.apk',
-        archiveType: 'apk',
+        type: 'apk',
         key: '/google-service-account.json',
         track: 'internal',
         releaseStatus: 'draft',

--- a/packages/expo-cli/src/commands/upload/submission-service/android/types.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/types.ts
@@ -1,7 +1,7 @@
 import { SubmissionContext, SubmitCommandOptions } from '../types';
 
 export interface AndroidSubmitCommandOptions extends SubmitCommandOptions {
-  archiveType?: string;
+  type?: string;
   key?: string;
   androidPackage?: string;
   track?: string;


### PR DESCRIPTION
Fixes https://forums.expo.io/t/github-actions-uploading-android-from-ubuntu-runner-use-submission-service/40593

The command option for specifying archive type is called `--type`, yet in the codebase, we were using `archiveType`. We made this error because the commander options weren't typed.

Things I did in this PR:
- I set the correct TS type for upload:android options.
- I renamed `archiveType` to `type`.
- I updated tests.