### PR TITLE
[expo-cli] add --skip-credentials-check option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to Expo CLI and related packages.
 - [expo-cli] expo publish - Clean up upload results logs ([#2516](https://github.com/expo/expo-cli/pull/2516) by [@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] expo eject - Added support for locales in eject and apply ([#2496](https://github.com/expo/expo-cli/pull/2496) by [@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] expo publish - Log bundles after building ([#2527](https://github.com/expo/expo-cli/pull/2527) by [@EvanBacon](https://github.com/EvanBacon))
+- [expo-cli] expo eas:build - Add --skip-credentials-check option ([#2442](https://github.com/expo/expo-cli/pull/2442) by [@satya164](https://github.com/satya164))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/credentials-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/credentials-test.ts
@@ -170,7 +170,7 @@ describe('ensureCredentialsAsync', () => {
 
       expect(prompts).toHaveBeenCalledTimes(1);
     });
-    it('should should throw an error when local or remote are not present (non interactive)', async () => {
+    it('should throw an error when local or remote are not present (non interactive)', async () => {
       const provider = createMockCredentialsProvider({
         hasRemote: false,
         hasLocal: false,

--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -29,7 +29,7 @@ import { printBuildResults, printLogsUrls } from './utils/misc';
 
 interface BuildOptions {
   platform: BuildCommandPlatform;
-  skipCredentialsCheck?: boolean; // TODO: noop for now
+  skipCredentialsCheck?: boolean;
   skipProjectConfiguration?: boolean;
   wait?: boolean;
   profile: string;

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -44,10 +44,14 @@ class AndroidBuilder implements Builder<Platform.Android> {
     if (!this.shouldLoadCredentials()) {
       return;
     }
-    const provider = new AndroidCredentialsProvider(this.ctx.commandCtx.projectDir, {
-      projectName: this.ctx.commandCtx.projectName,
-      accountName: this.ctx.commandCtx.accountName,
-    });
+    const provider = new AndroidCredentialsProvider(
+      this.ctx.commandCtx.projectDir,
+      {
+        projectName: this.ctx.commandCtx.projectName,
+        accountName: this.ctx.commandCtx.accountName,
+      },
+      { nonInteractive: this.ctx.commandCtx.nonInteractive }
+    );
     await provider.initAsync();
     const credentialsSource = await ensureCredentialsAsync(
       provider,

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -60,11 +60,18 @@ class iOSBuilder implements Builder<Platform.iOS> {
       this.ctx.commandCtx.projectDir,
       this.ctx.commandCtx.exp
     );
-    const provider = new iOSCredentialsProvider(this.ctx.commandCtx.projectDir, {
-      projectName: this.ctx.commandCtx.projectName,
-      accountName: this.ctx.commandCtx.accountName,
-      bundleIdentifier,
-    });
+    const provider = new iOSCredentialsProvider(
+      this.ctx.commandCtx.projectDir,
+      {
+        projectName: this.ctx.commandCtx.projectName,
+        accountName: this.ctx.commandCtx.accountName,
+        bundleIdentifier,
+      },
+      {
+        nonInteractive: this.ctx.commandCtx.nonInteractive,
+        skipCredentialsCheck: this.ctx.commandCtx.skipCredentialsCheck,
+      }
+    );
     await provider.initAsync();
     const credentialsSource = await ensureCredentialsAsync(
       provider,

--- a/packages/expo-cli/src/commands/eas-build/build/credentials.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/credentials.ts
@@ -96,9 +96,8 @@ export async function ensureCredentialsAsync(
     case CredentialsSource.REMOTE:
       log(log.chalk.bold(USING_REMOTE_CREDENTIALS_MSG));
       return CredentialsSource.REMOTE;
-    case CredentialsSource.AUTO: {
+    case CredentialsSource.AUTO:
       log('Resolving credentials source (auto mode)');
       return await ensureCredentialsAutoAsync(provider, workflow, nonInteractive);
-    }
   }
 }

--- a/packages/expo-cli/src/credentials/provider/AndroidCredentialsProvider.ts
+++ b/packages/expo-cli/src/credentials/provider/AndroidCredentialsProvider.ts
@@ -11,25 +11,29 @@ export interface AndroidCredentials {
   keystore: Keystore;
 }
 
-interface Options {
+interface AppLookupParams {
   projectName: string;
   accountName: string;
+}
+
+interface Options {
+  nonInteractive: boolean;
 }
 
 export default class AndroidCredentialsProvider implements CredentialsProvider {
   public readonly platform = 'android';
   private readonly ctx = new Context();
 
-  constructor(private projectDir: string, private options: Options) {}
+  constructor(private projectDir: string, private app: AppLookupParams, private options: Options) {}
 
   private get projectFullName(): string {
-    const { projectName, accountName } = this.options;
+    const { projectName, accountName } = this.app;
     return `@${accountName}/${projectName}`;
   }
 
   public async initAsync() {
     await this.ctx.init(this.projectDir, {
-      nonInteractive: this.ctx.nonInteractive,
+      nonInteractive: this.options.nonInteractive,
     });
   }
 

--- a/packages/expo-cli/src/credentials/provider/__tests__/AndroidCredentialsProvider-test.ts
+++ b/packages/expo-cli/src/credentials/provider/__tests__/AndroidCredentialsProvider-test.ts
@@ -7,6 +7,9 @@ const providerOptions = {
   projectName: 'slug123',
   accountName: 'owner123',
 };
+const cliOptions = {
+  nonInteractive: false,
+};
 
 const mockFetchKeystore = jest.fn();
 
@@ -47,7 +50,7 @@ describe('AndroidCredentialsProvider', () => {
         keyAlias: 'alias1',
         keyPassword: 'keypass',
       }));
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const hasRemote = await provider.hasRemoteAsync();
       expect(hasRemote).toBe(true);
@@ -58,13 +61,13 @@ describe('AndroidCredentialsProvider', () => {
         keystorePassword: 'pass1',
         keyPassword: 'keypass',
       }));
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const hasRemote = await provider.hasRemoteAsync();
       expect(hasRemote).toBe(false);
     });
     it('should return false if there are no credentials', async () => {
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const hasRemote = await provider.hasRemoteAsync();
       expect(hasRemote).toBe(false);
@@ -86,7 +89,7 @@ describe('AndroidCredentialsProvider', () => {
         './test.jks': 'somebinarycontent',
       });
 
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const hasLocal = await provider.hasLocalAsync();
       expect(hasLocal).toBe(true);
@@ -104,7 +107,7 @@ describe('AndroidCredentialsProvider', () => {
         }),
         './test.jks': 'somebinarycontent',
       });
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const hasLocal = await provider.hasLocalAsync();
       expect(hasLocal).toBe(true);
@@ -122,13 +125,13 @@ describe('AndroidCredentialsProvider', () => {
           },
         }),
       });
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const hasLocal = await provider.hasLocalAsync();
       expect(hasLocal).toBe(true);
     });
     it('should return false if there are no credentials.json file', async () => {
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const hasLocal = await provider.hasLocalAsync();
       expect(hasLocal).toBe(false);
@@ -142,7 +145,7 @@ describe('AndroidCredentialsProvider', () => {
         keyAlias: 'alias1',
         keyPassword: 'keypass',
       }));
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       await expect(
         provider.getCredentialsAsync(CredentialsSource.REMOTE)
@@ -154,12 +157,12 @@ describe('AndroidCredentialsProvider', () => {
         keystorePassword: 'pass1',
         keyPassword: 'keypass',
       }));
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       await expect(provider.getCredentialsAsync(CredentialsSource.REMOTE)).rejects.toThrowError();
     });
     it('should return false if there are no credentials', async () => {
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       await expect(provider.getCredentialsAsync(CredentialsSource.REMOTE)).rejects.toThrowError();
     });
@@ -180,7 +183,7 @@ describe('AndroidCredentialsProvider', () => {
         './test.jks': 'somebinarycontent',
       });
 
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       await expect(
         provider.getCredentialsAsync(CredentialsSource.LOCAL)
@@ -199,7 +202,7 @@ describe('AndroidCredentialsProvider', () => {
         }),
         './test.jks': 'somebinarycontent',
       });
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       await expect(provider.getCredentialsAsync(CredentialsSource.LOCAL)).rejects.toThrowError();
     });
@@ -216,12 +219,12 @@ describe('AndroidCredentialsProvider', () => {
           },
         }),
       });
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       await expect(provider.getCredentialsAsync(CredentialsSource.LOCAL)).rejects.toThrowError();
     });
     it('should return false if there are no credentials.json file', async () => {
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       await expect(provider.getCredentialsAsync(CredentialsSource.LOCAL)).rejects.toThrowError();
     });
