### PR TITLE
[webpack-config] fix: handle empty favicons

### DIFF
--- a/packages/pwa/src/Manifest.ts
+++ b/packages/pwa/src/Manifest.ts
@@ -234,10 +234,11 @@ export function getFaviconIconConfig(config: ExpoConfig): IconOptions | null {
   });
 
   // If the favicon is set but empty, we assume that the user does not want us to generate a favicon
-  if (!config.web?.favicon) {
-    return null;
-  }
   if (typeof config.web?.favicon === 'string') {
+    if (!config.web?.favicon) {
+      return null;
+    }
+
     return validate(config.web.favicon);
   }
   if (typeof config.icon === 'string') {

--- a/packages/pwa/src/Manifest.ts
+++ b/packages/pwa/src/Manifest.ts
@@ -233,7 +233,10 @@ export function getFaviconIconConfig(config: ExpoConfig): IconOptions | null {
     backgroundColor: 'transparent',
   });
 
-  // Allow empty objects
+  // If the favicon is set but empty, we assume that the user does not want us to generate a favicon
+  if (!config.web?.favicon) {
+    return null;
+  }
   if (typeof config.web?.favicon === 'string') {
     return validate(config.web.favicon);
   }


### PR DESCRIPTION
Currently, there is no possibility to prevent the injection of favicons. This fix allows users to specify an empty favicon and consequently no favicon will be injected nor generated.