### PR TITLE
[expo-cli] check `when` field when inquirer is used in noninteractive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 - [xdl] Fix incorrect check of the packager port in the "setOptionsAsync" function [#2270](https://github.com/expo/expo-cli/issues/2270)
 - [expo-cli] expo upload:android - Fix passing archive type from command line [#2383](https://github.com/expo/expo-cli/pull/2383)
+- [expo-cli] check `when` field when inquirer is used in noninteractive mode [#2393](https://github.com/expo/expo-cli/pull/2393)
 
 ### 📦 Packages updated
 

--- a/packages/expo-cli/src/prompt.ts
+++ b/packages/expo-cli/src/prompt.ts
@@ -11,8 +11,24 @@ export default function prompt(
   questions: CliQuestions,
   { nonInteractiveHelp }: { nonInteractiveHelp?: string } = {}
 ) {
-  const nQuestions = Array.isArray(questions) ? questions.length : 1;
-  if (program.nonInteractive && nQuestions !== 0) {
+  questions = Array.isArray(questions) ? questions : [questions];
+  const nAllQuestions = questions.length;
+  if (program.nonInteractive) {
+    const nQuestionsToAsk = questions.filter(question => {
+      if (!('when' in question)) {
+        return true;
+      } else if (typeof question.when === 'function') {
+        // if `when` is a function it takes object containing previous answers as argument
+        // in this case we want to detect if any question will be asked, so it
+        // always will be empty object
+        return question.when({});
+      } else {
+        return question.when;
+      }
+    }).length;
+    if (nAllQuestions === 0 || nQuestionsToAsk === 0) {
+      return {} as any;
+    }
     let message = `Input is required, but Expo CLI is in non-interactive mode.\n`;
     if (nonInteractiveHelp) {
       message += nonInteractiveHelp;


### PR DESCRIPTION
fixes #2327 