### PR TITLE
[image-utils] fix: backgroundColor setting when using jimp.resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 - [expo-cli] expo upload:android - fix `--use-submission-service` not resulting in non-zero exit code when upload fails ([#2530](https://github.com/expo/expo-cli/pull/2530) by [@mymattcarroll](https://github.com/mymattcarroll))
 - [expo-cli] Fix `generate-module` to support latest `expo-module-template` ([#2510](https://github.com/expo/expo-cli/pull/2510) by [@barthap](https://github.com/barthap))
+- [image-utils] Fix setting background color when calling `Jimp.resize` ([#2535](https://github.com/expo/expo-cli/pull/2535) by [@cruzach](https://github.com/cruzach))
 
 ### 📦 Packages updated
 

--- a/packages/image-utils/src/jimp.ts
+++ b/packages/image-utils/src/jimp.ts
@@ -105,7 +105,11 @@ export async function resize(
     );
   }
   if (background) {
-    initialImage = initialImage.background(Jimp.cssColorToHex(background));
+    initialImage = initialImage.composite(new Jimp(width, height, background), 0, 0, {
+      mode: Jimp.BLEND_DESTINATION_OVER,
+      opacitySource: 1,
+      opacityDest: 1,
+    });
   }
 
   return await initialImage.quality(jimpQuality);


### PR DESCRIPTION
# why 

`.background()` wasn't working, unless setting the background color to white. 

# how

`composite()` the original image on top of an image of the same height & width with the specified background color

# test

call 
```
await generateImageAsync(
            { projectRoot, cacheType: 'my-cache-type' },
            {
              src: icon,
              width: iconSizePx,
              height: iconSizePx,
              resizeMode: 'cover',
              backgroundColor: "#FF69B4"  // use any color but white
            }
          )
```

where `icon` is an image with transparency before & after this change to see 