### PR TITLE
[expo-cli][eject] Fix generated orientation in AndroidManifest

### DIFF
--- a/packages/config/src/android/Orientation.ts
+++ b/packages/config/src/android/Orientation.ts
@@ -7,6 +7,14 @@ export function getOrientation(config: ExpoConfig) {
   return typeof config.orientation === 'string' ? config.orientation : null;
 }
 
+function prepareOrientation(orientation: string) {
+  if (orientation === 'default') {
+    return 'unspecified';
+  }
+
+  return orientation;
+}
+
 export async function setAndroidOrientation(config: ExpoConfig, manifestDocument: Document) {
   const orientation = getOrientation(config);
   if (!orientation) {
@@ -16,7 +24,7 @@ export async function setAndroidOrientation(config: ExpoConfig, manifestDocument
   const mainActivity = manifestDocument.manifest.application[0].activity.filter(
     (e: any) => e['$']['android:name'] === '.MainActivity'
   );
-  mainActivity[0]['$'][SCREEN_ORIENTATION_ATTRIBUTE] = orientation;
+  mainActivity[0]['$'][SCREEN_ORIENTATION_ATTRIBUTE] = prepareOrientation(orientation);
 
   return manifestDocument;
 }

--- a/packages/config/src/android/Orientation.ts
+++ b/packages/config/src/android/Orientation.ts
@@ -7,7 +7,7 @@ export function getOrientation(config: ExpoConfig) {
   return typeof config.orientation === 'string' ? config.orientation : null;
 }
 
-function prepareOrientation(orientation: string) {
+export function prepareOrientation(orientation: string) {
   if (orientation === 'default') {
     return 'unspecified';
   }

--- a/packages/config/src/android/Orientation.ts
+++ b/packages/config/src/android/Orientation.ts
@@ -7,14 +7,6 @@ export function getOrientation(config: ExpoConfig) {
   return typeof config.orientation === 'string' ? config.orientation : null;
 }
 
-export function prepareOrientation(orientation: string) {
-  if (orientation === 'default') {
-    return 'unspecified';
-  }
-
-  return orientation;
-}
-
 export async function setAndroidOrientation(config: ExpoConfig, manifestDocument: Document) {
   const orientation = getOrientation(config);
   if (!orientation) {
@@ -24,7 +16,8 @@ export async function setAndroidOrientation(config: ExpoConfig, manifestDocument
   const mainActivity = manifestDocument.manifest.application[0].activity.filter(
     (e: any) => e['$']['android:name'] === '.MainActivity'
   );
-  mainActivity[0]['$'][SCREEN_ORIENTATION_ATTRIBUTE] = prepareOrientation(orientation);
+  mainActivity[0]['$'][SCREEN_ORIENTATION_ATTRIBUTE] =
+    orientation !== 'default' ? orientation : 'unspecified';
 
   return manifestDocument;
 }

--- a/packages/config/src/android/__tests__/Orientation-test.js
+++ b/packages/config/src/android/__tests__/Orientation-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 
 import { readAndroidManifestAsync } from '../Manifest';
-import { getOrientation, prepareOrientation, setAndroidOrientation } from '../Orientation';
+import { getOrientation, setAndroidOrientation } from '../Orientation';
 
 const fixturesPath = resolve(__dirname, 'fixtures');
 const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
@@ -13,10 +13,6 @@ describe('Android orientation', () => {
 
   it(`returns orientation if provided`, () => {
     expect(getOrientation({ orientation: 'landscape' })).toMatch('landscape');
-  });
-
-  it(`returns unspecified orientation if provided default`, () => {
-    expect(prepareOrientation('default')).toMatch('unspecified');
   });
 
   describe('File changes', () => {

--- a/packages/config/src/android/__tests__/Orientation-test.js
+++ b/packages/config/src/android/__tests__/Orientation-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 
 import { readAndroidManifestAsync } from '../Manifest';
-import { getOrientation, setAndroidOrientation } from '../Orientation';
+import { getOrientation, prepareOrientation, setAndroidOrientation } from '../Orientation';
 
 const fixturesPath = resolve(__dirname, 'fixtures');
 const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
@@ -13,6 +13,10 @@ describe('Android orientation', () => {
 
   it(`returns orientation if provided`, () => {
     expect(getOrientation({ orientation: 'landscape' })).toMatch('landscape');
+  });
+
+  it(`returns unspecified orientation if provided default`, () => {
+    expect(prepareOrientation('default')).toMatch('unspecified');
   });
 
   describe('File changes', () => {
@@ -41,6 +45,19 @@ describe('Android orientation', () => {
         e => e['$']['android:name'] === '.MainActivity'
       );
       expect(mainActivity[0]['$']['android:screenOrientation']).toMatch('portrait');
+    });
+
+    it('replaces orientation with unspecified if provided default', async () => {
+      androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+      androidManifestJson = await setAndroidOrientation(
+        { orientation: 'default' },
+        androidManifestJson
+      );
+
+      const mainActivity = androidManifestJson.manifest.application[0].activity.filter(
+        e => e['$']['android:name'] === '.MainActivity'
+      );
+      expect(mainActivity[0]['$']['android:screenOrientation']).toMatch('unspecified');
     });
   });
 });


### PR DESCRIPTION
Fixes #2429 

Tested by just ejecting project and checking if orientation in manifest is correct. Also wrote 2 tests and ran `jest`.