### PR TITLE
[expo-cli] rename eas.json field: buildCommand -> gradleCommand

### DIFF
--- a/packages/expo-cli/src/__tests__/easJson-test.ts
+++ b/packages/expo-cli/src/__tests__/easJson-test.ts
@@ -106,7 +106,7 @@ describe('eas.json', () => {
             release: { workflow: 'generic' },
             debug: {
               workflow: 'generic',
-              buildCommand: ':app:assembleDebug',
+              gradleCommand: ':app:assembleDebug',
               withoutCredentials: true,
             },
           },
@@ -121,7 +121,7 @@ describe('eas.json', () => {
         android: {
           credentialsSource: 'auto',
           workflow: 'generic',
-          buildCommand: ':app:assembleDebug',
+          gradleCommand: ':app:assembleDebug',
           withoutCredentials: true,
         },
         ios: {

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -15,7 +15,6 @@ import {
   Workflow,
 } from '../../../../easJson';
 import log from '../../../../log';
-import prompts from '../../../../prompts';
 import { ensureCredentialsAsync } from '../credentials';
 import gradleContent from '../templates/gradleContent';
 import { Builder, BuilderContext } from '../types';
@@ -151,7 +150,7 @@ class AndroidBuilder implements Builder {
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
       type: BuildType.Generic,
-      gradleCommand: buildProfile.buildCommand,
+      gradleCommand: buildProfile.gradleCommand,
       artifactPath: buildProfile.artifactPath,
     };
   }

--- a/packages/expo-cli/src/easJson.ts
+++ b/packages/expo-cli/src/easJson.ts
@@ -29,7 +29,7 @@ export interface AndroidManagedBuildProfile {
 export interface AndroidGenericBuildProfile {
   workflow: Workflow.Generic;
   credentialsSource: CredentialsSource;
-  buildCommand?: string;
+  gradleCommand?: string;
   artifactPath?: string;
   withoutCredentials?: boolean;
 }
@@ -83,7 +83,7 @@ const EasJsonSchema = Joi.object({
 const AndroidGenericSchema = Joi.object({
   workflow: Joi.string().valid('generic').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
-  buildCommand: Joi.string(),
+  gradleCommand: Joi.string(),
   artifactPath: Joi.string(),
   withoutCredentials: Joi.boolean(),
 });


### PR DESCRIPTION
For generic Android builds, `buildCommand` is an argument passed to `./gradlew`. Because of that, it'd be better to name it `gradleCommand` to make it self-explanatory. 