### PR TITLE
[xdl] update ios Podfile excluded unimodules for SDK 39

### DIFF
--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -403,6 +403,12 @@ function _renderUnversionedUniversalModulesDependencies(
   const sdkMajorVersion = parseSdkMajorVersion(sdkVersion);
 
   if (sdkMajorVersion >= 33) {
+    const excludedUnimodules = ['expo-bluetooth', 'expo-in-app-purchases', 'expo-payments-stripe'];
+
+    if (sdkMajorVersion < 39) {
+      excludedUnimodules.push('expo-splash-screen', 'expo-image', 'expo-updates');
+    }
+
     return indentString(
       `
 # Install unimodules
@@ -410,12 +416,7 @@ require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
 use_unimodules!(
   modules_paths: ['${universalModulesPath}'],
   exclude: [
-    'expo-bluetooth',
-    'expo-in-app-purchases',
-    'expo-payments-stripe',
-    'expo-splash-screen',
-    'expo-image',
-    'expo-updates',
+    ${excludedUnimodules.map(module => `'${module}'`).join(',\n    ')}
   ],
 )`,
       2


### PR DESCRIPTION
This will fix the iOS shell app build job in the expo/expo repo once we add SDK 39. Currently it's failing because the rendered Podfile in the shell app excludes unimodules that are needed in SDK 39 -- `expo-splash-screen` and `expo-updates`. This PR will make the excluded dependencies in the rendered Podfile match the current `ios/Podfile` in the expo/expo repo, while also still supporting older SDK versions.

Tested locally and the job succeeded.

TODO: we need to figure out a way to move this code out of XDL and into the expo repo -- at least determining the excluded unimodules, but potentially the entire process of generating the shell app workspace, now that we don't need to support ejecting to ExpoKit.