### PR TITLE
[expo-cli] unify credentials fixtures between android & ios

### DIFF
--- a/packages/expo-cli/src/commands/__tests__/publish-info-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-info-test.ts
@@ -2,7 +2,7 @@ import { ApiV2 } from '@expo/xdl';
 import { vol } from 'memfs';
 
 import { mockExpoXDL } from '../../__tests__/mock-utils';
-import { jester } from '../../credentials/test-fixtures/mocks-ios';
+import { jester } from '../../credentials/test-fixtures/mocks-constants';
 import { getPublicationDetailAsync, getPublishHistoryAsync } from '../utils/PublishUtils';
 
 jest.mock('fs');

--- a/packages/expo-cli/src/commands/__tests__/publish-modify-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-modify-test.ts
@@ -3,7 +3,7 @@ import { vol } from 'memfs';
 
 import { mockExpoXDL } from '../../__tests__/mock-utils';
 import { createTestProject } from '../../__tests__/project-utils';
-import { jester } from '../../credentials/test-fixtures/mocks-ios';
+import { jester } from '../../credentials/test-fixtures/mocks-constants';
 import {
   rollbackPublicationFromChannelAsync,
   setPublishToChannelAsync,

--- a/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
+++ b/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
@@ -2,13 +2,14 @@ import { vol } from 'memfs';
 
 import { mockExpoXDL } from '../../../__tests__/mock-utils';
 import {
-  getApiClientMock,
-  getApiV2MockCredentials,
   jester,
-  testAllCredentialsForApp,
   testAppJson,
   testBundleIdentifier,
   testExperienceName,
+} from '../../../credentials/test-fixtures/mocks-constants';
+import {
+  getApiV2WrapperMock,
+  testAllCredentialsForApp,
 } from '../../../credentials/test-fixtures/mocks-ios';
 import { BuilderOptions } from '../BaseBuilder.types';
 import IOSBuilder from '../ios/IOSBuilder';
@@ -44,7 +45,6 @@ jest.mock('../../../credentials/api/IosApiV2Wrapper', () => {
   return jest.fn(() => mockIosCredentialsApi);
 });
 
-const mockApiV2 = getApiV2MockCredentials();
 const mockedXDLModules = {
   UserManager: {
     ensureLoggedInAsync: jest.fn(() => jester),
@@ -52,7 +52,7 @@ const mockedXDLModules = {
     getCurrentUsernameAsync: jest.fn(() => jester.username),
   },
   ApiV2: {
-    clientForUser: jest.fn(() => mockApiV2),
+    clientForUser: jest.fn(),
   },
   Project: {
     getBuildStatusAsync: jest.fn(() => ({ jobs: [] })),
@@ -68,7 +68,7 @@ const mockedXDLModules = {
 mockExpoXDL(mockedXDLModules);
 
 beforeEach(() => {
-  mockIosCredentialsApi = getApiClientMock({});
+  mockIosCredentialsApi = getApiV2WrapperMock();
 });
 
 describe('build ios', () => {

--- a/packages/expo-cli/src/credentials/__tests__/api-ios-basic-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-ios-basic-test.ts
@@ -1,9 +1,7 @@
 import IosApi from '../api/IosApi';
+import { jester, jester2 } from '../test-fixtures/mocks-constants';
 import {
-  getApiClientMock,
-  getApiV2Mock,
-  jester,
-  jester2,
+  getApiV2WrapperMock,
   testAllCredentials,
   testAllCredentialsForApp,
   testAppCredential,
@@ -26,15 +24,14 @@ afterAll(() => {
   console.warn = originalWarn;
   console.log = originalLog;
 });
-beforeEach(() => {});
 
 describe('IosApi - Basic Tests', () => {
   let iosApi;
   let apiMock;
 
   beforeEach(() => {
-    iosApi = new IosApi(getApiV2Mock());
-    apiMock = getApiClientMock();
+    apiMock = getApiV2WrapperMock();
+    iosApi = new IosApi(jest.fn() as any);
     (iosApi as any).client = apiMock;
   });
   it('getAllCredentials', async () => {

--- a/packages/expo-cli/src/credentials/api/AndroidApi.ts
+++ b/packages/expo-cli/src/credentials/api/AndroidApi.ts
@@ -2,37 +2,38 @@ import { ApiV2 } from '@expo/xdl';
 import keyBy from 'lodash/keyBy';
 
 import { AndroidCredentials, FcmCredentials, Keystore } from '../credentials';
+import ApiClient from './AndroidApiV2Wrapper';
 
 export default class AndroidApi {
+  private client: ApiClient;
   private shouldRefetchAll: boolean = true;
   private credentials: { [key: string]: AndroidCredentials } = {};
 
-  constructor(private api: ApiV2) {}
+  constructor(api: ApiV2) {
+    this.client = new ApiClient(api);
+  }
 
   public async fetchAll(): Promise<{ [key: string]: AndroidCredentials }> {
     if (this.shouldRefetchAll) {
-      this.credentials = keyBy(
-        (await this.api.getAsync('credentials/android'))?.credentials || [],
-        'experienceName'
-      );
+      this.credentials = keyBy(await this.client.getAllCredentialsApi(), 'experienceName');
       this.shouldRefetchAll = false;
     }
     return this.credentials;
   }
 
   public async fetchKeystore(experienceName: string): Promise<Keystore | null> {
-    await this._ensureCredentialsFetched(experienceName);
+    await this.ensureCredentialsFetched(experienceName);
     return this.credentials[experienceName]?.keystore || null;
   }
 
   public async fetchCredentials(experienceName: string): Promise<AndroidCredentials> {
-    await this._ensureCredentialsFetched(experienceName);
+    await this.ensureCredentialsFetched(experienceName);
     return this.credentials[experienceName];
   }
 
   public async updateKeystore(experienceName: string, keystore: Keystore): Promise<void> {
-    await this._ensureCredentialsFetched(experienceName);
-    await this.api.putAsync(`credentials/android/keystore/${experienceName}`, { keystore });
+    await this.ensureCredentialsFetched(experienceName);
+    await this.client.updateKeystoreApi(experienceName, keystore);
     this.credentials[experienceName] = {
       experienceName,
       keystore,
@@ -41,13 +42,13 @@ export default class AndroidApi {
   }
 
   public async fetchFcmKey(experienceName: string): Promise<FcmCredentials | null> {
-    await this._ensureCredentialsFetched(experienceName);
+    await this.ensureCredentialsFetched(experienceName);
     return this.credentials?.[experienceName]?.pushCredentials;
   }
 
   public async updateFcmKey(experienceName: string, fcmApiKey: string): Promise<void> {
-    await this._ensureCredentialsFetched(experienceName);
-    await this.api.putAsync(`credentials/android/push/${experienceName}`, { fcmApiKey });
+    await this.ensureCredentialsFetched(experienceName);
+    await this.client.updateFcmKeyApi(experienceName, fcmApiKey);
     this.credentials[experienceName] = {
       experienceName,
       keystore: this.credentials[experienceName]?.keystore,
@@ -56,26 +57,24 @@ export default class AndroidApi {
   }
 
   public async removeFcmKey(experienceName: string): Promise<void> {
-    await this._ensureCredentialsFetched(experienceName);
-    await this.api.deleteAsync(`credentials/android/push/${experienceName}`);
-    this.credentials[experienceName] = {
-      experienceName,
-      keystore: this.credentials[experienceName]?.keystore,
-      pushCredentials: null,
-    };
+    await this.ensureCredentialsFetched(experienceName);
+    await this.client.removeFcmKeyApi(experienceName);
+    if (this.credentials[experienceName]) {
+      this.credentials[experienceName].pushCredentials = null;
+    }
   }
 
   public async removeKeystore(experienceName: string): Promise<void> {
-    await this._ensureCredentialsFetched(experienceName);
-    await this.api.deleteAsync(`credentials/android/keystore/${experienceName}`);
+    await this.ensureCredentialsFetched(experienceName);
+    await this.client.removeKeystoreApi(experienceName);
     if (this.credentials[experienceName]) {
       this.credentials[experienceName].keystore = null;
     }
   }
 
-  private async _ensureCredentialsFetched(experienceName: string): Promise<void> {
+  private async ensureCredentialsFetched(experienceName: string): Promise<void> {
     if (!this.credentials[experienceName]) {
-      const response = await this.api.getAsync(`credentials/android/${experienceName}`);
+      const response = await this.client.getAllCredentialsForAppApi(experienceName);
       this.credentials[experienceName] = {
         experienceName,
         keystore: response?.keystore,

--- a/packages/expo-cli/src/credentials/api/AndroidApiV2Wrapper.ts
+++ b/packages/expo-cli/src/credentials/api/AndroidApiV2Wrapper.ts
@@ -1,0 +1,30 @@
+import { ApiV2 } from '@expo/xdl';
+
+import { AndroidCredentials, Keystore } from '../credentials';
+
+type AllCredentialsApiResponse = AndroidCredentials[];
+
+// This class should not be used directly, use only as part of cached api client from ./AndroidApi.ts
+// or mock it in tests (it's easier to mock this class than ApiV2 directly)
+export default class ApiClient {
+  constructor(private api: ApiV2) {}
+
+  public async getAllCredentialsApi(): Promise<AllCredentialsApiResponse> {
+    return (await this.api.getAsync('credentials/android'))?.credentials || [];
+  }
+  public async getAllCredentialsForAppApi(experienceName: string): Promise<AndroidCredentials> {
+    return await this.api.getAsync(`credentials/android/${experienceName}`);
+  }
+  public async updateKeystoreApi(experienceName: string, keystore: Keystore): Promise<void> {
+    return await this.api.putAsync(`credentials/android/keystore/${experienceName}`, { keystore });
+  }
+  public async updateFcmKeyApi(experienceName: string, fcmApiKey: string): Promise<void> {
+    return await this.api.putAsync(`credentials/android/push/${experienceName}`, { fcmApiKey });
+  }
+  public async removeKeystoreApi(experienceName: string): Promise<void> {
+    await this.api.deleteAsync(`credentials/android/keystore/${experienceName}`);
+  }
+  public async removeFcmKeyApi(experienceName: string): Promise<void> {
+    await this.api.deleteAsync(`credentials/android/push/${experienceName}`);
+  }
+}

--- a/packages/expo-cli/src/credentials/test-fixtures/mocks-android.ts
+++ b/packages/expo-cli/src/credentials/test-fixtures/mocks-android.ts
@@ -1,15 +1,8 @@
-import { User } from '@expo/xdl';
 import merge from 'lodash/merge';
 
 import { AndroidCredentials } from '../credentials';
 import { testKeystore2Base64, testKeystoreBase64 } from './mock-keystore';
-
-export const testSlug = 'testApp';
-export const testSlug2 = 'testApp2';
-export const testExperienceName = `@jester/${testSlug}`;
-export const testJester2ExperienceName = `@jester2/${testSlug}`;
-export const testExperienceName2 = `@jester/${testSlug2}`;
-export const testPackageName = 'test.com.app';
+import { testExperienceName, testJester2ExperienceName } from './mocks-constants';
 
 export const testKeystore = {
   keystore: testKeystoreBase64,
@@ -42,87 +35,35 @@ export const testJester2AppCredentials = {
 
 export const testAllCredentials: { [key: string]: AndroidCredentials } = {
   [testExperienceName]: testAppCredentials,
-  [testJester2ExperienceName]: testJester2AppCredentials,
 };
 
-export const jester: User = {
-  kind: 'user',
-  username: 'jester',
-  nickname: 'jester',
-  userId: 'jester-id',
-  picture: 'jester-pic',
-  userMetadata: { onboarded: true },
-  currentConnection: 'Username-Password-Authentication',
-  sessionSecret: 'jester-secret',
-};
-
-export const jester2: User = {
-  kind: 'user',
-  username: 'jester2',
-  nickname: 'jester2',
-  userId: 'jester2-id',
-  picture: 'jester2-pic',
-  userMetadata: { onboarded: true },
-  currentConnection: 'Username-Password-Authentication',
-  sessionSecret: 'jester2-secret',
-};
-
-export function getApiV2MockCredentials(overridenMock: { [key: string]: any } = {}) {
-  const defaultCredentialsApiV2Mock = {
-    getAsync: jest.fn(path => {
-      if (path.match(/^credentials\/android$/)) {
-        return {
-          credentials: [testAppCredentials],
-        };
-      }
-      const match = path.match(/^credentials\/android\/(@[-a-zA-Z0-9]+\/[-a-zA-Z0-9]+)$/);
-      if (match) {
-        return testAllCredentials[match[1]];
-      }
-      return null;
-    }),
-  };
-  return getApiV2Mock(merge(defaultCredentialsApiV2Mock, overridenMock));
+export function getApiV2WrapperMock(override: object = {}) {
+  // by default all method throw exceptions to make sure that we only call what is expected
+  const getUnexpectedCallMock = () =>
+    jest.fn(() => {
+      throw new Error('unexpected call');
+    });
+  return merge(
+    {
+      getAllCredentialsApi: getUnexpectedCallMock(),
+      getAllCredentialsForAppApi: getUnexpectedCallMock(),
+      updateKeystoreApi: getUnexpectedCallMock(),
+      updateFcmKeyApi: getUnexpectedCallMock(),
+      removeKeystoreApi: getUnexpectedCallMock(),
+      removeFcmKeyApi: getUnexpectedCallMock(),
+    },
+    override
+  );
 }
 
-export function getApiV2Mock(overridenMock: { [key: string]: any } = {}) {
-  const defaultMock = {
-    sessionSecret: 'test-session',
-    getAsync: jest.fn(),
-    postAsync: jest.fn(),
-    putAsync: jest.fn(),
-    deleteAsync: jest.fn(),
-    uploadFormDataAsync: jest.fn(),
-    _requestAsync: jest.fn(),
-  };
-  return merge(defaultMock, overridenMock);
-}
-export const testAppJson = {
-  name: 'testing 123',
-  version: '0.1.0',
-  slug: testSlug,
-  sdkVersion: '33.0.0',
-  android: { package: testPackageName },
-};
-export const testAppJsonWithDifferentOwner = {
-  ...testAppJson,
-  owner: jester2.username,
-};
-
-export function getCtxMock(overridenMock: { [key: string]: any } = {}) {
-  const defaultMock = {
-    android: {
-      fetchAll: jest.fn(),
+export function getAndroidApiMock(override: object = {}) {
+  return merge(
+    {
+      fetchAll: jest.fn(() => testAllCredentials),
       fetchKeystore: jest.fn(() => testKeystore),
       updateKeystore: jest.fn(),
       removeKeystore: jest.fn(),
     },
-    ensureAppleCtx: jest.fn(),
-    user: jest.fn(),
-    hasAppleCtx: jest.fn(() => true),
-    hasProjectContext: true,
-    manifest: testAppJson,
-    projectDir: '.',
-  };
-  return merge(defaultMock, overridenMock);
+    override
+  );
 }

--- a/packages/expo-cli/src/credentials/test-fixtures/mocks-constants.ts
+++ b/packages/expo-cli/src/credentials/test-fixtures/mocks-constants.ts
@@ -1,0 +1,43 @@
+import { User } from '@expo/xdl';
+
+export const jester: User = {
+  kind: 'user',
+  username: 'jester',
+  nickname: 'jester',
+  userId: 'jester-id',
+  picture: 'jester-pic',
+  userMetadata: { onboarded: true },
+  currentConnection: 'Username-Password-Authentication',
+  sessionSecret: 'jester-secret',
+};
+
+export const jester2: User = {
+  kind: 'user',
+  username: 'jester2',
+  nickname: 'jester2',
+  userId: 'jester2-id',
+  picture: 'jester2-pic',
+  userMetadata: { onboarded: true },
+  currentConnection: 'Username-Password-Authentication',
+  sessionSecret: 'jester2-secret',
+};
+
+export const testUsername = jester.username;
+export const testSlug = 'testApp';
+export const testBundleIdentifier = 'test.com.app';
+export const testPackageName = 'test.com.app';
+export const testExperienceName = `@${testUsername}/${testSlug}`;
+export const testJester2ExperienceName = `@${jester2.username}/${testSlug}`;
+
+export const testAppJson = {
+  name: 'testing 123',
+  version: '0.1.0',
+  slug: testSlug,
+  sdkVersion: '38.0.0',
+  ios: { bundleIdentifier: testBundleIdentifier },
+};
+
+export const testAppJsonWithDifferentOwner = {
+  ...testAppJson,
+  owner: jester2.username,
+};

--- a/packages/expo-cli/src/credentials/test-fixtures/mocks-context.ts
+++ b/packages/expo-cli/src/credentials/test-fixtures/mocks-context.ts
@@ -1,0 +1,22 @@
+import merge from 'lodash/merge';
+
+import { getAndroidApiMock } from './mocks-android';
+import { testAppJson, testUsername } from './mocks-constants';
+import { appleCtxMock, getIosApiMock } from './mocks-ios';
+
+export function getCtxMock(mockOverride: { [key: string]: any } = {}) {
+  const defaultMock = {
+    ios: getIosApiMock(),
+    android: getAndroidApiMock(),
+    appleCtx: appleCtxMock,
+    ensureAppleCtx: jest.fn(),
+    user: {
+      username: testUsername,
+    },
+    hasAppleCtx: jest.fn(() => true),
+    hasProjectContext: true,
+    manifest: testAppJson,
+    projectDir: '.',
+  };
+  return merge(defaultMock, mockOverride);
+}

--- a/packages/expo-cli/src/credentials/test-fixtures/mocks-ios.ts
+++ b/packages/expo-cli/src/credentials/test-fixtures/mocks-ios.ts
@@ -1,4 +1,3 @@
-import { User } from '@expo/xdl';
 import merge from 'lodash/merge';
 
 import {
@@ -11,15 +10,10 @@ import {
   Team,
 } from '../../appleApi';
 import { IosDistCredentials, IosPushCredentials } from '../credentials';
+import { testBundleIdentifier, testExperienceName, testSlug } from './mocks-constants';
 
-/*
-Mock Credential objects for Jester
-*/
 const today = new Date();
 const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-export const testSlug = 'testApp';
-export const testExperienceName = `@jester/${testSlug}`;
-export const testBundleIdentifier = 'test.com.app';
 export const testAppLookupParams = {
   accountName: 'jester',
   projectName: testSlug,
@@ -76,6 +70,7 @@ export const testPushKey: PushKey = {
   apnsKeyId: 'test-key-id',
   teamId: 'test-team-id',
 };
+
 export const testIosPushCredential: IosPushCredentials = {
   id: 2,
   type: 'push-key',
@@ -112,111 +107,36 @@ export const testAllCredentials = {
   appCredentials: testAppCredentials,
 };
 
-export const jester: User = {
-  kind: 'user',
-  username: 'jester',
-  nickname: 'jester',
-  userId: 'jester-id',
-  picture: 'jester-pic',
-  userMetadata: { onboarded: true },
-  currentConnection: 'Username-Password-Authentication',
-  sessionSecret: 'jester-secret',
-};
-
-export const jester2: User = {
-  kind: 'user',
-  username: 'jester2',
-  nickname: 'jester2',
-  userId: 'jester2-id',
-  picture: 'jester2-pic',
-  userMetadata: { onboarded: true },
-  currentConnection: 'Username-Password-Authentication',
-  sessionSecret: 'jester2-secret',
-};
-
-export function getApiV2MockCredentials(overridenMock: { [key: string]: any } = {}) {
-  const defaultCredentialsApiV2Mock = {
-    getAsync: jest.fn(url => testAllCredentials),
-  };
-  return getApiV2Mock(merge(defaultCredentialsApiV2Mock, overridenMock));
-}
-export function getApiV2Mock(overridenMock: { [key: string]: any } = {}) {
-  const defaultMock = {
-    sessionSecret: 'test-session',
-    getAsync: jest.fn(),
-    postAsync: jest.fn(),
-    putAsync: jest.fn(),
-    deleteAsync: jest.fn(),
-    uploadFormDataAsync: jest.fn(),
-    _requestAsync: jest.fn(),
-  };
-  return merge(defaultMock, overridenMock);
+export function getApiV2WrapperMock(override: object = {}) {
+  // by default all method throw exceptions to make sure that we only call what is expected
+  const getUnexpectedCallMock = () =>
+    jest.fn(() => {
+      throw new Error('unexpected call');
+    });
+  return merge(
+    {
+      getAllCredentialsApi: getUnexpectedCallMock(),
+      getAllCredentialsForAppApi: getUnexpectedCallMock(),
+      getUserCredentialsByIdApi: getUnexpectedCallMock(),
+      createDistCertApi: getUnexpectedCallMock(),
+      updateDistCertApi: getUnexpectedCallMock(),
+      deleteDistCertApi: getUnexpectedCallMock(),
+      useDistCertApi: getUnexpectedCallMock(),
+      createPushKeyApi: getUnexpectedCallMock(),
+      updatePushKeyApi: getUnexpectedCallMock(),
+      deletePushKeyApi: getUnexpectedCallMock(),
+      usePushKeyApi: getUnexpectedCallMock(),
+      deletePushCertApi: getUnexpectedCallMock(),
+      updateProvisioningProfileApi: getUnexpectedCallMock(),
+      deleteProvisioningProfileApi: getUnexpectedCallMock(),
+    },
+    override
+  );
 }
 
-export function getApiClientMock(overridenMock: { [key: string]: any } = {}) {
-  // by default all method throw exceptions to make sure that we only what is expected
-  const defaultMock = {
-    getAllCredentialsApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    getAllCredentialsForAppApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    getUserCredentialsByIdApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    createDistCertApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    updateDistCertApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    deleteDistCertApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    useDistCertApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    createPushKeyApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    updatePushKeyApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    deletePushKeyApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    usePushKeyApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    deletePushCertApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    updateProvisioningProfileApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-    deleteProvisioningProfileApi: jest.fn(() => {
-      throw new Error('unexpected call');
-    }),
-  };
-  return merge(defaultMock, overridenMock);
-}
-
-export const testAppJson = {
-  name: 'testing 123',
-  version: '0.1.0',
-  slug: testSlug,
-  sdkVersion: '33.0.0',
-  ios: { bundleIdentifier: testBundleIdentifier },
-};
-export const testAppJsonWithDifferentOwner = {
-  ...testAppJson,
-  owner: jester2.username,
-};
-
-export function getCtxMock(overridenMock: { [key: string]: any } = {}) {
-  const defaultMock = {
-    ios: {
+export function getIosApiMock(override: object = {}) {
+  return merge(
+    {
       getDistCert: jest.fn(() => testDistCert),
       createDistCert: jest.fn(() => testIosDistCredential),
       useDistCert: jest.fn(),
@@ -228,17 +148,13 @@ export function getCtxMock(overridenMock: { [key: string]: any } = {}) {
       getProvisioningProfile: jest.fn(() => testProvisioningProfile),
       getAllCredentials: jest.fn(() => testAllCredentials),
     },
-    appleCtx: {
-      appleId: 'test-id',
-      appleIdPassword: 'test-password',
-      team: { id: 'test-team-id' },
-      fastlaneSession: 'test-fastlane-session',
-    },
-    ensureAppleCtx: jest.fn(),
-    user: jest.fn(),
-    hasAppleCtx: jest.fn(() => true),
-    hasProjectContext: true,
-    manifest: testAppJson,
-  };
-  return merge(defaultMock, overridenMock);
+    override
+  );
 }
+
+export const appleCtxMock = {
+  appleId: 'test-id',
+  appleIdPassword: 'test-password',
+  team: { id: 'test-team-id' },
+  fastlaneSession: 'test-fastlane-session',
+};

--- a/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Remove-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Remove-test.ts
@@ -2,7 +2,8 @@ import fs from 'fs-extra';
 
 import { mockExpoXDL } from '../../../__tests__/mock-utils';
 import prompt from '../../../prompt';
-import { getCtxMock, testExperienceName } from '../../test-fixtures/mocks-android';
+import { testExperienceName } from '../../test-fixtures/mocks-constants';
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import { RemoveKeystore } from '../AndroidKeystore';
 
 jest.mock('../../actions/list');

--- a/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
@@ -1,6 +1,7 @@
 import { mockExpoXDL } from '../../../__tests__/mock-utils';
 import prompts from '../../../prompts';
-import { getCtxMock, testExperienceName } from '../../test-fixtures/mocks-android';
+import { testExperienceName } from '../../test-fixtures/mocks-constants';
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import { UpdateKeystore } from '../AndroidKeystore';
 
 jest.mock('../../actions/list');

--- a/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
@@ -1,6 +1,6 @@
+import { jester } from '../../test-fixtures/mocks-constants';
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import {
-  getCtxMock,
-  jester,
   testAppLookupParams,
   testDistCertsFromApple,
   testIosDistCredential,

--- a/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
@@ -1,5 +1,5 @@
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import {
-  getCtxMock,
   testAppLookupParams,
   testProvisioningProfiles,
   testProvisioningProfilesFromApple,

--- a/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
@@ -1,6 +1,6 @@
+import { jester } from '../../test-fixtures/mocks-constants';
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import {
-  getCtxMock,
-  jester,
   testAppLookupParams,
   testIosPushCredential,
   testPushKeysFromApple,

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupAndroidKeystore-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupAndroidKeystore-test.ts
@@ -1,6 +1,7 @@
 import commandExists from 'command-exists';
 
-import { getCtxMock, testExperienceName } from '../../test-fixtures/mocks-android';
+import { testExperienceName } from '../../test-fixtures/mocks-constants';
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import { UpdateKeystore } from '../AndroidKeystore';
 import { SetupAndroidKeystore } from '../SetupAndroidKeystore';
 

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
@@ -1,5 +1,5 @@
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import {
-  getCtxMock,
   testAppLookupParams,
   testDistCertsFromApple,
   testIosDistCredential,

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
@@ -1,5 +1,5 @@
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import {
-  getCtxMock,
   testAppLookupParams,
   testIosPushCredential,
   testPushKeysFromApple,

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
@@ -1,5 +1,5 @@
+import { getCtxMock } from '../../test-fixtures/mocks-context';
 import {
-  getCtxMock,
   testAppLookupParams,
   testProvisioningProfiles,
   testProvisioningProfilesFromApple,


### PR DESCRIPTION
# Why

The previous version had separate approach for mocking context for android in iOS. Without those changes is hard to mock context in cases where both android and ios credentials are used

# How

- Added apiv2 wrapper for android credentials (the same as in iOS version) 
- Implemented one ctx mock with mocked credentials for both platforms
- unified naming of some helper function between platforms
