### PR TITLE
[cli] Clean up upload results logs

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -83,6 +83,7 @@
     "command-exists": "^1.2.8",
     "commander": "2.17.1",
     "concat-stream": "1.6.2",
+    "clipboardy": "2.3.0",
     "dateformat": "3.0.3",
     "delay-async": "1.2.0",
     "env-editor": "^0.4.1",

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -156,7 +156,7 @@ export async function action(projectDir: string, options: Options = {}) {
     // TODO: replace with websiteUrl from server when it is available, if that makes sense.
     const websiteUrl = url.replace('exp.host', 'expo.io');
 
-    let productionMessage = `🚀  Production: ${log.chalk.bold(
+    let productionMessage = `⚙️   Project page: ${log.chalk.bold(
       urlTerminalLink(websiteUrl, websiteUrl)
     )}`;
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5050,6 +5050,11 @@ arch@^2.1.0:
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.1.tgz#8f5c2731aa35a30929221bb0640eed65175ec84e"
   integrity sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==
 
+arch@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.2.tgz#0c52bbe7344bb4fa260c443d2cbad9c00ff2f0bf"
+  integrity sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==
+
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
@@ -6689,6 +6694,15 @@ clipboardy@1.2.3:
   dependencies:
     arch "^2.1.0"
     execa "^0.8.0"
+
+clipboardy@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.3.0.tgz#3c2903650c68e46a91b388985bc2774287dba290"
+  integrity sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==
+  dependencies:
+    arch "^2.1.1"
+    execa "^1.0.0"
+    is-wsl "^2.1.1"
 
 cliui@^3.0.3, cliui@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
Part 1 of cleaning up, upload logs. This addresses the last two lines.

- format the terminal links better on default terminals that don't support links
- copy project page to the clipboard at the end
- utilize dimming and font treatments better
- remove redundant code

## Before

<img width="1145" alt="Screen Shot 2020-08-26 at 8 58 43 PM" src="https://user-images.githubusercontent.com/9664363/91382616-f48f2800-e7de-11ea-87b1-953c74d1362a.png">

## After

<img width="818" alt="Screen Shot 2020-08-26 at 8 55 36 PM" src="https://user-images.githubusercontent.com/9664363/91382475-a9751500-e7de-11ea-9187-5ad9a3f5d1fa.png">

