### PR TITLE
[expo-cli] EAS Build - track build process with Segment

### DIFF
--- a/packages/expo-cli/src/commands/credentials.ts
+++ b/packages/expo-cli/src/commands/credentials.ts
@@ -14,7 +14,7 @@ type Options = {
   };
 };
 
-export default function(program: CommanderStatic) {
+export default function (program: CommanderStatic) {
   program
     .command('credentials:manager')
     .description('Manage your credentials')

--- a/packages/expo-cli/src/commands/eas-build/build/metadata.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/metadata.ts
@@ -1,10 +1,5 @@
-import {
-  AndroidBuildProfile,
-  CredentialsSource,
-  Workflow,
-  iOSBuildProfile,
-} from '../../../easJson';
-import { CommandContext } from '../types';
+import { CredentialsSource, Workflow } from '../../../easJson';
+import { BuilderContext, Platform, TrackingContext } from '../types';
 
 /**
  * We use require() to exclude package.json from TypeScript's analysis since it lives outside
@@ -48,24 +43,29 @@ export type BuildMetadata = {
    * It's undefined if the expo-updates package is not installed for the project.
    */
   releaseChannel?: string;
+
+  /**
+   * Tracking context
+   * It's used to track build process across different Expo services and tools.
+   */
+  trackingCtx: TrackingContext;
 };
 
-async function collectMetadata<T extends AndroidBuildProfile | iOSBuildProfile>(
-  commandCtx: CommandContext,
+async function collectMetadata<T extends Platform>(
+  ctx: BuilderContext<T>,
   {
     credentialsSource,
-    buildProfile,
   }: {
     credentialsSource?: CredentialsSource.LOCAL | CredentialsSource.REMOTE;
-    buildProfile: T;
   }
 ): Promise<BuildMetadata> {
   return {
-    appVersion: commandCtx.exp.version,
+    appVersion: ctx.commandCtx.exp.version,
     cliVersion: packageJSON.version,
-    workflow: buildProfile.workflow,
+    workflow: ctx.buildProfile.workflow,
     credentialsSource,
-    sdkVersion: commandCtx.exp.sdkVersion,
+    sdkVersion: ctx.commandCtx.exp.sdkVersion,
+    trackingCtx: ctx.trackingCtx,
   };
 }
 

--- a/packages/expo-cli/src/commands/eas-build/credentialsSync/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/credentialsSync/action.ts
@@ -1,3 +1,7 @@
+import { getConfig } from '@expo/config';
+import { Analytics, UserManager } from '@expo/xdl';
+import { v4 as uuidv4 } from 'uuid';
+
 import CommandError from '../../../CommandError';
 import { Context } from '../../../credentials/context';
 import * as credentialsJsonUpdateUtils from '../../../credentials/credentialsJson/update';
@@ -5,9 +9,10 @@ import { runCredentialsManager } from '../../../credentials/route';
 import { SetupAndroidBuildCredentialsFromLocal } from '../../../credentials/views/SetupAndroidKeystore';
 import { SetupIosBuildCredentialsFromLocal } from '../../../credentials/views/SetupIosBuildCredentials';
 import log from '../../../log';
+import { ensureProjectExistsAsync } from '../../../projects';
 import prompts from '../../../prompts';
 import { getBundleIdentifier } from '../build/utils/ios';
-import { BuildCommandPlatform } from '../types';
+import { AnalyticsEvent, BuildCommandPlatform, TrackingContext } from '../types';
 
 interface Options {
   parent: {
@@ -19,6 +24,17 @@ export default async function credentialsSyncAction(projectDir: string, options:
   if (options.parent.nonInteractive) {
     throw new CommandError('This command is not supported in --non-interactive mode');
   }
+  const user = await UserManager.ensureLoggedInAsync();
+  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+
+  const accountName = exp.owner || user.username;
+  const projectName = exp.slug;
+
+  const projectId = await ensureProjectExistsAsync(user, {
+    accountName,
+    projectName,
+  });
+
   const { update, platform } = await prompts([
     {
       type: 'select',
@@ -46,16 +62,26 @@ export default async function credentialsSyncAction(projectDir: string, options:
       ],
     },
   ]);
+
+  const trackingCtx = {
+    tracking_id: uuidv4(),
+    project_id: projectId,
+    account_name: accountName,
+    project_name: projectName,
+    request_platform: platform,
+  };
+  Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_COMMAND, trackingCtx);
   if (update === 'local') {
-    await updateLocalCredentialsAsync(projectDir, platform);
+    await updateLocalCredentialsAsync(projectDir, platform, trackingCtx);
   } else {
-    await updateRemoteCredentialsAsync(projectDir, platform);
+    await updateRemoteCredentialsAsync(projectDir, platform, trackingCtx);
   }
 }
 
 async function updateRemoteCredentialsAsync(
   projectDir: string,
-  platform: BuildCommandPlatform
+  platform: BuildCommandPlatform,
+  trackingCtx: TrackingContext
 ): Promise<void> {
   const ctx = new Context();
   await ctx.init(projectDir);
@@ -63,23 +89,50 @@ async function updateRemoteCredentialsAsync(
     throw new Error('project context is required'); // should be checked earlier
   }
   if ([BuildCommandPlatform.ALL, BuildCommandPlatform.ANDROID].includes(platform)) {
-    const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
-    await runCredentialsManager(ctx, new SetupAndroidBuildCredentialsFromLocal(experienceName));
+    try {
+      const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
+      await runCredentialsManager(ctx, new SetupAndroidBuildCredentialsFromLocal(experienceName));
+      Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_REMOTE_SUCCESS, {
+        ...trackingCtx,
+        platform: 'android',
+      });
+    } catch (error) {
+      Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_REMOTE_FAIL, {
+        ...trackingCtx,
+        platform: 'android',
+        reason: error.message,
+      });
+      throw error;
+    }
   }
   if ([BuildCommandPlatform.ALL, BuildCommandPlatform.IOS].includes(platform)) {
-    const bundleIdentifier = await getBundleIdentifier(projectDir, ctx.manifest);
-    const appLookupParams = {
-      accountName: ctx.manifest.owner ?? ctx.user.username,
-      projectName: ctx.manifest.slug,
-      bundleIdentifier,
-    };
-    await runCredentialsManager(ctx, new SetupIosBuildCredentialsFromLocal(appLookupParams));
+    try {
+      const bundleIdentifier = await getBundleIdentifier(projectDir, ctx.manifest);
+      const appLookupParams = {
+        accountName: ctx.manifest.owner ?? ctx.user.username,
+        projectName: ctx.manifest.slug,
+        bundleIdentifier,
+      };
+      await runCredentialsManager(ctx, new SetupIosBuildCredentialsFromLocal(appLookupParams));
+      Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_REMOTE_SUCCESS, {
+        ...trackingCtx,
+        platform: 'ios',
+      });
+    } catch (error) {
+      Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_REMOTE_FAIL, {
+        ...trackingCtx,
+        platform: 'ios',
+        reason: error.message,
+      });
+      throw error;
+    }
   }
 }
 
 export async function updateLocalCredentialsAsync(
   projectDir: string,
-  platform: BuildCommandPlatform
+  platform: BuildCommandPlatform,
+  trackingCtx: TrackingContext
 ): Promise<void> {
   const ctx = new Context();
   await ctx.init(projectDir);
@@ -87,12 +140,38 @@ export async function updateLocalCredentialsAsync(
     throw new Error('project context is required'); // should be checked earlier
   }
   if ([BuildCommandPlatform.ALL, BuildCommandPlatform.ANDROID].includes(platform)) {
-    log('Updating Android credentials in credentials.json');
-    await credentialsJsonUpdateUtils.updateAndroidCredentialsAsync(ctx);
+    try {
+      log('Updating Android credentials in credentials.json');
+      await credentialsJsonUpdateUtils.updateAndroidCredentialsAsync(ctx);
+      Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_LOCAL_SUCCESS, {
+        ...trackingCtx,
+        platform: 'android',
+      });
+    } catch (error) {
+      Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_LOCAL_FAIL, {
+        ...trackingCtx,
+        platform: 'android',
+        reason: error.message,
+      });
+      throw error;
+    }
   }
   if ([BuildCommandPlatform.ALL, BuildCommandPlatform.IOS].includes(platform)) {
-    const bundleIdentifier = await getBundleIdentifier(projectDir, ctx.manifest);
-    log('Updating iOS credentials in credentials.json');
-    await credentialsJsonUpdateUtils.updateIosCredentialsAsync(ctx, bundleIdentifier);
+    try {
+      const bundleIdentifier = await getBundleIdentifier(projectDir, ctx.manifest);
+      log('Updating iOS credentials in credentials.json');
+      await credentialsJsonUpdateUtils.updateIosCredentialsAsync(ctx, bundleIdentifier);
+      Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_REMOTE_SUCCESS, {
+        ...trackingCtx,
+        platform: 'android',
+      });
+    } catch (error) {
+      Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_REMOTE_FAIL, {
+        ...trackingCtx,
+        platform: 'ios',
+        reason: error.message,
+      });
+      throw error;
+    }
   }
 }

