### PR TITLE
[expo-cli] Force users to confirm deleting android credentials

### DIFF
--- a/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
@@ -97,6 +97,7 @@ class RemoveKeystore implements IView {
         type: 'confirm',
         name: 'confirm',
         message: 'Permanently delete the Android build credentials from our servers?',
+        default: false,
       },
     ];
     const answers = await prompt(questions);


### PR DESCRIPTION
This makes sure people don't accidentally press enter when they are asked questions. With this, people _have_ to input `y` first and confirm with enter.