### PR TITLE
[expo-cli] eas build: allow choosing scheme for ios project build

### DIFF
--- a/packages/config/src/ios/Scheme.ts
+++ b/packages/config/src/ios/Scheme.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '../Config.types';
 import { InfoPlist, URLScheme } from './IosConfig.types';
+import { findSchemeNames } from './utils/Xcodeproj';
 
 export function getScheme(config: { scheme?: string | string[] }): string[] {
   if (Array.isArray(config.scheme)) {
@@ -98,4 +99,8 @@ export function getSchemesFromPlist(infoPlist: InfoPlist): string[] {
     }, []);
   }
   return [];
+}
+
+export function getSchemesFromXcodeproj(projectRoot: string): string[] {
+  return findSchemeNames(projectRoot);
 }

--- a/packages/config/src/ios/utils/Xcodeproj.ts
+++ b/packages/config/src/ios/utils/Xcodeproj.ts
@@ -41,6 +41,14 @@ export function addFileToGroup(filepath: string, groupName: string, project: Pro
   return project;
 }
 
+export function findSchemeNames(projectRoot: string): string[] {
+  const schemePaths = globSync('ios/*.xcodeproj/xcshareddata/xcschemes/*.xcscheme', {
+    absolute: true,
+    cwd: projectRoot,
+  });
+  return schemePaths.map(schemePath => path.basename(schemePath).split('.')[0]);
+}
+
 /**
  * Get the pbxproj for the given path
  */

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -62,7 +62,7 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@expo/build-tools": "^0.1.14",
+    "@expo/build-tools": "^0.1.15",
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.2.19",
     "@expo/dev-tools": "0.13.34",

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
@@ -25,6 +25,9 @@ jest.mock('@expo/config', () => {
       ProvisioningProfile: {
         setProvisioningProfileForPbxproj: jest.fn(),
       },
+      Scheme: {
+        getSchemesFromXcodeproj: jest.fn(),
+      },
     },
   };
 });