--- a/packages/expo-cli/src/commands/eas-build/init/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/init/action.ts
@@ -4,6 +4,7 @@ import figures from 'figures';
 import fs from 'fs-extra';
 import ora from 'ora';
 import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 
 import { EasJsonReader } from '../../../easJson';
 import { gitAddAsync } from '../../../git';
@@ -83,6 +84,7 @@ async function initAction(projectDir: string, options: BuildOptions): Promise<vo
     requestedPlatform: BuildCommandPlatform.ALL,
     profile: 'release',
     projectDir,
+    trackingCtx: {},
     nonInteractive,
     skipCredentialsCheck: options?.skipCredentialsCheck,
     skipProjectConfiguration: false,

--- a/packages/expo-cli/src/commands/eas-build/status/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/status/action.ts
@@ -1,11 +1,11 @@
-import { ProjectConfig, getConfig } from '@expo/config';
-import { ApiV2, User, UserManager } from '@expo/xdl';
+import { getConfig } from '@expo/config';
+import { Analytics, ApiV2, UserManager } from '@expo/xdl';
 import ora from 'ora';
 
 import log from '../../../log';
 import { ensureProjectExistsAsync } from '../../../projects';
 import { printTableJsonArray } from '../../utils/cli-table';
-import { Build, BuildCommandPlatform, BuildStatus } from '../types';
+import { AnalyticsEvent, Build, BuildCommandPlatform, BuildStatus } from '../types';
 
 interface BuildStatusOptions {
   platform: BuildCommandPlatform;
@@ -42,8 +42,8 @@ async function statusAction(
     }
   }
 
