### PR TITLE
Added exitCode of 1 when android upload fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [expo-cli] expo upload:android - fix `--use-submission-service` not resulting in non-zero exit code when upload fails ([#2530](https://github.com/expo/expo-cli/pull/2530) by [@mymattcarroll](https://github.com/mymattcarroll))
+
 ### 📦 Packages updated
 
 ## [Wed Aug 26 12:13:11 2020 +0200](https://github.com/expo/expo-cli/commit/7d5820b3d6a32862205355a01684c66f3787354e)

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
@@ -217,6 +217,7 @@ class AndroidOnlineSubmitter {
         submissionStatus = submission.status;
         if (submissionStatus === SubmissionStatus.ERRORED) {
           submissionCompleted = true;
+          process.exitCode = 1;
           submissionSpinner.fail();
         } else if (submissionStatus === SubmissionStatus.FINISHED) {
           submissionCompleted = true;


### PR DESCRIPTION
## Why

Android upload using submission service does not result in a non-zero exit code for failed uploads. This makes the command silently fail in CI environments

- closes #2528 

## Test plan

Run `expo upload:android --use-submission-service --key ./invalid/google/account.json` in a project ensuring that the account does not have access to upload the app. Ensure that the exit code is non-zero. Can be easily seen in bash by using the `echo $?` command after running the upload command.