### PR TITLE
feat(webpack-config): add util function getRulesByMatchingFile

### DIFF
--- a/packages/webpack-config/src/utils/search.ts
+++ b/packages/webpack-config/src/utils/search.ts
@@ -174,7 +174,7 @@ function loaderToLoaderItemLoaderPart(loader: RuleSetUse | undefined): LoaderIte
 export function getRulesByMatchingFile(
   config: AnyConfiguration,
   files: string
-): { [key: string]: RuleItem[] } {
+): RuleItem[] {
   const rules = getRules(config);
   return rules.filter(({ rule }) => conditionMatchesFile(rule.test, file));
 }

--- a/packages/webpack-config/src/utils/search.ts
+++ b/packages/webpack-config/src/utils/search.ts
@@ -168,6 +168,20 @@ function loaderToLoaderItemLoaderPart(loader: RuleSetUse | undefined): LoaderIte
 /**
  *
  * @param config
+ * @param file
+ * @category utils
+ */
+export function getRulesByMatchingFile(
+  config: AnyConfiguration,
+  files: string
+): { [key: string]: RuleItem[] } {
+  const rules = getRules(config);
+  return rules.filter(({ rule }) => conditionMatchesFile(rule.test, file));
+}
+
+/**
+ *
+ * @param config
  * @param files
  * @category utils
  */
@@ -175,10 +189,9 @@ export function getRulesByMatchingFiles(
   config: AnyConfiguration,
   files: string[]
 ): { [key: string]: RuleItem[] } {
-  const rules = getRules(config);
   const selectedRules: { [key: string]: RuleItem[] } = {};
   for (const file of files) {
-    selectedRules[file] = rules.filter(({ rule }) => conditionMatchesFile(rule.test, file));
+    selectedRules[file] = getRulesByMatchingFile(config, file);
   }
   return selectedRules;
 }

--- a/packages/webpack-config/src/utils/search.ts
+++ b/packages/webpack-config/src/utils/search.ts
@@ -173,7 +173,7 @@ function loaderToLoaderItemLoaderPart(loader: RuleSetUse | undefined): LoaderIte
  */
 export function getRulesByMatchingFile(
   config: AnyConfiguration,
-  files: string
+  file: string
 ): RuleItem[] {
   const rules = getRules(config);
   return rules.filter(({ rule }) => conditionMatchesFile(rule.test, file));


### PR DESCRIPTION
This PR adds a util function to retrieve rules using a single file name. So far there is only `getRulesByMatchingFiles` which expects an array and which makes it unnecessary complex to retrieve rules when dealing with one file name only.