### PR TITLE
[webpack-config] Add default support for use-expo namespace

### DIFF
--- a/packages/webpack-config/src/loaders/createBabelLoader.ts
+++ b/packages/webpack-config/src/loaders/createBabelLoader.ts
@@ -23,6 +23,7 @@ const includeModulesThatContainPaths = [
   getModule('unimodules'),
   getModule('@react'),
   getModule('@expo'),
+  getModule('@use-expo'),
   getModule('@unimodules'),
   getModule('native-base'),
   getModule('styled-components'),


### PR DESCRIPTION
This enables default support in Expo web for use-expo hooks packages.