### PR TITLE
[Proposal] Implemented keychain storage for Apple ID

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -96,7 +96,7 @@
     "indent-string": "4.0.0",
     "inquirer": "5.2.0",
     "invariant": "2.2.4",
-    "keychain": "^1.3.0",
+    "keychain": "1.3.0",
     "klaw-sync": "6.0.0",
     "leven": "^3.1.0",
     "lodash": "4.17.15",

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -96,6 +96,7 @@
     "indent-string": "4.0.0",
     "inquirer": "5.2.0",
     "invariant": "2.2.4",
+    "keychain": "^1.3.0",
     "klaw-sync": "6.0.0",
     "leven": "^3.1.0",
     "lodash": "4.17.15",

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -215,7 +215,7 @@ async function _promptForAppleId({
 
     // https://docs.expo.io/distribution/security/#apple-developer-account-credentials
     const here = terminalLink('here', 'https://bit.ly/2VtGWhU');
-    log(wrap(chalk.bold(`The password is only used to authenticate with Apple`)));
+    log(wrap(chalk.bold(`The password is only used to authenticate with Apple and never stored on Expo servers`)));
     log(wrap(chalk.grey(`Learn more ${here}`)));
   }
 

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -147,7 +147,7 @@ async function _promptForAppleId({
 
   // If a new email was used then store it as a suggestion for next time.
   // This functionality is disabled using the keychain mechanism.
-  if (!Keychain.EXPO_NO_KEYCHAIN && lastAppleId !== promptAppleId) {
+  if (!Keychain.EXPO_NO_KEYCHAIN && lastAppleId && lastAppleId !== promptAppleId) {
     await UserSettings.setAsync('appleId', promptAppleId);
   }
 

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -20,6 +20,10 @@ function getKeychainServiceName(appleId: string): string {
 async function deletePasswordAsync({
   appleId,
 }: Pick<AppleCredentials, 'appleId'>): Promise<boolean> {
+  // Mac only right now.
+  if (process.platform !== 'darwin') {
+    return false;
+  }
   const keychainService = getKeychainServiceName(appleId);
   return new Promise((resolve, reject) => {
     keychain.deletePassword(
@@ -42,6 +46,11 @@ async function deletePasswordAsync({
 async function getPasswordAsync({
   appleId,
 }: Pick<AppleCredentials, 'appleId'>): Promise<string | null> {
+  // Mac only right now.
+  if (process.platform !== 'darwin') {
+    return null;
+  }
+  // If the user opts out, delete the password.
   if (NO_STORE_PASSWORD) {
     await deletePasswordAsync({ appleId });
     return null;
@@ -69,6 +78,10 @@ async function storePasswordAsync({
   appleId,
   appleIdPassword,
 }: AppleCredentials): Promise<boolean> {
+  // Mac only right now.
+  if (process.platform !== 'darwin') {
+    return false;
+  }
   if (NO_STORE_PASSWORD) {
     log('Skip storing Apple ID password in the native key chain.');
     return false;
@@ -215,7 +228,13 @@ async function _promptForAppleId({
 
     // https://docs.expo.io/distribution/security/#apple-developer-account-credentials
     const here = terminalLink('here', 'https://bit.ly/2VtGWhU');
-    log(wrap(chalk.bold(`The password is only used to authenticate with Apple and never stored on Expo servers`)));
+    log(
+      wrap(
+        chalk.bold(
+          `The password is only used to authenticate with Apple and never stored on Expo servers`
+        )
+      )
+    );
     log(wrap(chalk.grey(`Learn more ${here}`)));
   }
 

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -156,6 +156,11 @@ async function _promptForAppleId({
     const password = await getPasswordAsync({ appleId: promptAppleId });
 
     if (password) {
+      log(
+        `Using password from keychain. ${chalk.dim(
+          `Learn more ${chalk.underline('https://docs.expo.io/distribution/security#keychain')}`
+        )}`
+      );
       return { appleId: promptAppleId, appleIdPassword: password };
     }
   }
@@ -258,7 +263,7 @@ async function deletePasswordAsync({
   const serviceName = getKeychainServiceName(appleId);
   const success = await Keychain.deletePasswordAsync({ username: appleId, serviceName });
   if (success) {
-    log('Removed Apple ID password from the native key chain.');
+    log('Removed Apple ID password from the native Keychain.');
   }
   return success;
 }
@@ -278,12 +283,14 @@ async function getPasswordAsync({
 
 async function setPasswordAsync({ appleId, appleIdPassword }: AppleCredentials): Promise<boolean> {
   if (Keychain.EXPO_NO_KEYCHAIN) {
-    log('Skip storing Apple ID password in the native key chain.');
+    log('Skip storing Apple ID password in the native Keychain.');
     return false;
   }
 
   log(
-    `Saving Apple ID password to the local native key chain. You can disable this with ${chalk.bold`EXPO_NO_KEYCHAIN=true`}`
+    `Saving Apple ID password to the local native Keychain. ${chalk.dim(
+      `Learn more ${chalk.underline('https://docs.expo.io/distribution/security#keychain')}`
+    )}`
   );
   const serviceName = getKeychainServiceName(appleId);
   return Keychain.setPasswordAsync({ username: appleId, password: appleIdPassword, serviceName });

--- a/packages/expo-cli/src/appleApi/keychain.ts
+++ b/packages/expo-cli/src/appleApi/keychain.ts
@@ -1,0 +1,86 @@
+import getenv from 'getenv';
+// @ts-ignore
+import keychain from 'keychain';
+
+const KEYCHAIN_TYPE = 'internet';
+const IS_MAC = process.platform === 'darwin';
+const NO_PASSWORD_REGEX = /Could not find password/;
+export const EXPO_NO_KEYCHAIN = getenv.boolish('EXPO_NO_KEYCHAIN', false);
+
+type Credentials = {
+  serviceName: string;
+  username: string;
+  password: string;
+};
+
+export function deletePasswordAsync({
+  username,
+  serviceName,
+}: Pick<Credentials, 'username' | 'serviceName'>): Promise<boolean> {
+  if (!IS_MAC) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve, reject) => {
+    keychain.deletePassword(
+      { account: username, service: serviceName, type: KEYCHAIN_TYPE },
+      (error: Error) => {
+        if (error) {
+          if (error.message.match(NO_PASSWORD_REGEX)) {
+            return resolve(false);
+          }
+          reject(error);
+        } else {
+          resolve(true);
+        }
+      }
+    );
+  });
+}
+
+export function getPasswordAsync({
+  username,
+  serviceName,
+}: Pick<Credentials, 'serviceName' | 'username'>): Promise<string | null> {
+  if (!IS_MAC) {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve, reject) => {
+    keychain.getPassword(
+      { account: username, service: serviceName, type: KEYCHAIN_TYPE },
+      (error: Error, password: string) => {
+        if (error) {
+          if (error.message.match(NO_PASSWORD_REGEX)) {
+            return resolve(null);
+          }
+          reject(error);
+        } else {
+          resolve(password);
+        }
+      }
+    );
+  });
+}
+
+export function setPasswordAsync({
+  serviceName,
+  username,
+  password,
+}: Credentials): Promise<boolean> {
+  if (!IS_MAC) {
+    return Promise.resolve(false);
+  }
+  return new Promise((resolve, reject) => {
+    keychain.setPassword(
+      { account: username, service: serviceName, password, type: KEYCHAIN_TYPE },
+      (error: Error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(true);
+        }
+      }
+    );
+  });
+}

--- a/packages/expo-cli/src/appleApi/keychain.ts
+++ b/packages/expo-cli/src/appleApi/keychain.ts
@@ -5,6 +5,9 @@ import keychain from 'keychain';
 const KEYCHAIN_TYPE = 'internet';
 const IS_MAC = process.platform === 'darwin';
 const NO_PASSWORD_REGEX = /Could not find password/;
+
+// When enabled, the password will not only be skipped but also deleted.
+// This makes it easier to completely opt-out of Keychain functionality.
 export const EXPO_NO_KEYCHAIN = getenv.boolish('EXPO_NO_KEYCHAIN', false);
 
 type Credentials = {

--- a/packages/xdl/src/UserSettings.ts
+++ b/packages/xdl/src/UserSettings.ts
@@ -7,6 +7,7 @@ import * as Env from './Env';
 import { ConnectionType } from './User';
 
 export type UserSettingsData = {
+  appleId?: string;
   accessToken?: string;
   auth?: UserData | null;
   ignoreBundledBinaries?: string[];
@@ -17,6 +18,7 @@ export type UserSettingsData = {
 };
 
 export type UserData = {
+  appleId?: string;
   userId?: string;
   username?: string;
   currentConnection?: ConnectionType;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13254,7 +13254,7 @@ just-debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.0.0.tgz#87fccfaeffc0b68cd19d55f6722943f929ea35ea"
   integrity sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=
 
-keychain@^1.3.0:
+keychain@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/keychain/-/keychain-1.3.0.tgz#ccb8ddc64a62f34d541ac25e612186442a432410"
   integrity sha1-zLjdxkpi801UGsJeYSGGRCpDJBA=

--- a/yarn.lock
+++ b/yarn.lock
@@ -13254,6 +13254,11 @@ just-debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.0.0.tgz#87fccfaeffc0b68cd19d55f6722943f929ea35ea"
   integrity sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=
 
+keychain@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/keychain/-/keychain-1.3.0.tgz#ccb8ddc64a62f34d541ac25e612186442a432410"
+  integrity sha1-zLjdxkpi801UGsJeYSGGRCpDJBA=
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"


### PR DESCRIPTION
# Why

- Entering your apple ID and password can get tiring, especially if the command fails and you need to do it multiple times.
- I'm opening this PR as a discussion / proposal for adding keychain support on mac to store the Apple ID password. This is akin to Fastlane which has the same functionality.
- This PR also implements a feature to save the last used email between sessions and suggests it as the default value for the next time.
- When a user has `EXPO_NO_STORE_PASSWORD` truthy, the password and email will be deleted next time the CLI attempts to access it.
- I've also combined the auth logic for `upload:ios` and the other auth systems.
- Finally, since the username and password are being passed to Fastlane, I propose we store the password using the same keychain service name as Fastlane. This has two main considerations:
  1. When a user deletes the password for expo-cli with `EXPO_NO_STORE_PASSWORD`, they'll also be deleting it for Fastlane (and vise-versa).
  2. If a user has used Expo CLI before, Fastlane will access their password unprompted (and vise-versa). Granted any node tool can seemingly request to access any (internet) password in keychain.

- Currently this uses a light weight mac only package `keychain`, there is an alternative more popular cross-platform package [`keytar`](https://www.npmjs.com/package/keytar) but it is a native module which could potentially increase install time by a lot. 

