### PR TITLE
[xdl] Add EXPO_TOKEN authentication method

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -310,7 +310,9 @@ Please reload the project in the Expo app for the change to take effect.`
       }
       case 's': {
         const authSession = await UserManager.getSessionAsync();
-        if (authSession) {
+        if (authSession?.accessToken) {
+          log(chalk.yellow('Please remove the EXPO_TOKEN environment var to sign out.'));
+        } else if (authSession?.sessionSecret) {
           await UserManager.logoutAsync();
           log('Signed out.');
         } else {

--- a/packages/xdl/jest/integration-test-config.js
+++ b/packages/xdl/jest/integration-test-config.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+module.exports = {
+  preset: '../../jest/unit-test-config',
+  rootDir: path.resolve(__dirname, '..'),
+  displayName: require('../package.json').name,
+  roots: ['src'],
+  testTimeout: 20000,
+  testRegex: '__integration_tests__/.*(test|spec)\\.[jt]sx?$',
+};

--- a/packages/xdl/jest/integration-test-config.json
+++ b/packages/xdl/jest/integration-test-config.json
@@ -1,7 +1,0 @@
-{
-  "testEnvironment": "node",
-  "roots": ["src"],
-  "setupTestFrameworkScriptFile": "<rootDir>/jest/integration-test-setup.js",
-  "moduleFileExtensions": ["js", "json", "node"],
-  "testRegex": "__integration_tests__/.*\\.js$"
-}

--- a/packages/xdl/jest/integration-test-setup.js
+++ b/packages/xdl/jest/integration-test-setup.js
@@ -1,3 +1,0 @@
-'use strict';
-
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "watch": "concurrently \"tsc --emitDeclarationOnly --watch\" \"gulp watch\"",
     "test": "jest --config jest/unit-test-config.js",
-    "integration-tests": "jest --config jest/integration-test-config.json --rootDir ."
+    "integration-tests": "jest --config jest/integration-test-config.js"
   },
   "repository": {
     "type": "git",

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -54,7 +54,7 @@ async function _callMethodAsync(
   returnEntireResponse = false
 ) {
   const clientId = await Session.clientIdAsync();
-  const token = UserSettings.userToken();
+  const accessToken = UserSettings.accessToken();
   const session = await UserManager.getSessionAsync();
   const skipValidationToken = process.env['EXPO_SKIP_MANIFEST_VALIDATION_TOKEN'];
 
@@ -68,8 +68,8 @@ async function _callMethodAsync(
   }
 
   // Handle auth method, prioritizing authorization tokens before session secrets
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
+  if (accessToken) {
+    headers['Authorization'] = `Bearer ${accessToken}`;
   } else if (session) {
     headers['Expo-Session'] = session.sessionSecret;
   }

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -54,6 +54,7 @@ async function _callMethodAsync(
   returnEntireResponse = false
 ) {
   const clientId = await Session.clientIdAsync();
+  const token = UserSettings.userToken();
   const session = await UserManager.getSessionAsync();
   const skipValidationToken = process.env['EXPO_SKIP_MANIFEST_VALIDATION_TOKEN'];
 
@@ -66,7 +67,10 @@ async function _callMethodAsync(
     headers['Exp-Skip-Manifest-Validation-Token'] = skipValidationToken;
   }
 
-  if (session) {
+  // Handle auth method, prioritizing authorization tokens before session secrets
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  } else if (session) {
     headers['Expo-Session'] = session.sessionSecret;
   }
 

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -54,7 +54,6 @@ async function _callMethodAsync(
   returnEntireResponse = false
 ) {
   const clientId = await Session.clientIdAsync();
-  const accessToken = UserSettings.accessToken();
   const session = await UserManager.getSessionAsync();
   const skipValidationToken = process.env['EXPO_SKIP_MANIFEST_VALIDATION_TOKEN'];
 
@@ -68,9 +67,9 @@ async function _callMethodAsync(
   }
 
   // Handle auth method, prioritizing authorization tokens before session secrets
-  if (accessToken) {
-    headers['Authorization'] = `Bearer ${accessToken}`;
-  } else if (session) {
+  if (session?.accessToken) {
+    headers['Authorization'] = `Bearer ${session.accessToken}`;
+  } else if (session?.sessionSecret) {
     headers['Expo-Session'] = session.sessionSecret;
   }
 

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -68,11 +68,8 @@ export default class ApiV2Client {
   accessToken: string | null = null;
 
   static clientForUser(user?: APIV2ClientOptions | null): ApiV2Client {
-    if (user && (user.accessToken || user.sessionSecret)) {
-      return new ApiV2Client({
-        accessToken: user.accessToken,
-        sessionSecret: user.sessionSecret,
-      });
+    if (user) {
+      return new ApiV2Client(user);
     }
 
     return new ApiV2Client();

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -59,18 +59,18 @@ type QueryParameters = { [key: string]: string | number | boolean | null | undef
 
 type APIV2ClientOptions = {
   sessionSecret?: string;
-  authorizationToken?: string;
+  accessToken?: string;
 };
 
 export default class ApiV2Client {
   static exponentClient: string = 'xdl';
   sessionSecret: string | null = null;
-  authorizationToken: string | null = null;
+  accessToken: string | null = null;
 
   static clientForUser(user?: APIV2ClientOptions | null): ApiV2Client {
-    if (user && (user.authorizationToken || user.sessionSecret)) {
+    if (user && (user.accessToken || user.sessionSecret)) {
       return new ApiV2Client({
-        authorizationToken: user.authorizationToken,
+        accessToken: user.accessToken,
         sessionSecret: user.sessionSecret,
       });
     }
@@ -83,8 +83,8 @@ export default class ApiV2Client {
   }
 
   constructor(options: APIV2ClientOptions = {}) {
-    if (options.authorizationToken) {
-      this.authorizationToken = options.authorizationToken;
+    if (options.accessToken) {
+      this.accessToken = options.accessToken;
     }
     if (options.sessionSecret) {
       this.sessionSecret = options.sessionSecret;
@@ -203,8 +203,8 @@ export default class ApiV2Client {
     };
 
     // Handle auth method, prioritizing authorization tokens before session secrets
-    if (this.authorizationToken) {
-      reqOptions.headers['Authorization'] = `Bearer ${this.authorizationToken}`;
+    if (this.accessToken) {
+      reqOptions.headers['Authorization'] = `Bearer ${this.accessToken}`;
     } else if (this.sessionSecret) {
       reqOptions.headers['Expo-Session'] = this.sessionSecret;
     }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -2035,7 +2035,7 @@ function getManifestHandler(projectRoot: string) {
 export async function getSignedManifestStringAsync(
   manifest: ExpoConfig,
   // NOTE: we currently ignore the currentSession that is passed in, see the note below about analytics.
-  currentSession: { sessionSecret: string }
+  currentSession: { sessionSecret?: string; accessToken?: string }
 ) {
   const manifestString = JSON.stringify(manifest);
   if (_cachedSignedManifest.manifestString === manifestString) {

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -29,7 +29,7 @@ export type User = {
   currentConnection: ConnectionType;
   // auth methods
   sessionSecret?: string;
-  authorizationToken?: string;
+  accessToken?: string;
 };
 
 export type LegacyUser = {
@@ -200,8 +200,8 @@ export class UserManagerInstance {
     try {
       const currentUser = this._currentUser;
 
-      // If user is cached and there is an authorizationToken or sessionSecret, return the user
-      if (currentUser && (currentUser.authorizationToken || currentUser.sessionSecret)) {
+      // If user is cached and there is an accessToken or sessionSecret, return the user
+      if (currentUser && (currentUser.accessToken || currentUser.sessionSecret)) {
         return currentUser;
       }
 
@@ -210,16 +210,16 @@ export class UserManagerInstance {
       }
 
       const data = await this._readUserData();
-      const token = UserSettings.userToken();
+      const accessToken = UserSettings.accessToken();
 
       // No token, no session, no current user. Need to login
-      if (!token && (!data || !data.sessionSecret)) {
+      if (!accessToken && !data?.sessionSecret) {
         return null;
       }
 
       try {
-        const profileOptions = token
-          ? { authorizationToken: token }
+        const profileOptions = accessToken
+          ? { accessToken }
           : {
               currentConnection: data?.currentConnection,
               sessionSecret: data?.sessionSecret,
@@ -324,16 +324,16 @@ export class UserManagerInstance {
   async _getProfileAsync({
     currentConnection,
     sessionSecret,
-    authorizationToken,
+    accessToken,
   }: {
     currentConnection?: ConnectionType;
     sessionSecret?: string;
-    authorizationToken?: string;
+    accessToken?: string;
   }): Promise<User> {
     let user;
     const api = ApiV2Client.clientForUser({
       sessionSecret,
-      authorizationToken,
+      accessToken,
     });
 
     user = await api.postAsync('auth/userProfileAsync');
@@ -347,11 +347,11 @@ export class UserManagerInstance {
       kind: 'user',
       currentConnection,
       sessionSecret,
-      authorizationToken,
+      accessToken,
     };
 
     // note: do not persist the authorization token, must be env-var only
-    if (!authorizationToken) {
+    if (!accessToken) {
       await UserSettings.setAsync('auth', {
         userId: user.userId,
         username: user.username,

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -336,7 +336,7 @@ export class UserManagerInstance {
       authorizationToken,
     });
 
-    user = await api.getAsync('auth/userInfo');
+    user = await api.postAsync('auth/userProfileAsync');
 
     if (!user) {
       throw new Error('Unable to fetch user.');

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -242,19 +242,30 @@ export class UserManagerInstance {
   }
 
   async getCurrentUsernameAsync(): Promise<string | null> {
-    const data = await this._readUserData();
-    if (!data || !data.username) {
-      return null;
+    const token = UserSettings.accessToken();
+    if (token) {
+      const user = await this.getCurrentUserAsync();
+      if (user?.username) {
+        return user.username;
+      }
     }
-    return data.username;
+    const data = await this._readUserData();
+    if (data?.username) {
+      return data.username;
+    }
+    return null;
   }
 
-  async getSessionAsync(): Promise<{ sessionSecret: string } | null> {
-    const data = await this._readUserData();
-    if (!data || !data.sessionSecret) {
-      return null;
+  async getSessionAsync(): Promise<{ sessionSecret?: string; accessToken?: string } | null> {
+    const token = UserSettings.accessToken();
+    if (token) {
+      return { accessToken: token };
     }
-    return { sessionSecret: data.sessionSecret };
+    const data = await this._readUserData();
+    if (data?.sessionSecret) {
+      return { sessionSecret: data.sessionSecret };
+    }
+    return null;
   }
 
   /**

--- a/packages/xdl/src/UserSettings.ts
+++ b/packages/xdl/src/UserSettings.ts
@@ -107,7 +107,7 @@ async function anonymousIdentifier(): Promise<string> {
   return id;
 }
 
-function userToken(): string | null {
+function accessToken(): string | null {
   return process.env.EXPO_TOKEN || null;
 }
 
@@ -116,7 +116,7 @@ const UserSettings = Object.assign(userSettingsJsonFile(), {
   recentExpsJsonFile,
   userSettingsFile,
   userSettingsJsonFile,
-  userToken,
+  accessToken,
   anonymousIdentifier,
   SETTINGS_FILE_NAME,
 });

--- a/packages/xdl/src/UserSettings.ts
+++ b/packages/xdl/src/UserSettings.ts
@@ -107,11 +107,16 @@ async function anonymousIdentifier(): Promise<string> {
   return id;
 }
 
+function userToken(): string | null {
+  return process.env.EXPO_TOKEN || null;
+}
+
 const UserSettings = Object.assign(userSettingsJsonFile(), {
   dotExpoHomeDirectory,
   recentExpsJsonFile,
   userSettingsFile,
   userSettingsJsonFile,
+  userToken,
   anonymousIdentifier,
   SETTINGS_FILE_NAME,
 });

--- a/packages/xdl/src/__integration_tests__/Simulator-test.ts
+++ b/packages/xdl/src/__integration_tests__/Simulator-test.ts
@@ -1,14 +1,15 @@
 import delayAsync from 'delay-async';
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 40000;
+import * as Simulator from '../Simulator';
 
-const xdl = require('../xdl');
+describe.skip('simulator', () => {
+  it('opens and loads url in expo', async () => {
+    // This tests depends on the simulator, and could take some time to boot
+    jest.setTimeout(60000);
 
-describe('simulator', () => {
-  xit('opens and loads url in expo', async () => {
-    const Simulator = xdl.Simulator;
+    // Determine if we can run this test or not, if simulator isn't available warn and stop
     if (!(await Simulator._isSimulatorInstalledAsync())) {
-      throw new Error("Simulator isn't installed on this computer; can't run this test.");
+      return console.warn("Simulator isn't installed on this computer; can't run this test.");
     }
 
     // Quit the simulator to start the test
@@ -16,19 +17,21 @@ describe('simulator', () => {
       await Simulator._quitSimulatorAsync();
     }
 
-    await delayAsync(1000); // 3 seconds
+    await delayAsync(1000); // 1s
 
     // Open the simulator
     await Simulator._openAndBootSimulatorAsync();
 
-    await delayAsync(9000); // 3 seconds
+    await delayAsync(9000); // 9s
 
+    // If its not running now, we can't test
     if (!(await Simulator._isSimulatorRunningAsync())) {
       throw new Error(
         "Simulator should be running after being opened, but we're detecting that it isn't."
       );
     }
 
+    // Use a fresh Expo install for this test
     if (await Simulator._isExpoAppInstalledOnCurrentBootedSimulatorAsync()) {
       await Simulator._uninstallExpoAppFromSimulatorAsync();
     }
@@ -40,9 +43,10 @@ describe('simulator', () => {
       throw new Error("Expo app should be installed on this simulator but it isn't");
     }
 
+    // Try opening an Expo project, even when it doesn't exists Expo should be open
     await Simulator._openUrlInSimulatorAsync('exp://exp.host/@exponent/fluxpybird');
 
-    await delayAsync(6000);
+    await delayAsync(6000); // 6s
 
     await Simulator._uninstallExpoAppFromSimulatorAsync();
     if (await Simulator._isExpoAppInstalledOnCurrentBootedSimulatorAsync()) {

--- a/packages/xdl/src/__integration_tests__/UserManager-test.ts
+++ b/packages/xdl/src/__integration_tests__/UserManager-test.ts
@@ -4,16 +4,18 @@ import path from 'path';
 import uuid from 'uuid';
 
 import ApiV2Client from '../ApiV2';
-import { UserManagerInstance } from '../User';
+import { User, UserManagerInstance } from '../User';
 
-const _makeShortId = (salt, minLength = 10) => {
+const _makeShortId = (salt: string, minLength = 10) => {
   const hashIds = new HashIds(salt, minLength);
   return hashIds.encode(Date.now());
 };
 
-describe('UserManager', () => {
-  let userForTest;
-  let userForTestPassword;
+// Note: these tests are actually calling the API,
+// in the unit test "User-test.ts" the API is mocked and the same tests are executed.
+describe.skip('UserManager', () => {
+  let userForTest: User;
+  let userForTestPassword: string;
 
   beforeAll(async () => {
     process.env.__UNSAFE_EXPO_HOME_DIRECTORY = path.join(
@@ -115,7 +117,7 @@ describe('UserManager', () => {
     const _getProfileSpy = jest.fn(UserManager._getProfileAsync);
     UserManager._getProfileAsync = _getProfileSpy;
 
-    const users = await Promise.all([
+    const [first, second] = await Promise.all([
       UserManager.getCurrentUserAsync(),
       UserManager.getCurrentUserAsync(),
     ]);
@@ -123,7 +125,7 @@ describe('UserManager', () => {
     expect(_getProfileSpy).toHaveBeenCalledTimes(1);
 
     // This shouldn't have changed, but just double check it
-    expect(users[0].sessionSecret).toEqual(users[1].sessionSecret);
+    expect(first?.sessionSecret).toEqual(second?.sessionSecret);
   });
 });
 

--- a/packages/xdl/src/__integration_tests__/UserSessions-test.ts
+++ b/packages/xdl/src/__integration_tests__/UserSessions-test.ts
@@ -4,17 +4,19 @@ import path from 'path';
 import uuid from 'uuid';
 
 import ApiV2Client from '../ApiV2';
-import { UserManagerInstance } from '../User';
+import { User, UserManagerInstance } from '../User';
 import UserSettings from '../UserSettings';
 
-const _makeShortId = (salt, minLength = 10) => {
+const _makeShortId = (salt: string, minLength = 10) => {
   const hashIds = new HashIds(salt, minLength);
   return hashIds.encode(Date.now());
 };
 
-describe('User Sessions', () => {
-  let userForTest;
-  let userForTestPassword;
+// Note: these tests are actually calling the API,
+// in the unit test "User-test.ts" the API is mocked and the same tests are executed.
+describe.skip('User Sessions', () => {
+  let userForTest: User;
+  let userForTestPassword: string;
 
   beforeAll(async () => {
     process.env.__UNSAFE_EXPO_HOME_DIRECTORY = path.join(
@@ -61,7 +63,7 @@ describe('User Sessions', () => {
     await UserManager.loginAsync('user-pass', {
       username: userForTest.username,
       password: userForTestPassword,
-      testSession: true,
+      // testSession: true,
     });
 
     const user = await UserManager.getCurrentUserAsync();
@@ -74,9 +76,10 @@ describe('User Sessions', () => {
     expect(user.sessionSecret).not.toBe(undefined);
 
     // expect session to be in state.json
-    const { sessionSecret } = await UserSettings.getAsync('auth', {});
-    expect(sessionSecret).not.toBe(undefined);
+    const auth = await UserSettings.getAsync('auth', null);
+    expect(auth?.sessionSecret).not.toBe(undefined);
   });
+
   it('should remove a session token upon logout', async () => {
     const UserManager = _newTestUserManager();
     await UserManager.loginAsync('user-pass', {
@@ -87,8 +90,8 @@ describe('User Sessions', () => {
     await UserManager.logoutAsync();
 
     // expect session to be removed
-    const { sessionSecret } = await UserSettings.getAsync('auth', {});
-    expect(sessionSecret).toBe(undefined);
+    const auth = await UserSettings.getAsync('auth', null);
+    expect(auth?.sessionSecret).toBe(undefined);
   });
 
   it('should use the token in apiv2', async () => {

--- a/packages/xdl/src/__tests__/Project-publishAsync-test.ts
+++ b/packages/xdl/src/__tests__/Project-publishAsync-test.ts
@@ -97,7 +97,7 @@ describe('publishAsync', () => {
   const projectRoot = path.join(temporary.directory(), 'publish-test-app');
 
   beforeAll(async () => {
-    jest.setTimeout(180e3);
+    jest.setTimeout(240e3);
     ensureDirSync(projectRoot);
     for (const filename of ['App.js', 'app.json', 'package.json']) {
       copyFileSync(

--- a/packages/xdl/src/__tests__/User-test.ts
+++ b/packages/xdl/src/__tests__/User-test.ts
@@ -1,0 +1,192 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import uuid from 'uuid';
+
+import ApiV2 from '../ApiV2';
+import GlobalUserManager, { UserManagerInstance } from '../User';
+import UserSettings from '../UserSettings';
+
+jest.mock('../ApiV2', () => ({
+  clientForUser: jest.fn(),
+}));
+
+describe('User', () => {
+  // for some reason, tempy fails with memfs in XDL
+  const expoDir = path.join(os.tmpdir(), `.expo-${uuid.v4()}`);
+
+  beforeAll(() => {
+    process.env.__UNSAFE_EXPO_HOME_DIRECTORY = expoDir;
+    fs.mkdirpSync(expoDir);
+  });
+
+  afterAll(() => {
+    process.env.__UNSAFE_EXPO_HOME_DIRECTORY = '';
+    fs.removeSync(expoDir);
+  });
+
+  it('uses a UserManager singleton', () => {
+    const { default: manager } = jest.requireActual('../User');
+    expect(manager).toBe(GlobalUserManager);
+  });
+
+  it('is logged out by default', async () => {
+    const manager = _newTestUserManager();
+    await expect(manager.ensureLoggedInAsync()).rejects.toThrowError('Not logged in');
+  });
+
+  describe('credentials', () => {
+    it('authenticates with credentials', async () => {
+      const api = _newTestApiV2();
+      const manager = _newTestUserManager();
+
+      // Mock login response and authenticate
+      api.postAsync.mockResolvedValue({ sessionSecret: 'session-secret' });
+      await manager.loginAsync('user-pass', { username: 'expouser', password: 'expopass' });
+      expect(await manager.getCurrentUserAsync()).toHaveProperty('sessionSecret', 'session-secret');
+    });
+
+    it('locks to prevent fetching user twice, simultaneously', async () => {
+      const api = _newTestApiV2();
+      const manager = _newTestUserManager();
+
+      // Mock login response and authenticate
+      api.postAsync.mockResolvedValue({ sessionSecret: 'session-secret' });
+      await manager.loginAsync('user-pass', { username: 'expouser', password: 'expopass' });
+
+      // Empty in-memory cache, to force-fetch it
+      manager._currentUser = null;
+
+      // Check if the profile is fetched from API once
+      const profileSpy = jest.spyOn(manager, '_getProfileAsync');
+      const [first, second] = await Promise.all([
+        manager.getCurrentUserAsync(),
+        manager.getCurrentUserAsync(),
+      ]);
+      expect(profileSpy).toBeCalledTimes(1);
+      expect(first).toBe(second);
+
+      profileSpy.mockRestore();
+    });
+
+    it('adds user data to cache when authenticating with credentials', async () => {
+      const api = _newTestApiV2();
+      const manager = _newTestUserManager();
+
+      // Mock login response and authenticate
+      api.postAsync.mockResolvedValue({ sessionSecret: 'session-secret' });
+      await manager.loginAsync('user-pass', { username: 'expouser', password: 'expopass' });
+
+      // Check if the profile is loaded from cache instead of API
+      const profileSpy = jest.spyOn(manager, '_getProfileAsync');
+      await manager.getCurrentUserAsync();
+      expect(profileSpy).not.toBeCalled();
+
+      // Check if the settings-cache has the token
+      const auth = await UserSettings.getAsync('auth', null);
+      expect(auth?.sessionSecret).toBe('session-secret');
+
+      profileSpy.mockRestore();
+    });
+
+    it('removes user data from cache when logging out', async () => {
+      const api = _newTestApiV2();
+      const manager = _newTestUserManager();
+
+      // Mock login response and authenticate
+      api.postAsync.mockResolvedValue({ sessionSecret: 'session-secret' });
+      await manager.loginAsync('user-pass', { username: 'expouser', password: 'expopass' });
+
+      // Check if the settings-cache has the token
+      expect(await UserSettings.getAsync('auth', null)).toHaveProperty(
+        'sessionSecret',
+        'session-secret'
+      );
+
+      // Log user out and check if the cache is empty
+      await manager.logoutAsync();
+      expect(await UserSettings.getAsync('auth', null)).toBeNull();
+    });
+  });
+
+  describe('token', () => {
+    afterEach(() => {
+      process.env.EXPO_TOKEN = '';
+    });
+
+    it('authenticates with token', async () => {
+      const api = _newTestApiV2();
+      const manager = _newTestUserManager();
+
+      // Mock authorization token response and fetch the user
+      process.env.EXPO_TOKEN = 'auth-token';
+      api.postAsync.mockResolvedValue({ authorizationToken: 'auth-token' });
+      expect(await manager.getCurrentUserAsync()).toHaveProperty(
+        'authorizationToken',
+        'auth-token'
+      );
+    });
+
+    it(`doesn't cache user when authenticating with credentials`, async () => {
+      const api = _newTestApiV2();
+      const manager = _newTestUserManager();
+      const settingSpy = jest.spyOn(UserSettings, 'setAsync');
+
+      // Mock authorization token response and fetch the user
+      process.env.EXPO_TOKEN = 'auth-token';
+      api.postAsync.mockResolvedValue({ authorizationToken: 'auth-token' });
+      expect(await manager.getCurrentUserAsync()).toHaveProperty(
+        'authorizationToken',
+        'auth-token'
+      );
+      // Note: unfortunately, there is no other way to see if the user data was cached
+      expect(UserSettings.setAsync).not.toBeCalled();
+
+      settingSpy.mockRestore();
+    });
+
+    it('uses token over existing credentials session', async () => {
+      const api = _newTestApiV2();
+      const manager = _newTestUserManager();
+
+      // Mock login response and authenticate
+      api.postAsync.mockResolvedValue({ sessionSecret: 'session-secret' });
+      await manager.loginAsync('user-pass', { username: 'expouser', password: 'expopass' });
+      expect(await manager.getCurrentUserAsync()).toHaveProperty('sessionSecret', 'session-secret');
+
+      // Empty in-memory cache, to force-fetch it
+      manager._currentUser = null;
+
+      // Mock token response and get user
+      process.env.EXPO_TOKEN = 'auth-token';
+      api.postAsync.mockResolvedValue({ authorizationToken: 'auth-token' });
+      const user = await manager.getCurrentUserAsync();
+      expect(user).toHaveProperty('authorizationToken', 'auth-token');
+      expect(user).not.toHaveProperty('sessionSecret', 'session-secret');
+    });
+  });
+});
+
+function _newTestUserManager() {
+  const manager = new UserManagerInstance();
+  manager.initialize();
+  return manager;
+}
+
+function _newTestApiV2() {
+  const api = {
+    sessionSecret: null,
+    authorizationToken: null,
+    getAsync: jest.fn(),
+    postAsync: jest.fn(),
+    putAsync: jest.fn(),
+    patchAsync: jest.fn(),
+    deleteAsync: jest.fn(),
+    uploadFormDataAsync: jest.fn(),
+    _requestAsync: jest.fn(),
+  };
+
+  (ApiV2.clientForUser as jest.Mock).mockReturnValue(api);
+
+  return api;
+}

