### PR TITLE
[expo-cli] base64 decode when saving p8 file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to Expo CLI and related packages.
 - [xdl] Fix incorrect check of the packager port in the "setOptionsAsync" function [#2270](https://github.com/expo/expo-cli/issues/2270)
 - [expo-cli] expo upload:android - Fix passing archive type from command line [#2383](https://github.com/expo/expo-cli/pull/2383)
 - [expo-cli] check `when` field when inquirer is used in noninteractive mode [#2393](https://github.com/expo/expo-cli/pull/2393)
+- [expo-cli] base64 decode when saving p8 file [#2404](https://github.com/expo/expo-cli/pull/2404)
 
 ### 📦 Packages updated
 

--- a/packages/expo-cli/src/commands/fetch/ios.ts
+++ b/packages/expo-cli/src/commands/fetch/ios.ts
@@ -48,7 +48,7 @@ async function fetchIosCerts(projectDir: string): Promise<void> {
     }
     if (apnsKeyP8) {
       const apnsKeyP8Path = inProjectDir(`${remotePackageName}_apns_key.p8`);
-      await fs.writeFile(apnsKeyP8Path, apnsKeyP8);
+      await fs.writeFile(apnsKeyP8Path, Buffer.from(apnsKeyP8, 'base64'));
       log('Wrote push key credentials to disk.');
     }
     if (pushP12) {


### PR DESCRIPTION
# Why
`fetch:ios:certs`  creates push notification key base64 encoded