### PR TITLE
[cli][eject] Support projects with dynamic or missing configs

### DIFF
--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -108,7 +108,8 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
     recommendedPackage = exp.ios.bundleIdentifier;
   } else {
     const username = exp.owner ?? (await UserManager.getCurrentUsernameAsync());
-    const possibleId = `com.${username}.${exp.slug}`;
+    // It's common to use dashes in your node project name, strip them from the suggested package name.
+    const possibleId = `com.${username}.${exp.slug}`.split('-').join('');
     if (username && validatePackage(possibleId)) {
       recommendedPackage = possibleId;
     }


### PR DESCRIPTION
# Why

- expo-cli supports running and publishing projects without a config or with a dynamic .js config so eject should too.
- crna templates don't have configs but people may want to eject them immediately to use them as bare templates.

# How

- Strip slashes from name android package name suggestion to be more resilient. 
  - ex: I run `expo eject` in a project folder `my-cool-app`  (which doesn't have a config or name), the suggestion would've been blank cuz `com.bacon.my-cool-app` is invalid. Now it'll recommend `com.bacon.mycoolapp`.
- When the config file doesn't exist, write the generated config to `./app.json`
  - we don't need to account for custom config paths `--config` because those are validated beforehand.
- Remove code that attempts to read from `./app.json` which fails when a project uses a dynamic `app.config.js` file.
