### PR TITLE
[expo-cli] eas build: collect build metadata

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
@@ -184,6 +184,10 @@ describe('build command', () => {
       });
       expect(mockPostAsync).toBeCalledTimes(1);
       expect(postArguments?.url).toEqual('projects/fakeProjectId/builds');
+      expect(postArguments?.body?.metadata).toMatchObject({
+        workflow: 'generic',
+        credentialsSource: 'local',
+      });
       expect(postArguments?.body?.job).toEqual({
         platform: 'android',
         type: 'generic',
@@ -221,6 +225,10 @@ describe('build command', () => {
       });
       expect(mockPostAsync).toBeCalledTimes(1);
       expect(postArguments?.url).toEqual('projects/fakeProjectId/builds');
+      expect(postArguments?.body?.metadata).toMatchObject({
+        workflow: 'generic',
+        credentialsSource: 'local',
+      });
       expect(postArguments?.body?.job).toEqual({
         platform: 'ios',
         type: 'generic',
@@ -257,49 +265,47 @@ describe('build command', () => {
       });
 
       expect(mockPostAsync).toBeCalledTimes(2);
-      expect(postArguments).toEqual(
-        expect.arrayContaining([
-          {
-            url: 'projects/fakeProjectId/builds',
-            body: {
-              job: {
-                platform: 'android',
-                type: 'generic',
-                projectUrl: mockProjectUrl,
-                artifactPath: 'android/app/build/outputs/**/*.{apk,aab}',
-                gradleCommand: ':app:bundleRelease',
-                secrets: {
-                  keystore: {
-                    dataBase64: keystore.base64,
-                    keystorePassword: 'keystorePassword',
-                    keyAlias: 'keyAlias',
-                    keyPassword: 'keyPassword',
-                  },
-                },
-              },
-            },
+
+      expect(postArguments[0]?.url).toEqual('projects/fakeProjectId/builds');
+      expect(postArguments[0]?.body?.metadata).toMatchObject({
+        workflow: 'generic',
+        credentialsSource: 'local',
+      });
+      expect(postArguments[0]?.body?.job).toMatchObject({
+        platform: 'android',
+        type: 'generic',
+        projectUrl: mockProjectUrl,
+        artifactPath: 'android/app/build/outputs/**/*.{apk,aab}',
+        gradleCommand: ':app:bundleRelease',
+        secrets: {
+          keystore: {
+            dataBase64: keystore.base64,
+            keystorePassword: 'keystorePassword',
+            keyAlias: 'keyAlias',
+            keyPassword: 'keyPassword',
           },
-          {
-            url: 'projects/fakeProjectId/builds',
-            body: {
-              job: {
-                platform: 'ios',
-                type: 'generic',
-                projectUrl: mockProjectUrl,
-                artifactPath: 'ios/build/App.ipa',
-                scheme: 'testapp',
-                secrets: {
-                  distributionCertificate: {
-                    dataBase64: cert.base64,
-                    password: 'certPass',
-                  },
-                  provisioningProfileBase64: pprofile.base64,
-                },
-              },
-            },
+        },
+      });
+
+      expect(postArguments[1]?.url).toEqual('projects/fakeProjectId/builds');
+      expect(postArguments[1]?.body?.metadata).toMatchObject({
+        workflow: 'generic',
+        credentialsSource: 'local',
+      });
+      expect(postArguments[1]?.body?.job).toMatchObject({
+        platform: 'ios',
+        type: 'generic',
+        projectUrl: mockProjectUrl,
+        artifactPath: 'ios/build/App.ipa',
+        scheme: 'testapp',
+        secrets: {
+          distributionCertificate: {
+            dataBase64: cert.base64,
+            password: 'certPass',
           },
-        ])
-      );
+          provisioningProfileBase64: pprofile.base64,
+        },
+      });
     });
   });
 });

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -11,6 +11,7 @@ import AndroidCredentialsProvider, {
 import {
   AndroidGenericBuildProfile,
   AndroidManagedBuildProfile,
+  CredentialsSource,
   Workflow,
 } from '../../../../easJson';
 import { gitAddAsync } from '../../../../git';
@@ -36,7 +37,9 @@ class AndroidBuilder implements Builder<Platform.Android> {
 
   public async setupAsync(): Promise<void> {}
 
-  public async ensureCredentialsAsync(): Promise<void> {
+  public async ensureCredentialsAsync(): Promise<
+    CredentialsSource.LOCAL | CredentialsSource.REMOTE | undefined
+  > {
     this.credentialsPrepared = true;
     if (!this.shouldLoadCredentials()) {
       return;
@@ -53,6 +56,7 @@ class AndroidBuilder implements Builder<Platform.Android> {
       this.ctx.commandCtx.nonInteractive
     );
     this.credentials = await provider.getCredentialsAsync(credentialsSource);
+    return credentialsSource;
   }
 
   public async configureProjectAsync(): Promise<void> {

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
@@ -54,16 +54,15 @@ describe('AndroidBuilder', () => {
     it('should prepare valid job', async () => {
       setupCredentialsConfig();
       const ctx: any = {
-        eas: {
-          builds: {
-            android: {
-              credentialsSource: 'local',
-              workflow: 'generic',
-            },
-          },
+        platform: 'android',
+        buildProfile: {
+          credentialsSource: 'local',
+          workflow: 'generic',
         },
-        projectDir: '.',
-        user: jest.fn(),
+        commandCtx: {
+          projectDir: '.',
+          user: jest.fn(),
+        },
       };
       const builder = new AndroidBuilder(ctx);
       await builder.ensureCredentialsAsync();
@@ -90,16 +89,15 @@ describe('AndroidBuilder', () => {
     it('should prepare valid job', async () => {
       setupCredentialsConfig();
       const ctx: any = {
-        eas: {
-          builds: {
-            android: {
-              credentialsSource: 'local',
-              workflow: 'managed',
-            },
-          },
+        platform: 'android',
+        buildProfile: {
+          credentialsSource: 'local',
+          workflow: 'managed',
         },
-        projectDir: '.',
-        user: jest.fn(),
+        commandCtx: {
+          projectDir: '.',
+          user: jest.fn(),
+        },
       };
       const builder = new AndroidBuilder(ctx);
       await builder.ensureCredentialsAsync();

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
@@ -65,18 +65,17 @@ describe('iOSBuilder', () => {
     it('should prepare valid job', async () => {
       setupCredentialsConfig();
       const ctx: any = {
-        eas: {
-          builds: {
-            ios: {
-              credentialsSource: 'local',
-              workflow: 'generic',
-              scheme: 'testapp',
-            },
-          },
+        platform: 'ios',
+        buildProfile: {
+          credentialsSource: 'local',
+          workflow: 'generic',
+          scheme: 'testapp',
         },
-        projectDir: '.',
-        user: jest.fn(),
-        exp: { ios: { bundleIdentifier: 'example.bundle.identifier' } },
+        commandCtx: {
+          projectDir: '.',
+          user: jest.fn(),
+          exp: { ios: { bundleIdentifier: 'example.bundle.identifier' } },
+        },
       };
       const builder = new iOSBuilder(ctx);
       await builder.setupAsync();
@@ -103,17 +102,16 @@ describe('iOSBuilder', () => {
     it('should prepare valid job', async () => {
       setupCredentialsConfig();
       const ctx: any = {
-        eas: {
-          builds: {
-            ios: {
-              credentialsSource: 'local',
-              workflow: 'managed',
-            },
-          },
+        platform: 'ios',
+        buildProfile: {
+          credentialsSource: 'local',
+          workflow: 'managed',
         },
-        projectDir: '.',
-        user: jest.fn(),
-        exp: { ios: { bundleIdentifier: 'example.bundle.identifier' } },
+        commandCtx: {
+          projectDir: '.',
+          user: jest.fn(),
+          exp: { ios: { bundleIdentifier: 'example.bundle.identifier' } },
+        },
       };
       const builder = new iOSBuilder(ctx);
       await builder.ensureCredentialsAsync();

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -9,7 +9,12 @@ import iOSCredentialsProvider, {
   iOSCredentials,
 } from '../../../../credentials/provider/iOSCredentialsProvider';
 import * as ProvisioningProfileUtils from '../../../../credentials/utils/provisioningProfile';
-import { Workflow, iOSGenericBuildProfile, iOSManagedBuildProfile } from '../../../../easJson';
+import {
+  CredentialsSource,
+  Workflow,
+  iOSGenericBuildProfile,
+  iOSManagedBuildProfile,
+} from '../../../../easJson';
 import log from '../../../../log';
 import prompts from '../../../../prompts';
 import { ensureCredentialsAsync } from '../credentials';
@@ -45,7 +50,9 @@ class iOSBuilder implements Builder<Platform.iOS> {
     }
   }
 
-  public async ensureCredentialsAsync(): Promise<void> {
+  public async ensureCredentialsAsync(): Promise<
+    CredentialsSource.LOCAL | CredentialsSource.REMOTE | undefined
+  > {
     if (!this.shouldLoadCredentials()) {
       return;
     }
@@ -66,6 +73,7 @@ class iOSBuilder implements Builder<Platform.iOS> {
       this.ctx.commandCtx.nonInteractive
     );
     this.credentials = await provider.getCredentialsAsync(credentialsSource);
+    return credentialsSource;
   }
 
   public async setupAsync(): Promise<void> {

--- a/packages/expo-cli/src/commands/eas-build/build/metadata.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/metadata.ts
@@ -33,9 +33,8 @@ export type BuildMetadata = {
   /**
    * Credentials source
    * Credentials could be obtained either from credential.json or Expo servers.
-   * Auto mode means that both sources will be checked.
    */
-  credentialsSource: CredentialsSource;
+  credentialsSource?: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
 
   /**
    * Expo SDK version
@@ -53,13 +52,19 @@ export type BuildMetadata = {
 
 async function collectMetadata<T extends AndroidBuildProfile | iOSBuildProfile>(
   commandCtx: CommandContext,
-  buildProfile: T
+  {
+    credentialsSource,
+    buildProfile,
+  }: {
+    credentialsSource?: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
+    buildProfile: T;
+  }
 ): Promise<BuildMetadata> {
   return {
     appVersion: commandCtx.exp.version,
     cliVersion: packageJSON.version,
     workflow: buildProfile.workflow,
-    credentialsSource: buildProfile.credentialsSource,
+    credentialsSource,
     sdkVersion: commandCtx.exp.sdkVersion,
   };
 }

--- a/packages/expo-cli/src/commands/eas-build/build/metadata.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/metadata.ts
@@ -1,0 +1,67 @@
+import {
+  AndroidBuildProfile,
+  CredentialsSource,
+  Workflow,
+  iOSBuildProfile,
+} from '../../../easJson';
+import { CommandContext } from './types';
+
+/**
+ * We use require() to exclude package.json from TypeScript's analysis since it lives outside
+ * the src directory and would change the directory structure of the emitted files
+ * under the build directory
+ */
+const packageJSON = require('../../../../package.json');
+
+export type BuildMetadata = {
+  /**
+   * Application version (the expo.version key in app.json/app.config.js)
+   */
+  appVersion: string;
+
+  /**
+   * Expo CLI version
+   */
+  cliVersion: string;
+
+  /**
+   * Build workflow
+   * It's either 'generic' or 'managed'
+   */
+  workflow: Workflow;
+
+  /**
+   * Credentials source
+   * Credentials could be obtained either from credential.json or Expo servers.
+   * Auto mode means that both sources will be checked.
+   */
+  credentialsSource: CredentialsSource;
+
+  /**
+   * Expo SDK version
+   * It's determined by the expo package version in package.json.
+   * It's undefined if the expo package is not installed for the project.
+   */
+  sdkVersion?: string;
+
+  /**
+   * Release channel (for expo-updates)
+   * It's undefined if the expo-updates package is not installed for the project.
+   */
+  releaseChannel?: string;
+};
+
+async function collectMetadata<T extends AndroidBuildProfile | iOSBuildProfile>(
+  commandCtx: CommandContext,
+  buildProfile: T
+): Promise<BuildMetadata> {
+  return {
+    appVersion: commandCtx.exp.version,
+    cliVersion: packageJSON.version,
+    workflow: buildProfile.workflow,
+    credentialsSource: buildProfile.credentialsSource,
+    sdkVersion: commandCtx.exp.sdkVersion,
+  };
+}
+
+export { collectMetadata };

--- a/packages/expo-cli/src/commands/eas-build/build/types.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/types.ts
@@ -1,27 +1,37 @@
-import { Job } from '@expo/build-tools';
+import { Job, Platform } from '@expo/build-tools';
 import { ExpoConfig } from '@expo/config';
 import { User } from '@expo/xdl';
 
-import { EasConfig } from '../../../easJson';
+import { AndroidBuildProfile, iOSBuildProfile } from '../../../easJson';
 import { BuildCommandPlatform } from '../types';
 
-export interface BuilderContext {
+export interface CommandContext {
+  commandPlatform: BuildCommandPlatform;
+  profile: string;
   projectDir: string;
-  eas: EasConfig;
   user: User;
   accountName: string;
   projectName: string;
   exp: ExpoConfig;
-  platform: BuildCommandPlatform;
   nonInteractive: boolean;
   skipCredentialsCheck: boolean;
   skipProjectConfiguration: boolean;
 }
 
-export interface Builder {
-  ctx: BuilderContext;
+export interface Builder<T extends Platform> {
+  ctx: BuilderContext<T>;
   setupAsync(): Promise<void>;
   ensureCredentialsAsync(): Promise<void>;
   configureProjectAsync(): Promise<void>;
   prepareJobAsync(archiveUrl: string): Promise<Job>;
 }
+
+export interface BuilderContext<T extends Platform> {
+  commandCtx: CommandContext;
+  platform: T;
+  buildProfile: T extends Platform.Android ? AndroidBuildProfile : iOSBuildProfile;
+}
+
+export type PlatformBuildProfile<T extends Platform> = T extends Platform.Android
+  ? AndroidBuildProfile
+  : iOSBuildProfile;

--- a/packages/expo-cli/src/commands/eas-build/build/types.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/types.ts
@@ -2,11 +2,11 @@ import { Job, Platform } from '@expo/build-tools';
 import { ExpoConfig } from '@expo/config';
 import { User } from '@expo/xdl';
 
-import { AndroidBuildProfile, iOSBuildProfile } from '../../../easJson';
+import { AndroidBuildProfile, CredentialsSource, iOSBuildProfile } from '../../../easJson';
 import { BuildCommandPlatform } from '../types';
 
 export interface CommandContext {
-  commandPlatform: BuildCommandPlatform;
+  requestedPlatform: BuildCommandPlatform;
   profile: string;
   projectDir: string;
   user: User;
@@ -21,7 +21,7 @@ export interface CommandContext {
 export interface Builder<T extends Platform> {
   ctx: BuilderContext<T>;
   setupAsync(): Promise<void>;
-  ensureCredentialsAsync(): Promise<void>;
+  ensureCredentialsAsync(): Promise<CredentialsSource.LOCAL | CredentialsSource.REMOTE | undefined>;
   configureProjectAsync(): Promise<void>;
   prepareJobAsync(archiveUrl: string): Promise<Job>;
 }

--- a/packages/expo-cli/src/easJson.ts
+++ b/packages/expo-cli/src/easJson.ts
@@ -49,6 +49,7 @@ export interface iOSGenericBuildProfile {
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;
 export type iOSBuildProfile = iOSManagedBuildProfile | iOSGenericBuildProfile;
+export type BuildProfile = AndroidBuildProfile | iOSBuildProfile;
 
 interface EasJson {
   builds: {
@@ -150,7 +151,7 @@ export class EasJsonReader {
     };
   }
 
-  private validateBuildProfile<T>(
+  private validateBuildProfile<T extends BuildProfile>(
     platform: 'android' | 'ios' | 'all',
     buildProfileName: string,
     buildProfile?: { workflow: Workflow } & object


### PR DESCRIPTION
I added sending some basic build metadata to www: 
- app version (`expo.version` from `app.json`)
- expo-cli version
- workflow - either `generic` or `managed`
- credentials source - `auto`, `local` or `remote`
- sdk version - the expo package version