-  const user: User = await UserManager.ensureLoggedInAsync();
-  const { exp }: ProjectConfig = getConfig(projectDir);
+  const user = await UserManager.ensureLoggedInAsync();
+  const { exp } = getConfig(projectDir);
 
   const accountName = exp.owner || user.username;
   const projectName = exp.slug;
@@ -51,6 +51,13 @@ async function statusAction(
   const projectId = await ensureProjectExistsAsync(user, {
     accountName,
     projectName,
+  });
+
+  Analytics.logEvent(AnalyticsEvent.BUILD_STATUS_COMMAND, {
+    project_id: projectId,
+    account_name: accountName,
+    project_name: projectName,
+    requested_platform: platform,
   });
 
   const client = ApiV2.clientForUser(user);

--- a/packages/expo-cli/src/commands/eas-build/types.ts
+++ b/packages/expo-cli/src/commands/eas-build/types.ts
@@ -10,12 +10,16 @@ export enum BuildCommandPlatform {
   ALL = 'all',
 }
 
+export { Platform };
+
 export enum BuildStatus {
   IN_QUEUE = 'in-queue',
   IN_PROGRESS = 'in-progress',
   ERRORED = 'errored',
   FINISHED = 'finished',
 }
+
+export type TrackingContext = Record<string, string | number>;
 
 export interface Build {
   id: string;
@@ -38,6 +42,7 @@ export interface CommandContext {
   accountName: string;
   projectName: string;
   exp: ExpoConfig;
+  trackingCtx: TrackingContext;
   nonInteractive: boolean;
   skipCredentialsCheck: boolean;
   skipProjectConfiguration: boolean;
@@ -45,6 +50,7 @@ export interface CommandContext {
 
 export interface BuilderContext<T extends Platform> {
   commandCtx: CommandContext;
+  trackingCtx: TrackingContext;
   platform: T;
   buildProfile: T extends Platform.Android ? AndroidBuildProfile : iOSBuildProfile;
 }
@@ -60,3 +66,23 @@ export interface Builder<T extends Platform> {
 export type PlatformBuildProfile<T extends Platform> = T extends Platform.Android
   ? AndroidBuildProfile
   : iOSBuildProfile;
+
+export enum AnalyticsEvent {
+  BUILD_COMMAND = 'builds cli build command',
+  PROJECT_UPLOAD_SUCCESS = 'builds cli project upload success',
+  PROJECT_UPLOAD_FAIL = 'builds cli project upload fail',
+  GATHER_CREDENTIALS_SUCCESS = 'builds cli gather credentials success',
+  GATHER_CREDENTIALS_FAIL = 'builds cli gather credentials fail',
+  CONFIGURE_PROJECT_SUCCESS = 'builds cli configure project success',
+  CONFIGURE_PROJECT_FAIL = 'builds cli configure project fail',
+  BUILD_REQUEST_SUCCESS = 'build cli build request success',
+  BUILD_REQUEST_FAIL = 'builds cli build request fail',
+
+  BUILD_STATUS_COMMAND = 'builds cli build status',
+
+  CREDENTIALS_SYNC_COMMAND = 'builds cli credentials sync command',
+  CREDENTIALS_SYNC_UPDATE_LOCAL_SUCCESS = 'builds cli credentials sync update local success',
+  CREDENTIALS_SYNC_UPDATE_LOCAL_FAIL = 'builds cli credentials sync update local fail',
+  CREDENTIALS_SYNC_UPDATE_REMOTE_SUCCESS = 'builds cli credentials sync update remote success',
+  CREDENTIALS_SYNC_UPDATE_REMOTE_FAIL = 'builds cli credentials sync update remote fail',
+}

--- a/packages/expo-cli/src/commands/eas-build/utils/createBuilderContext.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/createBuilderContext.ts
@@ -16,9 +16,13 @@ export default function createBuilderContext<T extends Platform>({
   if (!buildProfile) {
     throw new Error(`${platform} build profile does not exist`);
   }
-
+  const builderTrackingCtx = {
+    ...commandCtx.trackingCtx,
+    platform,
+  };
   return {
     commandCtx,
+    trackingCtx: builderTrackingCtx,
     platform,
     buildProfile,
   };

--- a/packages/expo-cli/src/commands/eas-build/utils/createCommandContextAsync.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/createCommandContextAsync.ts
@@ -1,12 +1,13 @@
 import { getConfig } from '@expo/config';
 import { User, UserManager } from '@expo/xdl';
 
-import { BuildCommandPlatform, CommandContext } from '../types';
+import { BuildCommandPlatform, CommandContext, TrackingContext } from '../types';
 
 export default async function createCommandContextAsync({
   requestedPlatform,
   profile,
   projectDir,
+  trackingCtx,
   nonInteractive = false,
   skipCredentialsCheck = false,
   skipProjectConfiguration = false,
@@ -14,6 +15,7 @@ export default async function createCommandContextAsync({
   requestedPlatform: BuildCommandPlatform;
   profile: string;
   projectDir: string;
+  trackingCtx: TrackingContext;
   nonInteractive?: boolean;
   skipCredentialsCheck?: boolean;
   skipProjectConfiguration?: boolean;
@@ -31,6 +33,7 @@ export default async function createCommandContextAsync({
     accountName,
     projectName,
     exp,
+    trackingCtx,
     nonInteractive,
     skipCredentialsCheck,
     skipProjectConfiguration,

--- a/packages/expo-cli/src/commands/login.ts
+++ b/packages/expo-cli/src/commands/login.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 
 import { login } from '../accounts';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('login')
     .description('Login to an Expo account')

--- a/packages/expo-cli/src/commands/logout.ts
+++ b/packages/expo-cli/src/commands/logout.ts
@@ -12,7 +12,7 @@ async function action() {
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('logout')
     .description('Logout of an Expo account')

--- a/packages/expo-cli/src/commands/register.ts
+++ b/packages/expo-cli/src/commands/register.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 
 import { register } from '../accounts';
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('register')
     .helpGroup('auth')

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -687,7 +687,7 @@ async function maybeCleanNpmStateAsync(packageManager: any) {
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('upgrade')
     .alias('update')

--- a/packages/expo-cli/src/commands/whoami.ts
+++ b/packages/expo-cli/src/commands/whoami.ts
@@ -18,7 +18,7 @@ async function action(command: Command) {
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('whoami')
     .helpGroup('auth')


### PR DESCRIPTION
# Why

Add segment events to track the build process
Pass set of event properties to www to be used in Analytics calls in rest of the services

should be merged after https://github.com/expo/universe/pull/5699