### PR TITLE
[xdl] Expand Android permissions blacklist and add annotations

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -799,7 +799,7 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       'android.permission.SYSTEM_ALERT_WINDOW',
 
       // signature permissions - not available for 3rd party
-      'android.permission.MANAGE_DOCUMENTS',
+      'android.permission.MANAGE_DOCUMENTS', // https://github.com/expo/expo/pull/9727
       'android.permission.READ_SMS', // https://github.com/expo/expo/pull/2982
       'android.permission.REQUEST_INSTALL_PACKAGES', // https://github.com/expo/expo/pull/8969
 

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -778,22 +778,33 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
 
     // Permissions we need to remove from the generated manifest
     const blacklist = [
-      'android.permission.ACCESS_COARSE_LOCATION',
-      'android.permission.ACCESS_FINE_LOCATION',
-      'android.permission.CAMERA',
-      'android.permission.MANAGE_DOCUMENTS',
-      'android.permission.READ_CONTACTS',
-      'android.permission.WRITE_CONTACTS',
-      'android.permission.READ_CALENDAR',
-      'android.permission.WRITE_CALENDAR',
-      'android.permission.READ_EXTERNAL_STORAGE',
-      'android.permission.READ_INTERNAL_STORAGE',
+      // module permissions - included by default / requires user to add to `android.permissions` list
+      'android.permission.ACCESS_COARSE_LOCATION', // expo-bluetooth, expo-location
+      'android.permission.ACCESS_FINE_LOCATION', // expo-location
+      'android.permission.ACCESS_BACKGROUND_LOCATION', // expo-location
+      'android.permission.CAMERA', // expo-barcode-scanner, expo-camera, expo-image-picker
+      'android.permission.RECORD_AUDIO', // expo-camera
+      'android.permission.READ_CONTACTS', // expo-contacts
+      'android.permission.WRITE_CONTACTS', // expo-contacts
+      'android.permission.READ_CALENDAR', // expo-calendar
+      'android.permission.WRITE_CALENDAR', // expo-calendar
+      'android.permission.READ_EXTERNAL_STORAGE', // expo-file-system, expo-image, expo-media-library, expo-video-thumbnails
+      'android.permission.WRITE_EXTERNAL_STORAGE', // expo-file-system, expo-media-library
+      'android.permission.USE_FINGERPRINT', // expo-local-authentication
+      'android.permission.USE_BIOMETRIC', // expo-local-authentication
+      'android.permission.VIBRATE', // expo-haptics
+
+      // react native debugging permissions - not required for standalone apps
       'android.permission.READ_PHONE_STATE',
-      'android.permission.RECORD_AUDIO',
-      'android.permission.USE_FINGERPRINT',
-      'android.permission.VIBRATE',
-      'android.permission.WRITE_EXTERNAL_STORAGE',
-      'android.permission.READ_SMS',
+      'android.permission.SYSTEM_ALERT_WINDOW',
+
+      // signature permissions - not available for 3rd party
+      'android.permission.MANAGE_DOCUMENTS',
+      'android.permission.READ_SMS', // https://github.com/expo/expo/pull/2982
+      'android.permission.REQUEST_INSTALL_PACKAGES', // https://github.com/expo/expo/pull/8969
+
+      // other permissions
+      'android.permission.READ_INTERNAL_STORAGE',
       'com.anddoes.launcher.permission.UPDATE_COUNT',
       'com.android.launcher.permission.INSTALL_SHORTCUT',
       'com.google.android.gms.permission.ACTIVITY_RECOGNITION',


### PR DESCRIPTION
This is a replacement PR for #2307, and part of https://github.com/expo/expo/issues/9499. It adds some annotations to the permission list to know why permissions are or were added. This, together with the new Danger script that warns people when adding new permissions to android manifests should keep this up to date in the future 🚀 

The following permissions are added to the list:

- `android.permission.USE_BIOMETRIC` - Is part of the new Biometric Prompt in Android for `expo-local-authentication`.
- `android.permission.SYSTEM_ALERT_WINDOW` - Is only required for debugging (e.g. in Expo Client), [not required in production apps](https://reactnative.dev/docs/removing-default-permissions#docsNav).
- `android.permission.REQUEST_INSTALL_PACKAGES` - This is [dangerous/signature permission](https://developer.android.com/reference/android/Manifest.permission#REQUEST_INSTALL_PACKAGES) and [might get apps rejected when used](https://github.com/expo/expo/issues/8942).
- `android.permission.ACCESS_BACKGROUND_LOCATION` - Added in `expo-location` [but not in here](https://github.com/expo/expo/pull/9725).

Keep in mind that adding these to the blacklist _doesn't prevent users to include the permissions_. It only switches the permission from automatically added to manually included in the `android.permissions` manifest property list 😄 