### PR TITLE
[webpack-config] Disable offline support

### DIFF
--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -308,7 +308,7 @@ module.exports = async function(env, argv) {
 
 ### Service workers
 
-Service workers are great for emulating native functionality, but they can also lead to a lot of confusion so they are opt-in only in this Webpack config. To enable the default workbox plugin pass the options `{ offline: true }` to the creator method.
+Service workers are great for emulating native functionality, but they can also lead to a lot of confusion so they are opt-in only (starting in Expo SDK 39 and greater) in this Webpack config. To enable the default workbox plugin pass the options `{ offline: true }` to the creator method.
 
 #### How Expo service workers ... work
 

--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -32,7 +32,7 @@ Running `expo customize:web` will generate this default config in your project.
 ```js
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
-module.exports = async function (env, argv) {
+module.exports = async function(env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
   // Customize the config before returning it.
   return config;
@@ -45,16 +45,16 @@ module.exports = async function (env, argv) {
 
 The main options used to configure how `@expo/webpack-config` works.
 
-| name                        | type                                    | default     | description                                                                    |
-| --------------------------- | --------------------------------------- | ----------- | ------------------------------------------------------------------------------ |
-| `projectRoot`               | `string`                                | required    | Root of the Expo project.                                                      |
-| `https`                     | `boolean`                               | `false`     | Should the dev server use https protocol.                                      |
-| `offline`                   | `boolean`                               | `true`      | Passing `false` will disable offline support and skip adding a service worker. |
-| `mode`                      | `Mode`                                  | required    | The Webpack mode to bundle the project in.                                     |
-| `platform`                  | [`ExpoPlatform`](#ExpoPlatform)         | required    | The target platform to bundle for.                                             |
-| `pwa`                       | `boolean`                               | `true`      | Generate the PWA image assets in production mode.                              |
-| `babel`                     | [`ExpoBabelOptions`](#ExpoBabelOptions) | `undefined` | Control how the default Babel loader is configured.                            |
-| `removeUnusedImportExports` | `boolean`                               | `false`     | Enables advanced tree-shaking with deep scope analysis.                        |
+| name                        | type                                    | default     | description                                                          |
+| --------------------------- | --------------------------------------- | ----------- | -------------------------------------------------------------------- |
+| `projectRoot`               | `string`                                | required    | Root of the Expo project.                                            |
+| `https`                     | `boolean`                               | `false`     | Should the dev server use https protocol.                            |
+| `offline`                   | `boolean`                               | `false`     | Passing `true` will enable offline support and add a service worker. |
+| `mode`                      | `Mode`                                  | required    | The Webpack mode to bundle the project in.                           |
+| `platform`                  | [`ExpoPlatform`](#ExpoPlatform)         | required    | The target platform to bundle for.                                   |
+| `pwa`                       | `boolean`                               | `true`      | Generate the PWA image assets in production mode.                    |
+| `babel`                     | [`ExpoBabelOptions`](#ExpoBabelOptions) | `undefined` | Control how the default Babel loader is configured.                  |
+| `removeUnusedImportExports` | `boolean`                               | `false`     | Enables advanced tree-shaking with deep scope analysis.              |
 
 ### `Environment` internal
 
@@ -242,7 +242,7 @@ You may find that you want to include universal modules that aren't part of the 
 ```ts
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
-module.exports = async function (env, argv) {
+module.exports = async function(env, argv) {
   const config = await createExpoWebpackConfigAsync(
     {
       ...env,
@@ -266,7 +266,7 @@ If you're adding support to some other Webpack config like in Storybook or Gatsb
 ```ts
 const { withUnimodules } = require('@expo/webpack-config/addons');
 
-module.exports = function () {
+module.exports = function() {
   const someWebpackConfig = {
     /* Your custom Webpack config */
   };
@@ -296,7 +296,7 @@ If you want to modify the babel loader further, you can retrieve it using the he
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 const { getExpoBabelLoader } = require('@expo/webpack-config/utils');
 
-module.exports = async function (env, argv) {
+module.exports = async function(env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
   const loader = getExpoBabelLoader(config);
   if (loader) {
@@ -308,7 +308,7 @@ module.exports = async function (env, argv) {
 
 ### Service workers
 
-Service workers are great for emulating native functionality, so Expo web takes full advantage of them. But sometimes you'll need to drop down and modify them yourself.
+Service workers are great for emulating native functionality, but they can also lead to a lot of confusion so they are opt-in only in this Webpack config. To enable the default workbox plugin pass the options `{ offline: true }` to the creator method.
 
 #### How Expo service workers ... work
 
@@ -335,7 +335,7 @@ This can have some unfortunate side-effects as application libraries like expo-n
 ```js
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
-module.exports = async function (env, argv) {
+module.exports = async function(env, argv) {
   // Set offline to `false`
   const config = await createExpoWebpackConfigAsync({ ...env, offline: false }, argv);
   return config;

--- a/packages/webpack-config/e2e/__tests__/basic-test.js
+++ b/packages/webpack-config/e2e/__tests__/basic-test.js
@@ -30,7 +30,7 @@ describe('Basic', () => {
 
   if (isProduction) {
     it(`should register expo service worker`, async () => {
-      const elementId = getTestIdQuery('has-sw-text');
+      const elementId = getTestIdQuery('has-sw-text-false');
 
       await expect(page).toMatchElement(elementId, {
         text: 'Has SW installed',

--- a/packages/webpack-config/e2e/__tests__/basic-test.js
+++ b/packages/webpack-config/e2e/__tests__/basic-test.js
@@ -29,7 +29,7 @@ describe('Basic', () => {
   });
 
   if (isProduction) {
-    it(`should register expo service worker`, async () => {
+    xit(`should register expo service worker`, async () => {
       const elementId = getTestIdQuery('has-sw-text-false');
 
       await expect(page).toMatchElement(elementId, {

--- a/packages/webpack-config/e2e/basic/App.js
+++ b/packages/webpack-config/e2e/basic/App.js
@@ -51,9 +51,7 @@ export default function App() {
       <Text testID="asset-raw-font">{fontAsset}</Text>
       <Text testID="asset-raw-wildcard">{typeof randomAsset}</Text>
       {boolish('CI', false) && <Text testID="has-ci-text">Has CI env</Text>}
-      {isSWRegistered != null && (
-        <Text testID={`has-sw-text-${isSWRegistered}`}>Has SW installed</Text>
-      )}
+      {isSWRegistered != null && <Text testID="has-sw-text">Has SW installed</Text>}
       {global.ResizeObserver && (
         <Text testID="has-resize-observer">Has ResizeObserver polyfill</Text>
       )}

--- a/packages/webpack-config/e2e/basic/App.js
+++ b/packages/webpack-config/e2e/basic/App.js
@@ -51,7 +51,9 @@ export default function App() {
       <Text testID="asset-raw-font">{fontAsset}</Text>
       <Text testID="asset-raw-wildcard">{typeof randomAsset}</Text>
       {boolish('CI', false) && <Text testID="has-ci-text">Has CI env</Text>}
-      {isSWRegistered && <Text testID="has-sw-text">Has SW installed</Text>}
+      {isSWRegistered != null && (
+        <Text testID={`has-sw-text-${isSWRegistered}`}>Has SW installed</Text>
+      )}
       {global.ResizeObserver && (
         <Text testID="has-resize-observer">Has ResizeObserver polyfill</Text>
       )}

--- a/packages/webpack-config/e2e/basic/app.config.js
+++ b/packages/webpack-config/e2e/basic/app.config.js
@@ -1,6 +1,7 @@
 export default {
   name: 'basic',
   description: 'A Neat Expo App',
+  sdkVersion: '39.0.0',
   icon:
     'https://github.com/expo/expo/blob/master/templates/expo-template-blank/assets/icon.png?raw=true',
   splash: {

--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -503,7 +503,12 @@ Object {
     "watchContentBase": true,
   },
   "devtool": "cheap-module-source-map",
-  "entry": [Function],
+  "entry": Object {
+    "app": Array [
+      "node_modules/react-dev-utils/webpackHotDevClient.js",
+      "packages/webpack-config/e2e/basic/index.js",
+    ],
+  },
   "mode": "development",
   "module": Object {
     "rules": Array [
@@ -633,7 +638,6 @@ Object {
     "HotModuleReplacementPlugin",
     "WatchMissingNodeModulesPlugin",
     "ManifestPlugin",
-    "CopyPlugin",
   ],
   "resolve": Object {
     "alias": Object {
@@ -691,7 +695,11 @@ Object {
   "bail": true,
   "context": "packages/webpack-config/src",
   "devtool": "source-map",
-  "entry": [Function],
+  "entry": Object {
+    "app": Array [
+      "packages/webpack-config/e2e/basic/index.js",
+    ],
+  },
   "mode": "production",
   "module": Object {
     "rules": Array [
@@ -904,8 +912,6 @@ Object {
     "DefinePlugin",
     "MiniCssExtractPlugin",
     "ManifestPlugin",
-    "CopyPlugin",
-    "GenerateSW",
   ],
   "resolve": Object {
     "alias": Object {

--- a/packages/webpack-config/src/__tests__/webpack.config-test.js
+++ b/packages/webpack-config/src/__tests__/webpack.config-test.js
@@ -1,7 +1,7 @@
 import { dirname } from 'path';
 
-import normalizePaths from '../utils/normalizePaths';
 import createConfig from '..';
+import normalizePaths from '../utils/normalizePaths';
 
 const projectRoot = dirname(require.resolve('@expo/webpack-config/e2e/basic'));
 
@@ -50,6 +50,19 @@ describe(`ios`, () => {
   });
 });
 describe(`web`, () => {
+  // {offline: true} should add the copy webpack plugin and change the entry to account for the register-service-worker file.
+  it('web offline', async () => {
+    const config = await createConfig({
+      mode: 'development',
+      offline: true,
+      platform: 'web',
+      projectRoot,
+    });
+    const normalized = normalizeConfig(config);
+    expect(typeof normalized.entry).toBe('function');
+    expect(normalized.plugins).toContain('CopyPlugin');
+  });
+
   it('web development', async () => {
     const config = await createConfig({ mode: 'development', platform: 'web', projectRoot });
     const normalized = normalizeConfig(config);

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -34,21 +34,21 @@ export default async function createWebpackConfigAsync(
     console.warn('environment.info is deprecated');
   }
 
-  if (environment.offline === false) {
-    return config;
-  }
-  const { workbox = {} } = argv;
-  const publicUrl = workbox.publicUrl || getPublicPaths(environment).publicUrl;
+  if (environment.offline === true) {
+    const { workbox = {} } = argv;
+    const publicUrl = workbox.publicUrl || getPublicPaths(environment).publicUrl;
 
-  // No SW for native
-  if (['ios', 'android'].includes(env.platform || '')) {
-    return config;
-  }
+    // No SW for native
+    if (['ios', 'android'].includes(env.platform || '')) {
+      return config;
+    }
 
-  return withWorkbox(config, {
-    projectRoot: environment.projectRoot,
-    ...workbox,
-    publicUrl,
-    platform: env.platform,
-  });
+    return withWorkbox(config, {
+      projectRoot: environment.projectRoot,
+      ...workbox,
+      publicUrl,
+      platform: env.platform,
+    });
+  }
+  return config;
 }

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -54,9 +54,9 @@ export type Environment = {
    */
   projectRoot: string;
   /**
-   * Passing `true` will disable offline support and skip adding a service worker.
+   * Passing `true` will enable offline support and add a service worker.
    *
-   * @default true
+   * @default false
    */
   offline?: boolean;
   /**

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -249,16 +249,17 @@ export default async function (
     {
       from: locations.template.folder,
       to: locations.production.folder,
+      toType: 'dir',
       globOptions: {
         dot: true,
         // We generate new versions of these based on the templates
         ignore: [
-          'expo-service-worker.js',
-          'serve.json',
-          'index.html',
-          'icon.png',
+          '**/expo-service-worker.*',
+          // '**/serve.json',
+          // '**/index.html',
+          '**/icon.png',
           // We copy this over in `withWorkbox` as it must be part of the Webpack `entry` and have templates replaced.
-          'register-service-worker.js',
+          '**/register-service-worker.js',
         ],
       },
     },
@@ -268,7 +269,7 @@ export default async function (
     },
   ];
 
-  if (env.offline !== false) {
+  if (env.offline === true) {
     filesToCopy.push({
       from: locations.template.serviceWorker,
       to: locations.production.serviceWorker,

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -68,6 +68,7 @@ export type WebEnvironment = {
   pwa: boolean;
   mode: 'development' | 'production' | 'test' | 'none';
   https: boolean;
+  offline?: boolean;
 };
 
 export async function restartAsync(
@@ -346,6 +347,18 @@ export async function bundleAsync(projectRoot: string, options?: BundlingOptions
   const config = await createWebpackConfigAsync(env, fullOptions);
 
   await bundleWebAppAsync(projectRoot, config);
+
+  if (!env.offline) {
+    ProjectUtils.logInfo(
+      projectRoot,
+      WEBPACK_LOG_TAG,
+      withTag(
+        chalk.green(
+          'Note that offline (PWA) support is not enabled in this build. Learn more https://expo.fyi/enabling-web-service-workers\n'
+        )
+      )
+    );
+  }
 }
 
 export async function getProjectNameAsync(projectRoot: string): Promise<string> {


### PR DESCRIPTION
# Why

We'll be making offline support opt-in going forward due to increased complexity involved with automatically enabling them.
This effectively makes PWAs not work out of the box.

### Related
- https://github.com/expo/expo/pull/9821
- https://github.com/expo/fyi/pull/12