### PR TITLE
Fix next-adapter `external` bug

### DIFF
--- a/packages/webpack-config/src/addons/withUnimodules.ts
+++ b/packages/webpack-config/src/addons/withUnimodules.ts
@@ -187,7 +187,7 @@ export function ignoreExternalModules(
     }
     return ((ctx, req, cb) => {
       const relPath = path.join('node_modules', req);
-      return shouldIncludeModule(relPath) ? cb(null, []) : external(ctx, req, cb);
+      return shouldIncludeModule(relPath) ? cb() : external(ctx, req, cb);
     }) as ExternalsFunctionElement;
   });
 


### PR DESCRIPTION
- fix https://github.com/expo/expo-cli/issues/2345

Next.js was throwing the following node.js error:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "id" argument must be of type string. Received undefined
    at validateString (internal/validators.js:120:11)
    at Module.require (internal/modules/cjs/loader.js:1019:3)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.react-native-web/dist/exports/AppRegistry (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/.next/server/static/development/pages/_document.js:813:18)
    at __webpack_require__ (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/.next/server/static/development/pages/_document.js:23:31)
    at Module../pages/_document.js (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/.next/server/static/development/pages/_document.js:766:99)
    at __webpack_require__ (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/.next/server/static/development/pages/_document.js:23:31)
    at Object.0 (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/.next/server/static/development/pages/_document.js:779:18)
    at __webpack_require__ (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/.next/server/static/development/pages/_document.js:23:31)
    at /Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/.next/server/static/development/pages/_document.js:91:18
    at Object.<anonymous> (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/.next/server/static/development/pages/_document.js:94:10)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.loadComponents (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/node_modules/next/dist/next-server/server/load-components.js:24:25)
    at DevServer.findPageComponents (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/node_modules/next/dist/next-server/server/next-server.js:556:60)
    at DevServer.renderErrorToHTML (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/node_modules/next/dist/next-server/server/next-server.js:853:33)
    at DevServer.renderErrorToHTML (/Users/evanbacon/Documents/GitHub/lab/my-next-expo-app/node_modules/next/dist/server/next-dev-server.js:19:1184) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

Because Webpack had generated a module like `require(undefined)`

