### PR TITLE
[cli] Avoid using root client urls and print latest client version

### DIFF
--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -300,9 +300,8 @@ export default function (program: Command) {
       const sdkVersions = await Versions.sdkVersionsAsync();
       const latestSdk = await Versions.newestReleasedSdkVersionAsync();
       const currentSdk = sdkVersions[currentSdkVersion!];
-      const recommendedClient = currentSdk
-        ? ClientUpgradeUtils.getClient(currentSdk, 'ios')
-        : undefined;
+      const recommendedClient = ClientUpgradeUtils.getClient('ios', currentSdk);
+      const latestClient = ClientUpgradeUtils.getClient('ios', latestSdk.data);
 
       if (currentSdk && !recommendedClient) {
         log(
@@ -326,10 +325,12 @@ export default function (program: Command) {
         const answer = await prompt({
           type: 'confirm',
           name: 'upgradeToLatest',
-          message: 'Do you want to install the latest client?',
+          message: latestClient?.version
+            ? chalk`Do you want to install the latest client? {dim (${latestClient.version})}`
+            : 'Do you want to install the latest client?',
         });
         if (answer.upgradeToLatest) {
-          await Simulator.upgradeExpoAsync();
+          await Simulator.upgradeExpoAsync(latestClient?.url);
           log('Done!');
           return;
         }
@@ -350,7 +351,7 @@ export default function (program: Command) {
             : "It looks like we don't have a compatible client. Do you want to try the latest client?",
         });
         if (answer.updateToAClient) {
-          await Simulator.upgradeExpoAsync();
+          await Simulator.upgradeExpoAsync(latestClient?.url);
           log('Done!');
         } else {
           log('No client to install');
@@ -385,9 +386,8 @@ export default function (program: Command) {
       const sdkVersions = await Versions.sdkVersionsAsync();
       const latestSdk = await Versions.newestReleasedSdkVersionAsync();
       const currentSdk = sdkVersions[currentSdkVersion!];
-      const recommendedClient = currentSdk
-        ? ClientUpgradeUtils.getClient(currentSdk, 'android')
-        : undefined;
+      const recommendedClient = ClientUpgradeUtils.getClient('android', currentSdk);
+      const latestClient = ClientUpgradeUtils.getClient('android', latestSdk.data);
 
       if (currentSdk && !recommendedClient) {
         log(
@@ -411,10 +411,12 @@ export default function (program: Command) {
         const answer = await prompt({
           type: 'confirm',
           name: 'upgradeToLatest',
-          message: 'Do you want to install the latest client?',
+          message: latestClient?.version
+            ? chalk`Do you want to install the latest client? {dim (${latestClient.version})}`
+            : 'Do you want to install the latest client?',
         });
         if (answer.upgradeToLatest) {
-          await Android.upgradeExpoAsync();
+          await Android.upgradeExpoAsync(latestClient?.url);
           log('Done!');
           return;
         }
@@ -435,7 +437,7 @@ export default function (program: Command) {
             : "It looks like we don't have a compatible client. Do you want to try the latest client?",
         });
         if (answer.updateToAClient) {
-          await Android.upgradeExpoAsync();
+          await Android.upgradeExpoAsync(latestClient?.url);
           log('Done!');
         } else {
           log('No client to install');

--- a/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
+++ b/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
@@ -24,7 +24,7 @@ type ClientPlatform = 'android' | 'ios';
 
 export function getClient(platform: ClientPlatform, sdk?: Versions.SDKVersion | null) {
   if (!sdk) {
-    return undefined;
+    return null;
   }
 
   if (platform === 'android' && sdk.androidClientUrl) {
@@ -41,7 +41,7 @@ export function getClient(platform: ClientPlatform, sdk?: Versions.SDKVersion | 
     };
   }
 
-  return undefined;
+  return null;
 }
 
 interface AvailableClientOptions {

--- a/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
+++ b/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
@@ -22,7 +22,11 @@ export async function getExpoSdkConfig(path: string) {
 
 type ClientPlatform = 'android' | 'ios';
 
-export function getClient(sdk: Versions.SDKVersion, platform: ClientPlatform) {
+export function getClient(platform: ClientPlatform, sdk?: Versions.SDKVersion | null) {
+  if (!sdk) {
+    return undefined;
+  }
+
   if (platform === 'android' && sdk.androidClientUrl) {
     return {
       url: sdk.androidClientUrl,
@@ -57,13 +61,13 @@ export function getAvailableClients(options: AvailableClientOptions): AvailableC
   return Object.keys(options.sdkVersions)
     .reverse()
     .map(version => {
-      const client = getClient(options.sdkVersions[version], options.platform);
+      const client = getClient(options.platform, options.sdkVersions[version]);
 
       return {
         sdkVersionString: version,
         sdkVersion: options.sdkVersions[version],
-        clientUrl: client ? client.url : undefined,
-        clientVersion: client ? client.version : undefined,
+        clientUrl: client?.url,
+        clientVersion: client?.version,
       };
     })
     .filter(client => {


### PR DESCRIPTION
This avoids calling both `Simulator.upgradeExpoAsync()` and `await Android.upgradeExpoAsync()` without a client URL, from the `$ expo client:install:*` commands.

### Why?

The versions endpoints contain 2 root client URLs:
![Screenshot 2020-08-21 at 14 44 44](https://user-images.githubusercontent.com/1203991/90891990-e004f700-e3bc-11ea-821f-e6f2db37e0e2.png)

As I recall my chats with @tsapeta, these are deprecated and kept in for backward compatibility with the CLI. Calling either Android or Simulator `upgradeExpoAsync` without URL, causes the installers to use these root URLs. 

In the `$ expo client:install:*` commands, we actually know the _latest released sdk_ version and can pass these SDK-specific client urls to the installers.

![Screenshot 2020-08-21 at 14 48 20](https://user-images.githubusercontent.com/1203991/90892298-5efa2f80-e3bd-11ea-867b-dd2e953e61fa.png)

> We could also add the `await Versions.newestReleasedSdkVersionAsync()` inside the installers, but I'm not 100% sure if that would break existing stuff.

### Example

![Screenshot 2020-08-21 at 14 42 05](https://user-images.githubusercontent.com/1203991/90892464-a41e6180-e3bd-11ea-8c14-b2182fac0f77.png)