--- a/packages/xdl/src/__tests__/User-test.ts
+++ b/packages/xdl/src/__tests__/User-test.ts
@@ -176,7 +176,7 @@ function _newTestUserManager() {
 function _newTestApiV2() {
   const api = {
     sessionSecret: null,
-    authorizationToken: null,
+    accessToken: null,
     getAsync: jest.fn(),
     postAsync: jest.fn(),
     putAsync: jest.fn(),
@@ -186,7 +186,7 @@ function _newTestApiV2() {
     _requestAsync: jest.fn(),
   };
 
-  (ApiV2.clientForUser as jest.Mock).mockReturnValue(api);
+  (ApiV2.clientForUser as jest.MockedFunction<typeof ApiV2.clientForUser>).mockReturnValue(api);
 
   return api;
 }


### PR DESCRIPTION
## What I did

This integrates the `EXPO_TOKEN` authentication method, implemented as a `Bearer` authorization token.

- **Added the token retrieval in `UserSettings`**
I think this is the proper place for that. Eventually, it's an environmental setting but still set by the user. We could also move it to the `UserManager` itself, but I think using it from `UserSettings` makes more sense.

- **Added token in the `getSessionAsync` method**
When integrating the robots, I noticed this method is used in other areas to see if people are authenticated. With this, the DevTools also uses the proper username and other authentication stuff (e.g. username).

- ~~**Added to API v1 and v2**~~
~~I can't find traces of API v1 being used somewhere, but I added it using almost identical implementation. Again, the token is fetched from `UserSettings` by the `UserManager` and passed through within the (current) user. This should work fine for `ApiV2Client.clientForUser(user)` calls. For API v1, I added a call to `UserSettings` to fetch the token.~~ _**see section above**._

- **Token has priority over existing authentication session**
E.g. when a user runs this from his or her computer, we probably want to prioritize the `EXPO_TOKEN` value. When the user is already authenticated, this token is used over any existing session.

- **User session data from token isn't stored through `UserSettings`**
I think this is important to mention as well, I don't think any data fetched with the token should be stored. If users provide the token inline, this data should only be "available" during that same execution call (e.g. `EXPO_TOKEN=xxx expo publish`). It also doesn't interfere with existing sessions, falling back right to that when the token isn't set anymore.

## What needs to be done

- ~~**Add (unit) tests**~~ - Done, [see comment](https://github.com/expo/expo-cli/pull/2415#issuecomment-668082834)

- ~~**Double-check the analytics calls for EXPO_TOKEN sessions**~~ Done
Right now, when `ensureLoggedInAsync` is called, it fetches the user. If no current user is loaded yet, it will fetch the info and send out the login analytics event. I'm not sure if this is still valid when using the token. Every call using that token _and using `ensureLoggedInAsync`_ will send out the login event.

- ~~**Consider if we need to fail when using EXPO_TOKEN and `expo logout`**~~ Done
Logging out isn't that relevant here, I don't think we can even do that. As long as that token is defined in the environment, the user will still be authenticated using that token.
> As TC mentioned, this also applies to `logout`, `login`, and `register`

## See it in action

<details>
<summary><code>$ expo whoami</code> with inline and exported token</summary>
<img alt="whoami example" src="https://user-images.githubusercontent.com/1203991/89043784-51670200-d349-11ea-9168-b262f85192c8.png" />
</details>

<details>
<summary><code>$ expo build:android</code> with inline token</summary>
<img alt="build android example" src="https://user-images.githubusercontent.com/1203991/89043774-4f9d3e80-d349-11ea-81e6-b71523a3283c.png" />
</details>

<details>
<summary><code>$ expo build:ios</code> with exported token</summary>
<img alt="build ios example" src="https://user-images.githubusercontent.com/1203991/89043786-51ff9880-d349-11ea-90dd-234f748e12e8.png" />
</details>