### PR TITLE
Fix last used apple id

### DIFF
--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -147,7 +147,7 @@ async function _promptForAppleId({
 
   // If a new email was used then store it as a suggestion for next time.
   // This functionality is disabled using the keychain mechanism.
-  if (!Keychain.EXPO_NO_KEYCHAIN && lastAppleId && lastAppleId !== promptAppleId) {
+  if (!Keychain.EXPO_NO_KEYCHAIN && promptAppleId && lastAppleId !== promptAppleId) {
     await UserSettings.setAsync('appleId', promptAppleId);
   }
 


### PR DESCRIPTION
- Seems this broke in PR review, the username will now be saved and used as default for subsequent login attempts.