### PR TITLE
[expo-cli] Fixed default bare project name for 'expo init'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🎉 New features
 
 - [expo-cli]: EAS Build: warn user when credentials are not git ignored ([#2482](https://github.com/expo/expo-cli/pull/2482)) by [@wkozyra95](https://github.com/wkozyra95)
+- [expo-cli]: Fix default bare project name to match regex in `expo-init`. ([#2509](https://github.com/expo/expo-cli/pull/2509) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -498,7 +498,7 @@ async function promptForBareConfig(
     ({ projectName } = await prompt({
       name: 'projectName',
       message: 'What would you like to name your app?',
-      default: 'my-app',
+      default: 'MyApp',
       filter: (name: string) => name.trim(),
       validate: (name: string) => validateProjectName(name),
     }));


### PR DESCRIPTION
Fixes #2472 

Changed default name for bare projects to match regex pattern in `expo init`.