### PR TITLE
[expo-cli] Generate-module fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ This is the log of notable changes to Expo CLI and related packages.
 - [expo-cli] expo publish - Log bundles after building ([#2527](https://github.com/expo/expo-cli/pull/2527) by [@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] expo eas:build - Add --skip-credentials-check option ([#2442](https://github.com/expo/expo-cli/pull/2442) by [@satya164](https://github.com/satya164))
 - [expo-cli] Add a `eas:build:init` command ([#2443](https://github.com/expo/expo-cli/pull/2443) by [@satya164](https://github.com/satya164))
+- [expo-cli] expo generate-module - Support for templates with Android native unit tests ([#2548](https://github.com/expo/expo-cli/pull/2548) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 
 - [expo-cli] expo upload:android - fix `--use-submission-service` not resulting in non-zero exit code when upload fails ([#2530](https://github.com/expo/expo-cli/pull/2530) by [@mymattcarroll](https://github.com/mymattcarroll))
 - [expo-cli] Fix `generate-module` to support latest `expo-module-template` ([#2510](https://github.com/expo/expo-cli/pull/2510) by [@barthap](https://github.com/barthap))
+- [expo-cli] Fix `generate-module` filename generation for modules without `expo-` prefix ([#2548](https://github.com/expo/expo-cli/pull/2548) by [@barthap](https://github.com/barthap))
 - [image-utils] Fix setting background color when calling `Jimp.resize` ([#2535](https://github.com/expo/expo-cli/pull/2535) by [@cruzach](https://github.com/cruzach))
 
 ### 📦 Packages updated

--- a/packages/expo-cli/src/commands/generate-module/fetchTemplate.ts
+++ b/packages/expo-cli/src/commands/generate-module/fetchTemplate.ts
@@ -40,6 +40,6 @@ function isNpmPackage(template: string) {
     !template.match(/^_/) && // don't start with _
     template.toLowerCase() === template && // only lowercase
     !/[~'!()*]/.test(template.split('/').slice(-1)[0]) && // don't contain any character from [~'!()*]
-    template.match(/^(@([^/]+?)\/)?([^/@]+)(@(\d\.\d\.\d)(-[^/@]+)?)?$/) // has shape (@scope/)?actual-package-name(@0.1.1(-tag.1)?)?
+    template.match(/^(@([^/]+?)\/)?([^/@]+)(@(((\d\.\d\.\d)(-[^/@]+)?)|latest|next))?$/) // has shape (@scope/)?actual-package-name(@0.1.1(-tag.1)?|tag-name)?
   );
 }

--- a/packages/expo-cli/src/commands/generate-module/promptQuestionsAsync.ts
+++ b/packages/expo-cli/src/commands/generate-module/promptQuestionsAsync.ts
@@ -17,7 +17,7 @@ const generateCocoaPodDefaultName = (moduleName: string) => {
   if (moduleName.toLowerCase().startsWith('expo')) {
     return `EX${wordsToUpperCase(moduleName.substring(4))}`;
   }
-  return wordsToUpperCase(moduleName);
+  return `EX${wordsToUpperCase(moduleName)}`;
 };
 
 /**


### PR DESCRIPTION
## Why

Continuation of #2510 (that fix was rather critical). Trying to make `expo generate-module` more universal and generic.

## Changes
- Android test files are now properly renamed
- Java package is now automatically detected based on directory structure
- NPM template package name accepts templates with tags `@next` and `@latest` _(shall we make it less restrictive to accept any string as tag?)_
- Package names are now properly handled regardless of having `expo-` prefix.
- iOS pod name always defaults to `EXPackageName` (it didn't always add `EX` prefix before) - _idk if it's desirable change_.
- IO optimizations - parallelised some file processing.

## Test plan

Tested manually using custom testing template (custom package names etc). Checked if all renamings work as expected.