### PR TITLE
[expo-cli] read EXPO_APPLE_PASSWORD env when running build:ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 - [xdl] Fix incorrect check of the packager port in the "setOptionsAsync" function [#2270](https://github.com/expo/expo-cli/issues/2270)
 - [expo-cli] expo upload:android - Fix passing archive type from command line [#2383](https://github.com/expo/expo-cli/pull/2383)
+- [expo-cli] read `EXPO_APPLE_PASSWORD` env when running build:ios [#2394](https://github.com/expo/expo-cli/pull/2394)
 
 ### 📦 Packages updated
 

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import chalk from 'chalk';
 import pickBy from 'lodash/pickBy';
+import pick from 'lodash/pick';
 import { XDLError } from '@expo/xdl';
 
 import terminalLink from 'terminal-link';
@@ -70,7 +71,12 @@ class IOSBuilder extends BaseBuilder {
   async getAppleCtx(): Promise<apple.AppleCtx> {
     if (!this.appleCtx) {
       await apple.setup();
-      this.appleCtx = await apple.authenticate(this.options);
+
+      const appleApiOptions: apple.Options = pick(this.options, ['appleId', 'teamId']);
+      if (this.options.appleId && process.env.EXPO_APPLE_PASSWORD) {
+        appleApiOptions.appleIdPassword = process.env.EXPO_APPLE_PASSWORD;
+      }
+      this.appleCtx = await apple.authenticate(appleApiOptions);
     }
     return this.appleCtx;
   }


### PR DESCRIPTION
fixes #2343 