### PR TITLE
[expo-cli] changed error handling for ios upload to use fastlane exit code

### DIFF
--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -165,10 +165,8 @@ export default class IOSUploader extends BaseUploader {
     const appleCreds = { appleId, appleIdPassword, appleTeamId, companyName };
 
     log('Resolving the ITC team ID...');
-    const { itc_team_id: itcTeamId } = await runFastlaneAsync(
-      fastlane.resolveItcTeamId,
-      [],
-      appleCreds
+    const { itc_team_id: itcTeamId } = JSON.parse(
+      await runFastlaneAsync(fastlane.resolveItcTeamId, [], appleCreds)
     );
     log(`ITC team ID is ${itcTeamId}`);
     const updatedAppleCreds = {

--- a/packages/expo-cli/src/commands/upload/utils.ts
+++ b/packages/expo-cli/src/commands/upload/utils.ts
@@ -19,7 +19,7 @@ export async function runFastlaneAsync(
     companyName?: string;
   },
   pipeToLogger = false
-): Promise<{ [key: string]: any }> {
+): Promise<string> {
   const pipeToLoggerOptions: any = pipeToLogger
     ? { pipeToLogger: { stdout: true } }
     : { stdio: [0, 1, 'pipe'] };
@@ -46,21 +46,11 @@ export async function runFastlaneAsync(
     env,
   };
 
-  const { stderr } = await spawnAsyncThrowError(program, args, spawnOptions);
+  const { stderr, status } = await spawnAsyncThrowError(program, args, spawnOptions);
 
-  const res = JSON.parse(stderr);
-  if (res.result !== 'failure') {
-    return res;
-  } else {
-    let message =
-      res.reason !== 'Unknown reason'
-        ? res.reason
-        : res.rawDump?.message ?? 'Unknown error when running fastlane';
-    message = `${message}${
-      res?.rawDump?.backtrace
-        ? `\n${res.rawDump.backtrace.map((i: string) => `    ${i}`).join('\n')}`
-        : ''
-    }`;
-    throw new Error(message);
+  if (status !== 0) {
+    throw new Error(stderr);
   }
+
+  return stderr;
 }


### PR DESCRIPTION
### Why

- closes #2368

### Test plan

follow the steps in #2368, this should fix the issue.

If I could get some help running this locally, that would be greatly appreciated.