### PR TITLE
[xdl] Improved Android module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to Expo CLI and related packages.
 - [expo-cli] expo eject - Added support for locales in eject and apply ([#2496](https://github.com/expo/expo-cli/pull/2496) by [@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] expo publish - Log bundles after building ([#2527](https://github.com/expo/expo-cli/pull/2527) by [@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] Add shift+i hotkey in interactive prompt to select iOS simulator to open ([#2541](https://github.com/expo/expo-cli/pull/2541) by [[@EvanBacon](https://github.com/EvanBacon))
+- [expo-cli] Add shift+a hotkey in interactive prompt to select Android device/emulator to open ([#2550](https://github.com/expo/expo-cli/pull/2550) by [[@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] Improve edge case handling when upgrading Expo client in iOS simulator ([#2541](https://github.com/expo/expo-cli/pull/2541) by [[@EvanBacon](https://github.com/EvanBacon))
 - [expo-cli] expo eas:build - Add --skip-credentials-check option ([#2442](https://github.com/expo/expo-cli/pull/2442) by [@satya164](https://github.com/satya164))
 - [expo-cli] Add a `eas:build:init` command ([#2443](https://github.com/expo/expo-cli/pull/2443) by [@satya164](https://github.com/satya164))

--- a/packages/dev-tools/server/graphql/GraphQLSchema.ts
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.ts
@@ -551,7 +551,10 @@ const resolvers = {
       const currentProject = context.getCurrentProject();
       let result;
       if (platform === 'ANDROID') {
-        result = await Android.openProjectAsync(currentProject.projectDir);
+        result = await Android.openProjectAsync({
+          projectRoot: currentProject.projectDir,
+          shouldPrompt: false,
+        });
       } else {
         result = await Simulator.openProjectAsync({
           projectRoot: currentProject.projectDir,

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -49,7 +49,7 @@ const printUsage = async (projectDir: string, options: Pick<StartOptions, 'webOn
   const openDevToolsAtStartup = await UserSettings.getAsync('openDevToolsAtStartup', true);
   const username = await UserManager.getCurrentUsernameAsync();
   const devMode = dev ? 'development' : 'production';
-  const androidInfo = `${b`a`} to run on ${u`A`}ndroid device/emulator`;
+  const androidInfo = `${b`a`} to run on ${u`A`}ndroid (${b`shift+a`} to select the device/emulator)`;
   const iosInfo =
     process.platform === 'darwin'
       ? `${b`i`} to run on ${u`i`}OS simulator (${b`shift+i`} to select the simulator model)`
@@ -192,6 +192,11 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
     } else {
       switch (key) {
         case 'A':
+          clearConsole();
+          log('Trying to open the project on Android...');
+          await Android.openProjectAsync({ projectRoot, shouldPrompt: true });
+          printHelp();
+          break;
         case 'a': {
           clearConsole();
           log('Trying to open the project on Android...');

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -142,6 +142,15 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
       startWaitingForCommand();
     }
   });
+
+  Android.setInteractiveCallback(async (pause: boolean) => {
+    if (pause) {
+      stopWaitingForCommand();
+    } else {
+      startWaitingForCommand();
+    }
+  });
+
   UserManager.setInteractiveAuthenticationCallback(async () => {
     stopWaitingForCommand();
     try {
@@ -156,10 +165,11 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
   async function handleKeypress(key: string) {
     if (options.webOnly) {
       switch (key) {
+        case 'A':
         case 'a':
           clearConsole();
           log('Trying to open the web project in Chrome on Android...');
-          await Android.openWebProjectAsync(projectRoot);
+          await Android.openWebProjectAsync({ projectRoot });
           printHelp();
           break;
         case 'i':
@@ -181,10 +191,11 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
       }
     } else {
       switch (key) {
+        case 'A':
         case 'a': {
           clearConsole();
           log('Trying to open the project on Android...');
-          await Android.openProjectAsync(projectRoot);
+          await Android.openProjectAsync({ projectRoot });
           printHelp();
           break;
         }

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -77,9 +77,9 @@ async function handleMobileOptsAsync(
     (async () => {
       if (options.android) {
         if (options.webOnly) {
-          await Android.openWebProjectAsync(projectRoot);
+          await Android.openWebProjectAsync({ projectRoot });
         } else {
-          await Android.openProjectAsync(projectRoot);
+          await Android.openProjectAsync({ projectRoot });
         }
       }
     })(),

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -136,7 +136,7 @@ async function isBootAnimationCompleteAsync(pid?: string): Promise<boolean> {
 }
 
 async function startEmulatorAsync(device: Device): Promise<Device> {
-  Logger.global.info(`\u203A Attempting to open emulator named: ${device.name}`);
+  Logger.global.info(`\u203A Attempting to open emulator: ${device.name}`);
 
   // Start a process to open an emulator
   const emulatorProcess = child_process.spawn(
@@ -554,7 +554,7 @@ async function openUrlAsync({
       // _checkExpoUpToDateAsync(); // let this run in background
     }
 
-    Logger.global.info(`Opening on Android ${device.type}`);
+    Logger.global.info(`Opening with Android ${device.type}: ${device.name}`);
     try {
       await _openUrlAsync({ pid: device.pid!, url });
     } catch (e) {
@@ -881,7 +881,7 @@ async function promptForDeviceAsync(devices: Device[]): Promise<Device> {
       // @ts-ignore: broken types -- TODO: remove when migrating to `prompts`
       type: 'list',
       name: 'answer',
-      message: 'Select a simulator',
+      message: 'Select a device/emulator',
       // @ts-ignore
       choices: devices.map(item => {
         const isActive = item.isBooted;

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -157,7 +157,6 @@ async function startEmulatorAsync(device: Device): Promise<Device> {
 
   return new Promise<Device>((resolve, reject) => {
     const waitTimer = setInterval(async () => {
-      // if (await _isDeviceAttachedAsync()) {
       const bootedDevices = await getAttachedDevicesAsync();
       const connected = bootedDevices.find(({ name }) => name === device.name);
       if (connected) {
@@ -167,7 +166,6 @@ async function startEmulatorAsync(device: Device): Promise<Device> {
           resolve(connected);
         }
       }
-      // }
     }, 1000);
 
     // Reject command after timeout
@@ -509,7 +507,8 @@ async function _openUrlAsync({ pid, url }: { pid: string; url: string }) {
 
 async function attemptToStartEmulatorOrAssertAsync(device: Device): Promise<Device> {
   // TODO: Add a light-weight method for checking since a device could disconnect.
-  if (!device.isBooted) {
+
+  if (!(await isDeviceBootedAsync(device))) {
     device = await startEmulatorAsync(device);
   }
   // TODO: Validate specific device

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -3,9 +3,12 @@ import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import child_process from 'child_process';
 import fs from 'fs-extra';
+import { prompt } from 'inquirer';
 import trim from 'lodash/trim';
+import os from 'os';
 import path from 'path';
 import ProgressBar from 'progress';
+import semver from 'semver';
 
 import * as Analytics from './Analytics';
 import Api from './Api';
@@ -19,6 +22,14 @@ import * as Versions from './Versions';
 import { getUrlAsync as getWebpackUrlAsync } from './Webpack';
 import { getImageDimensionsAsync } from './tools/ImageUtils';
 
+type Device = {
+  pid?: string;
+  name: string;
+  type: 'emulator' | 'device';
+  isBooted: boolean;
+  isAuthorized: boolean;
+};
+
 let _lastUrl: string | null = null;
 let _isAdbOwner: boolean | null = null;
 
@@ -27,7 +38,7 @@ const CANT_START_ACTIVITY_ERROR = 'Activity not started, unable to resolve Inten
 
 const INSTALL_WARNING_TIMEOUT = 60 * 1000;
 
-const EMULATOR_MAX_WAIT_TIMEOUT = 30 * 1000;
+const EMULATOR_MAX_WAIT_TIMEOUT = 60 * 1000 * 3;
 
 function whichEmulator(): string {
   if (process.env.ANDROID_HOME) {
@@ -35,6 +46,7 @@ function whichEmulator(): string {
   }
   return 'emulator';
 }
+
 function whichADB(): string {
   if (process.env.ANDROID_HOME) {
     return `${process.env.ANDROID_HOME}/platform-tools/adb`;
@@ -45,44 +57,129 @@ function whichADB(): string {
 /**
  * Returns a list of emulator names.
  */
-async function getEmulatorsAsync(): Promise<string[]> {
+async function getEmulatorsAsync(): Promise<Device[]> {
   try {
     const { stdout } = await spawnAsync(whichEmulator(), ['-list-avds']);
-    return stdout.split('\n').filter(Boolean);
+    return stdout
+      .split(os.EOL)
+      .filter(Boolean)
+      .map(name => ({
+        name,
+        type: 'emulator',
+        // unsure from this
+        isBooted: false,
+        isAuthorized: true,
+      }));
   } catch {
     return [];
   }
 }
 
-async function maybeStartEmulatorAsync(name: string): Promise<void> {
-  Logger.global.info(`\u203A Attempting to open emulator named: ${name}`);
+/**
+ * Return the Emulator name for an emulator ID, this can be used to determine if an emulator is booted.
+ *
+ * @param emulatorId a value like `emulator-5554` from `abd devices`
+ */
+async function getAbdNameForEmulatorIdAsync(emulatorId: string): Promise<string | null> {
+  return (
+    trim(await getAdbOutputAsync(['-s', emulatorId, 'emu', 'avd', 'name']))
+      .split(/\r?\n/)
+      .shift() ?? null
+  );
+}
+
+export async function getAllAvailableDevicesAsync(): Promise<Device[]> {
+  const bootedDevices = await getAttachedDevicesAsync();
+
+  const data = await getEmulatorsAsync();
+  const connectedNames = bootedDevices.map(({ name }) => name);
+
+  const offlineEmulators = data
+    .filter(({ name }) => !connectedNames.includes(name))
+    .map(({ name, type }) => {
+      return {
+        name,
+        type,
+        isBooted: false,
+        // TODO: Are emulators always authorized?
+        isAuthorized: true,
+      };
+    });
+
+  const allDevices = bootedDevices.concat(offlineEmulators);
+
+  if (!allDevices.length) {
+    const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
+    throw new Error(
+      `No Android connected device found, and no emulators could be started automatically.\nPlease connect a device or create an emulator (https://docs.expo.io/workflow/android-studio-emulator).\nThen follow the instructions here to enable USB debugging:\n${genymotionMessage}`
+    );
+  }
+
+  return allDevices;
+}
+
+/**
+ * Returns true when a device's splash screen animation has stopped.
+ * This can be used to detect when a device is fully booted and ready to use.
+ *
+ * @param pid
+ */
+async function isBootAnimationCompleteAsync(pid?: string): Promise<boolean> {
+  try {
+    const output = await getAdbOutputAsync(
+      adbPidArgs(pid, 'shell', 'getprop', 'init.svc.bootanim')
+    );
+    return !!output.match(/stopped/);
+  } catch {
+    return false;
+  }
+}
+
+async function startEmulatorAsync(device: Device): Promise<Device> {
+  Logger.global.info(`\u203A Attempting to open emulator named: ${device.name}`);
 
   // Start a process to open an emulator
-  const emulatorProcess = child_process.spawn(whichEmulator(), [`@${name}`], {
-    stdio: 'ignore',
-    detached: true,
-  });
+  const emulatorProcess = child_process.spawn(
+    whichEmulator(),
+    [
+      `@${device.name}`,
+      // disable animation for faster boot -- this might make it harder to detect if it mounted properly tho
+      //'-no-boot-anim'
+      // '-google-maps-key' -- TODO: Use from config
+    ],
+    {
+      stdio: 'ignore',
+      detached: true,
+    }
+  );
 
   emulatorProcess.unref();
 
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<Device>((resolve, reject) => {
     const waitTimer = setInterval(async () => {
-      if (await _isDeviceAttachedAsync()) {
-        stopWaiting();
-        resolve();
+      // if (await _isDeviceAttachedAsync()) {
+      const bootedDevices = await getAttachedDevicesAsync();
+      const connected = bootedDevices.find(({ name }) => name === device.name);
+      if (connected) {
+        const isBooted = await isBootAnimationCompleteAsync(connected.pid);
+        if (isBooted) {
+          stopWaiting();
+          resolve(connected);
+        }
       }
+      // }
     }, 1000);
 
     // Reject command after timeout
-    const maxWait = setTimeout(() => {
-      const manualCommand = `${whichEmulator()} @${name}`;
+    const maxTimer = setTimeout(() => {
+      const manualCommand = `${whichEmulator()} @${device.name}`;
       stopWaitingAndReject(
-        `It took too long to start the Android emulator: ${name}. You can try starting the emulator manually from the terminal with: ${manualCommand}`
+        `It took too long to start the Android emulator: ${device.name}. You can try starting the emulator manually from the terminal with: ${manualCommand}`
       );
     }, EMULATOR_MAX_WAIT_TIMEOUT);
 
     const stopWaiting = () => {
-      clearTimeout(maxWait);
+      clearTimeout(maxTimer);
       clearInterval(waitTimer);
     };
 
@@ -95,21 +192,65 @@ async function maybeStartEmulatorAsync(name: string): Promise<void> {
     emulatorProcess.on('error', ({ message }) => stopWaitingAndReject(message));
 
     emulatorProcess.on('exit', () => {
-      const manualCommand = `${whichEmulator()} @${name}`;
+      const manualCommand = `${whichEmulator()} @${device.name}`;
       stopWaitingAndReject(
-        `The emulator (${name}) quit before it finished opening. You can try starting the emulator manually from the terminal with: ${manualCommand}`
+        `The emulator (${device.name}) quit before it finished opening. You can try starting the emulator manually from the terminal with: ${manualCommand}`
       );
     });
   });
 }
 
-async function maybeStartAnyEmulatorAsync(): Promise<boolean> {
-  const emulators = await getEmulatorsAsync();
-  if (emulators.length > 0) {
-    await maybeStartEmulatorAsync(emulators[0]);
-    return true;
-  }
-  return false;
+// TODO: This is very expensive for some operations.
+export async function getAttachedDevicesAsync(): Promise<Device[]> {
+  const output = await getAdbOutputAsync(['devices', '-l']);
+
+  const splitItems = output.trim().replace(/\n$/, '').split(os.EOL);
+  // First line is `"List of devices attached"`, remove it
+  // @ts-ignore: todo
+  const attachedDevices: {
+    props: string[];
+    type: Device['type'];
+    isAuthorized: Device['isAuthorized'];
+  }[] = splitItems
+    .slice(1, splitItems.length)
+    .map(line => {
+      // ['FA8251A00719', 'device', 'usb:336592896X', 'product:walleye', 'model:Pixel_2', 'device:walleye', 'transport_id:4']
+      // ['emulator-5554', 'offline', 'transport_id:1']
+      const props = line.split(' ');
+      const isAuthorized = props[1] !== 'unauthorized';
+      const type = line.includes('emulator') ? 'emulator' : 'device';
+      return { props, type, isAuthorized };
+    })
+    .filter(({ props: [pid] }) => !!pid);
+
+  const devicePromises = attachedDevices.map<Promise<Device>>(async props => {
+    const {
+      type,
+      props: [pid, ...deviceInfo],
+      isAuthorized,
+    } = props;
+
+    let name: string | null = null;
+
+    if (type === 'device') {
+      // Possibly formatted like `model:Pixel_2`
+      // Transform to `Pixel_2`
+      name = deviceInfo.find(info => info.includes('model:'))!.replace('model:', '');
+    } else {
+      // Given an emulator pid, get the emulator name which can be used to start the emulator later.
+      name = (await getAbdNameForEmulatorIdAsync(pid)) ?? '';
+    }
+
+    return {
+      pid,
+      name,
+      type,
+      isAuthorized,
+      isBooted: true,
+    };
+  });
+
+  return Promise.all(devicePromises);
 }
 
 export function isPlatformSupported(): boolean {
@@ -153,32 +294,17 @@ export async function getAdbOutputAsync(args: string[]): Promise<string> {
   }
 }
 
-// Device attached
-async function _isDeviceAttachedAsync() {
-  const output = await getAdbOutputAsync(['devices']);
-  const devices = output
-    .trim()
-    .split(/\r?\n/)
-    .reduce<string[]>((previous, line) => {
-      const [name, type] = line.split(/[ ,\t]+/).filter(Boolean);
-      return type === 'device' ? previous.concat(name) : previous;
-    }, []);
-  return devices.length > 0;
-}
-
-async function _isDeviceAuthorizedAsync() {
-  const devices = await getAdbOutputAsync(['devices']);
-  const lines = devices.trim().split(/\r?\n/);
-  lines.shift();
-  const listOfDevicesWithoutFirstLine = lines.join('\n');
-  // result looks like "072c4cf200e333c7  device" when authorized
-  // and "072c4cf200e333c7  unauthorized" when not.
-  return listOfDevicesWithoutFirstLine.includes('device');
+async function _isDeviceAuthorizedAsync(device: Device): Promise<boolean> {
+  // TODO: Get the latest version of the device in case isAuthorized changes.
+  return device.isAuthorized;
 }
 
 // Expo installed
-async function _isExpoInstalledAsync() {
-  const packages = await getAdbOutputAsync(['shell', 'pm', 'list', 'packages', '-f']);
+async function _isExpoInstalledAsync(device: Device) {
+  const packages = await getAdbOutputAsync(
+    adbPidArgs(device.pid, 'shell', 'pm', 'list', 'packages', '-f')
+  );
+
   const lines = packages.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -194,29 +320,24 @@ async function _isExpoInstalledAsync() {
   return false;
 }
 
-// async function _expoVersionAsync() {
-//   const info = await getAdbOutputAsync(['shell', 'dumpsys', 'package', 'host.exp.exponent']);
+async function getExpoVersionAsync(device: Device): Promise<string | null> {
+  const info = await getAdbOutputAsync(
+    adbPidArgs(device.pid, 'shell', 'dumpsys', 'package', 'host.exp.exponent')
+  );
 
-//   const regex = /versionName=([0-9.]+)/;
-//   const regexMatch = regex.exec(info);
-//   if (!regexMatch || regexMatch.length < 2) {
-//     return null;
-//   }
+  const regex = /versionName=([0-9.]+)/;
+  const regexMatch = regex.exec(info);
+  if (!regexMatch || regexMatch.length < 2) {
+    return null;
+  }
 
-//   return regexMatch[1];
-// }
+  return regexMatch[1];
+}
 
-// NOTE(brentvatne): Temporarily remove this. We should take care of installing
-// automatically, not just warn.
-async function _checkExpoUpToDateAsync() {
-  // let versions = await Versions.versionsAsync();
-  // let installedVersion = await _expoVersionAsync();
-  // if (!installedVersion || semver.lt(installedVersion, versions.androidVersion)) {
-  //   Logger.notifications.warn(
-  //     { code: NotificationCode.OLD_ANDROID_APP_VERSION },
-  //     'This version of the Expo app is out of date. Uninstall the app and run again to upgrade.'
-  //   );
-  // }
+async function isClientOutdatedAsync(device: Device): Promise<boolean> {
+  const versions = await Versions.versionsAsync();
+  const installedVersion = await getExpoVersionAsync(device);
+  return !installedVersion || semver.lt(installedVersion, versions.androidVersion);
 }
 
 function _apkCacheDirectory() {
@@ -246,10 +367,10 @@ export async function downloadApkAsync(
   return apkPath;
 }
 
-export async function installExpoAsync(url?: string) {
+export async function installExpoAsync({ device, url }: { device: Device; url?: string }) {
   const bar = new ProgressBar('Downloading the Expo client app [:bar] :percent :etas', {
     total: 100,
-    width: 40,
+    width: 64,
   });
 
   let warningTimer: NodeJS.Timeout;
@@ -273,24 +394,36 @@ export async function installExpoAsync(url?: string) {
   Logger.global.info(`Installing Expo on device`);
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
   warningTimer = setWarningTimer();
-  const result = await getAdbOutputAsync(['install', path]);
+  const result = await getAdbOutputAsync(adbPidArgs(device.pid, 'install', path));
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
 
   clearTimeout(warningTimer);
   return result;
 }
 
-export async function uninstallExpoAsync(): Promise<string | undefined> {
+export async function isDeviceBootedAsync({
+  name,
+}: { name?: string } = {}): Promise<Device | null> {
+  const devices = await getAttachedDevicesAsync();
+
+  if (!name) {
+    return devices[0] ?? null;
+  }
+
+  return devices.find(device => device.name === name) ?? null;
+}
+
+export async function uninstallExpoAsync(device: Device): Promise<string | undefined> {
   Logger.global.info('Uninstalling Expo from Android device.');
 
   // we need to check if its installed, else we might bump into "Failure [DELETE_FAILED_INTERNAL_ERROR]"
-  const isInstalled = await _isExpoInstalledAsync();
+  const isInstalled = await _isExpoInstalledAsync(device);
   if (!isInstalled) {
     return;
   }
 
   try {
-    return await getAdbOutputAsync(['uninstall', 'host.exp.exponent']);
+    return await getAdbOutputAsync(adbPidArgs(device.pid, 'uninstall', 'host.exp.exponent'));
   } catch (e) {
     Logger.global.error(
       'Could not uninstall Expo client from your device, please uninstall Expo client manually and try again.'
@@ -301,10 +434,16 @@ export async function uninstallExpoAsync(): Promise<string | undefined> {
 
 export async function upgradeExpoAsync(url?: string): Promise<boolean> {
   try {
-    await attemptToStartEmulatorOrAssertAsync();
+    const devices = await getAttachedDevicesAsync();
+    if (!devices.length) {
+      throw new Error('no devices connected');
+    }
+    const device = devices[0];
 
-    await uninstallExpoAsync();
-    await installExpoAsync(url);
+    await attemptToStartEmulatorOrAssertAsync(devices[0]);
+
+    await uninstallExpoAsync(device);
+    await installExpoAsync({ device, url });
     if (_lastUrl) {
       Logger.global.info(`Opening ${_lastUrl} in Expo.`);
       await getAdbOutputAsync([
@@ -327,43 +466,40 @@ export async function upgradeExpoAsync(url?: string): Promise<boolean> {
 }
 
 // Open Url
-export async function assertDeviceReadyAsync() {
+export async function assertDeviceReadyAsync(device: Device) {
   const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
 
-  if (!(await _isDeviceAuthorizedAsync())) {
+  if (!(await _isDeviceAuthorizedAsync(device))) {
     throw new Error(
       `This computer is not authorized to debug the device. Please follow the instructions here to enable USB debugging:\n${genymotionMessage}`
     );
   }
 }
 
-async function _openUrlAsync(url: string) {
+async function _openUrlAsync({ pid, url }: { pid: string; url: string }) {
   // NOTE(brentvatne): temporary workaround! launch expo client first, then
   // launch the project!
   // https://github.com/expo/expo/issues/7772
   // adb shell monkey -p host.exp.exponent -c android.intent.category.LAUNCHER 1
-  const openClient = await getAdbOutputAsync([
-    'shell',
-    'monkey',
-    '-p',
-    'host.exp.exponent',
-    '-c',
-    'android.intent.category.LAUNCHER',
-    '1',
-  ]);
+  const openClient = await getAdbOutputAsync(
+    adbPidArgs(
+      pid,
+      'shell',
+      'monkey',
+      '-p',
+      'host.exp.exponent',
+      '-c',
+      'android.intent.category.LAUNCHER',
+      '1'
+    )
+  );
   if (openClient.includes(CANT_START_ACTIVITY_ERROR)) {
     throw new Error(openClient.substring(openClient.indexOf('Error: ')));
   }
 
-  const openProject = await getAdbOutputAsync([
-    'shell',
-    'am',
-    'start',
-    '-a',
-    'android.intent.action.VIEW',
-    '-d',
-    url,
-  ]);
+  const openProject = await getAdbOutputAsync(
+    adbPidArgs(pid, 'shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url)
+  );
   if (openProject.includes(CANT_START_ACTIVITY_ERROR)) {
     throw new Error(openProject.substring(openProject.indexOf('Error: ')));
   }
@@ -371,37 +507,57 @@ async function _openUrlAsync(url: string) {
   return openProject;
 }
 
-async function attemptToStartEmulatorOrAssertAsync() {
-  if (!(await _isDeviceAttachedAsync())) {
-    // If no devices or emulators are attached we should attempt to open one.
-    if (!(await maybeStartAnyEmulatorAsync())) {
-      const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
-      throw new Error(
-        `No Android connected device found, and no emulators could be started automatically.\nPlease connect a device or create an emulator (https://docs.expo.io/workflow/android-studio-emulator).\nThen follow the instructions here to enable USB debugging:\n${genymotionMessage}`
-      );
-    }
+async function attemptToStartEmulatorOrAssertAsync(device: Device): Promise<Device> {
+  // TODO: Add a light-weight method for checking since a device could disconnect.
+  if (!device.isBooted) {
+    device = await startEmulatorAsync(device);
   }
-  await assertDeviceReadyAsync();
+  // TODO: Validate specific device
+  await assertDeviceReadyAsync(device);
+
+  return device;
 }
 
-async function openUrlAsync(url: string, isDetached: boolean = false): Promise<void> {
+async function openUrlAsync({
+  url,
+  device,
+  isDetached = false,
+}: {
+  url: string;
+  isDetached?: boolean;
+  device: Device;
+}): Promise<void> {
   try {
-    await attemptToStartEmulatorOrAssertAsync();
+    device = await attemptToStartEmulatorOrAssertAsync(device);
 
     let installedExpo = false;
-    if (!isDetached && !(await _isExpoInstalledAsync())) {
-      await installExpoAsync();
-      installedExpo = true;
+    if (!isDetached) {
+      let shouldInstall = !(await _isExpoInstalledAsync(device));
+      if (!shouldInstall && (await isClientOutdatedAsync(device))) {
+        const confirm = await confirmAsync({
+          message: `Expo client on ${device.name} (${device.type}) is outdated, would you like to upgrade?`,
+        });
+        if (confirm) {
+          await uninstallExpoAsync(device);
+          shouldInstall = true;
+        }
+      }
+
+      if (shouldInstall) {
+        await installExpoAsync({ device });
+        installedExpo = true;
+      }
     }
+    // process.exit(0);
 
     if (!isDetached) {
       _lastUrl = url;
-      _checkExpoUpToDateAsync(); // let this run in background
+      // _checkExpoUpToDateAsync(); // let this run in background
     }
 
-    Logger.global.info(`Opening on Android device`);
+    Logger.global.info(`Opening on Android ${device.type}`);
     try {
-      await _openUrlAsync(url);
+      await _openUrlAsync({ pid: device.pid!, url });
     } catch (e) {
       if (isDetached) {
         e.message = `Error running app. Have you installed the app already using Android Studio? Since you are detached you must build manually. ${e.message}`;
@@ -410,6 +566,10 @@ async function openUrlAsync(url: string, isDetached: boolean = false): Promise<v
       }
 
       throw e;
+    }
+
+    if (device.type === 'emulator') {
+      // TODO: Bring the emulator window to the front.
     }
 
     Analytics.logEvent('Open Url on Device', {
@@ -422,9 +582,13 @@ async function openUrlAsync(url: string, isDetached: boolean = false): Promise<v
   }
 }
 
-export async function openProjectAsync(
-  projectRoot: string
-): Promise<{ success: true; url: string } | { success: false; error: string }> {
+export async function openProjectAsync({
+  projectRoot,
+  shouldPrompt,
+}: {
+  projectRoot: string;
+  shouldPrompt?: boolean;
+}): Promise<{ success: true; url: string } | { success: false; error: string }> {
   try {
     await startAdbReverseAsync(projectRoot);
 
@@ -433,7 +597,13 @@ export async function openProjectAsync(
       skipSDKVersionRequirement: true,
     });
 
-    await openUrlAsync(projectUrl, !!exp.isDetached);
+    const devices = await getAllAvailableDevicesAsync();
+    let device: Device = devices[0];
+    if (shouldPrompt) {
+      device = await promptForDeviceAsync(devices);
+    }
+
+    await openUrlAsync({ url: projectUrl, device, isDetached: !!exp.isDetached });
     return { success: true, url: projectUrl };
   } catch (e) {
     Logger.global.error(`Couldn't start project on Android: ${e.message}`);
@@ -441,9 +611,13 @@ export async function openProjectAsync(
   }
 }
 
-export async function openWebProjectAsync(
-  projectRoot: string
-): Promise<{ success: true; url: string } | { success: false; error: string }> {
+export async function openWebProjectAsync({
+  projectRoot,
+  shouldPrompt,
+}: {
+  projectRoot: string;
+  shouldPrompt?: boolean;
+}): Promise<{ success: true; url: string } | { success: false; error: string }> {
   try {
     await startAdbReverseAsync(projectRoot);
 
@@ -454,7 +628,13 @@ export async function openWebProjectAsync(
         error: `The web project has not been started yet`,
       };
     }
-    await openUrlAsync(projectUrl, true);
+    const devices = await getAllAvailableDevicesAsync();
+    let device: Device = devices[0];
+    if (shouldPrompt) {
+      device = await promptForDeviceAsync(devices);
+    }
+
+    await openUrlAsync({ url: projectUrl, device, isDetached: true });
     return { success: true, url: projectUrl };
   } catch (e) {
     Logger.global.error(`Couldn't open the web project on Android: ${e.message}`);
@@ -472,11 +652,14 @@ export async function startAdbReverseAsync(projectRoot: string): Promise<boolean
     packagerInfo.packagerPort,
     packagerInfo.expoServerPort,
     ...userDefinedAdbReversePorts,
-  ];
+  ].filter(Boolean);
 
-  for (const port of adbReversePorts) {
-    if (!(await adbReverse(port))) {
-      return false;
+  const devices = await getAttachedDevicesAsync();
+  for (const device of devices) {
+    for (const port of adbReversePorts) {
+      if (!(await adbReverse({ device, port }))) {
+        return false;
+      }
     }
   }
 
@@ -492,20 +675,23 @@ export async function stopAdbReverseAsync(projectRoot: string): Promise<void> {
     packagerInfo.packagerPort,
     packagerInfo.expoServerPort,
     ...userDefinedAdbReversePorts,
-  ];
+  ].filter(Boolean);
 
-  for (const port of adbReversePorts) {
-    await adbReverseRemove(port);
+  const devices = await getAttachedDevicesAsync();
+  for (const device of devices) {
+    for (const port of adbReversePorts) {
+      await adbReverseRemove({ device, port });
+    }
   }
 }
 
-async function adbReverse(port: number) {
-  if (!(await _isDeviceAuthorizedAsync())) {
+async function adbReverse({ device, port }: { device: Device; port: number }): Promise<boolean> {
+  if (!(await _isDeviceAuthorizedAsync(device))) {
     return false;
   }
 
   try {
-    await getAdbOutputAsync(['reverse', `tcp:${port}`, `tcp:${port}`]);
+    await getAdbOutputAsync(adbPidArgs(device.pid, 'reverse', `tcp:${port}`, `tcp:${port}`));
     return true;
   } catch (e) {
     Logger.global.warn(`Couldn't adb reverse: ${e.message}`);
@@ -513,19 +699,33 @@ async function adbReverse(port: number) {
   }
 }
 
-async function adbReverseRemove(port: number) {
-  if (!(await _isDeviceAuthorizedAsync())) {
+async function adbReverseRemove({
+  device,
+  port,
+}: {
+  device: Device;
+  port: number;
+}): Promise<boolean> {
+  if (!(await _isDeviceAuthorizedAsync(device))) {
     return false;
   }
 
   try {
-    await getAdbOutputAsync(['reverse', '--remove', `tcp:${port}`]);
+    await getAdbOutputAsync(adbPidArgs(device.pid, 'reverse', '--remove', `tcp:${port}`));
     return true;
   } catch (e) {
     // Don't send this to warn because we call this preemptively sometimes
     Logger.global.debug(`Couldn't adb reverse remove: ${e.message}`);
     return false;
   }
+}
+
+function adbPidArgs(pid: Device['pid'], ...options: string[]): string[] {
+  const args = [];
+  if (pid) {
+    args.push('-s', pid);
+  }
+  return args.concat(options);
 }
 
 type DPIConstraint = {
@@ -658,4 +858,56 @@ export async function maybeStopAdbDaemonAsync() {
   } catch {
     return false;
   }
+}
+
+let _interactiveCallback: ((pause: boolean) => void) | null = null;
+
+/**
+ * Used to pause/resume interaction observers while prompting (made for TerminalUI).
+ *
+ * @param callback
+ */
+export function setInteractiveCallback(callback: (pause: boolean) => void) {
+  _interactiveCallback = callback;
+}
+
+async function promptForDeviceAsync(devices: Device[]): Promise<Device> {
+  // TODO: provide an option to add or download more simulators
+
+  // Pause interactions on the TerminalUI
+  _interactiveCallback?.(true);
+
+  const { answer } = await prompt([
+    {
+      // @ts-ignore: broken types -- TODO: remove when migrating to `prompts`
+      type: 'list',
+      name: 'answer',
+      message: 'Select a simulator',
+      // @ts-ignore
+      choices: devices.map(item => {
+        const isActive = item.isBooted;
+        const format = isActive ? chalk.bold : (text: string) => text;
+        return {
+          name: `${format(item.name)} ${chalk.dim(`(${item.type})`)}`,
+          value: item.name,
+        };
+      }),
+      // @ts-ignore
+      loop: false,
+    },
+  ]);
+  // Resume interactions on the TerminalUI
+  _interactiveCallback?.(false);
+  return devices.find(({ name }) => name === answer)!;
+}
+
+async function confirmAsync(options: { default?: boolean; message: string }): Promise<boolean> {
+  _interactiveCallback?.(true);
+  const { confirm } = await prompt({
+    type: 'confirm',
+    name: 'confirm',
+    ...options,
+  });
+  _interactiveCallback?.(false);
+  return confirm;
 }


### PR DESCRIPTION
- Give android parity with https://github.com/expo/expo-cli/pull/2541
- Support multiple connected android devices
- Support opening Android emulators/devices from a list
- Support prompt to update client automatically
- Improve emulator boot-up
- Improve error messages
- [ ] Discover what's causing the bug: When the client is first installed, opening a link to a project loads the project to 100% then stalls. This might be an Android client bug.
 