### PR TITLE
[package-manager] fix pod-install for macOS projects

### DIFF
--- a/packages/package-manager/src/CocoaPodsPackageManager.ts
+++ b/packages/package-manager/src/CocoaPodsPackageManager.ts
@@ -14,6 +14,8 @@ export class CocoaPodsPackageManager implements PackageManager {
     if (CocoaPodsPackageManager.isUsingPods(projectRoot)) return projectRoot;
     const iosProject = path.join(projectRoot, 'ios');
     if (CocoaPodsPackageManager.isUsingPods(iosProject)) return iosProject;
+    const macOsProject = path.join(projectRoot, 'macos');
+    if (CocoaPodsPackageManager.isUsingPods(macOsProject)) return macOsProject;
     return null;
   }
 


### PR DESCRIPTION
Currently running `npx pod-install`(or `pod-install` installed locally) in the React Native macOS projects result in error message: "CocoaPods is not supported in this project". 

This simple PR fixes this issue by adding test for `macos` directory as a root of CocoaPods project.

### Before
<img width="398" src="https://user-images.githubusercontent.com/719641/90242224-e4656900-de2c-11ea-8d52-adb9c2dd8059.png">

### After
<img width="802" src="https://user-images.githubusercontent.com/719641/90242236-e7f8f000-de2c-11ea-8a50-a4e246567278.png">
