### PR TITLE
Prompt for bundle ID and package name in expo apply

### DIFF
--- a/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
@@ -4,6 +4,8 @@ import fs from 'fs-extra';
 import { sync as globSync } from 'glob';
 import path from 'path';
 
+import { getOrPromptForPackage } from '../eject/ConfigValidation';
+
 async function modifyBuildGradleAsync(
   projectRoot: string,
   callback: (buildGradle: string) => string
@@ -54,6 +56,9 @@ async function modifyMainActivityJavaAsync(
 }
 
 export default async function configureAndroidProjectAsync(projectRoot: string) {
+  // Check package before reading the config because it may mutate the config if the user is prompted to define it.
+  await getOrPromptForPackage(projectRoot);
+
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   const username = await UserManager.getCurrentUsernameAsync();
 

--- a/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
@@ -2,11 +2,16 @@ import { IOSConfig, WarningAggregator, getConfig } from '@expo/config';
 import { IosPlist, UserManager } from '@expo/xdl';
 import path from 'path';
 
+import { getOrPromptForBundleIdentifier } from '../eject/ConfigValidation';
+
 export default async function configureIOSProjectAsync(projectRoot: string) {
+  // Check bundle ID before reading the config because it may mutate the config if the user is prompted to define it.
+  const bundleIdentifier = await getOrPromptForBundleIdentifier(projectRoot);
+  IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(projectRoot, bundleIdentifier);
+
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   const username = await UserManager.getCurrentUsernameAsync();
 
-  IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(projectRoot, exp.ios!.bundleIdentifier!);
   IOSConfig.Google.setGoogleServicesFile(exp, projectRoot);
   IOSConfig.DeviceFamily.setDeviceFamily(exp, projectRoot);
 

--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -77,9 +77,14 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
     }
   );
 
-  await attemptModification(projectRoot, `Your iOS bundle identifier is now: ${bundleIdentifier}`, {
-    ios: { bundleIdentifier },
-  });
+  await attemptModification(
+    projectRoot,
+    `Your iOS bundle identifier is now: ${bundleIdentifier}`,
+    {
+      ios: { ...(exp.ios || {}), bundleIdentifier },
+    },
+    { ios: { bundleIdentifier } }
+  );
 
   return bundleIdentifier;
 }
@@ -142,9 +147,16 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
     }
   );
 
-  await attemptModification(projectRoot, `Your Android package is now: ${packageName}`, {
-    android: { package: packageName },
-  });
+  await attemptModification(
+    projectRoot,
+    `Your Android package is now: ${packageName}`,
+    {
+      android: { ...(exp.android || {}), package: packageName },
+    },
+    {
+      android: { package: packageName },
+    }
+  );
 
   return packageName;
 }
@@ -152,7 +164,8 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
 async function attemptModification(
   projectRoot: string,
   modificationSuccessMessage: string,
-  edits: Partial<ExpoConfig>
+  edits: Partial<ExpoConfig>,
+  exactEdits: Partial<ExpoConfig>
 ): Promise<void> {
   const modification = await modifyConfigAsync(projectRoot, edits, {
     skipSDKVersionRequirement: true,
@@ -162,7 +175,7 @@ async function attemptModification(
     log(modificationSuccessMessage);
     log.newLine();
   } else {
-    warnAboutConfigAndExit(modification.type, modification.message!, edits);
+    warnAboutConfigAndExit(modification.type, modification.message!, exactEdits);
   }
 }
 

--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -17,7 +17,7 @@ function validatePackage(value: string): boolean {
 }
 
 export async function getOrPromptForBundleIdentifier(projectRoot: string): Promise<string> {
-  const { exp } = getConfig(projectRoot);
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
 
   const currentBundleId = exp.ios?.bundleIdentifier;
   if (currentBundleId) {
@@ -90,7 +90,7 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
 }
 
 export async function getOrPromptForPackage(projectRoot: string): Promise<string> {
-  const { exp } = getConfig(projectRoot);
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
 
   const currentPackage = exp.android?.package;
   if (currentPackage) {


### PR DESCRIPTION
Right now `expo apply` crashes if the project config doesn't have a bundle ID or package name defined. This prompts the user for the appropriate values using the same logic as eject.

This code does however get executed twice now when ejecting, but it might be ok since it's important that the command bails out as quickly as possible in `expo eject`.

Also added the ability to run in projects without Expo configs. I modified the order of operations, so Android config is done first, this way the package name is optimized for being shared across iOS and Android.