### PR TITLE
[expo-cli] Fix 'generate-module' to support latest expo-module-template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🐛 Bug fixes
 
 - [expo-cli] expo upload:android - fix `--use-submission-service` not resulting in non-zero exit code when upload fails ([#2530](https://github.com/expo/expo-cli/pull/2530) by [@mymattcarroll](https://github.com/mymattcarroll))
+- [expo-cli] Fix `generate-module` to support latest `expo-module-template` ([#2510](https://github.com/expo/expo-cli/pull/2510) by [@barthap](https://github.com/barthap))
 
 ### 📦 Packages updated
 


### PR DESCRIPTION
## Why

Due to https://github.com/expo/expo/pull/9319, package `expo-module-templates` changed directory structure (`kotlin` was renamed to `java` under `android/src/main`).

Currently, npm-published `expo-module-template@8.3.1` tagged as `latest` still has `kotlin` directory, but version `8.4.0`/`next` has that directory renamed.

Current CLI `expo generate-module` expects `kotlin` as directory. This PR prepares it to also expect `java`.

## How

Created a function to check which of these directories exist. If both - choose java; if none - throw human readable error.

## Test plan

Tested for both `expo-module-template` versions (`latest` and `next`). Also tested for package with invalid directory structure.