### PR TITLE
[expo-cli] turtle-v2 credentials change hasLocal,hasRemote bahviour

### DIFF
--- a/packages/expo-cli/src/credentials/local/__tests__/credentials-json-test.ts
+++ b/packages/expo-cli/src/credentials/local/__tests__/credentials-json-test.ts
@@ -37,7 +37,7 @@ describe('credentialsJson', () => {
     it('should throw error when credentials.json is missing', async () => {
       const promise = credentialsJson.readAndroidAsync('.');
       await expect(promise).rejects.toThrow(
-        'credentials.json must exist in the project root directory and consist a valid JSON'
+        'credentials.json must exist in the project root directory and contain a valid JSON'
       );
     });
 
@@ -116,7 +116,7 @@ describe('credentialsJson', () => {
     it('should throw error when credentials.json is missing', async () => {
       const promise = credentialsJson.readIosAsync('.');
       await expect(promise).rejects.toThrow(
-        'credentials.json must exist in the project root directory and consist a valid JSON'
+        'credentials.json must exist in the project root directory and contain a valid JSON'
       );
     });
     it('should throw error if ios field is missing', async () => {

--- a/packages/expo-cli/src/credentials/local/credentialsJson.ts
+++ b/packages/expo-cli/src/credentials/local/credentialsJson.ts
@@ -93,16 +93,7 @@ async function readIosAsync(projectDir: string): Promise<iOSCredentials> {
 }
 
 async function readAsync(projectDir: string): Promise<CredentialsJson> {
-  const credentialsJsonFilePath = path.join(projectDir, 'credentials.json');
-  let credentialsJSONRaw;
-  try {
-    const credentialsJSONContents = await fs.readFile(credentialsJsonFilePath, 'utf8');
-    credentialsJSONRaw = JSON.parse(credentialsJSONContents);
-  } catch (err) {
-    throw new Error(
-      `credentials.json must exist in the project root directory and consist a valid JSON`
-    );
-  }
+  const credentialsJSONRaw = await readRawAsync(projectDir);
 
   const { value: credentialsJson, error } = CredentialsJsonSchema.validate(credentialsJSONRaw, {
     stripUnknown: true,
@@ -116,7 +107,19 @@ async function readAsync(projectDir: string): Promise<CredentialsJson> {
   return credentialsJson;
 }
 
+async function readRawAsync(projectDir: string): Promise<any> {
+  const credentialsJsonFilePath = path.join(projectDir, 'credentials.json');
+  try {
+    const credentialsJSONContents = await fs.readFile(credentialsJsonFilePath, 'utf8');
+    return JSON.parse(credentialsJSONContents);
+  } catch (err) {
+    throw new Error(
+      `credentials.json must exist in the project root directory and contain a valid JSON`
+    );
+  }
+}
+
 const getAbsolutePath = (projectDir: string, filePath: string): string =>
   path.isAbsolute(filePath) ? filePath : path.join(projectDir, filePath);
 
-export default { readAndroidAsync, readIosAsync, fileExistsAsync };
+export default { readAndroidAsync, readIosAsync, readRawAsync, fileExistsAsync };

--- a/packages/expo-cli/src/credentials/provider/AndroidCredentialsProvider.ts
+++ b/packages/expo-cli/src/credentials/provider/AndroidCredentialsProvider.ts
@@ -1,4 +1,5 @@
 import { CredentialsSource } from '../../easJson';
+import log from '../../log';
 import { Context } from '../context';
 import { Keystore } from '../credentials';
 import { credentialsJson } from '../local';
@@ -42,9 +43,10 @@ export default class AndroidCredentialsProvider implements CredentialsProvider {
       return false;
     }
     try {
-      const credentials = await credentialsJson.readAndroidAsync(this.projectDir);
-      return this.isValidKeystore(credentials.keystore);
+      const rawCredentialsJson = await credentialsJson.readRawAsync(this.projectDir);
+      return !!rawCredentialsJson?.android;
     } catch (err) {
+      log.error(err); // malformed json
       return false;
     }
   }

--- a/packages/expo-cli/src/credentials/provider/__tests__/AndroidCredentialsProvider-test.ts
+++ b/packages/expo-cli/src/credentials/provider/__tests__/AndroidCredentialsProvider-test.ts
@@ -91,7 +91,7 @@ describe('AndroidCredentialsProvider', () => {
       const hasLocal = await provider.hasLocalAsync();
       expect(hasLocal).toBe(true);
     });
-    it('should return false if there are missing fields', async () => {
+    it('should return true if there are missing fields', async () => {
       vol.fromJSON({
         './credentials.json': JSON.stringify({
           android: {
@@ -107,9 +107,9 @@ describe('AndroidCredentialsProvider', () => {
       const provider = new AndroidCredentialsProvider('.', providerOptions);
       await provider.initAsync();
       const hasLocal = await provider.hasLocalAsync();
-      expect(hasLocal).toBe(false);
+      expect(hasLocal).toBe(true);
     });
-    it('should return false if file is missing', async () => {
+    it('should return true if file is missing', async () => {
       vol.fromJSON({
         './credentials.json': JSON.stringify({
           android: {
@@ -125,7 +125,7 @@ describe('AndroidCredentialsProvider', () => {
       const provider = new AndroidCredentialsProvider('.', providerOptions);
       await provider.initAsync();
       const hasLocal = await provider.hasLocalAsync();
-      expect(hasLocal).toBe(false);
+      expect(hasLocal).toBe(true);
     });
     it('should return false if there are no credentials.json file', async () => {
       const provider = new AndroidCredentialsProvider('.', providerOptions);

--- a/packages/expo-cli/src/credentials/provider/__tests__/iOSCredentialsProvider-test.ts
+++ b/packages/expo-cli/src/credentials/provider/__tests__/iOSCredentialsProvider-test.ts
@@ -58,7 +58,7 @@ describe('iOSCredentialsProvider', () => {
       const hasRemote = await provider.hasRemoteAsync();
       expect(hasRemote).toBe(true);
     });
-    it('should return false if dist cert is missing', async () => {
+    it('should return true if dist cert is missing', async () => {
       mockGetProvisioningProfile.mockImplementation(() => ({
         provisioningProfile: 'profileBase64',
         provisioningProfileId: 'id',
@@ -66,10 +66,10 @@ describe('iOSCredentialsProvider', () => {
       const provider = new iOSCredentialsProvider('.', providerOptions);
       await provider.initAsync();
       const hasRemote = await provider.hasRemoteAsync();
-      expect(hasRemote).toBe(false);
+      expect(hasRemote).toBe(true);
     });
 
-    it('should return false if provisioning profile is missing', async () => {
+    it('should return true if provisioning profile is missing', async () => {
       mockGetDistCert.mockImplementation(() => ({
         certP12: 'certbase64',
         certPassword: 'fakePassword',
@@ -77,7 +77,7 @@ describe('iOSCredentialsProvider', () => {
       const provider = new iOSCredentialsProvider('.', providerOptions);
       await provider.initAsync();
       const hasRemote = await provider.hasRemoteAsync();
-      expect(hasRemote).toBe(false);
+      expect(hasRemote).toBe(true);
     });
     it('should return false if there are no credentials', async () => {
       const provider = new iOSCredentialsProvider('.', providerOptions);
@@ -107,7 +107,7 @@ describe('iOSCredentialsProvider', () => {
       const hasLocal = await provider.hasLocalAsync();
       expect(hasLocal).toBe(true);
     });
-    it('should return false if there are missing fields', async () => {
+    it('should return true if there are missing fields', async () => {
       vol.fromJSON({
         './credentials.json': JSON.stringify({
           ios: {
@@ -124,9 +124,9 @@ describe('iOSCredentialsProvider', () => {
       const provider = new iOSCredentialsProvider('.', providerOptions);
       await provider.initAsync();
       const hasLocal = await provider.hasLocalAsync();
-      expect(hasLocal).toBe(false);
+      expect(hasLocal).toBe(true);
     });
-    it('should return false if file is missing', async () => {
+    it('should return true if file is missing', async () => {
       vol.fromJSON({
         './credentials.json': JSON.stringify({
           ios: {
@@ -142,7 +142,7 @@ describe('iOSCredentialsProvider', () => {
       const provider = new iOSCredentialsProvider('.', providerOptions);
       await provider.initAsync();
       const hasLocal = await provider.hasLocalAsync();
-      expect(hasLocal).toBe(false);
+      expect(hasLocal).toBe(true);
     });
     it('should return false if there are no credentials.json file', async () => {
       const provider = new iOSCredentialsProvider('.', providerOptions);

--- a/packages/expo-cli/src/credentials/provider/iOSCredentialsProvider.ts
+++ b/packages/expo-cli/src/credentials/provider/iOSCredentialsProvider.ts
@@ -1,4 +1,5 @@
 import { CredentialsSource } from '../../easJson';
+import log from '../../log';
 import { AppLookupParams } from '../api/IosApi';
 import { Context } from '../context';
 import { credentialsJson } from '../local';
@@ -30,7 +31,7 @@ export default class iOSCredentialsProvider implements CredentialsProvider {
   public async hasRemoteAsync(): Promise<boolean> {
     const distCert = await this.ctx.ios.getDistCert(this.app);
     const provisioningProfile = await this.ctx.ios.getProvisioningProfile(this.app);
-    return !!(distCert && provisioningProfile);
+    return !!(distCert || provisioningProfile);
   }
 
   public async hasLocalAsync(): Promise<boolean> {
@@ -38,9 +39,10 @@ export default class iOSCredentialsProvider implements CredentialsProvider {
       return false;
     }
     try {
-      await credentialsJson.readIosAsync(this.projectDir);
-      return true;
-    } catch (_) {
+      const rawCredentialsJson = await credentialsJson.readRawAsync(this.projectDir);
+      return !!rawCredentialsJson?.ios;
+    } catch (err) {
+      log.error(err); // malformed json
       return false;
     }
   }


### PR DESCRIPTION
# why

It's not clear what credentials are used during build, misconfiguration of credentials.json might cause expo-cli to use remote ones without any info for the user