### PR TITLE
Fix copy webpack plugin for web overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [webpack] Fix copy webpack plugin for web overrides ([#2558](https://github.com/expo/expo-cli/issues/2558))
+
 ## [Wed, 2 Sep 2020 11:12:02 -0700](https://github.com/expo/expo-cli/commit/c97aba21376324b2131bb5058d193aab5ceb77f4)
 
 ### 🎉 New features

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -250,6 +250,7 @@ export default async function (
       from: locations.template.folder,
       to: locations.production.folder,
       toType: 'dir',
+      noErrorOnMissing: true,
       globOptions: {
         dot: true,
         // We generate new versions of these based on the templates


### PR DESCRIPTION
- fix https://github.com/expo/expo-cli/issues/2554