### PR TITLE
[expo-cli] EAS builds: Android project autoconfiguration

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -88,6 +88,7 @@
     "env-editor": "^0.4.1",
     "envinfo": "7.5.0",
     "es6-error": "3.2.0",
+    "figures": "3.2.0",
     "fs-extra": "9.0.0",
     "getenv": "0.7.0",
     "glob": "7.1.6",

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
@@ -131,6 +131,7 @@ function setupProjectConfig(overrideConfig: any) {
       'package.json': JSON.stringify(packageJson),
       'node_modules/expo/package.json': '{ "version": "38.0.0" }',
       'cert.p12': cert.content,
+      'android/app/build.gradle': '',
     },
     '/projectdir'
   );
@@ -187,6 +188,10 @@ describe('build command', () => {
           },
         },
       });
+      expect(vol.existsSync('/projectdir/android/app/eas-build.gradle')).toBe(true);
+      expect(vol.readFileSync('/projectdir/android/app/build.gradle', 'utf-8')).toContain(
+        'apply from: "./eas-build.gradle"'
+      );
     });
   });
   describe('ios generic job', () => {

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -1,5 +1,7 @@
 import { BuildType, Job, Platform, iOS, sanitizeJob } from '@expo/build-tools';
 import { IOSConfig } from '@expo/config';
+import chalk from 'chalk';
+import figures from 'figures';
 import once from 'lodash/once';
 import ora from 'ora';
 
@@ -104,20 +106,14 @@ class iOSBuilder implements Builder {
       if (err instanceof gitUtils.DirtyGitTreeError) {
         spinner.succeed('We configured your iOS project to build it on the Expo servers');
         log.newLine();
-        log('Please review the following changes and pass the message to make the commit.');
-        log.newLine();
-        await gitUtils.showDiffAsync();
-        log.newLine();
-        const { confirm } = await prompts({
-          type: 'confirm',
-          name: 'confirm',
-          message: 'Can we commit these changes for you?',
-        });
-        if (confirm) {
-          await gitUtils.commitChangesAsync();
-          log.newLine();
-          log('✅ Successfully commited the configuration changes.');
-        } else {
+
+        try {
+          await gitUtils.reviewAndCommitChangesAsync('Configure Xcode project', {
+            nonInteractive: this.ctx.nonInteractive,
+          });
+
+          log(`${chalk.green(figures.tick)} Successfully committed the configuration changes.`);
+        } catch (e) {
           throw new Error(
             "Aborting, run the build command once you're ready. Make sure to commit any changes you've made."
           );

--- a/packages/expo-cli/src/commands/eas-build/build/templates/gradleContent.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/templates/gradleContent.ts
@@ -1,0 +1,52 @@
+export default `android {
+  signingConfigs {
+    release {
+      // This is necessary to avoid needing the user to define a release signing config manually
+      // If no release config is defined, and this is not present, build for assembleRelease will crash
+    }
+  }
+
+  buildTypes {
+    release {
+      // This is necessary to avoid needing the user to define a release build type manually
+    }
+  }
+}
+
+project.afterEvaluate {
+  android.signingConfigs.release { config ->
+    def debug = gradle.startParameter.taskNames.any { it.toLowerCase().contains('debug') }
+
+    if (debug) {
+      return
+    }
+
+    def credentialsJson = rootProject.file("../credentials.json");
+
+    if (credentialsJson.exists()) {
+      if (config.storeFile) {
+        println("Path to release keystore file is already set, ignoring 'credentials.json'")
+      } else {
+        try {
+          def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)
+
+          storeFile rootProject.file("../" + credentials.android.keystore.keystorePath)
+          storePassword credentials.android.keystore.keystorePassword
+          keyAlias credentials.android.keystore.keyAlias
+          keyPassword credentials.android.keystore.keyPassword
+        } catch (Exception e) {
+          println("An error occurred while parsing 'credentials.json': " + e.message)
+        }
+      }
+    } else {
+      if (config.storeFile == null) {
+        println("Couldn't find a 'credentials.json' file, skipping release keystore configuration")
+      }
+    }
+  }
+
+  android.buildTypes.release { config ->
+    config.signingConfig android.signingConfigs.release
+  }
+}
+`;

--- a/packages/expo-cli/src/commands/eas-build/build/types.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/types.ts
@@ -3,6 +3,7 @@ import { ExpoConfig } from '@expo/config';
 import { User } from '@expo/xdl';
 
 import { EasConfig } from '../../../easJson';
+import { BuildCommandPlatform } from '../types';
 
 export interface BuilderContext {
   projectDir: string;
@@ -11,7 +12,10 @@ export interface BuilderContext {
   accountName: string;
   projectName: string;
   exp: ExpoConfig;
+  platform: BuildCommandPlatform;
   nonInteractive: boolean;
+  skipCredentialsCheck: boolean;
+  skipProjectConfiguration: boolean;
 }
 
 export interface Builder {

--- a/packages/expo-cli/src/commands/eas-build/build/utils/git.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/utils/git.ts
@@ -2,6 +2,8 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import ora from 'ora';
 
+import CommandError from '../../../../CommandError';
+import log from '../../../../log';
 import prompts from '../../../../prompts';
 
 async function ensureGitStatusIsCleanAsync(): Promise<void> {
@@ -36,27 +38,57 @@ async function showDiffAsync(): Promise<void> {
   await spawnAsync('git', ['--no-pager', 'diff'], { stdio: ['ignore', 'inherit', 'inherit'] });
 }
 
-async function commitChangesAsync(commitMessage?: string): Promise<void> {
-  if (!commitMessage) {
-    const promptResult = await prompts({
-      type: 'text',
-      name: 'message',
-      message: 'Commit message:',
-      initial: 'Configure Xcode project',
-      validate: input => input !== '',
-    });
-    commitMessage = promptResult.message as string;
+async function addFileAsync(file: string, options?: { intentToAdd?: boolean }): Promise<void> {
+  if (options?.intentToAdd) {
+    await spawnAsync('git', ['add', '--intent-to-add', file]);
+  } else {
+    await spawnAsync('git', ['add', file]);
+  }
+}
+
+async function reviewAndCommitChangesAsync(
+  commitMessage: string,
+  { nonInteractive }: { nonInteractive: boolean }
+): Promise<void> {
+  if (nonInteractive) {
+    throw new CommandError(
+      'Cannot commit changes when --non-interactive is specified. Run the command in interactive mode to review and commit changes.'
+    );
   }
 
-  // add changed files only
+  log('Please review the following changes and pass the message to make the commit.');
+  log.newLine();
+  await showDiffAsync();
+  log.newLine();
+
+  const { confirm } = await prompts({
+    type: 'confirm',
+    name: 'confirm',
+    message: 'Can we commit these changes for you?',
+  });
+
+  if (!confirm) {
+    throw new Error('Aborting commit. Please review and commit the changes manually.');
+  }
+
+  const { message } = await prompts({
+    type: 'text',
+    name: 'message',
+    message: 'Commit message:',
+    initial: commitMessage,
+    validate: input => input !== '',
+  });
+
+  // Add changed files only
   await spawnAsync('git', ['add', '-u']);
-  await spawnAsync('git', ['commit', '-m', commitMessage]);
+  await spawnAsync('git', ['commit', '-m', message]);
 }
 
 export {
   DirtyGitTreeError,
   ensureGitStatusIsCleanAsync,
   makeProjectTarballAsync,
-  commitChangesAsync,
+  reviewAndCommitChangesAsync,
   showDiffAsync,
+  addFileAsync,
 };

--- a/packages/expo-cli/src/commands/eas-build/index.ts
+++ b/packages/expo-cli/src/commands/eas-build/index.ts
@@ -21,6 +21,7 @@ export default function (program: Command) {
       /^(all|android|ios)$/i
     )
     .option('--skip-credentials-check', 'Skip checking credentials', false)
+    .option('--skip-project-configuration', 'Skip configuring the project', false)
     .option('--no-wait', 'Exit immediately after scheduling build', false)
     .option('--profile <profile>', 'Build profile', 'release')
     .asyncActionProjectDir(buildAction, { checkConfig: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9682,6 +9682,13 @@ figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
   integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
 
+figures@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"


### PR DESCRIPTION
## Why

For generic Android builds, we want `expo-cli` to autoconfigure Gradle to build it on turtle workers, instead of the manual step described in https://github.com/expo/turtle-v2/blob/master/TUTORIAL.md.

## How

- I updated the `configureProjectAsync` for Android to write the required gradle script (`eas-build.gradle`)
- The gradle script is then imported in user's `build.gradle` file
- It hooks into gradle script and sets the appropriate credentials for release builds based on the `credentials.json` file
- After the changes, it shows the diff and asks the user to commit the changes

## Test plan

- I initialized a new project with `expo init` and select the `bare-minimal` template
- I created a minimal `eas.json`.
- I ran `expo eas:build --platform android`:
  - I generated credentials.
  - I observed that the gradle file was written and I was offered to commit those changes.
  - The build has been scheduled (I got the build URL).
  - I pressed `CTRL+C` and ran `git log` and I saw that a new commit has been made.
  - I saw that build finished successfully

Closes https://github.com/expo/turtle-v2/issues/271

![Kapture 2020-08-06 at 9 33 49](https://user-images.githubusercontent.com/1174278/89504238-007f5f80-d7c8-11ea-9afa-d6f6fa051314.gif)

