### PR TITLE
Hide eas commands from help

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/index.ts
+++ b/packages/expo-cli/src/commands/eas-build/index.ts
@@ -12,19 +12,16 @@ export default function (program: Command) {
   const easJsonPath = path.join(process.cwd(), 'eas.json');
   const hasEasJson = fs.pathExistsSync(easJsonPath);
 
-  if (hasEasJson || process.argv[2] !== '--help') {
-    // We don't want to show this in the help output for now
-    program
-      .command('eas:build:init [path]')
-      .description('Initialize build configuration for the project')
-      .helpGroup('eas')
-      .option('--skip-credentials-check', 'Skip checking credentials', false)
-      .asyncActionProjectDir(initAction, { checkConfig: true });
-  }
-
   if (!hasEasJson) {
     return;
   }
+
+  program
+    .command('eas:build:init [path]')
+    .description('Initialize build configuration for the project')
+    .helpGroup('eas')
+    .option('--skip-credentials-check', 'Skip checking credentials', false)
+    .asyncActionProjectDir(initAction, { checkConfig: true });
 
   program
     .command('eas:credentials:sync [path]')

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -100,7 +100,7 @@ Command.prototype.prepareCommands = function () {
       if (getenv.boolish('EXPO_DEBUG', false)) {
         return true;
       }
-      return cmd.__helpGroup !== 'internal';
+      return !['internal', 'eas'].includes(cmd.__helpGroup);
     })
     .map(function (cmd: Command, i: number) {
       const args = cmd._args.map(humanReadableArgName).join(' ');


### PR DESCRIPTION
it appears this was intended but the init command was present in help regardless. Now they'll only be visible with EXPO_DEBUG=1