### PR TITLE
[xdl] pass app.json updates config to expo-updates in standalone apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This is the log of notable changes to Expo CLI and related packages.
 - [expo-cli] expo eas:build - Add --skip-credentials-check option ([#2442](https://github.com/expo/expo-cli/pull/2442) by [@satya164](https://github.com/satya164))
 - [expo-cli] Add a `eas:build:init` command ([#2443](https://github.com/expo/expo-cli/pull/2443) by [@satya164](https://github.com/satya164))
 - [expo-cli] expo generate-module - Support for templates with Android native unit tests ([#2548](https://github.com/expo/expo-cli/pull/2548) by [@barthap](https://github.com/barthap))
+- [xdl] Add support for passing app.json updates config to expo-updates in SDK 39 standalone apps ([#2539](https://github.com/expo/expo-cli/pull/2539) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/xdl/src/detach/ExponentTools.ts
+++ b/packages/xdl/src/detach/ExponentTools.ts
@@ -9,6 +9,22 @@ import { Readable } from 'stream';
 import XDLError from '../XDLError';
 import LoggerDetach, { Logger, pipeOutputToLogger } from './Logger';
 
+function getManifestFileNameForSdkVersion(sdkVersion: string) {
+  if (parseSdkMajorVersion(sdkVersion) < 39) {
+    return 'shell-app-manifest.json';
+  } else {
+    return 'app.manifest';
+  }
+}
+
+function getBundleFileNameForSdkVersion(sdkVersion: string) {
+  if (parseSdkMajorVersion(sdkVersion) < 39) {
+    return 'shell-app.bundle';
+  } else {
+    return 'app.bundle';
+  }
+}
+
 function parseSdkMajorVersion(expSdkVersion: string) {
   // We assume that the unversioned SDK is the latest
   if (expSdkVersion === 'UNVERSIONED') {
@@ -247,4 +263,6 @@ export {
   regexFileAsync,
   deleteLinesInFileAsync,
   createSpawner,
+  getManifestFileNameForSdkVersion,
+  getBundleFileNameForSdkVersion,
 };

--- a/packages/xdl/src/detach/IosNSBundle.ts
+++ b/packages/xdl/src/detach/IosNSBundle.ts
@@ -32,6 +32,22 @@ const DEFAULT_FABRIC_KEY = '81130e95ea13cd7ed9a4f455e96214902c721c99';
 const DEFAULT_GAD_APPLICATION_ID = 'ca-app-pub-3940256099942544~1458002511';
 const KERNEL_URL = 'https://expo.io/@exponent/home';
 
+export function getManifestFileNameForSdkVersion(sdkVersion: string) {
+  if (parseSdkMajorVersion(sdkVersion) < 39) {
+    return 'shell-app-manifest.json';
+  } else {
+    return 'app.manifest';
+  }
+}
+
+export function getBundleFileNameForSdkVersion(sdkVersion: string) {
+  if (parseSdkMajorVersion(sdkVersion) < 39) {
+    return 'shell-app.bundle';
+  } else {
+    return 'app.bundle';
+  }
+}
+
 function _configureInfoPlistForLocalDevelopment(config: any, exp: ExpoConfig): ExpoConfig {
   // add detached scheme
   if (exp.isDetached && exp.detach?.scheme) {
@@ -490,6 +506,13 @@ async function _configureShellPlistAsync(context: AnyStandaloneContext): Promise
       // enable/disable code push if the developer provided specific behavior
       shellPlist.areRemoteUpdatesEnabled = config.updates.enabled;
     }
+    if (config.updates && config.updates.hasOwnProperty('checkAutomatically')) {
+      shellPlist.updatesCheckAutomatically =
+        config.updates.checkAutomatically !== 'ON_ERROR_RECOVERY';
+    }
+    if (config.updates && config.updates.hasOwnProperty('fallbackToCacheTimeout')) {
+      shellPlist.updatesFallbackToCacheTimeout = config.updates.fallbackToCacheTimeout;
+    }
     if (!manifestUsesSplashApi(config, 'ios') && parseSdkMajorVersion(config.sdkVersion) < 28) {
       // for people still using the old loading api, hide the native splash screen.
       // we can remove this code eventually.
@@ -600,8 +623,8 @@ export async function configureAsync(context: AnyStandaloneContext): Promise<voi
       await _preloadManifestAndBundleAsync(
         context.data.manifest,
         supportingDirectory,
-        'shell-app-manifest.json',
-        'shell-app.bundle'
+        getManifestFileNameForSdkVersion(context.data.manifest.sdkVersion),
+        getBundleFileNameForSdkVersion(context.data.manifest.sdkVersion)
       );
     }
 

--- a/packages/xdl/src/detach/IosNSBundle.ts
+++ b/packages/xdl/src/detach/IosNSBundle.ts
@@ -4,7 +4,9 @@ import path from 'path';
 
 import * as AssetBundle from './AssetBundle';
 import {
+  getBundleFileNameForSdkVersion,
   getManifestAsync,
+  getManifestFileNameForSdkVersion,
   manifestUsesSplashApi,
   parseSdkMajorVersion,
   saveUrlToPathAsync,
@@ -31,22 +33,6 @@ import {
 const DEFAULT_FABRIC_KEY = '81130e95ea13cd7ed9a4f455e96214902c721c99';
 const DEFAULT_GAD_APPLICATION_ID = 'ca-app-pub-3940256099942544~1458002511';
 const KERNEL_URL = 'https://expo.io/@exponent/home';
-
-export function getManifestFileNameForSdkVersion(sdkVersion: string) {
-  if (parseSdkMajorVersion(sdkVersion) < 39) {
-    return 'shell-app-manifest.json';
-  } else {
-    return 'app.manifest';
-  }
-}
-
-export function getBundleFileNameForSdkVersion(sdkVersion: string) {
-  if (parseSdkMajorVersion(sdkVersion) < 39) {
-    return 'shell-app.bundle';
-  } else {
-    return 'app.bundle';
-  }
-}
 
 function _configureInfoPlistForLocalDevelopment(config: any, exp: ExpoConfig): ExpoConfig {
   // add detached scheme
@@ -506,11 +492,11 @@ async function _configureShellPlistAsync(context: AnyStandaloneContext): Promise
       // enable/disable code push if the developer provided specific behavior
       shellPlist.areRemoteUpdatesEnabled = config.updates.enabled;
     }
-    if (config.updates && config.updates.hasOwnProperty('checkAutomatically')) {
+    if (config.updates?.hasOwnProperty('checkAutomatically')) {
       shellPlist.updatesCheckAutomatically =
         config.updates.checkAutomatically !== 'ON_ERROR_RECOVERY';
     }
-    if (config.updates && config.updates.hasOwnProperty('fallbackToCacheTimeout')) {
+    if (config.updates?.hasOwnProperty('fallbackToCacheTimeout')) {
       shellPlist.updatesFallbackToCacheTimeout = config.updates.fallbackToCacheTimeout;
     }
     if (!manifestUsesSplashApi(config, 'ios') && parseSdkMajorVersion(config.sdkVersion) < 28) {


### PR DESCRIPTION
Fixes https://github.com/expo/expo/issues/9922, along with https://github.com/expo/expo/pull/9985

This PR passes the `updates.checkAutomatically` and `updates.fallbackToCacheTimeout` app.json values, which were previously set at runtime, into build-time configuration values for standalone apps built by turtle. These values will then be read and passed directly to expo-updates by the ExpoKit kernels.

Further, starting with SDK 39 the filenames that the ExpoKit kernel expects for the embedded manifest and bundle have changed, from `shell-app-manifest.json` and `shell-app.bundle` to `app.manifest` and `app.bundle`. This PR makes that change accordingly for building standalone apps.