### PR TITLE
[xdl] Remove expo-image from SDK39 standalone apps

### DIFF
--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -403,10 +403,10 @@ function _renderUnversionedUniversalModulesDependencies(
   const sdkMajorVersion = parseSdkMajorVersion(sdkVersion);
 
   if (sdkMajorVersion >= 33) {
-    const excludedUnimodules = ['expo-bluetooth', 'expo-in-app-purchases', 'expo-payments-stripe'];
+    const excludedUnimodules = ['expo-bluetooth', 'expo-in-app-purchases', 'expo-payments-stripe', 'expo-image'];
 
     if (sdkMajorVersion < 39) {
-      excludedUnimodules.push('expo-splash-screen', 'expo-image', 'expo-updates');
+      excludedUnimodules.push('expo-splash-screen', 'expo-updates');
     }
 
     return indentString(


### PR DESCRIPTION
We don't advertise `expo-image` as production ready yet