@@ -104,6 +107,7 @@ const easJson = {
     ios: {
       release: {
         workflow: 'generic',
+        scheme: 'testapp',
         credentialsSource: 'local',
       },
     },
@@ -216,6 +220,7 @@ describe('build command', () => {
         type: 'generic',
         projectUrl: mockProjectUrl,
         artifactPath: 'ios/build/App.ipa',
+        scheme: 'testapp',
         secrets: {
           distributionCertificate: {
             dataBase64: cert.base64,
@@ -276,6 +281,7 @@ describe('build command', () => {
                 type: 'generic',
                 projectUrl: mockProjectUrl,
                 artifactPath: 'ios/build/App.ipa',
+                scheme: 'testapp',
                 secrets: {
                   distributionCertificate: {
                     dataBase64: cert.base64,

--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@expo/config';
 import { ApiV2, User, UserManager } from '@expo/xdl';
+import { build } from '@hapi/joi';
 import chalk from 'chalk';
 import delayAsync from 'delay-async';
 import fs from 'fs-extra';

--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -143,8 +143,8 @@ async function startBuildAsync(
 ): Promise<string> {
   const tarPath = path.join(os.tmpdir(), `${uuidv4()}.tar.gz`);
   try {
+    await builder.setupAsync();
     await builder.ensureCredentialsAsync();
-
     if (!builder.ctx.skipProjectConfiguration) {
       await builder.configureProjectAsync();
     }

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -41,6 +41,8 @@ class AndroidBuilder implements Builder {
     this.buildProfile = ctx.eas.builds.android;
   }
 
+  public async setupAsync(): Promise<void> {}
+
   public async ensureCredentialsAsync(): Promise<void> {
     this.credentialsPrepared = true;
     if (!this.shouldLoadCredentials()) {

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
@@ -64,6 +64,7 @@ describe('iOSBuilder', () => {
             ios: {
               credentialsSource: 'local',
               workflow: 'generic',
+              scheme: 'testapp',
             },
           },
         },
@@ -72,12 +73,14 @@ describe('iOSBuilder', () => {
         exp: { ios: { bundleIdentifier: 'example.bundle.identifier' } },
       };
       const builder = new iOSBuilder(ctx);
+      await builder.setupAsync();
       await builder.ensureCredentialsAsync();
       const job = await builder.prepareJobAsync(projectUrl);
       expect(job).toEqual({
         platform: 'ios',
         type: 'generic',
         projectUrl,
+        scheme: 'testapp',
         artifactPath: 'ios/build/App.ipa',
         secrets: {
           distributionCertificate: {

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -2,6 +2,7 @@ import { BuildType, Job, Platform, iOS, sanitizeJob } from '@expo/build-tools';
 import { IOSConfig } from '@expo/config';
 import chalk from 'chalk';
 import figures from 'figures';
+import sortBy from 'lodash/sortBy';
 import ora from 'ora';
 
 import iOSCredentialsProvider, {
@@ -15,6 +16,7 @@ import {
   iOSManagedBuildProfile,
 } from '../../../../easJson';
 import log from '../../../../log';
+import prompts from '../../../../prompts';
 import { ensureCredentialsAsync } from '../credentials';
 import { Builder, BuilderContext } from '../types';
 import * as gitUtils from '../utils/git';
@@ -35,6 +37,7 @@ interface CommonJobProperties {
 class iOSBuilder implements Builder {
   private credentials?: iOSCredentials;
   private buildProfile: iOSBuildProfile;
+  private scheme?: string;
 
   constructor(public readonly ctx: BuilderContext) {
     if (!ctx.eas.builds.ios) {
@@ -74,14 +77,22 @@ class iOSBuilder implements Builder {
   }
 
   public async configureProjectAsync(): Promise<void> {
+    if (this.buildProfile.workflow !== Workflow.Generic) {
+      return;
+    }
+
     // TODO: add simulator flow
     // assuming we're building for app store
     if (!this.credentials) {
       throw new Error('Call ensureCredentialsAsync first!');
     }
+
     const bundleIdentifier = await getBundleIdentifier(this.ctx.projectDir, this.ctx.exp);
 
     const spinner = ora('Making sure your iOS project is set up properly');
+
+    this.scheme =
+      (this.buildProfile as iOSGenericBuildProfile).scheme ?? (await this.resolveScheme());
 
     const profileName = ProvisioningProfileUtils.readProfileName(
       this.credentials.provisioningProfile
@@ -148,6 +159,7 @@ class iOSBuilder implements Builder {
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
       type: BuildType.Generic,
+      scheme: this.scheme,
       artifactPath: buildProfile.artifactPath,
     };
   }
@@ -170,6 +182,46 @@ class iOSBuilder implements Builder {
         this.buildProfile.buildType !== 'simulator') ||
       this.buildProfile.workflow === Workflow.Generic
     );
+  }
+
+  private async resolveScheme(): Promise<string> {
+    const schemes = IOSConfig.Scheme.getSchemesFromXcodeproj(this.ctx.projectDir);
+    if (schemes.length === 1) {
+      return schemes[0];
+    }
+
+    const sortedSchemes = sortBy(schemes);
+    log.newLine();
+    log(
+      `We've found multiple schemes in your Xcode project: ${log.chalk.bold(
+        sortedSchemes.join(', ')
+      )}`
+    );
+    log(
+      `You can specify the scheme you want to build at ${log.chalk.bold(
+        'builds.ios.PROFILE_NAME.scheme'
+      )} in eas.json.`
+    );
+    if (this.ctx.nonInteractive) {
+      const withoutTvOS = sortedSchemes.filter(i => !i.includes('tvOS'));
+      const scheme = withoutTvOS.length > 0 ? withoutTvOS[0] : sortedSchemes[0];
+      log(
+        `You've run Expo CLI in non-interactive mode, choosing the ${log.chalk.bold(
+          scheme
+        )} scheme.`
+      );
+      log.newLine();
+      return scheme;
+    } else {
+      const { selectedScheme } = await prompts({
+        type: 'select',
+        name: 'selectedScheme',
+        message: 'Which scheme would you like to build now?',
+        choices: sortedSchemes.map(scheme => ({ title: scheme, value: scheme })),
+      });
+      log.newLine();
+      return selectedScheme as string;
+    }
   }
 }
 

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -76,6 +76,12 @@ class iOSBuilder implements Builder {
     this.credentials = await provider.getCredentialsAsync(credentialsSource);
   }
 
+  public async setupAsync(): Promise<void> {
+    if (this.buildProfile.workflow === Workflow.Generic) {
+      this.scheme = this.buildProfile.scheme ?? (await this.resolveScheme());
+    }
+  }
+
   public async configureProjectAsync(): Promise<void> {
     if (this.buildProfile.workflow !== Workflow.Generic) {
       return;
@@ -89,10 +95,7 @@ class iOSBuilder implements Builder {
 
     const bundleIdentifier = await getBundleIdentifier(this.ctx.projectDir, this.ctx.exp);
 
-    const spinner = ora('Making sure your iOS project is set up properly');
-
-    this.scheme =
-      (this.buildProfile as iOSGenericBuildProfile).scheme ?? (await this.resolveScheme());
+    const spinner = ora('Configuring the Xcode project');
 
     const profileName = ProvisioningProfileUtils.readProfileName(
       this.credentials.provisioningProfile
@@ -111,7 +114,7 @@ class iOSBuilder implements Builder {
       spinner.succeed();
     } catch (err) {
       if (err instanceof gitUtils.DirtyGitTreeError) {
-        spinner.succeed('We configured your iOS project to build it on the Expo servers');
+        spinner.succeed('We configured the Xcode project to build it on the Expo servers');
         log.newLine();
 
         try {

--- a/packages/expo-cli/src/commands/eas-build/build/types.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/types.ts
@@ -20,6 +20,7 @@ export interface BuilderContext {
 
 export interface Builder {
   ctx: BuilderContext;
+  setupAsync(): Promise<void>;
   ensureCredentialsAsync(): Promise<void>;
   configureProjectAsync(): Promise<void>;
   prepareJobAsync(archiveUrl: string): Promise<Job>;

--- a/packages/expo-cli/src/easJson.ts
+++ b/packages/expo-cli/src/easJson.ts
@@ -43,6 +43,7 @@ export interface iOSManagedBuildProfile {
 export interface iOSGenericBuildProfile {
   workflow: Workflow.Generic;
   credentialsSource: CredentialsSource;
+  scheme?: string;
   artifactPath?: string;
 }
 
@@ -98,6 +99,7 @@ const AndroidManagedSchema = Joi.object({
 const iOSGenericSchema = Joi.object({
   workflow: Joi.string().valid('generic').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
+  scheme: Joi.string(),
   artifactPath: Joi.string(),
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,10 +1385,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/build-tools@^0.1.14":
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/@expo/build-tools/-/build-tools-0.1.14.tgz#173054ec8b28686403c4087e2cda16b1df57cbe0"
-  integrity sha512-MISsTvCl5i1S4iOBax3nS6ULCh757TPisZ6s0RCUtIle6UkXKVnsUhY6oP547Xr89CYANqEPx4MeT0uS3+P6Lw==
+"@expo/build-tools@^0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@expo/build-tools/-/build-tools-0.1.15.tgz#6374747ab6b1a8e3a4f84b16d89ddb7263fb9a5d"
+  integrity sha512-j0mu22hWLKBIwvZYmBNMWnAklZRq5cwC6ZyG3SJ5uC2vFK/IIhr3WSstz+dUwFZflCAUUsKRvIbZ2svgBImf4w==
   dependencies:
     "@expo/downloader" "0.0.8"
     "@expo/fastlane" "0.0.13"


### PR DESCRIPTION
This fixes an issue with building a project initialized with `react-native init`. Such a project has multiple schemes in the Xcode project. `fastlane` is unable to build the project if we don't specify the target explicitly. This PR fixes it by displaying a prompt select to choose the build scheme if multiple schemes were detected. If the CLI is run with the `--non-interactive` flag then the first scheme (without the `tvOS` suffix) is picked.