@@ -247,7 +250,7 @@ describe('AndroidCredentialsProvider', () => {
         }),
         './test.jks': 'somebinarycontent',
       });
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const isLocalSynced = await provider.isLocalSyncedAsync();
       expect(isLocalSynced).toBe(true);
@@ -272,7 +275,7 @@ describe('AndroidCredentialsProvider', () => {
         }),
         './test2.jks': 'somebinarycontent',
       });
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       const isLocalSynced = await provider.isLocalSyncedAsync();
       expect(isLocalSynced).toBe(false);
@@ -299,7 +302,7 @@ describe('AndroidCredentialsProvider', () => {
         }),
         './test2.jks': 'somebinarycontent',
       });
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       expect(await provider.getCredentialsAsync(CredentialsSource.LOCAL)).toEqual({
         keystore: {
@@ -330,7 +333,7 @@ describe('AndroidCredentialsProvider', () => {
         }),
         './test2.jks': 'somebinarycontent',
       });
-      const provider = new AndroidCredentialsProvider('.', providerOptions);
+      const provider = new AndroidCredentialsProvider('.', providerOptions, cliOptions);
       await provider.initAsync();
       expect(await provider.getCredentialsAsync(CredentialsSource.REMOTE)).toEqual({
         keystore: {


### PR DESCRIPTION
## Why

We want people to be able to skip checking for remote credentials.