### PR TITLE
[expo-cli][xdl] Skip SDK version validation for eas:build

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -88,7 +88,7 @@ async function createBuilderContextAsync(
   }
 ): Promise<BuilderContext> {
   const user: User = await UserManager.ensureLoggedInAsync();
-  const { exp } = getConfig(projectDir);
+  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
   const accountName = exp.owner || user.username;
   const projectName = exp.slug;
 

--- a/packages/expo-cli/src/commands/eas-build/index.ts
+++ b/packages/expo-cli/src/commands/eas-build/index.ts
@@ -16,7 +16,10 @@ export default function (program: Command) {
   program
     .command('eas:credentials:sync [project-dir]')
     .description('Update credentials.json with credentials stored on Expo servers')
-    .asyncActionProjectDir(credentialsSyncAction, { checkConfig: true });
+    .asyncActionProjectDir(credentialsSyncAction, {
+      checkConfig: true,
+      skipSDKVersionRequirement: true,
+    });
 
   program
     .command('eas:build [project-dir]')
@@ -30,7 +33,7 @@ export default function (program: Command) {
     .option('--skip-project-configuration', 'Skip configuring the project', false)
     .option('--no-wait', 'Exit immediately after scheduling build', false)
     .option('--profile <profile>', 'Build profile', 'release')
-    .asyncActionProjectDir(buildAction, { checkConfig: true });
+    .asyncActionProjectDir(buildAction, { checkConfig: true, skipSDKVersionRequirement: true });
 
   program
     .command('eas:build:status [project-dir]')
@@ -46,5 +49,5 @@ export default function (program: Command) {
       /^(in-queue|in-progress|errored|finished)$/
     )
     .option('-b --build-id <build-id>', 'Get the build with a specific build id')
-    .asyncActionProjectDir(statusAction, { checkConfig: true });
+    .asyncActionProjectDir(statusAction, { checkConfig: true, skipSDKVersionRequirement: true });
 }

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -106,7 +106,9 @@ export class Context {
     this._nonInteractive = options.nonInteractive;
 
     // Check if we are in project context by looking for a manifest
-    const status = await Doctor.validateWithoutNetworkAsync(projectDir);
+    const status = await Doctor.validateWithoutNetworkAsync(projectDir, {
+      skipSDKVersionRequirement: true,
+    });
     if (status !== Doctor.FATAL) {
       const { exp } = getConfig(projectDir);
       this._manifest = exp;

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -110,7 +110,7 @@ export class Context {
       skipSDKVersionRequirement: true,
     });
     if (status !== Doctor.FATAL) {
-      const { exp } = getConfig(projectDir);
+      const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
       this._manifest = exp;
       this._hasProjectContext = true;
       this.logOwnerAndProject();

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -110,7 +110,7 @@ Command.prototype.asyncAction = function (asyncFn: Action, skipUpdateCheck: bool
 // - Runs AsyncAction with the projectDir as an argument
 Command.prototype.asyncActionProjectDir = function (
   asyncFn: Action,
-  options: { checkConfig?: boolean } = {}
+  options: { checkConfig?: boolean; skipSDKVersionRequirement?: boolean } = {}
 ) {
   this.option('--config [file]', 'Specify a path to app.json or app.config.js');
   return this.asyncAction(async (projectDir: string, ...args: any[]) => {
@@ -300,7 +300,9 @@ Command.prototype.asyncActionProjectDir = function (
       log.setSpinner(spinner);
       // validate that this is a good projectDir before we try anything else
 
-      const status = await Doctor.validateWithoutNetworkAsync(projectDir);
+      const status = await Doctor.validateWithoutNetworkAsync(projectDir, {
+        skipSDKVersionRequirement: options.skipSDKVersionRequirement,
+      });
       if (status === Doctor.FATAL) {
         throw new Error(`There is an error with your project. See above logs for information.`);
       }

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -3,6 +3,7 @@ import {
   PackageJSONConfig,
   configFilename,
   getConfig,
+  getDefaultTarget,
   getPackageJson,
   resolveModule,
 } from '@expo/config';
@@ -158,7 +159,8 @@ async function _validateExpJsonAsync(
   exp: ExpoConfig,
   pkg: PackageJSONConfig,
   projectRoot: string,
-  allowNetwork: boolean
+  allowNetwork: boolean,
+  skipSDKVersionRequirement: boolean | undefined
 ): Promise<number> {
   if (!exp || !pkg) {
     // getConfig already logged an error
@@ -203,7 +205,7 @@ async function _validateExpJsonAsync(
   }
   ProjectUtils.clearNotification(projectRoot, 'doctor-versions-endpoint-failed');
 
-  if (!sdkVersion || !sdkVersions[sdkVersion]) {
+  if (!skipSDKVersionRequirement && (!sdkVersion || !sdkVersions[sdkVersion])) {
     ProjectUtils.logError(
       projectRoot,
       'expo',
@@ -215,7 +217,7 @@ async function _validateExpJsonAsync(
   ProjectUtils.clearNotification(projectRoot, 'doctor-invalid-sdk-version');
 
   // Skip validation if the correct token is set in env
-  if (sdkVersion !== 'UNVERSIONED') {
+  if (sdkVersion && sdkVersion !== 'UNVERSIONED') {
     try {
       const schema = await ExpSchema.getSchemaAsync(sdkVersion);
       const { schemaErrorMessage, assetsErrorMessage } = await validateWithSchema(
@@ -253,16 +255,18 @@ async function _validateExpJsonAsync(
     }
   }
 
-  const reactNativeIssue = await _validateReactNativeVersionAsync(
-    exp,
-    pkg,
-    projectRoot,
-    sdkVersions,
-    sdkVersion
-  );
+  if (sdkVersion) {
+    const reactNativeIssue = await _validateReactNativeVersionAsync(
+      exp,
+      pkg,
+      projectRoot,
+      sdkVersions,
+      sdkVersion
+    );
 
-  if (reactNativeIssue !== NO_ISSUES) {
-    return reactNativeIssue;
+    if (reactNativeIssue !== NO_ISSUES) {
+      return reactNativeIssue;
+    }
   }
 
   // TODO: Check any native module versions here
@@ -409,15 +413,25 @@ async function _validateNodeModulesAsync(projectRoot: string): Promise<number> {
   return NO_ISSUES;
 }
 
-export async function validateWithoutNetworkAsync(projectRoot: string): Promise<number> {
-  return validateAsync(projectRoot, false);
+export async function validateWithoutNetworkAsync(
+  projectRoot: string,
+  options: { skipSDKVersionRequirement?: boolean } = {}
+): Promise<number> {
+  return validateAsync(projectRoot, false, options.skipSDKVersionRequirement);
 }
 
-export async function validateWithNetworkAsync(projectRoot: string): Promise<number> {
-  return validateAsync(projectRoot, true);
+export async function validateWithNetworkAsync(
+  projectRoot: string,
+  options: { skipSDKVersionRequirement?: boolean } = {}
+): Promise<number> {
+  return validateAsync(projectRoot, true, options.skipSDKVersionRequirement);
 }
 
-async function validateAsync(projectRoot: string, allowNetwork: boolean): Promise<number> {
+async function validateAsync(
+  projectRoot: string,
+  allowNetwork: boolean,
+  skipSDKVersionRequirement: boolean | undefined
+): Promise<number> {
   if (getenv.boolish('EXPO_NO_DOCTOR', false)) {
     return NO_ISSUES;
   }
@@ -426,6 +440,7 @@ async function validateAsync(projectRoot: string, allowNetwork: boolean): Promis
   try {
     const config = getConfig(projectRoot, {
       strict: true,
+      skipSDKVersionRequirement,
     });
     exp = config.exp;
     pkg = config.pkg;
@@ -445,7 +460,13 @@ async function validateAsync(projectRoot: string, allowNetwork: boolean): Promis
     return status;
   }
 
-  const expStatus = await _validateExpJsonAsync(exp, pkg, projectRoot, allowNetwork);
+  const expStatus = await _validateExpJsonAsync(
+    exp,
+    pkg,
+    projectRoot,
+    allowNetwork,
+    skipSDKVersionRequirement
+  );
   if (expStatus === FATAL) {
     return expStatus;
   }

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -3,7 +3,6 @@ import {
   PackageJSONConfig,
   configFilename,
   getConfig,
-  getDefaultTarget,
   getPackageJson,
   resolveModule,
 } from '@expo/config';


### PR DESCRIPTION
You may want to run this in an app created with `npx react-native init` and you will not have an Expo SDK version in that context, so we should support that.