### PR TITLE
[expo-cli] Show better errors in non-interactive mode

### DIFF
--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -60,13 +60,15 @@ export default class AndroidBuilder extends BaseBuilder {
   }
 
   async collectAndValidateCredentials(): Promise<void> {
+    const nonInteractive = this.options.parent?.nonInteractive;
+
     const ctx = new Context();
-    await ctx.init(this.projectDir);
+    await ctx.init(this.projectDir, { nonInteractive });
 
     const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
 
     if (this.options.clearCredentials) {
-      if (this.options.parent?.nonInteractive) {
+      if (nonInteractive) {
         throw new BuildError(
           'Clearing your Android build credentials from our build servers is a PERMANENT and IRREVERSIBLE action, it\'s not supported when combined with the "--non-interactive" option'
         );
@@ -81,7 +83,7 @@ export default class AndroidBuilder extends BaseBuilder {
       await runCredentialsManager(
         ctx,
         new SetupAndroidKeystore(experienceName, {
-          nonInteractive: this.options.parent?.nonInteractive,
+          nonInteractive,
           allowMissingKeystore: true,
         })
       );

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -35,7 +35,16 @@ export default function (program: Command) {
       'Build a custom version of the Expo client for iOS using your own Apple credentials and install it on your mobile device using Safari.'
     )
     .asyncActionProjectDir(
-      async (projectDir: string, options: { appleId?: string; config?: string }) => {
+      async (
+        projectDir: string,
+        options: {
+          appleId?: string;
+          config?: string;
+          parent?: {
+            nonInteractive: boolean;
+          };
+        }
+      ) => {
         const disabledServices: { [key: string]: { name: string; reason: string } } = {
           pushNotifications: {
             name: 'Push Notifications',
@@ -83,7 +92,11 @@ export default function (program: Command) {
 
         const user = await UserManager.getCurrentUserAsync();
         const context = new Context();
-        await context.init(projectDir, { ...options, allowAnonymous: true });
+        await context.init(projectDir, {
+          ...options,
+          allowAnonymous: true,
+          nonInteractive: options.parent?.nonInteractive,
+        });
         await context.ensureAppleCtx();
         const appleContext = context.appleCtx;
         if (user) {

--- a/packages/expo-cli/src/commands/credentials.ts
+++ b/packages/expo-cli/src/commands/credentials.ts
@@ -9,6 +9,9 @@ import {
 
 type Options = {
   platform?: 'android' | 'ios';
+  parent?: {
+    nonInteractive: boolean;
+  };
 };
 
 export default function (program: CommanderStatic) {
@@ -19,7 +22,9 @@ export default function (program: CommanderStatic) {
     .asyncAction(async (options: Options) => {
       const projectDir = process.cwd();
       const context = new Context();
-      await context.init(projectDir);
+      await context.init(projectDir, {
+        nonInteractive: options.parent?.nonInteractive,
+      });
       let mainpage;
       if (options.platform === 'android') {
         mainpage = new SelectAndroidExperience();

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/credentials-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/credentials-test.ts
@@ -16,7 +16,7 @@ afterAll(() => {
   console.log = originalLog;
 });
 
-function crateMockCredentialsProvider({
+function createMockCredentialsProvider({
   hasRemote,
   hasLocal,
   isLocalSynced,
@@ -36,33 +36,48 @@ beforeEach(() => {
 describe('ensureCredentialsAsync', () => {
   describe('for generic builds', () => {
     it('should use local if there are only local credentials', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: false,
         hasLocal: true,
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Generic,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(src).toBe('local');
     });
     it('should use remote if there are only remote credentials', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: true,
         hasLocal: false,
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Generic,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(src).toBe('remote');
     });
     it('should use local when local and remote are the same', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: true,
         hasLocal: true,
         isLocalSynced: true,
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Generic,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(prompts).toHaveBeenCalledTimes(0);
       expect(src).toBe('local');
     });
     it('should ask when local and remote are not the same (select local)', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: true,
         hasLocal: true,
         isLocalSynced: false,
@@ -70,12 +85,17 @@ describe('ensureCredentialsAsync', () => {
       (prompts as any).mockImplementation(() => {
         return { select: 'local' };
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Generic,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(prompts).toHaveBeenCalledTimes(1);
       expect(src).toBe('local');
     });
     it('should ask when local and remote are not the same (select remote)', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: true,
         hasLocal: true,
         isLocalSynced: false,
@@ -83,47 +103,150 @@ describe('ensureCredentialsAsync', () => {
       (prompts as any).mockImplementation(() => {
         return { select: 'remote' };
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Generic,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(prompts).toHaveBeenCalledTimes(1);
       expect(src).toBe('remote');
+    });
+    it('should should throw an error when local and remote are not the same (non interactive)', async () => {
+      const provider = createMockCredentialsProvider({
+        hasRemote: true,
+        hasLocal: true,
+        isLocalSynced: false,
+      });
+
+      expect.assertions(2);
+
+      try {
+        await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO, true);
+      } catch (e) {
+        expect(e.message).toMatch(
+          'Contents of your local credentials.json for Android are not the same as credentials on Expo servers'
+        );
+      }
+
+      expect(prompts).toHaveBeenCalledTimes(0);
+    });
+    it('should ask when local or remote are not present (confirm)', async () => {
+      const provider = createMockCredentialsProvider({
+        hasRemote: false,
+        hasLocal: false,
+        isLocalSynced: false,
+      });
+      (prompts as any).mockImplementation(() => {
+        return { confirm: true };
+      });
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Generic,
+        CredentialsSource.AUTO,
+        false
+      );
+      expect(prompts).toHaveBeenCalledTimes(1);
+      expect(src).toBe('remote');
+    });
+    it('should ask when local or remote are not present (not confirm)', async () => {
+      const provider = createMockCredentialsProvider({
+        hasRemote: false,
+        hasLocal: false,
+        isLocalSynced: false,
+      });
+      (prompts as any).mockImplementation(() => {
+        return { confirm: false };
+      });
+      expect.assertions(2);
+
+      try {
+        await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO, false);
+      } catch (e) {
+        expect(e.message).toMatch(
+          'Aborting build process, credentials are not configured for Android'
+        );
+      }
+
+      expect(prompts).toHaveBeenCalledTimes(1);
+    });
+    it('should should throw an error when local or remote are not present (non interactive)', async () => {
+      const provider = createMockCredentialsProvider({
+        hasRemote: false,
+        hasLocal: false,
+        isLocalSynced: false,
+      });
+      (prompts as any).mockImplementation(() => {
+        return { confirm: true };
+      });
+
+      expect.assertions(2);
+
+      try {
+        await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.AUTO, true);
+      } catch (e) {
+        expect(e.message).toMatch('Credentials for this app are not configured');
+      }
+
+      expect(prompts).toHaveBeenCalledTimes(0);
     });
   });
 
   describe('for managed builds', () => {
     it('should use local if there are only local credentials', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: false,
         hasLocal: true,
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Managed, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Managed,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(src).toBe('local');
     });
     it('should use remote if there are only remote credentials', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: true,
         hasLocal: false,
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Managed, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Managed,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(src).toBe('remote');
     });
     it('should use local when local and remote are the same', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: true,
         hasLocal: true,
         isLocalSynced: true,
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Managed, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Managed,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(prompts).toHaveBeenCalledTimes(0);
       expect(src).toBe('local');
     });
 
     it('should use local even if remote have different credentials', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: true,
         hasLocal: true,
         isLocalSynced: false,
       });
-      const src = await ensureCredentialsAsync(provider, Workflow.Managed, CredentialsSource.AUTO);
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Managed,
+        CredentialsSource.AUTO,
+        false
+      );
       expect(prompts).toHaveBeenCalledTimes(0);
       expect(src).toBe('local');
     });
@@ -131,20 +254,7 @@ describe('ensureCredentialsAsync', () => {
 
   describe('with credentialsSource set to local', () => {
     it('should use local for generic builds when not synced without asking', async () => {
-      const provider = crateMockCredentialsProvider({
-        hasRemote: true,
-        hasLocal: true,
-        isLocalSynced: false,
-      });
-      const src = await ensureCredentialsAsync(provider, Workflow.Generic, CredentialsSource.LOCAL);
-      expect(prompts).toHaveBeenCalledTimes(0);
-      expect(src).toBe('local');
-    });
-  });
-
-  describe('with credentialsSource set to remote', () => {
-    it('should use remote for generic builds when not synced without asking', async () => {
-      const provider = crateMockCredentialsProvider({
+      const provider = createMockCredentialsProvider({
         hasRemote: true,
         hasLocal: true,
         isLocalSynced: false,
@@ -152,7 +262,26 @@ describe('ensureCredentialsAsync', () => {
       const src = await ensureCredentialsAsync(
         provider,
         Workflow.Generic,
-        CredentialsSource.REMOTE
+        CredentialsSource.LOCAL,
+        false
+      );
+      expect(prompts).toHaveBeenCalledTimes(0);
+      expect(src).toBe('local');
+    });
+  });
+
+  describe('with credentialsSource set to remote', () => {
+    it('should use remote for generic builds when not synced without asking', async () => {
+      const provider = createMockCredentialsProvider({
+        hasRemote: true,
+        hasLocal: true,
+        isLocalSynced: false,
+      });
+      const src = await ensureCredentialsAsync(
+        provider,
+        Workflow.Generic,
+        CredentialsSource.REMOTE,
+        false
       );
       expect(prompts).toHaveBeenCalledTimes(0);
       expect(src).toBe('remote');

--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -25,6 +25,9 @@ interface BuildOptions {
   skipCredentialsCheck?: boolean; // TODO: noop for now
   wait?: boolean;
   profile: string;
+  parent?: {
+    nonInteractive: boolean;
+  };
 }
 
 async function buildAction(projectDir: string, options: BuildOptions): Promise<void> {
@@ -42,7 +45,11 @@ async function buildAction(projectDir: string, options: BuildOptions): Promise<v
   await ensureGitStatusIsCleanAsync();
 
   const easConfig: EasConfig = await new EasJsonReader(projectDir, platform).readAsync(profile);
-  const ctx = await createBuilderContextAsync(projectDir, easConfig);
+  const ctx = await createBuilderContextAsync(
+    projectDir,
+    easConfig,
+    options.parent?.nonInteractive
+  );
   const projectId = await ensureProjectExistsAsync(ctx.user, {
     accountName: ctx.accountName,
     projectName: ctx.projectName,
@@ -62,7 +69,8 @@ async function buildAction(projectDir: string, options: BuildOptions): Promise<v
 
 async function createBuilderContextAsync(
   projectDir: string,
-  eas: EasConfig
+  eas: EasConfig,
+  nonInteractive: boolean = false
 ): Promise<BuilderContext> {
   const user: User = await UserManager.ensureLoggedInAsync();
   const { exp } = getConfig(projectDir);
@@ -76,6 +84,7 @@ async function createBuilderContextAsync(
     accountName,
     projectName,
     exp,
+    nonInteractive,
   };
 }
 

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -45,7 +45,8 @@ class AndroidBuilder implements Builder {
     const credentialsSource = await ensureCredentialsAsync(
       provider,
       this.buildProfile.workflow,
-      this.buildProfile.credentialsSource
+      this.buildProfile.credentialsSource,
+      this.ctx.nonInteractive
     );
     this.credentials = await provider.getCredentialsAsync(credentialsSource);
   }

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -56,7 +56,10 @@ class iOSBuilder implements Builder {
     if (!this.shouldLoadCredentials()) {
       return;
     }
-    const bundleIdentifier = await getBundleIdentifier(this.ctx);
+    const bundleIdentifier = this.ctx.exp?.ios?.bundleIdentifier;
+    if (!bundleIdentifier) {
+      throw new Error('"expo.ios.bundleIdentifier" field is required in your app.json');
+    }
     const provider = new iOSCredentialsProvider(this.ctx.projectDir, {
       projectName: this.ctx.projectName,
       accountName: this.ctx.accountName,
@@ -66,7 +69,8 @@ class iOSBuilder implements Builder {
     const credentialsSource = await ensureCredentialsAsync(
       provider,
       this.buildProfile.workflow,
-      this.buildProfile.credentialsSource
+      this.buildProfile.credentialsSource,
+      this.ctx.nonInteractive
     );
     this.credentials = await provider.getCredentialsAsync(credentialsSource);
   }
@@ -175,7 +179,6 @@ class iOSBuilder implements Builder {
     );
   }
 }
-
 const getBundleIdentifier = once(_getBundleIdentifier);
 
 async function _getBundleIdentifier(ctx: BuilderContext): Promise<string> {

--- a/packages/expo-cli/src/commands/eas-build/build/types.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/types.ts
@@ -11,6 +11,7 @@ export interface BuilderContext {
   accountName: string;
   projectName: string;
   exp: ExpoConfig;
+  nonInteractive: boolean;
 }
 
 export interface Builder {

--- a/packages/expo-cli/src/commands/fetch/android.ts
+++ b/packages/expo-cli/src/commands/fetch/android.ts
@@ -8,6 +8,12 @@ import { runCredentialsManager } from '../../credentials/route';
 import { DownloadKeystore } from '../../credentials/views/AndroidKeystore';
 import log from '../../log';
 
+type Options = {
+  parent?: {
+    nonInteractive: boolean;
+  };
+};
+
 async function maybeRenameExistingFile(projectDir: string, filename: string) {
   const desiredFilePath = path.resolve(projectDir, filename);
 
@@ -23,9 +29,14 @@ async function maybeRenameExistingFile(projectDir: string, filename: string) {
   }
 }
 
-export async function fetchAndroidKeystoreAsync(projectDir: string): Promise<void> {
+export async function fetchAndroidKeystoreAsync(
+  projectDir: string,
+  options: Options
+): Promise<void> {
   const ctx = new Context();
-  await ctx.init(projectDir);
+  await ctx.init(projectDir, {
+    nonInteractive: options.parent?.nonInteractive,
+  });
 
   const keystoreFilename = `${ctx.manifest.slug}.jks`;
   await maybeRenameExistingFile(projectDir, keystoreFilename);
@@ -42,9 +53,11 @@ export async function fetchAndroidKeystoreAsync(projectDir: string): Promise<voi
   );
 }
 
-export async function fetchAndroidHashesAsync(projectDir: string): Promise<void> {
+export async function fetchAndroidHashesAsync(projectDir: string, options: Options): Promise<void> {
   const ctx = new Context();
-  await ctx.init(projectDir);
+  await ctx.init(projectDir, {
+    nonInteractive: options.parent?.nonInteractive,
+  });
   const outputPath = path.resolve(projectDir, `${ctx.manifest.slug}.tmp.jks`);
   try {
     invariant(ctx.manifest.slug, 'app.json slug field must be set');
@@ -74,9 +87,14 @@ export async function fetchAndroidHashesAsync(projectDir: string): Promise<void>
   }
 }
 
-export async function fetchAndroidUploadCertAsync(projectDir: string): Promise<void> {
+export async function fetchAndroidUploadCertAsync(
+  projectDir: string,
+  options: Options
+): Promise<void> {
   const ctx = new Context();
-  await ctx.init(projectDir);
+  await ctx.init(projectDir, {
+    nonInteractive: options.parent?.nonInteractive,
+  });
 
   const keystorePath = path.resolve(projectDir, `${ctx.manifest.slug}.tmp.jks`);
 

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -19,6 +19,7 @@ interface AppleCtxOptions {
 
 interface CtxOptions extends AppleCtxOptions {
   allowAnonymous?: boolean;
+  nonInteractive?: boolean;
 }
 
 export class Context {
@@ -31,6 +32,11 @@ export class Context {
   _androidApiClient?: AndroidApi;
   _appleCtxOptions?: AppleCtxOptions;
   _appleCtx?: AppleCtx;
+  _nonInteractive?: boolean;
+
+  get nonInteractive(): boolean {
+    return this._nonInteractive === true;
+  }
 
   get user(): User {
     return this._user as User;
@@ -97,6 +103,7 @@ export class Context {
     this._iosApiClient = new IosApi(this.api);
     this._androidApiClient = new AndroidApi(this.api);
     this._appleCtxOptions = pick(options, ['appleId', 'appleIdPassword', 'teamId']);
+    this._nonInteractive = options.nonInteractive;
 
     // Check if we are in project context by looking for a manifest
     const status = await Doctor.validateWithoutNetworkAsync(projectDir);

--- a/packages/expo-cli/src/credentials/provider/AndroidCredentialsProvider.ts
+++ b/packages/expo-cli/src/credentials/provider/AndroidCredentialsProvider.ts
@@ -27,7 +27,9 @@ export default class AndroidCredentialsProvider implements CredentialsProvider {
   }
 
   public async initAsync() {
-    await this.ctx.init(this.projectDir);
+    await this.ctx.init(this.projectDir, {
+      nonInteractive: this.ctx.nonInteractive,
+    });
   }
 
   public async hasRemoteAsync(): Promise<boolean> {

--- a/packages/expo-cli/src/credentials/provider/iOSCredentialsProvider.ts
+++ b/packages/expo-cli/src/credentials/provider/iOSCredentialsProvider.ts
@@ -22,7 +22,9 @@ export default class iOSCredentialsProvider implements CredentialsProvider {
   constructor(private projectDir: string, private app: AppLookupParams) {}
 
   public async initAsync() {
-    await this.ctx.init(this.projectDir);
+    await this.ctx.init(this.projectDir, {
+      nonInteractive: this.ctx.nonInteractive,
+    });
   }
 
   public async hasRemoteAsync(): Promise<boolean> {

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -1,5 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 
+import CommandError from '../../CommandError';
 import log from '../../log';
 import prompt from '../../prompt';
 import { displayAndroidAppCredentials } from '../actions/list';

--- a/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 
+import CommandError from '../../CommandError';
 import log from '../../log';
 import prompt from '../../prompt';
 import { Context, IView } from '../context';
@@ -8,6 +9,13 @@ export class UpdateFcmKey implements IView {
   constructor(private experienceName: string) {}
 
   async open(ctx: Context): Promise<IView | null> {
+    if (ctx.nonInteractive) {
+      throw new CommandError(
+        'NON_INTERACTIVE',
+        "Start the CLI without the '--non-interactive' flag to update the FCM Api key."
+      );
+    }
+
     const { fcmApiKey } = await prompt([
       {
         type: 'input',

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -130,6 +130,7 @@ export class SelectAndroidExperience implements IView {
   async open(ctx: Context): Promise<IView | null> {
     if (ctx.hasProjectContext && this.askAboutProjectMode) {
       const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
+
       const { runProjectContext } = await prompt([
         {
           type: 'confirm',
@@ -137,6 +138,7 @@ export class SelectAndroidExperience implements IView {
           message: `You are currently in a directory with ${experienceName} experience. Do you want to select it?`,
         },
       ]);
+
       if (runProjectContext) {
         invariant(ctx.manifest.slug, 'app.json slug field must be set');
         const view = new androidView.ExperienceView(experienceName);

--- a/packages/expo-cli/src/credentials/views/SetupIosBuildCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosBuildCredentials.ts
@@ -11,7 +11,7 @@ import { SetupIosDist } from './SetupIosDist';
 import { SetupIosProvisioningProfile } from './SetupIosProvisioningProfile';
 
 export class SetupIosBuildCredentials implements IView {
-  constructor(private app: AppLookupParams, private nonInteractive: boolean = false) {}
+  constructor(private app: AppLookupParams) {}
 
   async open(ctx: Context): Promise<IView | null> {
     await this.bestEffortAppleCtx(ctx);
@@ -35,10 +35,7 @@ export class SetupIosBuildCredentials implements IView {
     }
 
     try {
-      await runCredentialsManager(
-        ctx,
-        new SetupIosProvisioningProfile(this.app, this.nonInteractive)
-      );
+      await runCredentialsManager(ctx, new SetupIosProvisioningProfile(this.app));
     } catch (error) {
       log.error('Failed to set up Provisioning Profile');
       throw error;
@@ -55,7 +52,7 @@ export class SetupIosBuildCredentials implements IView {
       return;
     }
 
-    if (this.nonInteractive) {
+    if (ctx.nonInteractive) {
       return;
     }
 

--- a/packages/expo-cli/src/credentials/views/SetupIosDist.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosDist.ts
@@ -3,7 +3,7 @@ import { Context, IView } from '../context';
 import * as iosDistView from './IosDistCert';
 
 export class SetupIosDist implements IView {
-  constructor(private app: AppLookupParams, private nonInteractive: boolean = false) {}
+  constructor(private app: AppLookupParams) {}
 
   async open(ctx: Context): Promise<IView | null> {
     if (!ctx.user) {
@@ -20,6 +20,6 @@ export class SetupIosDist implements IView {
       }
     }
 
-    return new iosDistView.CreateOrReuseDistributionCert(this.app, this.nonInteractive);
+    return new iosDistView.CreateOrReuseDistributionCert(this.app);
   }
 }

--- a/packages/expo-cli/src/credentials/views/SetupIosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosProvisioningProfile.ts
@@ -12,7 +12,7 @@ interface ProvisioningProfileOptions {
 }
 
 export class SetupIosProvisioningProfile implements IView {
-  constructor(private app: AppLookupParams, private nonInteractive: boolean = false) {}
+  constructor(private app: AppLookupParams) {}
 
   async open(ctx: Context): Promise<IView | null> {
     if (!ctx.user) {
@@ -35,7 +35,7 @@ export class SetupIosProvisioningProfile implements IView {
     // The configured profile is associated with some other dist cert
     const configuredWithSameDistCert = appCredentials.distCredentialsId === distCert.id;
     if (!configuredProfile || !configuredWithSameDistCert) {
-      return new iosProfileView.CreateOrReuseProvisioningProfile(this.app, this.nonInteractive);
+      return new iosProfileView.CreateOrReuseProvisioningProfile(this.app);
     }
 
     if (!ctx.hasAppleCtx()) {
@@ -63,7 +63,7 @@ export class SetupIosProvisioningProfile implements IView {
         this.app.bundleIdentifier
       );
       if (!isValid) {
-        return new iosProfileView.CreateOrReuseProvisioningProfile(this.app, this.nonInteractive);
+        return new iosProfileView.CreateOrReuseProvisioningProfile(this.app);
       }
       return null;
     }
@@ -76,7 +76,7 @@ export class SetupIosProvisioningProfile implements IView {
 
     // Profile can't be found on Apple servers
     if (!profileFromApple) {
-      return new iosProfileView.CreateOrReuseProvisioningProfile(this.app, this.nonInteractive);
+      return new iosProfileView.CreateOrReuseProvisioningProfile(this.app);
     }
 
     await iosProfileView.configureAndUpdateProvisioningProfile(

--- a/packages/expo-cli/src/credentials/views/SetupIosPush.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosPush.ts
@@ -1,5 +1,6 @@
 import { prompt } from 'inquirer';
 
+import CommandError from '../../CommandError';
 import log from '../../log';
 import { Question } from '../../prompt';
 import { AppLookupParams } from '../api/IosApi';
@@ -7,7 +8,7 @@ import { Context, IView } from '../context';
 import * as iosPushView from './IosPushCredentials';
 
 export class SetupIosPush implements IView {
-  constructor(private app: AppLookupParams, private nonInteractive: boolean = false) {}
+  constructor(private app: AppLookupParams) {}
 
   async open(ctx: Context): Promise<IView | null> {
     if (!ctx.user) {
@@ -20,6 +21,13 @@ export class SetupIosPush implements IView {
     const deprecatedPushP12 = appCredentials?.credentials?.pushP12;
     const deprecatedPushPassword = appCredentials?.credentials?.pushPassword;
     if (deprecatedPushId && deprecatedPushP12 && deprecatedPushPassword) {
+      if (ctx.nonInteractive) {
+        throw new CommandError(
+          'NON_INTERACTIVE',
+          "We've detected legacy Push Certificates on file. Start the CLI without the '--non-interactive' flag to upgrade to the newer standard."
+        );
+      }
+
       const confirmQuestion: Question = {
         type: 'confirm',
         name: 'confirm',
@@ -44,6 +52,6 @@ export class SetupIosPush implements IView {
       }
     }
 
-    return new iosPushView.CreateOrReusePushKey(this.app, this.nonInteractive);
+    return new iosPushView.CreateOrReusePushKey(this.app);
   }
 }

--- a/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Remove-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Remove-test.ts
@@ -77,9 +77,39 @@ describe('RemoveKeystore', () => {
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
-      expect((prompt as any).mock.calls.length).toBe(2);
+      expect((prompt as any).mock.calls.length).toBe(1);
       expect(ctx.android.fetchKeystore.mock.calls.length).toBe(2);
       expect(ctx.android.removeKeystore.mock.calls.length).toBe(1);
+    });
+
+    it('should not display a prompt in non-interactive mode', async () => {
+      const ctx = getCtxMock({ nonInteractive: true });
+
+      // first: prompt with warning message, true means continue
+      // second: ask if cli should display credentials, user won't see that because when() should return false
+      (prompt as any)
+        .mockImplementationOnce(() => ({ confirm: true }))
+        .mockImplementationOnce(question => {
+          if (question.when()) {
+            throw new Error("shouldn't happen");
+          }
+          return { confirm: undefined };
+        })
+        .mockImplementation(() => {
+          throw new Error("shouldn't happen");
+        });
+
+      const view = new RemoveKeystore(testExperienceName);
+
+      expect.assertions(2);
+
+      try {
+        await view.open(ctx);
+      } catch (e) {
+        expect(e.message).toMatch('Deleting build credentials is a destructive operation');
+      }
+
+      expect(prompt).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
@@ -39,8 +39,8 @@ beforeEach(() => {
 describe('IosDistCert', () => {
   describe('CreateIosDist', () => {
     it('Basic Case - Create a Dist Cert and save it to Expo Servers', async () => {
-      const ctx = getCtxMock();
-      const createIosDist = new CreateIosDist(jester.username, true);
+      const ctx = getCtxMock({ nonInteractive: true });
+      const createIosDist = new CreateIosDist(jester.username);
       await createIosDist.open(ctx as any);
 
       // expect dist cert is created
@@ -52,8 +52,8 @@ describe('IosDistCert', () => {
   });
   describe('CreateOrReuseDistributionCert', () => {
     it('Reuse Autosuggested Dist Cert ', async () => {
-      const ctx = getCtxMock();
-      const createOrReuseIosDist = new CreateOrReuseDistributionCert(testAppLookupParams, true);
+      const ctx = getCtxMock({ nonInteractive: true });
+      const createOrReuseIosDist = new CreateOrReuseDistributionCert(testAppLookupParams);
       await createOrReuseIosDist.open(ctx as any);
 
       // expect suggested dist cert is used
@@ -69,9 +69,9 @@ describe('IosDistCert', () => {
       // no available certs on apple dev portal
       mockDistCertManagerList.mockImplementation(() => [] as any);
 
-      const ctx = getCtxMock();
+      const ctx = getCtxMock({ nonInteractive: true });
 
-      const createOrReuseIosDist = new CreateOrReuseDistributionCert(testAppLookupParams, true);
+      const createOrReuseIosDist = new CreateOrReuseDistributionCert(testAppLookupParams);
       await createOrReuseIosDist.open(ctx as any);
 
       // expect dist cert is used

--- a/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
@@ -44,8 +44,8 @@ beforeEach(() => {
 describe('IosProvisioningProfile', () => {
   describe('CreateProvisioningProfile', () => {
     it('Basic Case - Create a Provisioning Profile and save it to Expo Servers', async () => {
-      const ctx = getCtxMock();
-      const createProvisioningProfile = new CreateProvisioningProfile(testAppLookupParams, true);
+      const ctx = getCtxMock({ nonInteractive: true });
+      const createProvisioningProfile = new CreateProvisioningProfile(testAppLookupParams);
       await createProvisioningProfile.open(ctx as any);
 
       // expect provisioning profile is created
@@ -57,10 +57,9 @@ describe('IosProvisioningProfile', () => {
   });
   describe('CreateOrReuseProvisioningProfile', () => {
     it('Use Autosuggested Provisioning Profile ', async () => {
-      const ctx = getCtxMock();
+      const ctx = getCtxMock({ nonInteractive: true });
       const createOrReuseProvisioningProfile = new CreateOrReuseProvisioningProfile(
-        testAppLookupParams,
-        true
+        testAppLookupParams
       );
       await createOrReuseProvisioningProfile.open(ctx as any);
 
@@ -77,10 +76,9 @@ describe('IosProvisioningProfile', () => {
       // no available certs on apple dev portal
       mockProvProfManagerList.mockImplementation(() => [] as any);
 
-      const ctx = getCtxMock();
+      const ctx = getCtxMock({ nonInteractive: true });
       const createOrReuseProvisioningProfile = new CreateOrReuseProvisioningProfile(
-        testAppLookupParams,
-        true
+        testAppLookupParams
       );
       const createProvisioningProfile = await createOrReuseProvisioningProfile.open(ctx as any);
       await createProvisioningProfile.open(ctx as any);

--- a/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
@@ -39,8 +39,8 @@ beforeEach(() => {
 describe('IosPushCredentials', () => {
   describe('CreateIosPush', () => {
     it('Basic Case - Create a Push Key and save it to Expo Servers', async () => {
-      const ctx = getCtxMock();
-      const createIosPush = new CreateIosPush(jester.username, true /* nonInteractive */);
+      const ctx = getCtxMock({ nonInteractive: true });
+      const createIosPush = new CreateIosPush(jester.username);
       await createIosPush.open(ctx as any);
 
       // expect push key is created
@@ -52,8 +52,8 @@ describe('IosPushCredentials', () => {
   });
   describe('CreateOrReusePushKey', () => {
     it('Reuse Autosuggested Push Key ', async () => {
-      const ctx = getCtxMock();
-      const createOrReusePushKey = new CreateOrReusePushKey(testAppLookupParams, true);
+      const ctx = getCtxMock({ nonInteractive: true });
+      const createOrReusePushKey = new CreateOrReusePushKey(testAppLookupParams);
       await createOrReusePushKey.open(ctx as any);
 
       // expect suggested push key is used
@@ -69,8 +69,8 @@ describe('IosPushCredentials', () => {
       // no available keys on apple dev portal
       mockPushKeyManagerList.mockImplementation(() => [] as any);
 
-      const ctx = getCtxMock();
-      const createOrReusePushKey = new CreateOrReusePushKey(testAppLookupParams, true);
+      const ctx = getCtxMock({ nonInteractive: true });
+      const createOrReusePushKey = new CreateOrReusePushKey(testAppLookupParams);
       await createOrReusePushKey.open(ctx as any);
 
       // expect suggested push key is used

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
@@ -41,8 +41,9 @@ describe('SetupIosDist', () => {
       ios: {
         getDistCert: jest.fn(),
       },
+      nonInteractive: true,
     });
-    const setupIosDist = new SetupIosDist(testAppLookupParams, true);
+    const setupIosDist = new SetupIosDist(testAppLookupParams);
     const createOrReuse = await setupIosDist.open(ctx as any);
     await createOrReuse.open(ctx as any);
 

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
@@ -41,8 +41,9 @@ describe('SetupIosPush', () => {
       ios: {
         getPushKey: jest.fn(),
       },
+      nonInteractive: true,
     });
-    const setupIosPush = new SetupIosPush(testAppLookupParams, true);
+    const setupIosPush = new SetupIosPush(testAppLookupParams);
     const createOrReuse = await setupIosPush.open(ctx as any);
     await createOrReuse.open(ctx as any);
 

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
@@ -44,8 +44,9 @@ describe('SetupProvisioningProfile', () => {
       ios: {
         getProvisioningProfile: jest.fn(),
       },
+      nonInteractive: true,
     });
-    const setupProvisioningProfile = new SetupIosProvisioningProfile(testAppLookupParams, true);
+    const setupProvisioningProfile = new SetupIosProvisioningProfile(testAppLookupParams);
     const createOrReuse = await setupProvisioningProfile.open(ctx as any);
     await createOrReuse.open(ctx as any);
 


### PR DESCRIPTION
## Why

Previously we were showing generic errors with the --non-interactive flag when we needed to show a prompt. This commit changes it to show more helpful error messages.