### PR TITLE
[webpack-config] Allow empty string to skip favicon generation - added tests

### DIFF
--- a/packages/pwa/src/Manifest.ts
+++ b/packages/pwa/src/Manifest.ts
@@ -235,6 +235,10 @@ export function getFaviconIconConfig(config: ExpoConfig): IconOptions | null {
 
   // Allow empty objects
   if (typeof config.web?.favicon === 'string') {
+    // Empty string can be used to disable favicon generation.
+    if (!config.web?.favicon) {
+      return null;
+    }
     return validate(config.web.favicon);
   }
   if (typeof config.icon === 'string') {

--- a/packages/pwa/src/__tests__/Manifest-test.ts
+++ b/packages/pwa/src/__tests__/Manifest-test.ts
@@ -64,6 +64,14 @@ describe('getFaviconIconConfig', () => {
     const icon = Manifest.getFaviconIconConfig(config);
     expect(icon.src).toBe(config.icon);
   });
+  it(`allow empty favicon with empty string in web.favicon`, () => {
+    const config = {
+      web: { favicon: '' },
+      icon: 'icon',
+    };
+    const icon = Manifest.getFaviconIconConfig(config);
+    expect(icon).toBe(null);
+  });
 });
 describe('getSafariIconConfig', () => {
   it(`defaults to ios.icon`, () => {


### PR DESCRIPTION
- Skip favicon generation by passing an empty string `{ web.favicon: "" }`
- Wrote a unit test for this functionality -- missing in #2423 