### PR TITLE
[expo-cli][config] EAS builds: iOS project autoconfiguration

### DIFF
--- a/packages/config/src/ios/BundleIdentifier.ts
+++ b/packages/config/src/ios/BundleIdentifier.ts
@@ -15,7 +15,7 @@ import {
   isNotTestHost,
 } from './utils/Xcodeproj';
 
-export function getBundleIdentifier(config: ExpoConfig) {
+function getBundleIdentifier(config: ExpoConfig): string | null {
   return config.ios && config.ios.bundleIdentifier ? config.ios.bundleIdentifier : null;
 }
 
@@ -23,8 +23,7 @@ export function getBundleIdentifier(config: ExpoConfig) {
  * In Turtle v1 we set the bundleIdentifier directly on Info.plist rather
  * than in pbxproj
  */
-
-export function setBundleIdentifier(config: ExpoConfig, infoPlist: InfoPlist) {
+function setBundleIdentifier(config: ExpoConfig, infoPlist: InfoPlist): InfoPlist {
   const bundleIdentifier = getBundleIdentifier(config);
 
   if (!bundleIdentifier) {
@@ -45,16 +44,15 @@ export function setBundleIdentifier(config: ExpoConfig, infoPlist: InfoPlist) {
  * @param {boolean} [updateProductName=true]  Whether to update PRODUCT_NAME
  */
 
-export function updateBundleIdentifierForPbxproj(
+function updateBundleIdentifierForPbxproj(
   pbxprojPath: string,
   bundleIdentifier: string,
   updateProductName: boolean = true
-) {
+): void {
   const project = Project(pbxprojPath);
   project.parseSync();
 
   const configurationLists = getXCConfigurationLists(project);
-  // TODO(dsokal): figure out if configuring only the entries from the first configuration list is fine
   const buildConfigurations = configurationLists[0].buildConfigurations.map(i => i.value);
 
   Object.entries(getXCBuildConfigurationSection(project))
@@ -86,11 +84,11 @@ export function updateBundleIdentifierForPbxproj(
  * @param {string} bundleIdentifier Desired bundle identifier
  * @param {boolean} [updateProductName=true]  Whether to update PRODUCT_NAME
  */
-export function setBundleIdentifierForPbxproj(
+function setBundleIdentifierForPbxproj(
   projectRoot: string,
   bundleIdentifier: string,
   updateProductName: boolean = true
-) {
+): void {
   // Get all pbx projects in the ${projectRoot}/ios directory
   const pbxprojPaths = globSync('ios/*/project.pbxproj', { absolute: true, cwd: projectRoot });
 
@@ -105,7 +103,7 @@ export function setBundleIdentifierForPbxproj(
 
 const defaultBundleId = '$(PRODUCT_BUNDLE_IDENTIFIER)';
 
-export function resetAllPlistBundleIdentifiers(projectRoot: string) {
+function resetAllPlistBundleIdentifiers(projectRoot: string): void {
   const infoPlistPaths = globSync('ios/*/Info.plist', { absolute: true, cwd: projectRoot });
 
   for (const plistPath of infoPlistPaths) {
@@ -113,7 +111,7 @@ export function resetAllPlistBundleIdentifiers(projectRoot: string) {
   }
 }
 
-export function resetPlistBundleIdentifier(plistPath: string) {
+function resetPlistBundleIdentifier(plistPath: string): void {
   const rawPlist = fs.readFileSync(plistPath, 'utf8');
   const plistObject = plist.parse(rawPlist) as PlistObject;
 
@@ -136,3 +134,12 @@ export function resetPlistBundleIdentifier(plistPath: string) {
     }
   }
 }
+
+export {
+  getBundleIdentifier,
+  setBundleIdentifier,
+  updateBundleIdentifierForPbxproj,
+  setBundleIdentifierForPbxproj,
+  resetAllPlistBundleIdentifiers,
+  resetPlistBundleIdentifier,
+};

--- a/packages/config/src/ios/BundleIdentifier.ts
+++ b/packages/config/src/ios/BundleIdentifier.ts
@@ -4,6 +4,7 @@ import { sync as globSync } from 'glob';
 // @ts-ignore
 import { project as Project } from 'xcode';
 
+import { ExpoConfig } from '../Config.types';
 import { InfoPlist } from './IosConfig.types';
 import {
   ConfigurationSectionEntry,
@@ -13,7 +14,6 @@ import {
   isNotComment,
   isNotTestHost,
 } from './utils/Xcodeproj';
-import { ExpoConfig } from '../Config.types';
 
 export function getBundleIdentifier(config: ExpoConfig) {
   return config.ios && config.ios.bundleIdentifier ? config.ios.bundleIdentifier : null;

--- a/packages/config/src/ios/Entitlements.ts
+++ b/packages/config/src/ios/Entitlements.ts
@@ -7,9 +7,10 @@ import { addWarningIOS } from '../WarningAggregator';
 import {
   getPbxproj,
   getProjectName,
+  getXCBuildConfigurationSection,
   isBuildConfig,
-  removeComments,
-  removeTestHosts,
+  isNotComment,
+  isNotTestHost,
 } from './utils/Xcodeproj';
 
 // TODO: should it be possible to turn off these entitlements by setting false in app.json and running apply
@@ -83,10 +84,10 @@ function createEntitlementsFile(projectRoot: string) {
    * Add file to pbxproj under CODE_SIGN_ENTITLEMENTS
    */
   const project = getPbxproj(projectRoot);
-  Object.entries(project.pbxXCBuildConfigurationSection())
-    .filter(removeComments)
+  Object.entries(getXCBuildConfigurationSection(project))
+    .filter(isNotComment)
     .filter(isBuildConfig)
-    .filter(removeTestHosts)
+    .filter(isNotTestHost)
     .forEach(({ 1: { buildSettings } }: any) => {
       buildSettings.CODE_SIGN_ENTITLEMENTS = entitlementsRelativePath;
     });

--- a/packages/config/src/ios/IosConfig.types.ts
+++ b/packages/config/src/ios/IosConfig.types.ts
@@ -13,6 +13,7 @@ export type InfoPlist = {
   CFBundleShortVersionString?: string;
   CFBundleVersion?: string;
   CFBundleDisplayName?: string;
+  CFBundleIdentifier?: string;
   CFBundleName?: string;
   CFBundleURLTypes?: URLScheme[];
   ITSAppUsesNonExemptEncryption?: boolean;

--- a/packages/config/src/ios/ProvisioningProfile.ts
+++ b/packages/config/src/ios/ProvisioningProfile.ts
@@ -1,0 +1,55 @@
+import fs from 'fs-extra';
+
+import {
+  ConfigurationSectionEntry,
+  ProjectSectionEntry,
+  getPbxproj,
+  getProjectSection,
+  getXCBuildConfigurationSection,
+  getXCConfigurationLists,
+  isBuildConfig,
+  isNotComment,
+  isNotTestHost,
+} from './utils/Xcodeproj';
+
+type ProvisioningProfileSettings = {
+  appleTeamId: string;
+  profileName: string;
+};
+
+function setProvisioningProfileForPbxproj(
+  projectRoot: string,
+  { profileName, appleTeamId }: ProvisioningProfileSettings
+): void {
+  const project = getPbxproj(projectRoot);
+
+  const configurationLists = getXCConfigurationLists(project);
+  // TODO(dsokal): figure out if configuring only the entries from the first configuration list is fine
+  const buildConfigurations = configurationLists[0].buildConfigurations.map(i => i.value);
+
+  Object.entries(getXCBuildConfigurationSection(project))
+    .filter(isNotComment)
+    .filter(isBuildConfig)
+    .filter(isNotTestHost)
+    .filter(([, item]: ConfigurationSectionEntry) => item.buildSettings.PRODUCT_NAME)
+    .filter(([key]: ConfigurationSectionEntry) => buildConfigurations.includes(key))
+    .forEach(([, item]: ConfigurationSectionEntry) => {
+      item.buildSettings.PROVISIONING_PROFILE_SPECIFIER = `"${profileName}"`;
+      item.buildSettings.DEVELOPMENT_TEAM = appleTeamId;
+      item.buildSettings.CODE_SIGN_IDENTITY = '"iPhone Distribution"';
+      item.buildSettings.CODE_SIGN_STYLE = 'Manual';
+    });
+
+  Object.entries(getProjectSection(project))
+    .filter(isNotComment)
+    .forEach(([, item]: ProjectSectionEntry) => {
+      // TODO(dsokal): figure out if we need to configure anything else than the first target
+      const targetId = item.targets[0].value;
+      item.attributes.TargetAttributes[targetId].DevelopmentTeam = appleTeamId;
+      item.attributes.TargetAttributes[targetId].ProvisioningStyle = 'Manual';
+    });
+
+  fs.writeFileSync(project.filepath, project.writeSync());
+}
+
+export { setProvisioningProfileForPbxproj };

--- a/packages/config/src/ios/__tests__/BundleIdentifier-test.ts
+++ b/packages/config/src/ios/__tests__/BundleIdentifier-test.ts
@@ -1,28 +1,75 @@
-import { getBundleIdentifier, setBundleIdentifier } from '../BundleIdentifier';
+import { fs as memfs, vol } from 'memfs';
+import path from 'path';
 
-describe('bundle identifier', () => {
-  it(`returns null if no bundleIdentifier is provided`, () => {
-    expect(getBundleIdentifier({})).toBe(null);
-  });
+import { ExpoConfig } from '../../Config.types';
+import {
+  getBundleIdentifier,
+  setBundleIdentifier,
+  setBundleIdentifierForPbxproj,
+} from '../BundleIdentifier';
 
-  it(`returns the bundleIdentifier if provided`, () => {
-    expect(getBundleIdentifier({ ios: { bundleIdentifier: 'com.example.xyz' } })).toBe(
-      'com.example.xyz'
-    );
-  });
+const baseExpoConfig: ExpoConfig = {
+  name: 'testproject',
+  slug: 'testproject',
+  platforms: ['ios'],
+  version: '1.0.0',
+};
 
-  it(`sets the CFBundleShortVersionString if bundleIdentifier is given`, () => {
-    expect(
-      setBundleIdentifier({ ios: { bundleIdentifier: 'host.exp.exponent' } }, {})
-    ).toMatchObject({
-      CFBundleIdentifier: 'host.exp.exponent',
+jest.mock('fs');
+
+const originalFs = jest.requireActual('fs');
+
+describe('BundleIdentifier module', () => {
+  describe(getBundleIdentifier, () => {
+    it('returns null if no bundleIdentifier is provided', () => {
+      expect(getBundleIdentifier(baseExpoConfig)).toBe(null);
+    });
+
+    it('returns the bundleIdentifier if provided', () => {
+      expect(
+        getBundleIdentifier({ ...baseExpoConfig, ios: { bundleIdentifier: 'com.example.xyz' } })
+      ).toBe('com.example.xyz');
     });
   });
 
-  it(`makes no changes to the infoPlist no bundleIdentifier is provided`, () => {
-    expect(setBundleIdentifier({}, {})).toMatchObject({});
+  describe(setBundleIdentifier, () => {
+    it('sets the CFBundleShortVersionString if bundleIdentifier is given', () => {
+      expect(
+        setBundleIdentifier(
+          { ...baseExpoConfig, ios: { bundleIdentifier: 'host.exp.exponent' } },
+          {}
+        )
+      ).toMatchObject({
+        CFBundleIdentifier: 'host.exp.exponent',
+      });
+    });
+
+    it('makes no changes to the infoPlist no bundleIdentifier is provided', () => {
+      expect(setBundleIdentifier(baseExpoConfig, {})).toMatchObject({});
+    });
+  });
+
+  describe(setBundleIdentifierForPbxproj, () => {
+    const projectRoot = '/testproject';
+    const pbxProjPath = 'ios/testproject.xcodeproj/project.pbxproj';
+
+    beforeEach(() => {
+      vol.fromJSON(
+        {
+          [pbxProjPath]: originalFs.readFileSync(
+            path.join(__dirname, 'fixtures/project.pbxproj'),
+            'utf-8'
+          ),
+        },
+        projectRoot
+      );
+    });
+    afterEach(() => vol.reset());
+
+    it('sets the bundle identifier in the pbxproj file', () => {
+      setBundleIdentifierForPbxproj(projectRoot, 'com.swmansion.dominik.abcd.v2');
+      const pbxprojContents = memfs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+      expect(pbxprojContents).toMatchSnapshot();
+    });
   });
 });
-
-// TODO
-xdescribe('updating pbxproject', () => {});

--- a/packages/config/src/ios/__tests__/BundleIdentifier-test.ts
+++ b/packages/config/src/ios/__tests__/BundleIdentifier-test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { ExpoConfig } from '../../Config.types';
 import {
   getBundleIdentifier,
+  getBundleIdentifierFromPbxproj,
   setBundleIdentifier,
   setBundleIdentifierForPbxproj,
 } from '../BundleIdentifier';
@@ -29,6 +30,30 @@ describe('BundleIdentifier module', () => {
       expect(
         getBundleIdentifier({ ...baseExpoConfig, ios: { bundleIdentifier: 'com.example.xyz' } })
       ).toBe('com.example.xyz');
+    });
+  });
+
+  describe(getBundleIdentifierFromPbxproj, () => {
+    const projectRoot = '/testproject';
+
+    afterEach(() => vol.reset());
+
+    it('returns null if no project.pbxproj exists', () => {
+      vol.mkdirpSync(projectRoot);
+      expect(getBundleIdentifierFromPbxproj(projectRoot)).toBeNull();
+    });
+
+    it('returns the bundle identifier defined in project.pbxproj', () => {
+      vol.fromJSON(
+        {
+          'ios/testproject.xcodeproj/project.pbxproj': originalFs.readFileSync(
+            path.join(__dirname, 'fixtures/project.pbxproj'),
+            'utf-8'
+          ),
+        },
+        projectRoot
+      );
+      expect(getBundleIdentifierFromPbxproj(projectRoot)).toBe('org.name.testproject');
     });
   });
 

--- a/packages/config/src/ios/__tests__/ProvisioningProfile-test.ts
+++ b/packages/config/src/ios/__tests__/ProvisioningProfile-test.ts
@@ -1,0 +1,39 @@
+import { fs as memfs, vol } from 'memfs';
+import path from 'path';
+
+import { setProvisioningProfileForPbxproj } from '../ProvisioningProfile';
+
+jest.mock('fs');
+
+const originalFs = jest.requireActual('fs');
+
+describe('ProvisioningProfile module', () => {
+  describe(setProvisioningProfileForPbxproj, () => {
+    const projectRoot = '/testproject';
+    const pbxProjPath = 'ios/testproject.xcodeproj/project.pbxproj';
+
+    beforeEach(() => {
+      vol.fromJSON(
+        {
+          [pbxProjPath]: originalFs.readFileSync(
+            path.join(__dirname, 'fixtures/project.pbxproj'),
+            'utf-8'
+          ),
+        },
+        projectRoot
+      );
+    });
+    afterEach(() => {
+      vol.reset();
+    });
+
+    it('configures the project.pbxproj file with the profile name and apple team id', async () => {
+      setProvisioningProfileForPbxproj(projectRoot, {
+        profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+        appleTeamId: 'J5FM626PE2',
+      });
+      const pbxprojContents = memfs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+      expect(pbxprojContents).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/config/src/ios/__tests__/__snapshots__/BundleIdentifier-test.ts.snap
+++ b/packages/config/src/ios/__tests__/__snapshots__/BundleIdentifier-test.ts.snap
@@ -1,0 +1,465 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BundleIdentifier module setBundleIdentifierForPbxproj sets the bundle identifier in the pbxproj file 1`] = `
+"// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		96905EF65AED1B983A6B3ABC /* libPods-testproject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = \\"<group>\\"; };
+		13B07F961A680F5B00A75B9A /* testproject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = testproject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = testproject/AppDelegate.h; sourceTree = \\"<group>\\"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = testproject/AppDelegate.m; sourceTree = \\"<group>\\"; };
+		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = \\"<group>\\"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = testproject/Images.xcassets; sourceTree = \\"<group>\\"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = testproject/Info.plist; sourceTree = \\"<group>\\"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = testproject/main.m; sourceTree = \\"<group>\\"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = \\"libPods-testproject.a\\"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = \\"Pods-testproject.debug.xcconfig\\"; path = \\"Target Support Files/Pods-testproject/Pods-testproject.debug.xcconfig\\"; sourceTree = \\"<group>\\"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = \\"Pods-testproject.release.xcconfig\\"; path = \\"Target Support Files/Pods-testproject/Pods-testproject.release.xcconfig\\"; sourceTree = \\"<group>\\"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = testproject/SplashScreen.storyboard; sourceTree = \\"<group>\\"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = \\"<group>\\"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-testproject.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* testproject */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+			);
+			name = testproject;
+			sourceTree = \\"<group>\\";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */,
+			);
+			name = Frameworks;
+			sourceTree = \\"<group>\\";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = \\"<group>\\";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* testproject */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = \\"<group>\\";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* testproject.app */,
+			);
+			name = Products;
+			sourceTree = \\"<group>\\";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = testproject/Supporting;
+			sourceTree = \\"<group>\\";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* testproject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget \\"testproject\\" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				FD10A7F022414F080027D42C /* Start Packager */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = testproject;
+			productName = testproject;
+			productReference = 13B07F961A680F5B00A75B9A /* testproject.app */;
+			productType = \\"com.apple.product-type.application\\";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1120;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject \\"testproject\\" */;
+			compatibilityVersion = \\"Xcode 3.2\\";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = \\"\\";
+			projectRoot = \\"\\";
+			targets = (
+				13B07F861A680F5B00A75B9A /* testproject */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = \\"Bundle React Native code and images\\";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"export NODE_BINARY=node\\\\n../node_modules/react-native/scripts/react-native-xcode.sh\\\\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\\\\n\\";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				\\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\",
+				\\"\${PODS_ROOT}/Manifest.lock\\",
+			);
+			name = \\"[CP] Check Pods Manifest.lock\\";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				\\"$(DERIVED_FILE_DIR)/Pods-testproject-checkManifestLockResult.txt\\",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"diff \\\\\\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\\\\\" \\\\\\"\${PODS_ROOT}/Manifest.lock\\\\\\" > /dev/null\\\\nif [ $? != 0 ] ; then\\\\n    # print error to STDERR\\\\n    echo \\\\\\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\\\\\" >&2\\\\n    exit 1\\\\nfi\\\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\\\necho \\\\\\"SUCCESS\\\\\\" > \\\\\\"\${SCRIPT_OUTPUT_FILE_0}\\\\\\"\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+		FD10A7F022414F080027D42C /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = \\"Start Packager\\";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"export RCT_METRO_PORT=\\\\\\"\${RCT_METRO_PORT:=8081}\\\\\\"\\\\necho \\\\\\"export RCT_METRO_PORT=\${RCT_METRO_PORT}\\\\\\" > \\\\\\"\${SRCROOT}/../node_modules/react-native/scripts/.packager.env\\\\\\"\\\\nif [ -z \\\\\\"\${RCT_NO_LAUNCH_PACKAGER+xxx}\\\\\\" ] ; then\\\\n  if nc -w 5 -z localhost \${RCT_METRO_PORT} ; then\\\\n    if ! curl -s \\\\\\"http://localhost:\${RCT_METRO_PORT}/status\\\\\\" | grep -q \\\\\\"packager-status:running\\\\\\" ; then\\\\n      echo \\\\\\"Port \${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\\\\\\"\\\\n      exit 2\\\\n    fi\\\\n  else\\\\n    open \\\\\\"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\\\\\\" || echo \\\\\\"Can't start packager automatically\\\\\\"\\\\n  fi\\\\nfi\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13B07FB21A68108700A75B9A /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = testproject;
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"$(inherited)\\",
+					\\"FB_SONARKIT_ENABLED=1\\",
+				);
+				INFOPLIST_FILE = testproject/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks\\";
+				OTHER_LDFLAGS = (
+					\\"$(inherited)\\",
+					\\"-ObjC\\",
+					\\"-lc++\\",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = \\"com.swmansion.dominik.abcd.v2\\";
+				PRODUCT_NAME = v2;
+				SWIFT_OPTIMIZATION_LEVEL = \\"-Onone\\";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = \\"apple-generic\\";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = testproject/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks\\";
+				OTHER_LDFLAGS = (
+					\\"$(inherited)\\",
+					\\"-ObjC\\",
+					\\"-lc++\\",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = \\"com.swmansion.dominik.abcd.v2\\";
+				PRODUCT_NAME = v2;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = \\"apple-generic\\";
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				\\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\\" = \\"iPhone Developer\\";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"DEBUG=1\\",
+					\\"$(inherited)\\",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"/usr/lib/swift $(inherited)\\";
+				LIBRARY_SEARCH_PATHS = (
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(inherited)\\\\\\"\\",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				\\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\\" = \\"iPhone Developer\\";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"/usr/lib/swift $(inherited)\\";
+				LIBRARY_SEARCH_PATHS = (
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(inherited)\\\\\\"\\",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget \\"testproject\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject \\"testproject\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}
+"
+`;

--- a/packages/config/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
+++ b/packages/config/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
@@ -1,0 +1,475 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures the project.pbxproj file with the profile name and apple team id 1`] = `
+"// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		96905EF65AED1B983A6B3ABC /* libPods-testproject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = \\"<group>\\"; };
+		13B07F961A680F5B00A75B9A /* testproject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = testproject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = testproject/AppDelegate.h; sourceTree = \\"<group>\\"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = testproject/AppDelegate.m; sourceTree = \\"<group>\\"; };
+		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = \\"<group>\\"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = testproject/Images.xcassets; sourceTree = \\"<group>\\"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = testproject/Info.plist; sourceTree = \\"<group>\\"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = testproject/main.m; sourceTree = \\"<group>\\"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = \\"libPods-testproject.a\\"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = \\"Pods-testproject.debug.xcconfig\\"; path = \\"Target Support Files/Pods-testproject/Pods-testproject.debug.xcconfig\\"; sourceTree = \\"<group>\\"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = \\"Pods-testproject.release.xcconfig\\"; path = \\"Target Support Files/Pods-testproject/Pods-testproject.release.xcconfig\\"; sourceTree = \\"<group>\\"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = testproject/SplashScreen.storyboard; sourceTree = \\"<group>\\"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = \\"<group>\\"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-testproject.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* testproject */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+			);
+			name = testproject;
+			sourceTree = \\"<group>\\";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */,
+			);
+			name = Frameworks;
+			sourceTree = \\"<group>\\";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = \\"<group>\\";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* testproject */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = \\"<group>\\";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* testproject.app */,
+			);
+			name = Products;
+			sourceTree = \\"<group>\\";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = testproject/Supporting;
+			sourceTree = \\"<group>\\";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* testproject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget \\"testproject\\" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				FD10A7F022414F080027D42C /* Start Packager */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = testproject;
+			productName = testproject;
+			productReference = 13B07F961A680F5B00A75B9A /* testproject.app */;
+			productType = \\"com.apple.product-type.application\\";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1120;
+						DevelopmentTeam = J5FM626PE2;
+						ProvisioningStyle = Manual;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject \\"testproject\\" */;
+			compatibilityVersion = \\"Xcode 3.2\\";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = \\"\\";
+			projectRoot = \\"\\";
+			targets = (
+				13B07F861A680F5B00A75B9A /* testproject */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = \\"Bundle React Native code and images\\";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"export NODE_BINARY=node\\\\n../node_modules/react-native/scripts/react-native-xcode.sh\\\\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\\\\n\\";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				\\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\",
+				\\"\${PODS_ROOT}/Manifest.lock\\",
+			);
+			name = \\"[CP] Check Pods Manifest.lock\\";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				\\"$(DERIVED_FILE_DIR)/Pods-testproject-checkManifestLockResult.txt\\",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"diff \\\\\\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\\\\\" \\\\\\"\${PODS_ROOT}/Manifest.lock\\\\\\" > /dev/null\\\\nif [ $? != 0 ] ; then\\\\n    # print error to STDERR\\\\n    echo \\\\\\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\\\\\" >&2\\\\n    exit 1\\\\nfi\\\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\\\necho \\\\\\"SUCCESS\\\\\\" > \\\\\\"\${SCRIPT_OUTPUT_FILE_0}\\\\\\"\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+		FD10A7F022414F080027D42C /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = \\"Start Packager\\";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"export RCT_METRO_PORT=\\\\\\"\${RCT_METRO_PORT:=8081}\\\\\\"\\\\necho \\\\\\"export RCT_METRO_PORT=\${RCT_METRO_PORT}\\\\\\" > \\\\\\"\${SRCROOT}/../node_modules/react-native/scripts/.packager.env\\\\\\"\\\\nif [ -z \\\\\\"\${RCT_NO_LAUNCH_PACKAGER+xxx}\\\\\\" ] ; then\\\\n  if nc -w 5 -z localhost \${RCT_METRO_PORT} ; then\\\\n    if ! curl -s \\\\\\"http://localhost:\${RCT_METRO_PORT}/status\\\\\\" | grep -q \\\\\\"packager-status:running\\\\\\" ; then\\\\n      echo \\\\\\"Port \${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\\\\\\"\\\\n      exit 2\\\\n    fi\\\\n  else\\\\n    open \\\\\\"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\\\\\\" || echo \\\\\\"Can't start packager automatically\\\\\\"\\\\n  fi\\\\nfi\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13B07FB21A68108700A75B9A /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = testproject;
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"$(inherited)\\",
+					\\"FB_SONARKIT_ENABLED=1\\",
+				);
+				INFOPLIST_FILE = testproject/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks\\";
+				OTHER_LDFLAGS = (
+					\\"$(inherited)\\",
+					\\"-ObjC\\",
+					\\"-lc++\\",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.testproject;
+				PRODUCT_NAME = testproject;
+				SWIFT_OPTIMIZATION_LEVEL = \\"-Onone\\";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = \\"apple-generic\\";
+				PROVISIONING_PROFILE_SPECIFIER = \\"*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z\\";
+				DEVELOPMENT_TEAM = J5FM626PE2;
+				CODE_SIGN_IDENTITY = \\"iPhone Distribution\\";
+				CODE_SIGN_STYLE = Manual;
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = testproject/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks\\";
+				OTHER_LDFLAGS = (
+					\\"$(inherited)\\",
+					\\"-ObjC\\",
+					\\"-lc++\\",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.testproject;
+				PRODUCT_NAME = testproject;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = \\"apple-generic\\";
+				PROVISIONING_PROFILE_SPECIFIER = \\"*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z\\";
+				DEVELOPMENT_TEAM = J5FM626PE2;
+				CODE_SIGN_IDENTITY = \\"iPhone Distribution\\";
+				CODE_SIGN_STYLE = Manual;
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				\\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\\" = \\"iPhone Developer\\";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"DEBUG=1\\",
+					\\"$(inherited)\\",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"/usr/lib/swift $(inherited)\\";
+				LIBRARY_SEARCH_PATHS = (
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(inherited)\\\\\\"\\",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				\\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\\" = \\"iPhone Developer\\";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"/usr/lib/swift $(inherited)\\";
+				LIBRARY_SEARCH_PATHS = (
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(inherited)\\\\\\"\\",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget \\"testproject\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject \\"testproject\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}
+"
+`;

--- a/packages/config/src/ios/__tests__/fixtures/project.pbxproj
+++ b/packages/config/src/ios/__tests__/fixtures/project.pbxproj
@@ -1,0 +1,460 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		96905EF65AED1B983A6B3ABC /* libPods-testproject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		13B07F961A680F5B00A75B9A /* testproject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = testproject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = testproject/AppDelegate.h; sourceTree = "<group>"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = testproject/AppDelegate.m; sourceTree = "<group>"; };
+		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = testproject/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = testproject/Info.plist; sourceTree = "<group>"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = testproject/main.m; sourceTree = "<group>"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-testproject.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-testproject.debug.xcconfig"; path = "Target Support Files/Pods-testproject/Pods-testproject.debug.xcconfig"; sourceTree = "<group>"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-testproject.release.xcconfig"; path = "Target Support Files/Pods-testproject/Pods-testproject.release.xcconfig"; sourceTree = "<group>"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = testproject/SplashScreen.storyboard; sourceTree = "<group>"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-testproject.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* testproject */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+			);
+			name = testproject;
+			sourceTree = "<group>";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* testproject */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* testproject.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = testproject/Supporting;
+			sourceTree = "<group>";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* testproject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "testproject" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				FD10A7F022414F080027D42C /* Start Packager */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = testproject;
+			productName = testproject;
+			productReference = 13B07F961A680F5B00A75B9A /* testproject.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1120;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "testproject" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* testproject */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\n";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-testproject-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FD10A7F022414F080027D42C /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Start Packager";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13B07FB21A68108700A75B9A /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = testproject;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = testproject/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.testproject;
+				PRODUCT_NAME = testproject;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = testproject/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.testproject;
+				PRODUCT_NAME = testproject;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "testproject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "testproject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}

--- a/packages/config/src/ios/index.ts
+++ b/packages/config/src/ios/index.ts
@@ -10,6 +10,7 @@ import { InfoPlist } from './IosConfig.types';
 import * as Locales from './Locales';
 import * as Name from './Name';
 import * as Orientation from './Orientation';
+import * as ProvisioningProfile from './ProvisioningProfile';
 import * as RequiresFullScreen from './RequiresFullScreen';
 import * as Scheme from './Scheme';
 import * as SplashScreen from './SplashScreen';
@@ -35,6 +36,7 @@ export {
   InfoPlist,
   Name,
   Orientation,
+  ProvisioningProfile,
   RequiresFullScreen,
   Scheme,
   Updates,

--- a/packages/config/src/ios/utils/Xcodeproj.ts
+++ b/packages/config/src/ios/utils/Xcodeproj.ts
@@ -61,16 +61,17 @@ export function getPbxproj(projectRoot: string): Pbxproj {
   return project;
 }
 
-export type ProjectSection = { [key: string]: ProjectSectionItem };
+export type ProjectSection = Record<string, ProjectSectionItem>;
 export type ProjectSectionItem = {
   isa: string;
   attributes: {
-    TargetAttributes: {
-      [key: string]: {
+    TargetAttributes: Record<
+      string,
+      {
         DevelopmentTeam?: string;
         ProvisioningStyle?: string;
-      };
-    };
+      }
+    >;
   };
   targets: {
     value: string;
@@ -82,7 +83,7 @@ export function getProjectSection(project: Pbxproj): ProjectSection {
   return project.pbxProjectSection();
 }
 
-export type ConfigurationLists = { [key: string]: ConfigurationList };
+export type ConfigurationLists = Record<string, ConfigurationList>;
 export type ConfigurationList = {
   isa: string;
   buildConfigurations: {
@@ -98,7 +99,7 @@ export function getXCConfigurationLists(project: Pbxproj): ConfigurationList[] {
     .map(([, value]) => value);
 }
 
-export type ConfigurationSection = { [key: string]: ConfigurationSectionItem };
+export type ConfigurationSection = Record<string, ConfigurationSectionItem>;
 export type ConfigurationSectionItem = {
   isa: string;
   buildSettings: {

--- a/packages/config/src/ios/utils/Xcodeproj.ts
+++ b/packages/config/src/ios/utils/Xcodeproj.ts
@@ -19,10 +19,13 @@ export function getSourceRoot(projectRoot: string) {
   return path.dirname(paths[0]);
 }
 
+// TODO: define this type later
+export type Pbxproj = any;
+
 // TODO(brentvatne): I couldn't figure out how to do this with an existing
 // higher level function exposed by the xcode library, but we should find out how to do
 // that and replace this with it
-export function addFileToGroup(filepath: string, groupName: string, project: Project) {
+export function addFileToGroup(filepath: string, groupName: string, project: Project): Pbxproj {
   const file = new pbxFile(filepath);
   file.uuid = project.generateUuid();
   file.fileRef = project.generateUuid();
@@ -41,7 +44,7 @@ export function addFileToGroup(filepath: string, groupName: string, project: Pro
 /**
  * Get the pbxproj for the given path
  */
-export function getPbxproj(projectRoot: string) {
+export function getPbxproj(projectRoot: string): Pbxproj {
   const pbxprojPaths = globSync('ios/*/project.pbxproj', { absolute: true, cwd: projectRoot });
   const [pbxprojPath, ...otherPbxprojPaths] = pbxprojPaths;
 
@@ -58,21 +61,73 @@ export function getPbxproj(projectRoot: string) {
   return project;
 }
 
-export function removeComments([item]: any[]): boolean {
-  return !item.endsWith(`_comment`);
+export type ProjectSection = { [key: string]: ProjectSectionItem };
+export type ProjectSectionItem = {
+  isa: string;
+  attributes: {
+    TargetAttributes: {
+      [key: string]: {
+        DevelopmentTeam?: string;
+        ProvisioningStyle?: string;
+      };
+    };
+  };
+  targets: {
+    value: string;
+  }[];
+};
+export type ProjectSectionEntry = [string, ProjectSectionItem];
+
+export function getProjectSection(project: Pbxproj): ProjectSection {
+  return project.pbxProjectSection();
 }
 
-export function isBuildConfig(input: any[]): boolean {
-  const {
-    1: { isa },
-  } = input;
-  return isa === 'XCBuildConfiguration';
+export type ConfigurationLists = { [key: string]: ConfigurationList };
+export type ConfigurationList = {
+  isa: string;
+  buildConfigurations: {
+    value: string;
+  }[];
+};
+export type ConfigurationListsEntry = [string, ConfigurationList];
+
+export function getXCConfigurationLists(project: Pbxproj): ConfigurationList[] {
+  const lists = project.pbxXCConfigurationList() as ConfigurationLists;
+  return Object.entries(lists)
+    .filter(isNotComment)
+    .map(([, value]) => value);
 }
 
-export function removeTestHosts(input: any[]): boolean {
-  const {
-    1: { buildSettings },
-  } = input;
+export type ConfigurationSection = { [key: string]: ConfigurationSectionItem };
+export type ConfigurationSectionItem = {
+  isa: string;
+  buildSettings: {
+    PRODUCT_NAME?: string;
+    PRODUCT_BUNDLE_IDENTIFIER?: string;
+    PROVISIONING_PROFILE_SPECIFIER?: string;
+    TEST_HOST?: any;
+    DEVELOPMENT_TEAM?: string;
+    CODE_SIGN_IDENTITY?: string;
+    CODE_SIGN_STYLE?: string;
+  };
+};
+export type ConfigurationSectionEntry = [string, ConfigurationSectionItem];
 
-  return !buildSettings.TEST_HOST;
+export function getXCBuildConfigurationSection(project: Pbxproj): ConfigurationSection {
+  return project.pbxXCBuildConfigurationSection();
+}
+
+export function isBuildConfig([, sectionItem]: ConfigurationSectionEntry): boolean {
+  return sectionItem.isa === 'XCBuildConfiguration';
+}
+
+export function isNotTestHost([, sectionItem]: ConfigurationSectionEntry): boolean {
+  return !sectionItem.buildSettings.TEST_HOST;
+}
+
+export function isNotComment([key]:
+  | ConfigurationSectionEntry
+  | ProjectSectionEntry
+  | ConfigurationListsEntry): boolean {
+  return !key.endsWith(`_comment`);
 }

--- a/packages/expo-cli/__mocks__/ora.js
+++ b/packages/expo-cli/__mocks__/ora.js
@@ -3,6 +3,9 @@ const ora = jest.fn(() => {
     start: jest.fn(() => {
       return { stop: jest.fn(), succeed: jest.fn(), fail: jest.fn() };
     }),
+    stop: jest.fn(),
+    succeed: jest.fn(),
+    fail: jest.fn(),
   };
 });
 

--- a/packages/expo-cli/src/commands/build-native/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build-native/AndroidBuilder.ts
@@ -50,6 +50,10 @@ class AndroidBuilder implements Builder {
     this.credentials = await provider.getCredentialsAsync(credentialsSource);
   }
 
+  public async configureProjectAsync(): Promise<void> {
+    // TODO: implement me
+  }
+
   public async prepareJobAsync(archiveUrl: string): Promise<Job> {
     if (!this.credentialsPrepared) {
       throw new Error('ensureCredentialsAsync should be called before prepareJobAsync');

--- a/packages/expo-cli/src/commands/build-native/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/build-native/__tests__/build-test.ts
@@ -2,7 +2,8 @@ import merge from 'lodash/merge';
 import { vol } from 'memfs';
 
 import { mockExpoXDL } from '../../../__tests__/mock-utils';
-import { buildAction } from '../index';
+import { provisioningProfileBase64 } from '../../../credentials/utils/__tests__/tests-fixtures';
+import { BuildPlatform, buildAction } from '../index';
 
 const mockedUser = {
   username: 'jester',
@@ -10,6 +11,20 @@ const mockedUser = {
 
 const mockProjectUrl = 'http://fakeurl.com';
 const mockPostAsync = jest.fn();
+jest.mock('@expo/config', () => {
+  const pkg = jest.requireActual('@expo/config');
+  return {
+    ...pkg,
+    IOSConfig: {
+      BundleIdenitifer: {
+        setBundleIdentifierForPbxproj: jest.fn(),
+      },
+      ProvisioningProfile: {
+        setProvisioningProfileForPbxproj: jest.fn(),
+      },
+    },
+  };
+});
 jest.mock('fs');
 jest.mock('prompts');
 jest.mock('../../../projects', () => {
@@ -17,7 +32,7 @@ jest.mock('../../../projects', () => {
     ensureProjectExistsAsync: () => 'fakeProjectId',
   };
 });
-jest.mock('../utils');
+jest.mock('../utils/git');
 jest.mock('../../../uploads', () => ({
   UploadType: {},
   uploadAsync: () => mockProjectUrl,
@@ -51,7 +66,7 @@ const credentialsJson = {
     },
   },
   ios: {
-    provisioningProfilePath: './pprofile',
+    provisioningProfilePath: 'pprofile',
     distributionCertificate: {
       path: 'cert.p12',
       password: 'certPass',
@@ -65,8 +80,8 @@ const keystore = {
 };
 
 const pprofile = {
-  content: 'pprofilecontent',
-  base64: 'cHByb2ZpbGVjb250ZW50',
+  content: Buffer.from(provisioningProfileBase64, 'base64'),
+  base64: provisioningProfileBase64,
 };
 
 const cert = {
@@ -104,16 +119,19 @@ const packageJson = {
 };
 
 function setupProjectConfig(overrideConfig: any) {
-  vol.fromJSON({
-    './credentials.json': JSON.stringify(merge(credentialsJson, overrideConfig.credentialsJson)),
-    './keystore.jks': overrideConfig.keystore ?? keystore.content,
-    './eas.json': JSON.stringify(merge(easJson, overrideConfig.easJson)),
-    './app.json': JSON.stringify(appJson),
-    './package.json': JSON.stringify(packageJson),
-    './node_modules/expo/package.json': '{ "version": "38.0.0" }',
-    './pprofile': pprofile.content,
-    './cert.p12': cert.content,
-  });
+  vol.fromJSON(
+    {
+      'credentials.json': JSON.stringify(merge(credentialsJson, overrideConfig.credentialsJson)),
+      'keystore.jks': overrideConfig.keystore ?? keystore.content,
+      'eas.json': JSON.stringify(merge(easJson, overrideConfig.easJson)),
+      'app.json': JSON.stringify(appJson),
+      'package.json': JSON.stringify(packageJson),
+      'node_modules/expo/package.json': '{ "version": "38.0.0" }',
+      'cert.p12': cert.content,
+    },
+    '/projectdir'
+  );
+  vol.writeFileSync('/projectdir/pprofile', pprofile.content);
 }
 
 const originalWarn = console.warn;
@@ -144,8 +162,8 @@ describe('build command', () => {
         return { buildId: 'fakeBuildId' };
       });
       setupProjectConfig({});
-      await buildAction('.', {
-        platform: 'android',
+      await buildAction('/projectdir', {
+        platform: BuildPlatform.ANDROID,
         wait: false,
         profile: 'release',
       });
@@ -177,8 +195,8 @@ describe('build command', () => {
         return { buildId: 'fakeBuildId' };
       });
       setupProjectConfig({});
-      await buildAction('.', {
-        platform: 'ios',
+      await buildAction('/projectdir', {
+        platform: BuildPlatform.IOS,
         wait: false,
         profile: 'release',
       });
@@ -211,8 +229,8 @@ describe('build command', () => {
         return { buildId: 'fakeIosBuildId' };
       });
       setupProjectConfig({});
-      await buildAction('.', {
-        platform: 'all',
+      await buildAction('/projectdir', {
+        platform: BuildPlatform.ALL,
         wait: false,
         profile: 'release',
       });

--- a/packages/expo-cli/src/commands/build-native/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/build-native/__tests__/build-test.ts
@@ -18,6 +18,8 @@ jest.mock('@expo/config', () => {
     IOSConfig: {
       BundleIdenitifer: {
         setBundleIdentifierForPbxproj: jest.fn(),
+        getBundleIdentifierFromPbxproj: jest.fn(),
+        getBundleIdentifier: jest.fn(),
       },
       ProvisioningProfile: {
         setProvisioningProfileForPbxproj: jest.fn(),

--- a/packages/expo-cli/src/commands/build-native/build.ts
+++ b/packages/expo-cli/src/commands/build-native/build.ts
@@ -13,7 +13,7 @@ import { EasConfig } from '../../easJson';
 import log from '../../log';
 import { UploadType, uploadAsync } from '../../uploads';
 import { createProgressTracker } from '../utils/progress';
-import { makeProjectTarballAsync } from './utils';
+import { makeProjectTarballAsync } from './utils/git';
 
 export enum BuildStatus {
   IN_QUEUE = 'in-queue',
@@ -47,6 +47,7 @@ export interface BuilderContext {
 export interface Builder {
   ctx: BuilderContext;
   ensureCredentialsAsync(): Promise<void>;
+  configureProjectAsync(): Promise<void>;
   prepareJobAsync(archiveUrl: string): Promise<Job>;
 }
 
@@ -77,6 +78,7 @@ export async function startBuildAsync(
   const tarPath = path.join(os.tmpdir(), `${uuidv4()}.tar.gz`);
   try {
     await builder.ensureCredentialsAsync();
+    await builder.configureProjectAsync();
 
     const fileSize = await makeProjectTarballAsync(tarPath);
 

--- a/packages/expo-cli/src/commands/build-native/credentials.ts
+++ b/packages/expo-cli/src/commands/build-native/credentials.ts
@@ -52,7 +52,7 @@ async function ensureCredentialsAutoAsync(
         const { confirm } = await prompts({
           type: 'confirm',
           name: 'confirm',
-          message: 'Do you want to generete new credentials?',
+          message: 'Do you want to generate new credentials?',
         });
         if (confirm) {
           return CredentialsSource.REMOTE;

--- a/packages/expo-cli/src/commands/build-native/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build-native/iOSBuilder.ts
@@ -12,11 +12,11 @@ import {
   iOSGenericBuildProfile,
   iOSManagedBuildProfile,
 } from '../../easJson';
+import log from '../../log';
+import prompts from '../../prompts';
 import { Builder, BuilderContext } from './build';
 import { ensureCredentialsAsync } from './credentials';
 import * as gitUtils from './utils/git';
-import log from '../../log';
-import prompts from '../../prompts';
 
 interface CommonJobProperties {
   platform: Platform.iOS;

--- a/packages/expo-cli/src/commands/build-native/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build-native/iOSBuilder.ts
@@ -121,7 +121,7 @@ class iOSBuilder implements Builder {
           log('✅ Successfully commited the configuration changes.');
         } else {
           throw new Error(
-            "Aborting, run the build command once you're ready. Make sure commit any changes you've made."
+            "Aborting, run the build command once you're ready. Make sure to commit any changes you've made."
           );
         }
       } else {

--- a/packages/expo-cli/src/commands/build-native/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build-native/iOSBuilder.ts
@@ -97,7 +97,7 @@ class iOSBuilder implements Builder {
       await gitUtils.ensureGitStatusIsCleanAsync();
       spinner.succeed();
     } catch (err) {
-      if (/Please commit all changes/.exec(err.message)) {
+      if (err instanceof gitUtils.DirtyGitTreeError) {
         spinner.succeed('We configured your iOS project to build it on the Expo servers');
         log.newLine();
         log('Please review the following changes and pass the message to make the commit.');
@@ -199,7 +199,7 @@ Otherwise, you'll see this prompt again in the future.`
       log.newLine();
       const { bundleIdentifier } = await prompts({
         type: 'select',
-        name: 'source',
+        name: 'bundleIdentifier',
         message: 'Which bundle identifier should we use?',
         choices: [
           {

--- a/packages/expo-cli/src/commands/build-native/index.ts
+++ b/packages/expo-cli/src/commands/build-native/index.ts
@@ -16,7 +16,8 @@ import {
   waitForBuildEndAsync,
 } from './build';
 import iOSBuilder from './iOSBuilder';
-import { printBuildResults, printBuildTable, printLogsUrls } from './utils';
+import { ensureGitStatusIsCleanAsync } from './utils/git';
+import { printBuildResults, printBuildTable, printLogsUrls } from './utils/misc';
 
 enum BuildPlatform {
   ANDROID = 'android',
@@ -71,6 +72,9 @@ export async function buildAction(projectDir: string, options: BuildOptions): Pr
         .join(', ')}`
     );
   }
+
+  await ensureGitStatusIsCleanAsync();
+
   const easConfig: EasConfig = await new EasJsonReader(projectDir, platform).readAsync(profile);
   const ctx = await createBuilderContextAsync(projectDir, easConfig);
   const projectId = await ensureProjectExistsAsync(ctx.user, {

--- a/packages/expo-cli/src/commands/build-native/index.ts
+++ b/packages/expo-cli/src/commands/build-native/index.ts
@@ -19,7 +19,7 @@ import iOSBuilder from './iOSBuilder';
 import { ensureGitStatusIsCleanAsync } from './utils/git';
 import { printBuildResults, printBuildTable, printLogsUrls } from './utils/misc';
 
-enum BuildPlatform {
+export enum BuildPlatform {
   ANDROID = 'android',
   IOS = 'ios',
   ALL = 'all',

--- a/packages/expo-cli/src/commands/build-native/utils/git.ts
+++ b/packages/expo-cli/src/commands/build-native/utils/git.ts
@@ -1,0 +1,52 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs-extra';
+import ora from 'ora';
+
+import prompts from '../../../prompts';
+
+async function ensureGitStatusIsCleanAsync(): Promise<void> {
+  const changes = (await spawnAsync('git', ['status', '-s', '-uno'])).stdout;
+  if (changes.length > 0) {
+    throw new Error('Please commit all changes before building your project. Aborting...');
+  }
+}
+
+async function makeProjectTarballAsync(tarPath: string): Promise<number> {
+  const spinner = ora('Making project tarball').start();
+  await spawnAsync('git', [
+    'archive',
+    '--format=tar.gz',
+    '--prefix',
+    'project/',
+    '-o',
+    tarPath,
+    'HEAD',
+  ]);
+  spinner.succeed('Project tarball created.');
+
+  const { size } = await fs.stat(tarPath);
+  return size;
+}
+
+async function showDiff(): Promise<void> {
+  await spawnAsync('git', ['--no-pager', 'diff'], { stdio: ['ignore', 'inherit', 'inherit'] });
+}
+
+async function commitChangesAsync(commitMessage?: string): Promise<void> {
+  if (!commitMessage) {
+    const promptResult = await prompts({
+      type: 'text',
+      name: 'message',
+      message: 'Commit message:',
+      initial: 'Configure Xcode project',
+      validate: input => input !== '',
+    });
+    commitMessage = promptResult.message as string;
+  }
+
+  // add changed files only
+  await spawnAsync('git', ['add', '-u']);
+  await spawnAsync('git', ['commit', '-m', commitMessage]);
+}
+
+export { ensureGitStatusIsCleanAsync, makeProjectTarballAsync, commitChangesAsync, showDiff };

--- a/packages/expo-cli/src/commands/build-native/utils/git.ts
+++ b/packages/expo-cli/src/commands/build-native/utils/git.ts
@@ -7,9 +7,13 @@ import prompts from '../../../prompts';
 async function ensureGitStatusIsCleanAsync(): Promise<void> {
   const changes = (await spawnAsync('git', ['status', '-s', '-uno'])).stdout;
   if (changes.length > 0) {
-    throw new Error('Please commit all changes before building your project. Aborting...');
+    throw new DirtyGitTreeError(
+      'Please commit all changes before building your project. Aborting...'
+    );
   }
 }
+
+class DirtyGitTreeError extends Error {}
 
 async function makeProjectTarballAsync(tarPath: string): Promise<number> {
   const spinner = ora('Making project tarball').start();
@@ -49,4 +53,10 @@ async function commitChangesAsync(commitMessage?: string): Promise<void> {
   await spawnAsync('git', ['commit', '-m', commitMessage]);
 }
 
-export { ensureGitStatusIsCleanAsync, makeProjectTarballAsync, commitChangesAsync, showDiff };
+export {
+  DirtyGitTreeError,
+  ensureGitStatusIsCleanAsync,
+  makeProjectTarballAsync,
+  commitChangesAsync,
+  showDiff,
+};

--- a/packages/expo-cli/src/commands/build-native/utils/misc.ts
+++ b/packages/expo-cli/src/commands/build-native/utils/misc.ts
@@ -1,8 +1,8 @@
 import { UserManager } from '@expo/xdl';
 
 import log from '../../../log';
-import * as UrlUtils from '../../utils/url';
 import { printTableJsonArray } from '../../utils/cli-table';
+import * as UrlUtils from '../../utils/url';
 import { BuildInfo } from '../build';
 
 function printBuildTable(builds: BuildInfo[]) {

--- a/packages/expo-cli/src/commands/build-native/utils/misc.ts
+++ b/packages/expo-cli/src/commands/build-native/utils/misc.ts
@@ -1,34 +1,9 @@
-import spawnAsync from '@expo/spawn-async';
 import { UserManager } from '@expo/xdl';
-import fs from 'fs-extra';
-import ora from 'ora';
 
-import log from '../../log';
-import { printTableJsonArray } from '../utils/cli-table';
-import * as UrlUtils from '../utils/url';
-import { BuildInfo } from './build';
-
-async function makeProjectTarballAsync(tarPath: string) {
-  const spinner = ora('Making project tarball').start();
-  const changes = (await spawnAsync('git', ['status', '-s'])).stdout;
-  if (changes.length > 0) {
-    spinner.fail('Could not make project tarball');
-    throw new Error('Please commit all files before trying to build your project. Aborting...');
-  }
-  await spawnAsync('git', [
-    'archive',
-    '--format=tar.gz',
-    '--prefix',
-    'project/',
-    '-o',
-    tarPath,
-    'HEAD',
-  ]);
-  spinner.succeed('Project tarball created.');
-
-  const { size } = await fs.stat(tarPath);
-  return size;
-}
+import log from '../../../log';
+import * as UrlUtils from '../../utils/url';
+import { printTableJsonArray } from '../../utils/cli-table';
+import { BuildInfo } from '../build';
 
 function printBuildTable(builds: BuildInfo[]) {
   const headers = ['started', 'platform', 'status', 'artifact'];
@@ -97,4 +72,4 @@ async function printBuildResults(buildInfo: (BuildInfo | null)[]): Promise<void>
   }
 }
 
-export { makeProjectTarballAsync, printBuildTable, printLogsUrls, printBuildResults };
+export { printBuildTable, printLogsUrls, printBuildResults };

--- a/packages/expo-cli/src/credentials/local/credentialsJson.ts
+++ b/packages/expo-cli/src/credentials/local/credentialsJson.ts
@@ -64,7 +64,7 @@ async function readAndroidAsync(projectDir: string): Promise<AndroidCredentials>
   const keystoreInfo = credentialsJson.android.keystore;
   return {
     keystore: {
-      keystore: await fs.readFile(keystoreInfo.keystorePath, 'base64'),
+      keystore: await fs.readFile(path.join(projectDir, keystoreInfo.keystorePath), 'base64'),
       keystorePassword: keystoreInfo.keystorePassword,
       keyAlias: keystoreInfo.keyAlias,
       keyPassword: keystoreInfo.keyPassword,
@@ -78,9 +78,15 @@ async function readIosAsync(projectDir: string): Promise<iOSCredentials> {
     throw new Error('iOS credentials are missing from credentials.json'); // TODO: add fyi
   }
   return {
-    provisioningProfile: await fs.readFile(credentialsJson.ios.provisioningProfilePath, 'base64'),
+    provisioningProfile: await fs.readFile(
+      path.join(projectDir, credentialsJson.ios.provisioningProfilePath),
+      'base64'
+    ),
     distributionCertificate: {
-      certP12: await fs.readFile(credentialsJson.ios.distributionCertificate.path, 'base64'),
+      certP12: await fs.readFile(
+        path.join(projectDir, credentialsJson.ios.distributionCertificate.path),
+        'base64'
+      ),
       certPassword: credentialsJson.ios.distributionCertificate.password,
     },
   };

--- a/packages/expo-cli/src/credentials/local/credentialsJson.ts
+++ b/packages/expo-cli/src/credentials/local/credentialsJson.ts
@@ -64,7 +64,7 @@ async function readAndroidAsync(projectDir: string): Promise<AndroidCredentials>
   const keystoreInfo = credentialsJson.android.keystore;
   return {
     keystore: {
-      keystore: await fs.readFile(path.join(projectDir, keystoreInfo.keystorePath), 'base64'),
+      keystore: await fs.readFile(getAbsolutePath(projectDir, keystoreInfo.keystorePath), 'base64'),
       keystorePassword: keystoreInfo.keystorePassword,
       keyAlias: keystoreInfo.keyAlias,
       keyPassword: keystoreInfo.keyPassword,
@@ -79,12 +79,12 @@ async function readIosAsync(projectDir: string): Promise<iOSCredentials> {
   }
   return {
     provisioningProfile: await fs.readFile(
-      path.join(projectDir, credentialsJson.ios.provisioningProfilePath),
+      getAbsolutePath(projectDir, credentialsJson.ios.provisioningProfilePath),
       'base64'
     ),
     distributionCertificate: {
       certP12: await fs.readFile(
-        path.join(projectDir, credentialsJson.ios.distributionCertificate.path),
+        getAbsolutePath(projectDir, credentialsJson.ios.distributionCertificate.path),
         'base64'
       ),
       certPassword: credentialsJson.ios.distributionCertificate.password,
@@ -115,5 +115,8 @@ async function readAsync(projectDir: string): Promise<CredentialsJson> {
 
   return credentialsJson;
 }
+
+const getAbsolutePath = (projectDir: string, filePath: string): string =>
+  path.isAbsolute(filePath) ? filePath : path.join(projectDir, filePath);
 
 export default { readAndroidAsync, readIosAsync, fileExistsAsync };

--- a/packages/expo-cli/src/credentials/utils/__tests__/provisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/utils/__tests__/provisioningProfile-test.ts
@@ -1,19 +1,35 @@
-import provisioningProfileUtils from '../provisioningProfile';
+import * as provisioningProfileUtils from '../provisioningProfile';
 import { provisioningProfileBase64 } from './tests-fixtures';
+
+const MALFORMED_PROVISIONING_PROFILE = 'aWV5Zmd3eXVlZmdl';
 
 describe('provisioningProfileUtils', () => {
   describe('readAppleTeam', () => {
-    it('should return correct teamId', () => {
+    it('returns correct teamId', () => {
       const team = provisioningProfileUtils.readAppleTeam(provisioningProfileBase64);
       expect(team).toEqual({
         teamId: 'QL76XYH73P',
         teamName: 'Alicja Warchał',
       });
     });
-    it('should throw parsing error on incorrect file', () => {
-      expect(() => provisioningProfileUtils.readAppleTeam('aWV5Zmd3eXVlZmdl')).toThrowError(
-        'Provisioning profile is malformed'
-      );
+
+    it('throws an error if provisioning profile is maflormed', () => {
+      expect(() =>
+        provisioningProfileUtils.readAppleTeam(MALFORMED_PROVISIONING_PROFILE)
+      ).toThrowError('Provisioning profile is malformed');
+    });
+  });
+
+  describe('readProfileName', () => {
+    it('returns correct profile name', () => {
+      const profileName = provisioningProfileUtils.readProfileName(provisioningProfileBase64);
+      expect(profileName).toEqual('org.reactjs.native.example.testapp.turtlev2 profil');
+    });
+
+    it('throws an error if provisioning profile is maflormed', () => {
+      expect(() =>
+        provisioningProfileUtils.readProfileName(MALFORMED_PROVISIONING_PROFILE)
+      ).toThrowError('Provisioning profile is malformed');
     });
   });
 });

--- a/packages/expo-cli/src/credentials/utils/provisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/utils/provisioningProfile.ts
@@ -6,14 +6,7 @@ interface AppleTeam {
 }
 
 function readAppleTeam(dataBase64: string): AppleTeam {
-  let profilePlist;
-  try {
-    const buffer = Buffer.from(dataBase64, 'base64');
-    const profile = buffer.toString('utf-8');
-    profilePlist = plist.parse(profile) as PlistObject;
-  } catch (error) {
-    throw new Error('Provisioning profile is malformed');
-  }
+  const profilePlist = parse(dataBase64);
   const teamId = (profilePlist['TeamIdentifier'] as PlistArray)?.[0] as string;
   const teamName = profilePlist['TeamName'] as string;
   if (!teamId) {
@@ -22,4 +15,19 @@ function readAppleTeam(dataBase64: string): AppleTeam {
   return { teamId, teamName };
 }
 
-export default { readAppleTeam };
+function readProfileName(dataBase64: string): string {
+  const profilePlist = parse(dataBase64);
+  return profilePlist['Name'] as string;
+}
+
+function parse(dataBase64: string): PlistObject {
+  try {
+    const buffer = Buffer.from(dataBase64, 'base64');
+    const profile = buffer.toString('utf-8');
+    return plist.parse(profile) as PlistObject;
+  } catch (error) {
+    throw new Error('Provisioning profile is malformed');
+  }
+}
+
+export { readAppleTeam, readProfileName };

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -24,7 +24,7 @@ import {
   IosDistCredentials,
   provisioningProfileSchema,
 } from '../credentials';
-import provisioningProfileUtils from '../utils/provisioningProfile';
+import * as provisioningProfileUtils from '../utils/provisioningProfile';
 
 export class RemoveProvisioningProfile implements IView {
   constructor(


### PR DESCRIPTION
# Why

For generic iOS builds, we want `expo-cli` to autoconfigure the Xcode project so that it's buildable by Turtle workers. 
Generally, in order to do that, a user would need to:
- **have a Mac!**
- if the app's credentials were generated with expo-cli:
  - add the provisioning profile to `~/Library/MobileDevice/Provisioning\ Profiles`
  - add the distribution certificate to the keychain
- open Xcode
- choose the appropriate provisioning profile on the `Signing & Capabilities` tab
- commit changes to the `project.pbxproj` file

The whole process is described in https://github.com/expo/turtle-v2/blob/master/TUTORIAL.md

We need to automate this process so the user doesn't need to perform tedious tasks whenever he regenerates his credentials or sets up a new project. We also want to allow users to configure iOS projects on Windows and Linux.

This PR tries to solve all these problems.

# How

There are two parts of this PR: 
- New features in `@expo/config`:
  - I added a new module - `ProvisioningProfile` - with only one function for now: `setProvisioningProfileForPbxproj`. It takes two parameters - the profile name and the apple team id. It modifies the `project.pbxproj` file the same way as if the user made the changes with Xcode.
  - I added/improved some TS types here and there.
  - I cleaned up a few things and added tests for the `BundleIdentifier`.
- Changes to `expo-cli:
  - I added a new step during the build process - `configureProjectAsync` - this is the step where the whole project setup is going to happen. This function is called just after the credentials are set up:
    - for Android, it's just an empty function for now (we'll probably implement `build.gradle` modifications there)
    - for iOS, we're reading the profile name and the apple team id from the provisioning profile and then configuring the project.pbxproj with the bundle identifier, profile name, and apple team id. I'm using the new features from `@expo/config` for that.
  - After the changes to the project have been made, we're showing the git diff to the user and asking if he wants to commit them. We're prompting him for the commit message.
  - Next, the build process works the same way as always.

# Test Plan

I tested these changes manually:
- I initialized a new bare project with `expo init`.
- I set the iOS bundle identifier in `app.json`.
- I added a minimal `eas.json`.
- I ran `expo build --platform ios`:
  - I generated credentials.
  - I observed that the CLI updated `project.pbxproj` and I was offered to commit those changes.
  - I passed the commit message.
  - The build has been scheduled (I got the build URL).
  - I pressed `CTRL+C` and ran `git log` and I saw that a new commit has been made.
- :tada: check out this gif - https://turtle-v2-test.s3.us-east-2.amazonaws.com/Kapture+2020-07-28+at+14.57.03.gif

I also added some unit/integration tests.

