### PR TITLE
Use prompts package for simulator/emulator

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -84,6 +84,7 @@
     "pretty-bytes": "^5.3.0",
     "probe-image-size": "4.0.0",
     "progress": "2.0.3",
+    "prompts": "^2.3.2",
     "raven": "2.6.3",
     "react-dev-utils": "~10.2.1",
     "read-last-lines": "1.6.0",

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -3,11 +3,11 @@ import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import child_process from 'child_process';
 import fs from 'fs-extra';
-import { prompt } from 'inquirer';
 import trim from 'lodash/trim';
 import os from 'os';
 import path from 'path';
 import ProgressBar from 'progress';
+import prompts from 'prompts';
 import semver from 'semver';
 
 import * as Analytics from './Analytics';
@@ -203,7 +203,10 @@ async function startEmulatorAsync(device: Device): Promise<Device> {
 export async function getAttachedDevicesAsync(): Promise<Device[]> {
   const output = await getAdbOutputAsync(['devices', '-l']);
 
-  const splitItems = output.trim().replace(/\n$/, '').split(os.EOL);
+  const splitItems = output
+    .trim()
+    .replace(/\n$/, '')
+    .split(os.EOL);
   // First line is `"List of devices attached"`, remove it
   // @ts-ignore: todo
   const attachedDevices: {
@@ -535,6 +538,7 @@ async function openUrlAsync({
       let shouldInstall = !(await _isExpoInstalledAsync(device));
       if (!shouldInstall && (await isClientOutdatedAsync(device))) {
         const confirm = await Prompts.confirmAsync({
+          initial: true,
           message: `Expo client on ${device.name} (${device.type}) is outdated, would you like to upgrade?`,
         });
         if (confirm) {
@@ -598,9 +602,12 @@ export async function openProjectAsync({
     });
 
     const devices = await getAllAvailableDevicesAsync();
-    let device: Device = devices[0];
+    let device: Device | null = devices[0];
     if (shouldPrompt) {
       device = await promptForDeviceAsync(devices);
+    }
+    if (!device) {
+      return { success: false, error: 'escaped' };
     }
 
     await openUrlAsync({ url: projectUrl, device, isDetached: !!exp.isDetached });
@@ -629,9 +636,12 @@ export async function openWebProjectAsync({
       };
     }
     const devices = await getAllAvailableDevicesAsync();
-    let device: Device = devices[0];
+    let device: Device | null = devices[0];
     if (shouldPrompt) {
       device = await promptForDeviceAsync(devices);
+    }
+    if (!device) {
+      return { success: false, error: 'escaped' };
     }
 
     await openUrlAsync({ url: projectUrl, device, isDetached: true });
@@ -860,32 +870,31 @@ export async function maybeStopAdbDaemonAsync() {
   }
 }
 
-async function promptForDeviceAsync(devices: Device[]): Promise<Device> {
+async function promptForDeviceAsync(devices: Device[]): Promise<Device | null> {
   // TODO: provide an option to add or download more simulators
 
   // Pause interactions on the TerminalUI
   Prompts.pauseInteractions();
 
-  const { answer } = await prompt([
-    {
-      // @ts-ignore: broken types -- TODO: remove when migrating to `prompts`
-      type: 'list',
-      name: 'answer',
-      message: 'Select a device/emulator',
-      // @ts-ignore
-      choices: devices.map(item => {
-        const isActive = item.isBooted;
-        const format = isActive ? chalk.bold : (text: string) => text;
-        return {
-          name: `${format(item.name)} ${chalk.dim(`(${item.type})`)}`,
-          value: item.name,
-        };
-      }),
-      // @ts-ignore
-      loop: false,
+  const { value } = await prompts({
+    type: 'autocomplete',
+    name: 'value',
+    limit: 11,
+    message: 'Select a device/emulator',
+    choices: devices.map(item => {
+      const isActive = item.isBooted;
+      const format = isActive ? chalk.bold : (text: string) => text;
+      return {
+        title: `${format(item.name)} ${chalk.dim(`(${item.type})`)}`,
+        value: item.name,
+      };
+    }),
+    suggest: (input: any, choices: any) => {
+      const regex = new RegExp(input, 'i');
+      return choices.filter((choice: any) => regex.test(choice.title));
     },
-  ]);
+  });
   // Resume interactions on the TerminalUI
   Prompts.resumeInteractions();
-  return devices.find(({ name }) => name === answer)!;
+  return value ? devices.find(({ name }) => name === value)! : null;
 }

--- a/packages/xdl/src/Prompts.ts
+++ b/packages/xdl/src/Prompts.ts
@@ -1,4 +1,4 @@
-import { prompt } from 'inquirer';
+import prompts from 'prompts';
 
 type InteractionOptions = { pause: boolean; canEscape?: boolean };
 
@@ -38,15 +38,15 @@ export function resumeInteractions(options: Omit<InteractionOptions, 'pause'> = 
 }
 
 export async function confirmAsync(options: {
-  default?: boolean;
+  initial?: boolean;
   message: string;
 }): Promise<boolean> {
   pauseInteractions();
-  const { confirm } = await prompt({
+  const { value } = await prompts({
     type: 'confirm',
-    name: 'confirm',
+    name: 'value',
     ...options,
   });
   resumeInteractions();
-  return confirm;
+  return value;
 }


### PR DESCRIPTION
- Adds support for cancelling out of simulator/emulator list and going back to the Terminal UI (currently just ctrl+c)
- Adds auto complete support for searching through lists
- prompts is a much smaller package, better in the long run
- Temporarily removes looping lists

<img width="619" alt="Screen Shot 2020-09-03 at 9 14 58 PM" src="https://user-images.githubusercontent.com/9664363/92157486-c33fd900-ee2a-11ea-86a9-835e01c68270.png">
