### PR TITLE
[expo-cli] Only run expo service checks from the doctor command

### DIFF
--- a/packages/expo-cli/src/commands/doctor.ts
+++ b/packages/expo-cli/src/commands/doctor.ts
@@ -4,6 +4,9 @@ import { Command } from 'commander';
 import log from '../log';
 
 async function action(projectDir: string) {
+  // note: this currently only warns when something isn't right, it doesn't fail
+  await Doctor.validateExpoServersAsync(projectDir);
+
   if ((await Doctor.validateWithNetworkAsync(projectDir)) === Doctor.NO_ISSUES) {
     log(`Didn't find any issues with your project!`);
   }


### PR DESCRIPTION
I did 2 things here:

1. This makes _absolutely_ sure the Expo services check is only executed with `$ expo doctor` and not commands like `$ expo start` or `$ expo publish`.
2. Disabled the `exp.host` check, people report on the forum that this might be intermittent issues. Eventually, I could randomly reproduce this locally.