### PR TITLE
[expo-cli] revert PR #2404 and remove encoding from IosPushCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This is the log of notable changes to Expo CLI and related packages.
 - [xdl] Fix incorrect check of the packager port in the "setOptionsAsync" function [#2270](https://github.com/expo/expo-cli/issues/2270)
 - [expo-cli] expo upload:android - Fix passing archive type from command line [#2383](https://github.com/expo/expo-cli/pull/2383)
 - [expo-cli] check `when` field when inquirer is used in noninteractive mode [#2393](https://github.com/expo/expo-cli/pull/2393)
-- [expo-cli] base64 decode when saving p8 file [#2404](https://github.com/expo/expo-cli/pull/2404)
+- [expo-cli] do not base64 encode push notification [#2406](https://github.com/expo/expo-cli/pull/2406)
 
 ### 📦 Packages updated
 

--- a/packages/expo-cli/src/commands/fetch/ios.ts
+++ b/packages/expo-cli/src/commands/fetch/ios.ts
@@ -48,7 +48,7 @@ async function fetchIosCerts(projectDir: string): Promise<void> {
     }
     if (apnsKeyP8) {
       const apnsKeyP8Path = inProjectDir(`${remotePackageName}_apns_key.p8`);
-      await fs.writeFile(apnsKeyP8Path, Buffer.from(apnsKeyP8, 'base64'));
+      await fs.writeFile(apnsKeyP8Path, apnsKeyP8);
       log('Wrote push key credentials to disk.');
     }
     if (pushP12) {

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -567,7 +567,7 @@ export async function getPushKeyFromParams(builderOptions: {
 
   return {
     apnsKeyId: pushId,
-    apnsKeyP8: await fs.readFile(pushP8Path, 'base64'),
+    apnsKeyP8: await fs.readFile(pushP8Path, 'utf8'),
     teamId,
   } as PushKey;
 }


### PR DESCRIPTION
Reverting changes made in #2404 (I initially assumed that push key is base encoded on a server)
Remove encoding from `getPushKeyFromParams`