### PR TITLE
[expo-cli] upload:android - add better error messages for issues with downloading archive file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🎉 New features
 
 - [xdl] Log output from Gradle Wrapper is a lot cleaner now. It doesn't print dots when the appropriate Gradle version is being downloaded ([#2355](https://github.com/expo/expo-cli/pull/2355)).
+- [expo-cli] expo upload:android - Add better erro messages when downloading archive file failed [#2384](https://github.com/expo/expo-cli/pull/2384).
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🎉 New features
 
 - [xdl] Log output from Gradle Wrapper is a lot cleaner now. It doesn't print dots when the appropriate Gradle version is being downloaded ([#2355](https://github.com/expo/expo-cli/pull/2355)).
-- [expo-cli] expo upload:android - Add better erro messages when downloading archive file failed [#2384](https://github.com/expo/expo-cli/pull/2384).
+- [expo-cli] expo upload:android - Add better error messages when downloading archive file failed [#2384](https://github.com/expo/expo-cli/pull/2384).
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
@@ -2,6 +2,8 @@ import { SubmissionError } from '../SubmissionService.types';
 import log from '../../../../log';
 
 enum SubmissionErrorCode {
+  ARCHIVE_DOWNLOAD_NOT_FOUND_ERROR = 'SUBMISSION_SERVICE_COMMON_ARCHIVE_DOWNLOAD_NOT_FOUND_ERROR',
+  ARCHIVE_DOWNLOAD_FORBIDDEN_ERROR = 'SUBMISSION_SERVICE_COMMON_ARCHIVE_DOWNLOAD_FORBIDDEN_ERROR',
   ANDROID_UNKNOWN_ERROR = 'SUBMISSION_SERVICE_ANDROID_UNKNOWN_ERROR',
   ANDROID_FIRST_UPLOAD_ERROR = 'SUBMISSION_SERVICE_ANDROID_FIRST_UPLOAD_ERROR',
   ANDROID_OLD_VERSION_CODE_ERROR = 'SUBMISSION_SERVICE_ANDROID_OLD_VERSION_CODE_ERROR',
@@ -9,6 +11,10 @@ enum SubmissionErrorCode {
 }
 
 const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
+  [SubmissionErrorCode.ARCHIVE_DOWNLOAD_NOT_FOUND_ERROR]:
+    "Failed to download the archive file (Response code: 404 Not Found). Please make sure the URL you've provided is correct.",
+  [SubmissionErrorCode.ARCHIVE_DOWNLOAD_FORBIDDEN_ERROR]:
+    'Failed to download the archive file (Response code: 403 Forbidden). This is most probably caused by trying to upload an expired build. All Expo builds expire after 30 days.',
   [SubmissionErrorCode.ANDROID_UNKNOWN_ERROR]:
     "We couldn't figure out what went wrong. Please see logs to learn more.",
   [SubmissionErrorCode.ANDROID_FIRST_UPLOAD_ERROR]:

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
@@ -14,7 +14,7 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
   [SubmissionErrorCode.ARCHIVE_DOWNLOAD_NOT_FOUND_ERROR]:
     "Failed to download the archive file (Response code: 404 Not Found). Please make sure the URL you've provided is correct.",
   [SubmissionErrorCode.ARCHIVE_DOWNLOAD_FORBIDDEN_ERROR]:
-    'Failed to download the archive file (Response code: 403 Forbidden). This is most probably caused by trying to upload an expired build. All Expo builds expire after 30 days.',
+    'Failed to download the archive file (Response code: 403 Forbidden). This is most probably caused by trying to upload an expired build artifact. All Expo build artifacts expire after 30 days.',
   [SubmissionErrorCode.ANDROID_UNKNOWN_ERROR]:
     "We couldn't figure out what went wrong. Please see logs to learn more.",
   [SubmissionErrorCode.ANDROID_FIRST_UPLOAD_ERROR]:


### PR DESCRIPTION
Follow-up PR to https://github.com/expo/turtle-v2/pull/258.

I've noticed that we're not providing good error messages when we failed to download the archive file.
There are two main reasons for this to happen:
- the user provided an incorrect URL (404 error)
- the download URL has expired (403 error from AWS S3).

In this PR, I'm adding proper error messages for these issues.