### PR TITLE
[expo-cli] minor eas.json improvements

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -157,7 +157,7 @@ class AndroidBuilder implements Builder {
 
   private async prepareManagedJobAsync(
     archiveUrl: string,
-    buildProfile: AndroidManagedBuildProfile
+    _buildProfile: AndroidManagedBuildProfile
   ): Promise<Partial<Android.ManagedJob>> {
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -152,12 +152,13 @@ class iOSBuilder implements Builder {
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
       type: BuildType.Generic,
+      artifactPath: buildProfile.artifactPath,
     };
   }
 
   private async prepareManagedJobAsync(
     archiveUrl: string,
-    buildProfile: iOSManagedBuildProfile
+    _buildProfile: iOSManagedBuildProfile
   ): Promise<Partial<iOS.ManagedJob>> {
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),

--- a/packages/expo-cli/src/easJson.ts
+++ b/packages/expo-cli/src/easJson.ts
@@ -23,7 +23,7 @@ export enum CredentialsSource {
 export interface AndroidManagedBuildProfile {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
-  buildType?: 'app-bundle' | 'apk';
+  buildType?: 'apk' | 'app-bundle';
 }
 
 export interface AndroidGenericBuildProfile {
@@ -43,6 +43,7 @@ export interface iOSManagedBuildProfile {
 export interface iOSGenericBuildProfile {
   workflow: Workflow.Generic;
   credentialsSource: CredentialsSource;
+  artifactPath?: string;
 }
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;
@@ -91,13 +92,15 @@ const AndroidGenericSchema = Joi.object({
 const AndroidManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
-  buildType: Joi.string().valid('apk', 'app-bundle'),
+  buildType: Joi.string().valid('apk', 'app-bundle').default('app-bundle'),
 });
 
 const iOSGenericSchema = Joi.object({
   workflow: Joi.string().valid('generic').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
+  artifactPath: Joi.string(),
 });
+
 const iOSManagedSchema = Joi.object({
   workflow: Joi.string().valid('managed').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),


### PR DESCRIPTION
- I added the `artifactPath` field for generic iOS build profiles 
- I set `app-bundle` as the default build type for managed Android profiles. (It's not relevant for now but I've decided to fix it now)