### PR TITLE
[cli] Redesign help prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [expo-cli] expo --help redesigned ([#2538](https://github.com/expo/expo-cli/pull/2538) by [@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] expo upload - support tar.gz files from builds v2 ([#2504](https://github.com/expo/expo-cli/pull/2504) by [@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] Implemented keychain storage for Apple ID ([#2508](https://github.com/expo/expo-cli/pull/2508) by [@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] expo publish - Clean up upload results logs ([#2516](https://github.com/expo/expo-cli/pull/2516) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/dev-tools/server/dev-server.ts
+++ b/packages/dev-tools/server/dev-server.ts
@@ -13,7 +13,7 @@ async function run(): Promise<void> {
   try {
     const projectDir = process.argv[2];
     if (!projectDir) {
-      throw new Error('No project dir specified.\nUsage: yarn dev <project-dir>');
+      throw new Error('No project dir specified.\nUsage: yarn dev <path>');
     }
 
     const app: any = next({ dev: true });

--- a/packages/dev-tools/server/dev-server.ts
+++ b/packages/dev-tools/server/dev-server.ts
@@ -13,7 +13,7 @@ async function run(): Promise<void> {
   try {
     const projectDir = process.argv[2];
     if (!projectDir) {
-      throw new Error('No project dir specified.\nUsage: yarn dev <path>');
+      throw new Error('No project dir specified.\nUsage: yarn dev [path]');
     }
 
     const app: any = next({ dev: true });

--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -1,12 +1,13 @@
 import JsonFile from '@expo/json-file';
 import path from 'path';
+import stripAnsi from 'strip-ansi';
 import temporary from 'tempy';
 
 import { runAsync, tryRunAsync } from '../TestUtils';
 
 test('init --help', async () => {
   const { stdout } = await runAsync(['init', '--help']);
-  expect(stdout).toMatch('Usage: init');
+  expect(stripAnsi(stdout)).toMatch('Usage: init');
 });
 
 test('init (no dir name)', async () => {

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -111,6 +111,7 @@
     "react-dev-utils": "~10.2.1",
     "semver": "5.5.0",
     "slash": "1.0.0",
+    "strip-ansi": "^6.0.0",
     "tar": "^6.0.5",
     "tempy": "^0.3.0",
     "terminal-link": "^2.1.1",

--- a/packages/expo-cli/src/commands/apply.ts
+++ b/packages/expo-cli/src/commands/apply.ts
@@ -36,9 +36,9 @@ async function ensureConfigExistsAsync(projectRoot: string): Promise<void> {
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('apply <path>')
+    .command('apply [path]')
     .option(
       '-p, --platform [platform]',
       'Configure only the given platform ("ios" or "android")',

--- a/packages/expo-cli/src/commands/apply.ts
+++ b/packages/expo-cli/src/commands/apply.ts
@@ -36,17 +36,18 @@ async function ensureConfigExistsAsync(projectRoot: string): Promise<void> {
   }
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('apply [project-dir]')
+    .command('apply <path>')
     .option(
       '-p, --platform [platform]',
       'Configure only the given platform ("ios" or "android")',
       /^(android|ios)$/i
     )
+    .helpGroup('experimental')
     // .option('--interactive', 'TODO: provide a flag where people can see a diff for each option to be applied and approve or reject it')
     .description(
-      'Take the configuration from app.json or app.config.js and apply it to a native project.'
+      'Take the configuration from app.json or app.config.js and apply it to a native project'
     )
     .asyncActionProjectDir(async (projectDir: string, options: Options) => {
       await ensureConfigExistsAsync(projectDir);

--- a/packages/expo-cli/src/commands/apply.ts
+++ b/packages/expo-cli/src/commands/apply.ts
@@ -46,9 +46,7 @@ export default function(program: Command) {
     )
     .helpGroup('experimental')
     // .option('--interactive', 'TODO: provide a flag where people can see a diff for each option to be applied and approve or reject it')
-    .description(
-      'Take the configuration from app.json or app.config.js and apply it to a native project'
-    )
+    .description('Sync the configuration from app.json to a native project')
     .asyncActionProjectDir(async (projectDir: string, options: Options) => {
       await ensureConfigExistsAsync(projectDir);
 

--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -50,10 +50,11 @@ async function maybeBailOnWorkflowWarning({
   return !answer.ignoreWorkflowWarning;
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('build:ios [project-dir]')
+    .command('build:ios <path>')
     .alias('bi')
+    .helpGroup('build')
     .option('-c, --clear-credentials', 'Clear all credentials stored on Expo servers.')
     .option('--clear-dist-cert', 'Remove Distribution Certificate stored on Expo servers.')
     .option('--clear-push-key', 'Remove Push Notifications Key stored on Expo servers.')
@@ -88,9 +89,7 @@ export default function (program: Command) {
     )
     .option('--skip-credentials-check', 'Skip checking credentials.')
     .option('--skip-workflow-check', 'Skip warning about build service bare workflow limitations.')
-    .description(
-      'Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.'
-    )
+    .description('Build and sign a standalone IPA for the Apple App Store')
     .asyncActionProjectDir(
       async (projectDir: string, options: IosOptions) => {
         if (!options.skipWorkflowCheck) {
@@ -126,8 +125,9 @@ export default function (program: Command) {
     );
 
   program
-    .command('build:android [project-dir]')
+    .command('build:android <path>')
     .alias('ba')
+    .helpGroup('build')
     .option('-c, --clear-credentials', 'Clear stored credentials.')
     .option('--release-channel <channel-name>', 'Pull from specified release channel.', 'default')
     .option('--no-publish', 'Disable automatic publishing before building.')
@@ -138,9 +138,7 @@ export default function (program: Command) {
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     .option('--skip-workflow-check', 'Skip warning about build service bare workflow limitations.')
     .option('-t --type <build>', 'Type of build: [app-bundle|apk].')
-    .description(
-      'Build a standalone APK or App Bundle for your project, signed and ready for submission to the Google Play Store.'
-    )
+    .description('Build and sign a standalone APK or App Bundle for the Google Play Store')
     .asyncActionProjectDir(
       async (projectDir: string, options: AndroidOptions) => {
         if (options.generateKeystore) {
@@ -178,14 +176,15 @@ export default function (program: Command) {
     );
 
   program
-    .command('build:web [project-dir]')
+    .command('build:web <path>')
+    .helpGroup('build')
     .option('-c, --clear', 'Clear all cached build files and assets.')
     .option(
       '--no-pwa',
       'Prevent webpack from generating the manifest.json and injecting meta into the index.html head.'
     )
     .option('-d, --dev', 'Turns dev flag on before bundling')
-    .description('Build a production bundle for your project, compressed and ready for deployment.')
+    .description('Build the web app for production')
     .asyncActionProjectDir(
       (projectDir: string, options: { pwa: boolean; clear: boolean; dev: boolean }) => {
         return Webpack.bundleAsync(projectDir, {
@@ -196,13 +195,14 @@ export default function (program: Command) {
     );
 
   program
-    .command('build:status [project-dir]')
+    .command('build:status <path>')
     .alias('bs')
+    .helpGroup('build')
     .option(
       '--public-url <url>',
       'The URL of an externally hosted manifest (for self-hosted apps).'
     )
-    .description(`Gets the status of a current (or most recently finished) build for your project.`)
+    .description(`Get the status of the latest build for the project`)
     .asyncActionProjectDir(async (projectDir: string, options: { publicUrl?: string }) => {
       if (options.publicUrl && !UrlUtils.isHttps(options.publicUrl)) {
         throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');

--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -27,13 +27,15 @@ async function action(projectDir: string, options: Options) {
   }
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('bundle-assets [project-dir]')
+    .command(
+      'bundle-assets <path>',
+      'Bundles assets for a detached app. This command should be executed from xcode or gradle',
+      { noHelp: true }
+    )
+    .helpGroup('internal')
     .option('--dest [dest]', 'Destination directory for assets')
     .option('--platform [platform]', 'detached project platform')
-    .description(
-      'Bundles assets for a detached app. This command should be executed from xcode or gradle.'
-    )
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -29,10 +29,9 @@ async function action(projectDir: string, options: Options) {
 
 export default function(program: Command) {
   program
-    .command(
-      'bundle-assets <path>',
-      'Bundle assets for a detached app. This command should be executed from xcode or gradle',
-      { noHelp: true }
+    .command('bundle-assets <path>')
+    .description(
+      'Bundle assets for a detached app. This command should be executed from xcode or gradle'
     )
     .helpGroup('internal')
     .option('--dest [dest]', 'Destination directory for assets')

--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -31,7 +31,7 @@ export default function(program: Command) {
   program
     .command(
       'bundle-assets <path>',
-      'Bundles assets for a detached app. This command should be executed from xcode or gradle',
+      'Bundle assets for a detached app. This command should be executed from xcode or gradle',
       { noHelp: true }
     )
     .helpGroup('internal')

--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -27,9 +27,9 @@ async function action(projectDir: string, options: Options) {
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('bundle-assets <path>')
+    .command('bundle-assets [path]')
     .description(
       'Bundle assets for a detached app. This command should be executed from xcode or gradle'
     )

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -24,15 +24,19 @@ import * as ClientUpgradeUtils from '../utils/ClientUpgradeUtils';
 import { createClientBuildRequest, getExperienceName, isAllowedToBuild } from './clientBuildApi';
 import generateBundleIdentifier from './generateBundleIdentifier';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('client:ios [project-dir]')
+    .command('client:ios <path>')
+    .helpGroup('experimental')
+    .description(
+      'Experimental: build a custom version of the Expo client for iOS using your own Apple credentials'
+    )
+    .longDescription(
+      'Build a custom version of the Expo client for iOS using your own Apple credentials and install it on your mobile device using Safari.'
+    )
     .option(
       '--apple-id <login>',
       'Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable).'
-    )
-    .description(
-      'Build a custom version of the Expo client for iOS using your own Apple credentials and install it on your mobile device using Safari.'
     )
     .asyncActionProjectDir(
       async (
@@ -287,6 +291,7 @@ export default function (program: Command) {
   program
     .command('client:install:ios')
     .description('Install the Expo client for iOS on the simulator')
+    .helpGroup('client')
     .asyncAction(async () => {
       const currentSdkConfig = await ClientUpgradeUtils.getExpoSdkConfig(process.cwd());
       const currentSdkVersion = currentSdkConfig ? currentSdkConfig.sdkVersion : undefined;
@@ -372,6 +377,7 @@ export default function (program: Command) {
   program
     .command('client:install:android')
     .description('Install the Expo client for Android on a connected device or emulator')
+    .helpGroup('client')
     .asyncAction(async () => {
       const currentSdkConfig = await ClientUpgradeUtils.getExpoSdkConfig(process.cwd());
       const currentSdkVersion = currentSdkConfig ? currentSdkConfig.sdkVersion : undefined;

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -24,9 +24,9 @@ import * as ClientUpgradeUtils from '../utils/ClientUpgradeUtils';
 import { createClientBuildRequest, getExperienceName, isAllowedToBuild } from './clientBuildApi';
 import generateBundleIdentifier from './generateBundleIdentifier';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('client:ios <path>')
+    .command('client:ios [path]')
     .helpGroup('experimental')
     .description(
       'Experimental: build a custom version of the Expo client for iOS using your own Apple credentials'

--- a/packages/expo-cli/src/commands/credentials.ts
+++ b/packages/expo-cli/src/commands/credentials.ts
@@ -14,10 +14,11 @@ type Options = {
   };
 };
 
-export default function (program: CommanderStatic) {
+export default function(program: CommanderStatic) {
   program
     .command('credentials:manager')
     .description('Manage your credentials')
+    .helpGroup('credentials')
     .option('-p --platform <platform>', 'Platform: [android|ios]', /^(android|ios)$/i)
     .asyncAction(async (options: Options) => {
       const projectDir = process.cwd();

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -145,9 +145,9 @@ export async function action(projectDir: string = './', options: Options = { for
   await generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder });
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('customize:web <path>')
+    .command('customize:web [path]')
     .description('Eject the default web files for customization')
     .helpGroup('eject')
     .option('-f, --force', 'Allows replacing existing files')

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -145,10 +145,11 @@ export async function action(projectDir: string = './', options: Options = { for
   await generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder });
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('customize:web [project-dir]')
-    .description('Generate static web files into your project.')
+    .command('customize:web <path>')
+    .description('Eject the default web files for customization')
+    .helpGroup('eject')
     .option('-f, --force', 'Allows replacing existing files')
     .allowOffline()
     .asyncAction(action);

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -31,7 +31,7 @@ async function action(): Promise<void> {
 export default function(program: Command) {
   program
     .command('diagnostics <path>')
-    .description('Prints environment info to console')
+    .description('Log environment info to the console')
     .helpGroup('info')
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -28,9 +28,10 @@ async function action(): Promise<void> {
   console.log(info);
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('diagnostics [project-dir]')
-    .description('Prints environment info to console.')
+    .command('diagnostics <path>')
+    .description('Prints environment info to console')
+    .helpGroup('info')
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -28,9 +28,9 @@ async function action(): Promise<void> {
   console.log(info);
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('diagnostics <path>')
+    .command('diagnostics [path]')
     .description('Log environment info to the console')
     .helpGroup('info')
     .asyncAction(action);

--- a/packages/expo-cli/src/commands/doctor.ts
+++ b/packages/expo-cli/src/commands/doctor.ts
@@ -16,7 +16,7 @@ async function action(projectDir: string) {
 export default function(program: Command) {
   program
     .command('doctor <path>')
-    .description('Diagnoses issues with your Expo project')
+    .description('Diagnose issues with your project')
     .helpGroup('info')
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/doctor.ts
+++ b/packages/expo-cli/src/commands/doctor.ts
@@ -8,7 +8,7 @@ async function action(projectDir: string) {
   await Doctor.validateExpoServersAsync(projectDir);
 
   if ((await Doctor.validateWithNetworkAsync(projectDir)) === Doctor.NO_ISSUES) {
-    log(`Didn't find any issues with your project!`);
+    log(`Didn't find any issues with the project!`);
   }
   process.exit();
 }
@@ -16,7 +16,7 @@ async function action(projectDir: string) {
 export default function(program: Command) {
   program
     .command('doctor <path>')
-    .description('Diagnose issues with your project')
+    .description('Diagnose issues with the project')
     .helpGroup('info')
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/doctor.ts
+++ b/packages/expo-cli/src/commands/doctor.ts
@@ -13,9 +13,10 @@ async function action(projectDir: string) {
   process.exit();
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('doctor [project-dir]')
-    .description('Diagnoses issues with your Expo project.')
+    .command('doctor <path>')
+    .description('Diagnoses issues with your Expo project')
+    .helpGroup('info')
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/doctor.ts
+++ b/packages/expo-cli/src/commands/doctor.ts
@@ -13,9 +13,9 @@ async function action(projectDir: string) {
   process.exit();
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('doctor <path>')
+    .command('doctor [path]')
     .description('Diagnose issues with the project')
     .helpGroup('info')
     .asyncActionProjectDir(action);

--- a/packages/expo-cli/src/commands/eas-build/index.ts
+++ b/packages/expo-cli/src/commands/eas-build/index.ts
@@ -37,7 +37,7 @@ export default function(program: Command) {
 
   program
     .command('eas:build:status <path>')
-    .description('Get the status of the latest builds for your project.')
+    .description('Log the status of the latest builds for your project.')
     .option(
       '-p --platform <platform>',
       'Get builds for specified platform: ios, android, all',

--- a/packages/expo-cli/src/commands/eas-build/index.ts
+++ b/packages/expo-cli/src/commands/eas-build/index.ts
@@ -6,7 +6,7 @@ import buildAction from './build/action';
 import credentialsSyncAction from './credentialsSync/action';
 import statusAction from './status/action';
 
-export default function (program: Command) {
+export default function(program: Command) {
   // don't register `expo eas:build:*` commands if eas.json doesn't exist
   const easJsonPath = path.join(process.cwd(), 'eas.json');
   if (!fs.pathExistsSync(easJsonPath)) {
@@ -14,7 +14,7 @@ export default function (program: Command) {
   }
 
   program
-    .command('eas:credentials:sync [project-dir]')
+    .command('eas:credentials:sync <path>')
     .description('Update credentials.json with credentials stored on Expo servers')
     .asyncActionProjectDir(credentialsSyncAction, {
       checkConfig: true,
@@ -22,7 +22,7 @@ export default function (program: Command) {
     });
 
   program
-    .command('eas:build [project-dir]')
+    .command('eas:build <path>')
     .description('Build an app binary for your project.')
     .option(
       '-p --platform <platform>',
@@ -36,7 +36,7 @@ export default function (program: Command) {
     .asyncActionProjectDir(buildAction, { checkConfig: true, skipSDKVersionRequirement: true });
 
   program
-    .command('eas:build:status [project-dir]')
+    .command('eas:build:status <path>')
     .description('Get the status of the latest builds for your project.')
     .option(
       '-p --platform <platform>',

--- a/packages/expo-cli/src/commands/eas-build/index.ts
+++ b/packages/expo-cli/src/commands/eas-build/index.ts
@@ -6,7 +6,7 @@ import buildAction from './build/action';
 import credentialsSyncAction from './credentialsSync/action';
 import statusAction from './status/action';
 
-export default function(program: Command) {
+export default function (program: Command) {
   // don't register `expo eas:build:*` commands if eas.json doesn't exist
   const easJsonPath = path.join(process.cwd(), 'eas.json');
   if (!fs.pathExistsSync(easJsonPath)) {
@@ -14,7 +14,7 @@ export default function(program: Command) {
   }
 
   program
-    .command('eas:credentials:sync <path>')
+    .command('eas:credentials:sync [path]')
     .description('Update credentials.json with credentials stored on Expo servers')
     .asyncActionProjectDir(credentialsSyncAction, {
       checkConfig: true,
@@ -22,7 +22,7 @@ export default function(program: Command) {
     });
 
   program
-    .command('eas:build <path>')
+    .command('eas:build [path]')
     .description('Build an app binary for your project.')
     .option(
       '-p --platform <platform>',
@@ -36,7 +36,7 @@ export default function(program: Command) {
     .asyncActionProjectDir(buildAction, { checkConfig: true, skipSDKVersionRequirement: true });
 
   program
-    .command('eas:build:status <path>')
+    .command('eas:build:status [path]')
     .description('Log the status of the latest builds for your project.')
     .option(
       '-p --platform <platform>',

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -47,16 +47,21 @@ async function action(
   }
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('eject [project-dir]')
+    .command('eject <path>')
     .description(
+      // TODO: Use Learn more link when it lands
+      `Create native iOS and Android project files. Read more: https://expo.fyi/eject`
+    )
+    .longDescription(
       'Creates Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.'
     )
+    .helpGroup('eject')
     .option(
       '--eject-method [type]',
       `Eject method to use. [Depreacted]: Ejecting to ExpoKit is not available on SDK >= 37 and not recommended for older SDK versions. We recommend updating to SDK >= 37 and ejecting to bare.`,
-      value => value.toLowerCase()
+      (value: string) => value.toLowerCase()
     )
     .option(
       '-f --force',

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -55,7 +55,7 @@ export default function(program: Command) {
       `Create native iOS and Android project files. Read more: https://expo.fyi/eject`
     )
     .longDescription(
-      'Creates Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.'
+      'Create Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.'
     )
     .helpGroup('eject')
     .option(

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -47,9 +47,9 @@ async function action(
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('eject <path>')
+    .command('eject [path]')
     .description(
       // TODO: Use Learn more link when it lands
       `Create native iOS and Android project files. Read more: https://expo.fyi/eject`

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -169,9 +169,9 @@ function collect<T>(val: T, memo: T[]): T[] {
   return memo;
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('export <path>')
+    .command('export [path]')
     .description('Export the static files of the app for hosting it on a web server')
     .helpGroup('core')
     .option('-p, --public-url <url>', 'The public url that will host the static files. (Required)')

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -169,10 +169,11 @@ function collect<T>(val: T, memo: T[]): T[] {
   return memo;
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('export [project-dir]')
-    .description('Exports the static files of the app for hosting it on a web server.')
+    .command('export <path>')
+    .description('Exports the static files of the app for hosting it on a web server')
+    .helpGroup('core')
     .option('-p, --public-url <url>', 'The public url that will host the static files. (Required)')
     .option(
       '--output-dir <dir>',

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -172,7 +172,7 @@ function collect<T>(val: T, memo: T[]): T[] {
 export default function(program: Command) {
   program
     .command('export <path>')
-    .description('Exports the static files of the app for hosting it on a web server')
+    .description('Export the static files of the app for hosting it on a web server')
     .helpGroup('core')
     .option('-p, --public-url <url>', 'The public url that will host the static files. (Required)')
     .option(
@@ -186,7 +186,7 @@ export default function(program: Command) {
       './assets'
     )
     .option('-d, --dump-assetmap', 'Dump the asset map for further processing.')
-    .option('--dev', 'Configures static files for developing locally using a non-https server')
+    .option('--dev', 'Configure static files for developing locally using a non-https server')
     .option('-f, --force', 'Overwrite files in output directory without prompting for confirmation')
     .option('-s, --dump-sourcemap', 'Dump the source map for debugging the JS bundle.')
     .option('-q, --quiet', 'Suppress verbose output.')

--- a/packages/expo-cli/src/commands/fetch/index.ts
+++ b/packages/expo-cli/src/commands/fetch/index.ts
@@ -7,32 +7,40 @@ import {
 } from './android';
 import fetchIosCerts from './ios';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('fetch:ios:certs [project-dir]')
-    .description(
+    .command('fetch:ios:certs <path>')
+    .description(`Download the project's iOS standalone app signing credentials`)
+    .longDescription(
       `Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.`
     )
+    .helpGroup('credentials')
     .asyncActionProjectDir(fetchIosCerts);
 
   program
-    .command('fetch:android:keystore [project-dir]')
-    .description(
+    .command('fetch:android:keystore <path>')
+    .description("Download the project's Android keystore")
+    .longDescription(
       "Fetch this project's Android Keystore. Writes Keystore to PROJECT_DIR/PROJECT_NAME.jks and prints passwords to stdout."
     )
+    .helpGroup('credentials')
     .asyncActionProjectDir(fetchAndroidKeystoreAsync);
 
   program
-    .command('fetch:android:hashes [project-dir]')
-    .description(
+    .command('fetch:android:hashes <path>')
+    .description("Compute and log the project's Android key hashes")
+    .longDescription(
       "Fetch this project's Android key hashes needed to set up Google/Facebook authentication. Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console."
     )
+    .helpGroup('credentials')
     .asyncActionProjectDir(fetchAndroidHashesAsync);
 
   program
-    .command('fetch:android:upload-cert [project-dir]')
-    .description(
-      "Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate."
+    .command('fetch:android:upload-cert <path>')
+    .description("Download the project's Android keystore")
+    .longDescription(
+      "Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate"
     )
+    .helpGroup('credentials')
     .asyncActionProjectDir(fetchAndroidUploadCertAsync);
 }

--- a/packages/expo-cli/src/commands/fetch/index.ts
+++ b/packages/expo-cli/src/commands/fetch/index.ts
@@ -7,9 +7,9 @@ import {
 } from './android';
 import fetchIosCerts from './ios';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('fetch:ios:certs <path>')
+    .command('fetch:ios:certs [path]')
     .description(`Download the project's iOS standalone app signing credentials`)
     .longDescription(
       `Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.`
@@ -18,7 +18,7 @@ export default function(program: Command) {
     .asyncActionProjectDir(fetchIosCerts);
 
   program
-    .command('fetch:android:keystore <path>')
+    .command('fetch:android:keystore [path]')
     .description("Download the project's Android keystore")
     .longDescription(
       "Fetch this project's Android Keystore. Writes Keystore to PROJECT_DIR/PROJECT_NAME.jks and prints passwords to stdout."
@@ -27,7 +27,7 @@ export default function(program: Command) {
     .asyncActionProjectDir(fetchAndroidKeystoreAsync);
 
   program
-    .command('fetch:android:hashes <path>')
+    .command('fetch:android:hashes [path]')
     .description("Compute and log the project's Android key hashes")
     .longDescription(
       "Fetch this project's Android key hashes needed to set up Google/Facebook authentication. Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console."
@@ -36,7 +36,7 @@ export default function(program: Command) {
     .asyncActionProjectDir(fetchAndroidHashesAsync);
 
   program
-    .command('fetch:android:upload-cert <path>')
+    .command('fetch:android:upload-cert [path]')
     .description("Download the project's Android keystore")
     .longDescription(
       "Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate"

--- a/packages/expo-cli/src/commands/generate-module.ts
+++ b/packages/expo-cli/src/commands/generate-module.ts
@@ -4,11 +4,8 @@ import generateModuleAsync from './generate-module/generateModuleAsync';
 
 export default function(program: Command) {
   program
-    .command(
-      'generate-module <path>',
-      'Generate a universal module for Expo from a template in the specified directory',
-      { noHelp: true }
-    )
+    .command('generate-module <path>')
+    .description('Generate a universal module for Expo from a template in the specified directory')
     .helpGroup('internal')
     .option(
       '--template <TemplatePath>',

--- a/packages/expo-cli/src/commands/generate-module.ts
+++ b/packages/expo-cli/src/commands/generate-module.ts
@@ -2,9 +2,9 @@ import { Command } from 'commander';
 
 import generateModuleAsync from './generate-module/generateModuleAsync';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('generate-module <path>')
+    .command('generate-module [path]')
     .description('Generate a universal module for Expo from a template in the specified directory')
     .helpGroup('internal')
     .option(

--- a/packages/expo-cli/src/commands/generate-module.ts
+++ b/packages/expo-cli/src/commands/generate-module.ts
@@ -2,15 +2,17 @@ import { Command } from 'commander';
 
 import generateModuleAsync from './generate-module/generateModuleAsync';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('generate-module [new-module-project]')
-    .option(
-      '--template [localTemplateDirectory]',
-      'Local directory or npm package containing template for universal Expo module'
+    .command(
+      'generate-module <path>',
+      'Generate a universal module for Expo from a template in the specified directory',
+      { noHelp: true }
     )
-    .description(
-      'Generate a universal module for Expo from a template in [new-module-project] directory.'
+    .helpGroup('internal')
+    .option(
+      '--template <TemplatePath>',
+      'Local directory or npm package containing template for universal Expo module'
     )
     .asyncAction(generateModuleAsync);
 }

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -81,7 +81,6 @@ async function action(projectDir: string, command: Command) {
 
   let parentDir;
   let dirName;
-
   if (projectDir) {
     const root = path.resolve(projectDir);
     parentDir = path.dirname(root);
@@ -90,7 +89,7 @@ async function action(projectDir: string, command: Command) {
     if (validationResult !== true) {
       throw new CommandError('INVALID_PROJECT_DIR', validationResult);
     }
-  } else if (command.parent && command.parent.nonInteractive) {
+  } else if (command.parent?.nonInteractive) {
     throw new CommandError(
       'NON_INTERACTIVE',
       'The project dir argument is required in non-interactive mode.'
@@ -560,9 +559,9 @@ async function promptForManagedConfig(
   return { expo };
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('init <path>')
+    .command('init [path]')
     .alias('i')
     .helpGroup('core')
     .description('Create a new Expo project')

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -560,13 +560,12 @@ async function promptForManagedConfig(
   return { expo };
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('init [project-dir]')
+    .command('init <path>')
     .alias('i')
-    .description(
-      'Initializes a directory with an example project. Run it without any options and you will be prompted for the name and type.'
-    )
+    .helpGroup('core')
+    .description('Create a new Expo project')
     .option(
       '-t, --template [name]',
       'Specify which template to use. Valid options are "blank", "tabs", "bare-minimum" or a package on npm (e.g. "expo-template-bare-typescript") that includes an Expo project template.'

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -124,6 +124,6 @@ export default function install(program: Command) {
     .helpGroup('core')
     .option('--npm', 'Use npm to install dependencies. (default when package-lock.json exists)')
     .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
-    .description('Installs a unimodule or other package to a project')
+    .description('Install a unimodule or other package to a project')
     .asyncAction(installAsync);
 }

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -121,8 +121,9 @@ export default function install(program: Command) {
   program
     .command('install [packages...]')
     .alias('add')
+    .helpGroup('core')
     .option('--npm', 'Use npm to install dependencies. (default when package-lock.json exists)')
     .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
-    .description('Installs a unimodule or other package to a project.')
+    .description('Installs a unimodule or other package to a project')
     .asyncAction(installAsync);
 }

--- a/packages/expo-cli/src/commands/login.ts
+++ b/packages/expo-cli/src/commands/login.ts
@@ -4,7 +4,7 @@ import { login } from '../accounts';
 
 export default function(program: Command) {
   program
-    .command('login', 'Login to your Expo account')
+    .command('login', 'Login to an Expo account')
     .alias('signin')
     .helpGroup('auth')
     .option('-u, --username [string]', 'Username')

--- a/packages/expo-cli/src/commands/login.ts
+++ b/packages/expo-cli/src/commands/login.ts
@@ -2,11 +2,11 @@ import { Command } from 'commander';
 
 import { login } from '../accounts';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('login')
+    .command('login', 'Login to your Expo account')
     .alias('signin')
-    .description('Login with your Expo account')
+    .helpGroup('auth')
     .option('-u, --username [string]', 'Username')
     .option('-p, --password [string]', 'Password')
     .asyncAction(login);

--- a/packages/expo-cli/src/commands/login.ts
+++ b/packages/expo-cli/src/commands/login.ts
@@ -4,7 +4,8 @@ import { login } from '../accounts';
 
 export default function(program: Command) {
   program
-    .command('login', 'Login to an Expo account')
+    .command('login')
+    .description('Login to an Expo account')
     .alias('signin')
     .helpGroup('auth')
     .option('-u, --username [string]', 'Username')

--- a/packages/expo-cli/src/commands/logout.ts
+++ b/packages/expo-cli/src/commands/logout.ts
@@ -14,7 +14,8 @@ async function action() {
 
 export default function(program: Command) {
   program
-    .command('logout', 'Logout of an Expo account')
+    .command('logout')
+    .description('Logout of an Expo account')
     .helpGroup('auth')
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/commands/logout.ts
+++ b/packages/expo-cli/src/commands/logout.ts
@@ -12,6 +12,9 @@ async function action() {
   }
 }
 
-export default function (program: Command) {
-  program.command('logout').description('Logout from your Expo account').asyncAction(action);
+export default function(program: Command) {
+  program
+    .command('logout', 'Logout of your Expo account')
+    .helpGroup('auth')
+    .asyncAction(action);
 }

--- a/packages/expo-cli/src/commands/logout.ts
+++ b/packages/expo-cli/src/commands/logout.ts
@@ -14,7 +14,7 @@ async function action() {
 
 export default function(program: Command) {
   program
-    .command('logout', 'Logout of your Expo account')
+    .command('logout', 'Logout of an Expo account')
     .helpGroup('auth')
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/commands/prepare-detached-build.ts
+++ b/packages/expo-cli/src/commands/prepare-detached-build.ts
@@ -12,9 +12,8 @@ async function action(projectDir: string, options: Options) {
 
 export default function(program: Command) {
   program
-    .command('prepare-detached-build <path>', 'Prepare a detached project for building', {
-      noHelp: true,
-    })
+    .command('prepare-detached-build <path>')
+    .description('Prepare a detached project for building')
     .helpGroup('internal')
     .option('--platform [platform]', 'detached project platform')
     .option('--skipXcodeConfig [bool]', '[iOS only] if true, do not configure Xcode project')

--- a/packages/expo-cli/src/commands/prepare-detached-build.ts
+++ b/packages/expo-cli/src/commands/prepare-detached-build.ts
@@ -12,7 +12,7 @@ async function action(projectDir: string, options: Options) {
 
 export default function(program: Command) {
   program
-    .command('prepare-detached-build <path>', 'Prepares a detached project for building', {
+    .command('prepare-detached-build <path>', 'Prepare a detached project for building', {
       noHelp: true,
     })
     .helpGroup('internal')

--- a/packages/expo-cli/src/commands/prepare-detached-build.ts
+++ b/packages/expo-cli/src/commands/prepare-detached-build.ts
@@ -10,11 +10,13 @@ async function action(projectDir: string, options: Options) {
   await Detach.prepareDetachedBuildAsync(projectDir, options);
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('prepare-detached-build [project-dir]')
+    .command('prepare-detached-build <path>', 'Prepares a detached project for building', {
+      noHelp: true,
+    })
+    .helpGroup('internal')
     .option('--platform [platform]', 'detached project platform')
     .option('--skipXcodeConfig [bool]', '[iOS only] if true, do not configure Xcode project')
-    .description('Prepares a detached project for building')
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/prepare-detached-build.ts
+++ b/packages/expo-cli/src/commands/prepare-detached-build.ts
@@ -10,9 +10,9 @@ async function action(projectDir: string, options: Options) {
   await Detach.prepareDetachedBuildAsync(projectDir, options);
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('prepare-detached-build <path>')
+    .command('prepare-detached-build [path]')
     .description('Prepare a detached project for building')
     .helpGroup('internal')
     .option('--platform [platform]', 'detached project platform')

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -15,9 +15,10 @@ const HORIZ_CELL_WIDTH_BIG = 40;
 
 export default (program: any) => {
   program
-    .command('publish:history [project-dir]')
+    .command('publish:history <path>')
     .alias('ph')
-    .description('View a log of your published releases.')
+    .description("Log the project's releases")
+    .helpGroup('publish')
     .option(
       '-c, --release-channel <channel-name>',
       'Filter by release channel. If this flag is not included, the most recent publications will be shown.'
@@ -86,9 +87,10 @@ export default (program: any) => {
       { checkConfig: true }
     );
   program
-    .command('publish:details [project-dir]')
+    .command('publish:details <path>')
     .alias('pd')
-    .description('View the details of a published release.')
+    .description('Log details of a published release')
+    .helpGroup('publish')
     .option('--publish-id <publish-id>', 'Publication id. (Required)')
     .option('-r, --raw', 'Produce some raw output.')
     .asyncActionProjectDir(

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -15,7 +15,7 @@ const HORIZ_CELL_WIDTH_BIG = 40;
 
 export default (program: any) => {
   program
-    .command('publish:history <path>')
+    .command('publish:history [path]')
     .alias('ph')
     .description("Log the project's releases")
     .helpGroup('publish')
@@ -87,7 +87,7 @@ export default (program: any) => {
       { checkConfig: true }
     );
   program
-    .command('publish:details <path>')
+    .command('publish:details [path]')
     .alias('pd')
     .description('Log details of a published release')
     .helpGroup('publish')

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -12,9 +12,9 @@ import {
   setPublishToChannelAsync,
 } from './utils/PublishUtils';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('publish:set <path>')
+    .command('publish:set [path]')
     .alias('ps')
     .description('Specify the channel to serve a published release')
     .helpGroup('publish')
@@ -55,7 +55,7 @@ export default function(program: Command) {
       { checkConfig: true }
     );
   program
-    .command('publish:rollback <path>')
+    .command('publish:rollback [path]')
     .alias('pr')
     .description('Undo an update to a channel')
     .helpGroup('publish')

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -12,11 +12,12 @@ import {
   setPublishToChannelAsync,
 } from './utils/PublishUtils';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('publish:set [project-dir]')
+    .command('publish:set <path>')
     .alias('ps')
-    .description('Set a published release to be served from a specified channel.')
+    .description('Specify the channel to serve a published release')
+    .helpGroup('publish')
     .option(
       '-c, --release-channel <channel-name>',
       'The channel to set the published release. (Required)'
@@ -54,9 +55,10 @@ export default function (program: Command) {
       { checkConfig: true }
     );
   program
-    .command('publish:rollback [project-dir]')
+    .command('publish:rollback <path>')
     .alias('pr')
-    .description('Rollback an update to a channel.')
+    .description('Undo an update to a channel')
+    .helpGroup('publish')
     .option('--channel-id <channel-id>', 'This flag is deprecated.')
     .option('-c, --release-channel <channel-name>', 'The channel to rollback from. (Required)')
     .option('-s, --sdk-version <version>', 'The sdk version to rollback. (Required)')

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -310,9 +310,10 @@ export function logBareWorkflowWarnings(pkg: PackageJSONConfig) {
 
 export default function(program: Command) {
   program
-    .command('publish [project-dir]')
+    .command('publish <path>')
     .alias('p')
     .description('Publishes your project to exp.host')
+    .helpGroup('core')
     .option('-q, --quiet', 'Suppress verbose output from the Metro bundler.')
     .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')
     .option('-c, --clear', 'Clear the Metro bundler cache')

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -312,7 +312,7 @@ export default function(program: Command) {
   program
     .command('publish <path>')
     .alias('p')
-    .description('Deploy your project to Expo hosting')
+    .description('Deploy a project to Expo hosting')
     .helpGroup('core')
     .option('-q, --quiet', 'Suppress verbose output from the Metro bundler.')
     .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -312,7 +312,7 @@ export default function(program: Command) {
   program
     .command('publish <path>')
     .alias('p')
-    .description('Publishes your project to exp.host')
+    .description('Deploy your project to Expo hosting')
     .helpGroup('core')
     .option('-q, --quiet', 'Suppress verbose output from the Metro bundler.')
     .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -308,9 +308,9 @@ export function logBareWorkflowWarnings(pkg: PackageJSONConfig) {
   );
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('publish <path>')
+    .command('publish [path]')
     .alias('p')
     .description('Deploy a project to Expo hosting')
     .helpGroup('core')

--- a/packages/expo-cli/src/commands/push-creds-web.ts
+++ b/packages/expo-cli/src/commands/push-creds-web.ts
@@ -15,9 +15,9 @@ type VapidData = {
 const vapidSubjectDescription =
   'URL or `mailto:` URL which provides a point of contact in case the push service needs to contact the message sender.';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('push:web:upload <path>')
+    .command('push:web:upload [path]')
     .description('Upload VAPID key pair and VAPID subject for web push notifications.')
     .helpGroup('notifications')
     .option('--vapid-pubkey [vapid-public-key]', 'URL-safe base64-encoded VAPID public key.')
@@ -34,7 +34,7 @@ export default function(program: Command) {
     });
 
   program
-    .command('push:web:generate <path>')
+    .command('push:web:generate [path]')
     .description('Generate VAPID key pair for web push notifications.')
     .helpGroup('notifications')
     .option('--vapid-subject [vapid-subject]', vapidSubjectDescription)
@@ -49,7 +49,7 @@ export default function(program: Command) {
     });
 
   program
-    .command('push:web:show <path>')
+    .command('push:web:show [path]')
     .description(
       'Log the VAPID public key, the VAPID private key, and the VAPID subject currently in use for web notifications for this project.'
     )
@@ -78,7 +78,7 @@ export default function(program: Command) {
     });
 
   program
-    .command('push:web:clear <path>')
+    .command('push:web:clear [path]')
     .description(
       'Delete previously uploaded VAPID public key, VAPID private key, and VAPID subject.'
     )

--- a/packages/expo-cli/src/commands/push-creds-web.ts
+++ b/packages/expo-cli/src/commands/push-creds-web.ts
@@ -18,7 +18,7 @@ const vapidSubjectDescription =
 export default function(program: Command) {
   program
     .command('push:web:upload <path>')
-    .description('Uploads VAPID key pair and VAPID subject for web push notifications.')
+    .description('Upload VAPID key pair and VAPID subject for web push notifications.')
     .helpGroup('notifications')
     .option('--vapid-pubkey [vapid-public-key]', 'URL-safe base64-encoded VAPID public key.')
     .option('--vapid-pvtkey [vapid-private-key]', 'URL-safe base64-encoded VAPID private key.')
@@ -35,7 +35,7 @@ export default function(program: Command) {
 
   program
     .command('push:web:generate <path>')
-    .description('Generates VAPID key pair for web push notifications.')
+    .description('Generate VAPID key pair for web push notifications.')
     .helpGroup('notifications')
     .option('--vapid-subject [vapid-subject]', vapidSubjectDescription)
     .asyncActionProjectDir(async (projectDir: string, options: VapidData) => {
@@ -51,7 +51,7 @@ export default function(program: Command) {
   program
     .command('push:web:show <path>')
     .description(
-      'Prints the VAPID public key, the VAPID private key, and the VAPID subject currently in use for web notifications for this project.'
+      'Log the VAPID public key, the VAPID private key, and the VAPID subject currently in use for web notifications for this project.'
     )
     .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {
@@ -80,7 +80,7 @@ export default function(program: Command) {
   program
     .command('push:web:clear <path>')
     .description(
-      'Deletes previously uploaded VAPID public key, VAPID private key, and VAPID subject.'
+      'Delete previously uploaded VAPID public key, VAPID private key, and VAPID subject.'
     )
     .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {

--- a/packages/expo-cli/src/commands/push-creds-web.ts
+++ b/packages/expo-cli/src/commands/push-creds-web.ts
@@ -15,10 +15,11 @@ type VapidData = {
 const vapidSubjectDescription =
   'URL or `mailto:` URL which provides a point of contact in case the push service needs to contact the message sender.';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('push:web:upload [project-dir]')
+    .command('push:web:upload <path>')
     .description('Uploads VAPID key pair and VAPID subject for web push notifications.')
+    .helpGroup('notifications')
     .option('--vapid-pubkey [vapid-public-key]', 'URL-safe base64-encoded VAPID public key.')
     .option('--vapid-pvtkey [vapid-private-key]', 'URL-safe base64-encoded VAPID private key.')
     .option('--vapid-subject [vapid-subject]', vapidSubjectDescription)
@@ -33,8 +34,9 @@ export default function (program: Command) {
     });
 
   program
-    .command('push:web:generate [project-dir]')
+    .command('push:web:generate <path>')
     .description('Generates VAPID key pair for web push notifications.')
+    .helpGroup('notifications')
     .option('--vapid-subject [vapid-subject]', vapidSubjectDescription)
     .asyncActionProjectDir(async (projectDir: string, options: VapidData) => {
       if (!options.vapidSubject) {
@@ -47,10 +49,11 @@ export default function (program: Command) {
     });
 
   program
-    .command('push:web:show [project-dir]')
+    .command('push:web:show <path>')
     .description(
       'Prints the VAPID public key, the VAPID private key, and the VAPID subject currently in use for web notifications for this project.'
     )
+    .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {
       const {
         args: { remotePackageName },
@@ -75,10 +78,11 @@ export default function (program: Command) {
     });
 
   program
-    .command('push:web:clear [project-dir]')
+    .command('push:web:clear <path>')
     .description(
       'Deletes previously uploaded VAPID public key, VAPID private key, and VAPID subject.'
     )
+    .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {
       log('Reading project configuration...');
       const {

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -6,7 +6,7 @@ import log from '../log';
 export default function(program: Command) {
   program
     .command('push:android:upload <path>')
-    .description('Uploads a Firebase Cloud Messaging key for Android push notifications')
+    .description('Upload an FCM key for Android push notifications')
     .helpGroup('notifications')
     .option('--api-key [api-key]', 'Server API key for FCM.')
     .asyncActionProjectDir(async (projectDir: string, options: { apiKey?: string }) => {
@@ -24,7 +24,7 @@ export default function(program: Command) {
 
   program
     .command('push:android:show <path>')
-    .description('Print the value currently in use for FCM notifications for this project')
+    .description('Log the value currently in use for FCM notifications for this project')
     .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {
       const ctx = new Context();
@@ -42,7 +42,7 @@ export default function(program: Command) {
 
   program
     .command('push:android:clear <path>')
-    .description('Deletes a previously uploaded FCM credential')
+    .description('Delete a previously uploaded FCM credential')
     .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {
       const ctx = new Context();

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -3,9 +3,9 @@ import { Command } from 'commander';
 import { Context } from '../credentials/context';
 import log from '../log';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('push:android:upload <path>')
+    .command('push:android:upload [path]')
     .description('Upload an FCM key for Android push notifications')
     .helpGroup('notifications')
     .option('--api-key [api-key]', 'Server API key for FCM.')
@@ -23,7 +23,7 @@ export default function(program: Command) {
     });
 
   program
-    .command('push:android:show <path>')
+    .command('push:android:show [path]')
     .description('Log the value currently in use for FCM notifications for this project')
     .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {
@@ -41,7 +41,7 @@ export default function(program: Command) {
     });
 
   program
-    .command('push:android:clear <path>')
+    .command('push:android:clear [path]')
     .description('Delete a previously uploaded FCM credential')
     .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -3,10 +3,11 @@ import { Command } from 'commander';
 import { Context } from '../credentials/context';
 import log from '../log';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('push:android:upload [project-dir]')
-    .description('Uploads a Firebase Cloud Messaging key for Android push notifications.')
+    .command('push:android:upload <path>')
+    .description('Uploads a Firebase Cloud Messaging key for Android push notifications')
+    .helpGroup('notifications')
     .option('--api-key [api-key]', 'Server API key for FCM.')
     .asyncActionProjectDir(async (projectDir: string, options: { apiKey?: string }) => {
       if (!options.apiKey || options.apiKey.length === 0) {
@@ -22,8 +23,9 @@ export default function (program: Command) {
     });
 
   program
-    .command('push:android:show [project-dir]')
-    .description('Print the value currently in use for FCM notifications for this project.')
+    .command('push:android:show <path>')
+    .description('Print the value currently in use for FCM notifications for this project')
+    .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {
       const ctx = new Context();
       await ctx.init(projectDir);
@@ -39,8 +41,9 @@ export default function (program: Command) {
     });
 
   program
-    .command('push:android:clear [project-dir]')
-    .description('Deletes a previously uploaded FCM credential.')
+    .command('push:android:clear <path>')
+    .description('Deletes a previously uploaded FCM credential')
+    .helpGroup('notifications')
     .asyncActionProjectDir(async (projectDir: string) => {
       const ctx = new Context();
       await ctx.init(projectDir);

--- a/packages/expo-cli/src/commands/register.ts
+++ b/packages/expo-cli/src/commands/register.ts
@@ -2,9 +2,10 @@ import { Command } from 'commander';
 
 import { register } from '../accounts';
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('register')
+    .helpGroup('auth')
     .description('Sign up for a new Expo account')
     .asyncAction(() => register());
 }

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -38,11 +38,12 @@ async function action(projectDir: string, options: Options) {
   }
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('send [project-dir]')
-    .description(`Send the project's url to an email address`)
-    .option('-s, --send-to  [dest]', 'Email address to send the URL to')
+    .command('send <path>')
+    .description(`Send the project's URL to an email address`)
+    .helpGroup('core')
+    .option('-s, --send-to [dest]', 'Email address to send the URL to')
     .urlOpts()
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -41,7 +41,7 @@ async function action(projectDir: string, options: Options) {
 export default function(program: Command) {
   program
     .command('send <path>')
-    .description(`Send the project's URL to an email address`)
+    .description(`Share the project's URL to an email address`)
     .helpGroup('core')
     .option('-s, --send-to [dest]', 'Email address to send the URL to')
     .urlOpts()

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -38,9 +38,9 @@ async function action(projectDir: string, options: Options) {
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('send <path>')
+    .command('send [path]')
     .description(`Share the project's URL to an email address`)
     .helpGroup('core')
     .option('-s, --send-to [dest]', 'Email address to send the URL to')

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -328,7 +328,7 @@ export default (program: any) => {
   program
     .command('start <path>')
     .alias('r')
-    .description('Starts or restarts a local server for your app and gives you a URL to it')
+    .description('Start a local dev server for your app')
     .helpGroup('core')
     .option('-s, --send-to [dest]', 'An email address to send a link to')
     .option('-c, --clear', 'Clear the Metro bundler cache')
@@ -359,7 +359,7 @@ export default (program: any) => {
   program
     .command('start:web <path>')
     .alias('web')
-    .description('Starts the Webpack dev server for web projects')
+    .description('Start a Webpack dev server for the web app')
     .helpGroup('core')
     .option('--dev', 'Turn development mode on')
     .option('--no-dev', 'Turn development mode off')

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -326,7 +326,7 @@ async function configureProjectAsync(
 
 export default (program: any) => {
   program
-    .command('start <path>')
+    .command('start [path]')
     .alias('r')
     .description('Start a local dev server for the app')
     .helpGroup('core')
@@ -357,7 +357,7 @@ export default (program: any) => {
     );
 
   program
-    .command('start:web <path>')
+    .command('start:web [path]')
     .alias('web')
     .description('Start a Webpack dev server for the web app')
     .helpGroup('core')

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -326,9 +326,10 @@ async function configureProjectAsync(
 
 export default (program: any) => {
   program
-    .command('start [project-dir]')
+    .command('start <path>')
     .alias('r')
     .description('Starts or restarts a local server for your app and gives you a URL to it')
+    .helpGroup('core')
     .option('-s, --send-to [dest]', 'An email address to send a link to')
     .option('-c, --clear', 'Clear the Metro bundler cache')
     .option(
@@ -356,9 +357,10 @@ export default (program: any) => {
     );
 
   program
-    .command('start:web [project-dir]')
+    .command('start:web <path>')
     .alias('web')
     .description('Starts the Webpack dev server for web projects')
+    .helpGroup('core')
     .option('--dev', 'Turn development mode on')
     .option('--no-dev', 'Turn development mode off')
     .option('--minify', 'Minify code')

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -328,7 +328,7 @@ export default (program: any) => {
   program
     .command('start <path>')
     .alias('r')
-    .description('Start a local dev server for your app')
+    .description('Start a local dev server for the app')
     .helpGroup('core')
     .option('-s, --send-to [dest]', 'An email address to send a link to')
     .option('-c, --clear', 'Clear the Metro bundler cache')

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -687,13 +687,14 @@ async function maybeCleanNpmStateAsync(packageManager: any) {
   }
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('upgrade [targetSdkVersion]')
+    .command('upgrade')
     .alias('update')
+    .description('Upgrade the project packages and config for the given SDK version')
+    .helpGroup('info')
     .option('--npm', 'Use npm to install dependencies. (default when package-lock.json exists)')
     .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
-    .description('Upgrades your project dependencies and app.json and to the given SDK version')
     .asyncAction(async (requestedSdkVersion: string | null, options: Options) => {
       const { projectRoot, workflow } = await findProjectRootAsync(process.cwd());
 

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -14,9 +14,9 @@ export default function(program: Command) {
   program
     .command('upload:android <path>')
     .alias('ua')
-    .description('Uploads an Android binary to the Google Play Store')
+    .description('Upload an Android binary to the Google Play Store')
     .helpGroup('upload')
-    .option('--latest', 'uploads the latest build')
+    .option('--latest', 'upload the latest build')
     .option('--id <id>', 'id of the build to upload')
     .option('--path <path>', 'path to the .apk/.aab file')
     .option('--url <url>', 'app archive url')
@@ -63,10 +63,10 @@ export default function(program: Command) {
     .alias('ui')
     .description('macOS only: Upload an iOS binary to Apple. An alternative to Transporter.app')
     .longDescription(
-      'Uploads an iOS binary to Apple TestFlight (MacOS only). Uses the latest build by default'
+      'Upload an iOS binary to Apple TestFlight (MacOS only). Uses the latest build by default'
     )
     .helpGroup('upload')
-    .option('--latest', 'uploads the latest build (default)')
+    .option('--latest', 'upload the latest build (default)')
     .option('--id <id>', 'id of the build to upload')
     .option('--path <path>', 'path to the .ipa file')
     .option('--url <url>', 'app archive url')

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -10,10 +10,12 @@ import { SubmissionMode } from './upload/submission-service/types';
 
 const SOURCE_OPTIONS = ['id', 'latest', 'path', 'url'];
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('upload:android [projectDir]')
+    .command('upload:android <path>')
     .alias('ua')
+    .description('Uploads an Android binary to the Google Play Store')
+    .helpGroup('upload')
     .option('--latest', 'uploads the latest build')
     .option('--id <id>', 'id of the build to upload')
     .option('--path <path>', 'path to the .apk/.aab file')
@@ -41,7 +43,6 @@ export default function (program: Command) {
       'Experimental: Use Submission Service for uploading your app. The upload process will happen on Expo servers.'
     )
     .option('--verbose', 'Always print logs from Submission Service')
-    .description('Uploads an Android standalone app to Google Play Store.')
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: AndroidSubmitCommandOptions) => {
       // TODO: remove this once we verify `fastlane supply` works on linux / windows
@@ -58,8 +59,13 @@ export default function (program: Command) {
     });
 
   program
-    .command('upload:ios [projectDir]')
+    .command('upload:ios <path>')
     .alias('ui')
+    .description('macOS only: Upload an iOS binary to Apple. An alternative to Transporter.app')
+    .longDescription(
+      'Uploads an iOS binary to Apple TestFlight (MacOS only). Uses the latest build by default'
+    )
+    .helpGroup('upload')
     .option('--latest', 'uploads the latest build (default)')
     .option('--id <id>', 'id of the build to upload')
     .option('--path <path>', 'path to the .ipa file')
@@ -97,10 +103,8 @@ export default function (program: Command) {
       'English'
     )
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
-    .description(
-      'Uploads a standalone app to Apple TestFlight (works on macOS only). Uploads the latest build by default.'
-    )
-    .on('--help', function () {
+
+    .on('--help', function() {
       console.log('Available languages:');
       console.log(`  ${LANGUAGES.join(', ')}`);
       console.log();

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -10,15 +10,15 @@ import { SubmissionMode } from './upload/submission-service/types';
 
 const SOURCE_OPTIONS = ['id', 'latest', 'path', 'url'];
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('upload:android <path>')
+    .command('upload:android [path]')
     .alias('ua')
     .description('Upload an Android binary to the Google Play Store')
     .helpGroup('upload')
     .option('--latest', 'upload the latest build')
     .option('--id <id>', 'id of the build to upload')
-    .option('--path <path>', 'path to the .apk/.aab file')
+    .option('--path [path]', 'path to the .apk/.aab file')
     .option('--url <url>', 'app archive url')
     .option('--key <key>', 'path to the JSON key used to authenticate with Google Play')
     .option(
@@ -59,7 +59,7 @@ export default function(program: Command) {
     });
 
   program
-    .command('upload:ios <path>')
+    .command('upload:ios [path]')
     .alias('ui')
     .description('macOS only: Upload an iOS binary to Apple. An alternative to Transporter.app')
     .longDescription(
@@ -68,7 +68,7 @@ export default function(program: Command) {
     .helpGroup('upload')
     .option('--latest', 'upload the latest build (default)')
     .option('--id <id>', 'id of the build to upload')
-    .option('--path <path>', 'path to the .ipa file')
+    .option('--path [path]', 'path to the .ipa file')
     .option('--url <url>', 'app archive url')
     .option(
       '--apple-id <apple-id>',
@@ -104,7 +104,7 @@ export default function(program: Command) {
     )
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
 
-    .on('--help', function() {
+    .on('--help', function () {
       console.log('Available languages:');
       console.log(`  ${LANGUAGES.join(', ')}`);
       console.log();

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -74,27 +74,29 @@ async function action(projectDir: string, options: ProjectUrlOptions & URLOption
   }
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('url [project-dir]')
+    .command('url <path>')
     .alias('u')
+    .helpGroup('url')
+
     .option('-w, --web', 'Return the URL of the web app')
-    .description('Displays the URL you can use to view your project in Expo')
+    .description('Log a URL for opening the project in the Expo client')
     .urlOpts()
     .allowOffline()
     .asyncActionProjectDir(action);
 
   program
-    .command('url:ipa [project-dir]')
+    .command('url:ipa <path>')
+    .helpGroup('url')
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
-    .description('Displays the standalone iOS binary URL you can use to download your app binary')
+    .description('Log the download URL for the standalone iOS binary')
     .asyncActionProjectDir(logArtifactUrl('ios'));
 
   program
-    .command('url:apk [project-dir]')
+    .command('url:apk <path>')
+    .helpGroup('url')
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
-    .description(
-      'Displays the standalone Android binary URL you can use to download your app binary'
-    )
+    .description('Log the download URL for the standalone Android binary')
     .asyncActionProjectDir(logArtifactUrl('android'));
 }

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -74,9 +74,9 @@ async function action(projectDir: string, options: ProjectUrlOptions & URLOption
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('url <path>')
+    .command('url [path]')
     .alias('u')
     .helpGroup('url')
 
@@ -87,14 +87,14 @@ export default function(program: Command) {
     .asyncActionProjectDir(action);
 
   program
-    .command('url:ipa <path>')
+    .command('url:ipa [path]')
     .helpGroup('url')
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     .description('Log the download URL for the standalone iOS binary')
     .asyncActionProjectDir(logArtifactUrl('ios'));
 
   program
-    .command('url:apk <path>')
+    .command('url:apk [path]')
     .helpGroup('url')
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     .description('Log the download URL for the standalone Android binary')

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -21,14 +21,14 @@ type Webhook = {
   secret?: string;
 };
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('webhooks <path>')
+    .command('webhooks [path]')
     .helpGroup('webhooks')
     .description('List all webhooks for a project')
     .asyncActionProjectDir(listAsync);
   program
-    .command('webhooks:add <path>')
+    .command('webhooks:add [path]')
     .helpGroup('webhooks')
     .description('Add a webhook to a project')
     .option('--url <url>', 'URL to request. (Required)')
@@ -39,13 +39,13 @@ export default function(program: Command) {
     )
     .asyncActionProjectDir(addAsync);
   program
-    .command('webhooks:remove <path>')
+    .command('webhooks:remove [path]')
     .helpGroup('webhooks')
     .option('--id <id>', 'ID of the webhook to remove.')
     .description('Delete a webhook')
     .asyncActionProjectDir(removeAsync);
   program
-    .command('webhooks:update <path>')
+    .command('webhooks:update [path]')
     .helpGroup('webhooks')
     .description('Update an existing webhook')
     .option('--id <id>', 'ID of the webhook to update.')

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -21,14 +21,16 @@ type Webhook = {
   secret?: string;
 };
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('webhooks [project-dir]')
-    .description('List all webhooks for a project.')
+    .command('webhooks <path>')
+    .helpGroup('webhooks')
+    .description('List all webhooks for a project')
     .asyncActionProjectDir(listAsync);
   program
-    .command('webhooks:add [project-dir]')
-    .description('Add webhook to a project.')
+    .command('webhooks:add <path>')
+    .helpGroup('webhooks')
+    .description('Add webhook to a project')
     .option('--url <url>', 'URL to request. (Required)')
     .option('--event <event-type>', 'Event type that triggers the webhook. [build] (Required)')
     .option(
@@ -37,12 +39,15 @@ export default function (program: Command) {
     )
     .asyncActionProjectDir(addAsync);
   program
-    .command('webhooks:remove [project-dir]')
+    .command('webhooks:remove <path>')
+    .helpGroup('webhooks')
     .option('--id <id>', 'ID of the webhook to remove.')
-    .description('Delete a webhook.')
+    .description('Delete a webhook')
     .asyncActionProjectDir(removeAsync);
   program
-    .command('webhooks:update [project-dir]')
+    .command('webhooks:update <path>')
+    .helpGroup('webhooks')
+    .description('Update an existing webhook')
     .option('--id <id>', 'ID of the webhook to update.')
     .option('--url [url]', 'URL the webhook will request.')
     .option('--event [event-type]', 'Event type that triggers the webhook. [build]')
@@ -50,7 +55,6 @@ export default function (program: Command) {
       '--secret [secret]',
       "Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header."
     )
-    .description('Update a webhook for a project.')
     .asyncActionProjectDir(updateAsync);
 }
 

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -30,7 +30,7 @@ export default function(program: Command) {
   program
     .command('webhooks:add <path>')
     .helpGroup('webhooks')
-    .description('Add webhook to a project')
+    .description('Add a webhook to a project')
     .option('--url <url>', 'URL to request. (Required)')
     .option('--event <event-type>', 'Event type that triggers the webhook. [build] (Required)')
     .option(

--- a/packages/expo-cli/src/commands/whoami.ts
+++ b/packages/expo-cli/src/commands/whoami.ts
@@ -20,7 +20,7 @@ async function action(command: Command) {
 
 export default function(program: Command) {
   program
-    .command('whoami', "Who you're logged in as")
+    .command('whoami', "Display who you're signed in as")
     .helpGroup('auth')
     .alias('w')
     .asyncAction(action);

--- a/packages/expo-cli/src/commands/whoami.ts
+++ b/packages/expo-cli/src/commands/whoami.ts
@@ -20,7 +20,7 @@ async function action(command: Command) {
 
 export default function(program: Command) {
   program
-    .command('whoami', "Display who you're signed in as")
+    .command('whoami', 'Return the currently authenticated account')
     .helpGroup('auth')
     .alias('w')
     .asyncAction(action);

--- a/packages/expo-cli/src/commands/whoami.ts
+++ b/packages/expo-cli/src/commands/whoami.ts
@@ -20,8 +20,9 @@ async function action(command: Command) {
 
 export default function(program: Command) {
   program
-    .command('whoami', 'Return the currently authenticated account')
+    .command('whoami')
     .helpGroup('auth')
     .alias('w')
+    .description('Return the currently authenticated account')
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/commands/whoami.ts
+++ b/packages/expo-cli/src/commands/whoami.ts
@@ -18,10 +18,10 @@ async function action(command: Command) {
   }
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
-    .command('whoami')
+    .command('whoami', "Who you're logged in as")
+    .helpGroup('auth')
     .alias('w')
-    .description('Checks with the server and then says who you are logged in as')
     .asyncAction(action);
 }

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -21,11 +21,13 @@ import boxen from 'boxen';
 import chalk from 'chalk';
 import program, { Command, Option } from 'commander';
 import fs from 'fs';
+import getenv from 'getenv';
 import leven from 'leven';
 import findLastIndex from 'lodash/findLastIndex';
 import ora from 'ora';
 import path from 'path';
 import ProgressBar from 'progress';
+import stripAnsi from 'strip-ansi';
 import url from 'url';
 
 import { loginOrRegisterAsync } from './accounts';
@@ -54,8 +56,235 @@ Command.prototype.allowOffline = function() {
   return this;
 };
 
+// Add support for logical command groupings
+Command.prototype.helpGroup = function(name: string) {
+  if (this.commands[this.commands.length - 1]) {
+    this.commands[this.commands.length - 1].__helpGroup = name;
+  } else {
+    this.parent.helpGroup(name);
+  }
+  return this;
+};
+
+// A longer description that will be displayed then the command is used with --help
+Command.prototype.longDescription = function(name: string) {
+  if (this.commands[this.commands.length - 1]) {
+    this.commands[this.commands.length - 1].__longDescription = name;
+  } else {
+    this.parent.longDescription(name);
+  }
+  return this;
+};
+
+function pad(str: string, width: number): string {
+  // Pulled from commander for overriding
+  const len = Math.max(0, width - stripAnsi(str).length);
+  return str + Array(len + 1).join(' ');
+}
+
+function humanReadableArgName(arg: any): string {
+  // Pulled from commander for overriding
+  const nameOutput = arg.name + (arg.variadic === true ? '...' : '');
+  return arg.required ? `<${nameOutput}>` : `[${nameOutput}]`;
+}
+
+function breakSentence(input: string): string {
+  // Break a sentence by the word after a max character count
+  return input.replace(/(.{1,72})(?:\n|$| )/g, '$1\n').trim();
+}
+
+Command.prototype.prepareCommands = function() {
+  return this.commands
+    .filter(function(cmd: Command) {
+      // Display all commands with EXPO_DEBUG, otherwise use the noHelp option.
+      if (getenv.boolish('EXPO_DEBUG', false)) {
+        return true;
+      }
+      return !cmd._noHelp;
+    })
+    .map(function(cmd: Command, i: number) {
+      const args = cmd._args.map(humanReadableArgName).join(' ');
+
+      // Remove alias. We still show this with --help on the command.
+      const alias = null; //cmd._alias;
+
+      const description = cmd._description;
+      return [
+        cmd._name +
+          (alias ? '|' + alias : '') +
+          // Remove the redundant [options] string that's shown after every command.
+          // (cmd.options.length ? ' [options]' : '') +
+          (args ? ' ' + args : ''),
+        breakSentence(description),
+        cmd.__helpGroup ?? 'misc',
+      ];
+    });
+};
+
+Command.prototype.helpInformation = function() {
+  let desc: string[] = [];
+  // Use the long description if available, otherwise use the regular description.
+  const description = this.__longDescription ?? this._description;
+  if (description) {
+    desc = [replaceAll(breakSentence(description), '\n', pad('\n', 3)), ''];
+
+    const argsDescription = this._argsDescription;
+    if (argsDescription && this._args.length) {
+      const width = this.padWidth();
+      desc.push('Arguments:');
+      desc.push('');
+      this._args.forEach(({ name }: { name: string }) => {
+        desc.push('  ' + pad(name, width) + '  ' + argsDescription[name]);
+      });
+      desc.push('');
+    }
+  }
+
+  let cmdName = this._name;
+  if (this._alias) {
+    // Here is the only place we show the command alias
+    cmdName = `${cmdName}|${this._alias}`;
+  }
+
+  // Dim the options to keep things consistent.
+  const usage = `${chalk.bold`Usage:`} ${cmdName} ${chalk.dim(this.usage())}\n`;
+
+  const commandHelp = '' + this.commandHelp();
+
+  const options = [chalk.bold`Options:`, '\n' + this.optionHelp().replace(/^/gm, '    '), ''];
+
+  // return ['', usage, ...desc, ...options, commandHelp].join('\n') + '\n';
+  return ['', usage, ...desc, ...options, commandHelp].join(pad('\n', 3)) + '\n';
+};
+
+function replaceAll(string: string, search: string, replace: string): string {
+  return string.split(search).join(replace);
+}
+
+// Extended the help renderer to add a custom format and groupings.
+Command.prototype.commandHelp = function() {
+  if (!this.commands.length) {
+    return '';
+  }
+  const width: number = this.padWidth();
+  const commands: string[][] = this.prepareCommands();
+
+  const helpGroups: Record<string, string[][]> = {};
+
+  // Sort commands into helpGroups
+  for (const command of commands) {
+    const groupName = command[2];
+    if (!helpGroups[groupName]) {
+      helpGroups[groupName] = [];
+    }
+    helpGroups[groupName].push(command);
+  }
+
+  const groupOrder = [
+    ...new Set([
+      'auth',
+      'core',
+      'client',
+      'info',
+      'publish',
+      'build',
+      'credentials',
+      'notifications',
+      'url',
+      'webhooks',
+      'upload',
+      'eject',
+      'experimental',
+      'internal',
+      // add any others and remove duplicates
+      ...Object.keys(helpGroups),
+    ]),
+  ];
+
+  const subGroupOrder: Record<string, string[]> = {
+    core: [
+      'init',
+      'start',
+      'start:web',
+      'publish',
+      'export',
+      // 'install',
+      // 'send',
+    ],
+  };
+
+  const sortSubGroupWithOrder = (groupName: string, group: string[][]): string[][] => {
+    const order: string[] = subGroupOrder[groupName];
+    if (!order?.length) {
+      return group;
+    }
+
+    const sortedCommands: string[][] = [];
+
+    while (order.length) {
+      const key = order.shift()!;
+      const index = group.findIndex(item => item[0].startsWith(key));
+      if (index >= 0) {
+        const [item] = group.splice(index, 1);
+        sortedCommands.push(item);
+      }
+    }
+
+    return sortedCommands.concat(group);
+  };
+
+  // Reverse the groups
+  const sortedGroups: Record<string, string[][]> = {};
+  while (groupOrder.length) {
+    const group = groupOrder.shift()!;
+    if (group in helpGroups) {
+      sortedGroups[group] = helpGroups[group];
+    }
+  }
+
+  // Render everything.
+  return [
+    '' + chalk.bold('Commands:'),
+    '',
+    // Render all of the groups.
+    Object.keys(sortedGroups)
+      .map(groupName => {
+        // Sort subgroups that have a defined order
+        const group = sortSubGroupWithOrder(groupName, helpGroups[groupName]);
+        return (
+          group
+            // Render the command and description
+            .map(([cmd, description]: string[]) => {
+              // Dim the arguments that come after the command, this makes scanning a bit easier.
+              let [noArgsCmd, ...noArgsCmdArgs] = cmd.split(' ');
+              if (noArgsCmdArgs.length) {
+                noArgsCmd += ` ${chalk.dim(noArgsCmdArgs.join(' '))}`;
+              }
+
+              // Word wrap the description.
+              let wrappedDescription = description;
+              if (description) {
+                // Ensure the wrapped description appears on the same padded line.
+                wrappedDescription = '  ' + replaceAll(description, '\n', pad('\n', width + 3));
+              }
+
+              const paddedName = wrappedDescription ? pad(noArgsCmd, width) : noArgsCmd;
+              return paddedName + wrappedDescription;
+            })
+            .join('\n')
+            .replace(/^/gm, '    ')
+        );
+      })
+      // Double new line to add spacing between groups
+      .join('\n\n'),
+    '',
+  ].join('\n');
+};
+
 program.on('--help', () => {
-  log(`To learn more about a specific command and its options use 'expo [command] --help'\n`);
+  log(`  Run a command with --help for more info 💡`);
+  log(`    $ expo start --help`);
+  log();
 });
 
 export type Action = (...args: any[]) => void;
@@ -347,10 +576,7 @@ function runAsync(programName: string) {
     program.name(programName);
     program
       .version(packageJSON.version)
-      .option(
-        '--non-interactive',
-        'Fail, if an interactive prompt would be required to continue. Enabled by default if stdin is not a TTY.'
-      );
+      .option('--non-interactive', 'Fail, if an interactive prompt would be required to continue.');
 
     // Load each module found in ./commands by 'registering' it with our commander instance
     registerCommands(program);

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -100,7 +100,7 @@ Command.prototype.prepareCommands = function() {
       if (getenv.boolish('EXPO_DEBUG', false)) {
         return true;
       }
-      return !cmd._noHelp;
+      return cmd.__helpGroup !== 'internal';
     })
     .map(function(cmd: Command, i: number) {
       const args = cmd._args.map(humanReadableArgName).join(' ');


### PR DESCRIPTION
- Unify project-dir, projectRoot, project-root into -> `[path]`
- Remove redundant `[options]` from all commands
- Dim <path> for easier scanning
- group commands by category
- added subgroup ordering for better priority
- Updated descriptions
  - Word wrap descriptions after a set character length, this length is still slightly larger than the default mac terminal size
  - Made all descriptions more concise and follow the same linguistic format
  - Removed ending period - some had it and others didn't
  - Created `.longDescription()` which shows up in the `⌘ --help`
- remove aliases from help: `start|r` -> `start`
  - Aliases will still be shown in the `⌘ --help`
- Remove internal commands from `--help` - these will now only show up when `EXPO_DEBUG` is enabled
  - `bundle-assets`
  - `generate-module`
  - `prepare-detached-build`

## Before

<img width="1165" alt="Screen Shot 2020-08-28 at 4 25 05 PM" src="https://user-images.githubusercontent.com/9664363/91622262-1a394000-e94b-11ea-8691-61c21a6f8c7f.png">

## After

<img width="1165" alt="Screen Shot 2020-08-28 at 4 14 35 PM" src="https://user-images.githubusercontent.com/9664363/91622197-d5150e00-e94a-11ea-9546-73344da6456e.png">

Notice it can go all the way down to x110 whereas before the optimal range was 300+

<img width="892" alt="Screen Shot 2020-08-28 at 4 26 36 PM" src="https://user-images.githubusercontent.com/9664363/91622323-713f1500-e94b-11ea-8dc7-661b59f83777.png">


This PR doesn't address the global `expo` options which are clearly a mess, will do that later.
