### PR TITLE
[cli] Fix requested sdk in upgrade command

### DIFF
--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -683,9 +683,9 @@ async function maybeCleanNpmStateAsync(packageManager: any) {
   }
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
-    .command('upgrade')
+    .command('upgrade [sdk-version]')
     .alias('update')
     .description('Upgrade the project packages and config for the given SDK version')
     .helpGroup('info')


### PR DESCRIPTION
Fixes #2556

## Why?

Becuase we didn't declare the optional `sdk-version` value you can provide, Commander returns the command instance to `requestedSdkVersion` parameter. This messes up two things:

1. The requested SDK version by outputting "this is an unknown version, you want to try it anyways"
2. If you continue after the warning, it tries to fetch `options.npm` and `options.yarn`. But, due to 1, this is undefined and breaks the upgrade attempt.