### PR TITLE
[expo-cli] don't print function string in error message

### DIFF
--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -22,7 +22,7 @@ export async function loginOrRegisterAsync(): Promise<User> {
   if (program.nonInteractive) {
     throw new CommandError(
       'NOT_LOGGED_IN',
-      `Not logged in. Use \`${program.name} login -u username -p password\` to log in.`
+      `Not logged in. Use \`${program.name()} login -u username -p password\` to log in.`
     );
   }
 


### PR DESCRIPTION
Currently, if user is not logged in, the function string is printed in the error message because of a typo. This commit fixes it so that the program name is displayed instead.