### PR TITLE
[expo-cli] cleanup apple id credentials logic

### DIFF
--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -73,10 +73,12 @@ async function _requestAppleIdCreds(options: Options): Promise<AppleCredentials>
 }
 
 function _getAppleIdFromParams({ appleId, appleIdPassword }: Options): AppleCredentials | null {
-  const passedAppleIdPassword = appleIdPassword || process.env.EXPO_APPLE_PASSWORD;
+  const passedAppleIdPassword = appleId
+    ? appleIdPassword || process.env.EXPO_APPLE_PASSWORD
+    : undefined;
 
   // none of the apple id params were set, assume user has no intention of passing it in
-  if (!appleId && !passedAppleIdPassword) {
+  if (!appleId) {
     return null;
   }
 

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -17,8 +17,6 @@ const secondsToMilliseconds = (seconds: number): number => seconds * 1000;
 export default class BaseBuilder {
   protected projectConfig: ProjectConfig;
   manifest: ExpoConfig;
-  private user?: User;
-  private loadedUser: boolean = false;
 
   async getUserAsync(): Promise<User> {
     return await UserManager.ensureLoggedInAsync();

--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -104,7 +104,11 @@ export default function (program: Command) {
             return;
           }
         }
-
+        if (options.skipCredentialsCheck && options.clearCredentials) {
+          throw new CommandError(
+            "--skip-credentials-check and --clear-credentials can't be used together"
+          );
+        }
         if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
           throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
         }

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -83,8 +83,8 @@ export default function (program: Command) {
 
         const user = await UserManager.getCurrentUserAsync();
         const context = new Context();
-        await context.init(projectDir, { allowAnonymous: true });
-        await context.ensureAppleCtx(options);
+        await context.init(projectDir, { ...options, allowAnonymous: true });
+        await context.ensureAppleCtx();
         const appleContext = context.appleCtx;
         if (user) {
           await context.ios.getAllCredentials(user.username); // initialize credentials


### PR DESCRIPTION
# Why

- bestEfortAppleCtx needs to be triggered before clearing credentials (because a user might want to revoke them)
- removing unused code
- env EXPO_APPLE_PASSWORD should be ignored if `--apple-id` is not specified( users in `expo credentials:manager` have seen error to specify apple-id even though that command does not support it)
- passing appleId and password to ensureAppleCtx relies on the order of calls