### PR TITLE
[eject] Add support for iCloud storage

### DIFF
--- a/packages/config/src/ios/Entitlements.ts
+++ b/packages/config/src/ios/Entitlements.ts
@@ -17,16 +17,36 @@ import {
 
 export function setICloudEntitlement(
   config: ExpoConfig,
-  _appleTeamId: string,
+  bundleIdentifier: string,
+  _appleTeamId: string | null,
   entitlementsPlist: any
 ) {
   if (config.ios?.usesIcloudStorage) {
-    // TODO: need access to the appleTeamId for this one!
-    addWarningIOS(
-      'ios.usesIcloudStorage',
-      'Enable the iCloud Storage Entitlement from the Capabilities tab in your Xcode project.'
-      // TODO: add a link to a docs page with more information on how to do this
-    );
+    if (!_appleTeamId) {
+      // TODO: need access to the appleTeamId for this one!
+      addWarningIOS(
+        'ios.usesIcloudStorage',
+        'Enable the iCloud Storage Entitlement from the Capabilities tab in your Xcode project.'
+        // TODO: add a link to a docs page with more information on how to do this
+      );
+      return entitlementsPlist;
+    }
+
+    return {
+      ...entitlementsPlist,
+      'com.apple.developer.icloud-services': ['CloudDocuments'],
+      'com.apple.developer.ubiquity-kvstore-identifier': `${_appleTeamId}.${bundleIdentifier}`,
+      'com.apple.developer.ubiquity-container-identifiers': [`iCloud.${bundleIdentifier}`],
+      'com.apple.developer.icloud-container-identifiers': [`iCloud.${bundleIdentifier}`],
+    };
+  } else if (config.ios?.usesIcloudStorage === false) {
+    // If the value if manually set to false then remove all of the keys.
+    delete entitlementsPlist['com.apple.developer.icloud-services'];
+    delete entitlementsPlist['com.apple.developer.ubiquity-kvstore-identifier'];
+    delete entitlementsPlist['com.apple.developer.ubiquity-container-identifiers'];
+    delete entitlementsPlist['com.apple.developer.icloud-container-identifiers'];
+
+    return entitlementsPlist;
   }
 
   return entitlementsPlist;

--- a/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
@@ -3,6 +3,7 @@ import { getProjectName } from '@expo/config/build/ios/utils/Xcodeproj';
 import { IosPlist, UserManager } from '@expo/xdl';
 import path from 'path';
 
+import { authenticate } from '../../appleApi';
 import { getOrPromptForBundleIdentifier } from '../eject/ConfigValidation';
 
 export default async function configureIOSProjectAsync(projectRoot: string) {
@@ -43,11 +44,16 @@ export default async function configureIOSProjectAsync(projectRoot: string) {
   // TODO: fix this on Windows! We will ignore errors for now so people can just proceed
   try {
     // Configure entitlements/capabilities
-    await modifyEntitlementsPlistAsync(projectRoot, entitlementsPlist => {
+    await modifyEntitlementsPlistAsync(projectRoot, async entitlementsPlist => {
+      let appleTeamId: string | null = null;
+      if (exp.ios?.usesIcloudStorage) {
+        appleTeamId = (await authenticate()).team.id;
+      }
       // TODO: We don't have a mechanism for getting the apple team id here yet
       entitlementsPlist = IOSConfig.Entitlements.setICloudEntitlement(
         exp,
-        'TODO-GET-APPLE-TEAM-ID',
+        bundleIdentifier,
+        appleTeamId,
         entitlementsPlist
       );
 

--- a/packages/xdl/src/detach/IosPlist.ts
+++ b/packages/xdl/src/detach/IosPlist.ts
@@ -47,7 +47,7 @@ async function modifyAsync(plistPath: string, plistName: string, transform: (con
   }
 
   // apply transformation
-  config = transform(config);
+  config = await transform(config);
 
   // back up old plist and swap in modified one
   fs.copyFileSync(configPlistName, `${configPlistName}.bak`);


### PR DESCRIPTION
- [x] Prompt for Apple Team ID and configure entitlements like ExpoKit.
- [ ] Add a system to prevent prompting for the Team ID each time
  - Add team ID to config?
  - Cache team ID?
  - Lock file?
- [ ] Test this functionality somehow
- [ ] Link frameworks in Xcode