### PR TITLE
[expo-cli] Eas build fix prompt for unsynced credentials

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -136,7 +136,6 @@ async function startBuildAsync<T extends Platform>(
     await builder.setupAsync();
     const credentialsSource = await builder.ensureCredentialsAsync();
     if (!builder.ctx.commandCtx.skipProjectConfiguration) {
-      await builder.ensureCredentialsAsync();
       await builder.ensureProjectConfiguredAsync();
     }
 


### PR DESCRIPTION
# Why

- When credentials exist both on Expo servers and in credntials.json, but Expo server ones are incomplete, expo-cli triggers generation of missing credentials when it supposes to just compare existing ones.
- duplicated ensure credentials call