### PR TITLE
[cli] Add two-factor authentication to login

### DIFF
--- a/packages/expo-cli/src/__mocks__/prompts.ts
+++ b/packages/expo-cli/src/__mocks__/prompts.ts
@@ -14,6 +14,10 @@ const prompt = jest.fn(
 // see: https://github.com/terkelg/prompts/issues/254
 prompt.separator = (title: string): Choice => ({ title, disable: true, value: undefined });
 
+export const selectAsync = jest.fn(
+  (questions: any, options?: PromptOptions) => prompt(questions, options).value
+);
+
 export const confirmAsync = jest.fn(
   (questions: Question | Question[], options?: PromptOptions) => prompt(questions, options).value
 );

--- a/packages/expo-cli/src/__tests__/accounts-test.ts
+++ b/packages/expo-cli/src/__tests__/accounts-test.ts
@@ -1,0 +1,297 @@
+import { ApiV2 } from '@expo/xdl';
+
+import { _retryUsernamePasswordAuthWithOTPAsync, UserSecondFactorDeviceMethod } from '../accounts';
+import { jester } from '../credentials/test-fixtures/mocks-constants';
+import prompt, { selectAsync } from '../prompts';
+import { mockExpoXDL } from './mock-utils';
+
+jest.mock('../prompts');
+
+mockExpoXDL({
+  UserManager: {
+    initialize: () => {},
+    loginAsync: () => jester,
+  },
+  ApiV2: {
+    clientForUser: jest.fn(),
+  },
+});
+
+const originalWarn = console.warn;
+const originalLog = console.log;
+beforeAll(() => {
+  console.warn = jest.fn();
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.warn = originalWarn;
+  console.log = originalLog;
+});
+
+beforeEach(() => {
+  (prompt as any).mockReset();
+  (prompt as any).mockImplementation(() => {
+    throw new Error('Should not be called');
+  });
+
+  (selectAsync as any).mockReset();
+  (selectAsync as any).mockImplementation(() => {
+    throw new Error('Should not be called');
+  });
+
+  (ApiV2.clientForUser as any).mockReset();
+  (ApiV2.clientForUser as any).mockImplementation(() => {
+    throw new Error('Should not be called');
+  });
+});
+
+describe(_retryUsernamePasswordAuthWithOTPAsync, () => {
+  it('shows SMS OTP prompt when SMS is primary and code was automatically sent', async () => {
+    const consoleFn = jest.fn();
+    console.log = consoleFn;
+
+    (prompt as any)
+      .mockImplementationOnce(() => ({ otp: 'hello' }))
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    const result = await _retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
+      secondFactorDevices: [
+        {
+          id: 'p0',
+          is_primary: true,
+          method: UserSecondFactorDeviceMethod.SMS,
+          sms_phone_number: 'testphone',
+        },
+      ],
+      smsAutomaticallySent: true,
+    });
+
+    expect(consoleFn.mock.calls[0][0]).toContain(
+      'One-time password was sent to the phone number ending'
+    );
+    expect(result).toBe(jester);
+  });
+
+  it('shows authenticator OTP prompt when authenticator is primary', async () => {
+    const consoleFn = jest.fn();
+    console.log = consoleFn;
+
+    (prompt as any)
+      .mockImplementationOnce(() => ({ otp: 'hello' }))
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    const result = await _retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
+      secondFactorDevices: [
+        {
+          id: 'p0',
+          is_primary: true,
+          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+          sms_phone_number: undefined,
+        },
+      ],
+      smsAutomaticallySent: false,
+    });
+
+    expect(consoleFn.mock.calls[0][0]).toEqual('One-time password from authenticator required.');
+    expect(result).toBe(jester);
+  });
+
+  it('shows menu when user bails on primary', async () => {
+    (prompt as any)
+      .mockImplementationOnce(() => ({ otp: null }))
+      .mockImplementationOnce(() => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    (selectAsync as any)
+      .mockImplementationOnce(() => -1)
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    const result = await _retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
+      secondFactorDevices: [
+        {
+          id: 'p0',
+          is_primary: true,
+          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+          sms_phone_number: undefined,
+        },
+        {
+          id: 'p2',
+          is_primary: false,
+          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+          sms_phone_number: undefined,
+        },
+      ],
+      smsAutomaticallySent: false,
+    });
+
+    expect((selectAsync as any).mock.calls.length).toEqual(1);
+    expect(result).toBe(jester);
+  });
+
+  it('shows a warning when when user bails on primary and does not have any secondary set up', async () => {
+    const consoleFn = jest.fn();
+    console.warn = consoleFn;
+
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process exit called');
+    });
+
+    (prompt as any)
+      .mockImplementationOnce(() => ({ otp: null }))
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    await expect(
+      _retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
+        secondFactorDevices: [
+          {
+            id: 'p0',
+            is_primary: true,
+            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+            sms_phone_number: undefined,
+          },
+        ],
+        smsAutomaticallySent: false,
+      })
+    ).rejects.toThrowError('process exit called');
+
+    expect(consoleFn.mock.calls[0][0]).toContain(
+      'No other second-factor devices set up. Ensure you have set up and certified a backup device.'
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('prompts for authenticator OTP when user selects authenticator secondary', async () => {
+    (prompt as any)
+      .mockImplementationOnce(() => ({ otp: null }))
+      .mockImplementationOnce(() => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    (selectAsync as any)
+      .mockImplementationOnce(() => -1)
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    await _retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
+      secondFactorDevices: [
+        {
+          id: 'p0',
+          is_primary: true,
+          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+          sms_phone_number: undefined,
+        },
+        {
+          id: 'p2',
+          is_primary: false,
+          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+          sms_phone_number: undefined,
+        },
+      ],
+      smsAutomaticallySent: false,
+    });
+
+    expect((prompt as any).mock.calls.length).toBe(2); // first OTP, second OTP
+  });
+
+  it('requests SMS OTP and prompts for SMS OTP when user selects SMS secondary', async () => {
+    (prompt as any)
+      .mockImplementationOnce(() => ({ otp: null }))
+      .mockImplementationOnce(() => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    (selectAsync as any)
+      .mockImplementationOnce(() => 0)
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    const postAsyncFn = jest.fn();
+    (ApiV2.clientForUser as any)
+      .mockImplementationOnce(() => ({ postAsync: postAsyncFn }))
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    await _retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
+      secondFactorDevices: [
+        {
+          id: 'p0',
+          is_primary: true,
+          method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+          sms_phone_number: undefined,
+        },
+        {
+          id: 'p2',
+          is_primary: false,
+          method: UserSecondFactorDeviceMethod.SMS,
+          sms_phone_number: 'wat',
+        },
+      ],
+      smsAutomaticallySent: false,
+    });
+
+    expect((prompt as any).mock.calls.length).toBe(2); // first OTP, second OTP
+    expect(postAsyncFn.mock.calls[0]).toEqual([
+      'auth/send-sms-otp',
+      {
+        username: 'blah',
+        password: 'blah',
+        secondFactorDeviceID: 'p2',
+      },
+    ]);
+  });
+
+  it('exits when user bails on primary and backup', async () => {
+    (prompt as any)
+      .mockImplementationOnce(() => ({ otp: null }))
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    (selectAsync as any)
+      .mockImplementationOnce(() => -2)
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process exit called');
+    });
+
+    await expect(
+      _retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
+        secondFactorDevices: [
+          {
+            id: 'p0',
+            is_primary: true,
+            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+            sms_phone_number: undefined,
+          },
+          {
+            id: 'p2',
+            is_primary: false,
+            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
+            sms_phone_number: undefined,
+          },
+        ],
+        smsAutomaticallySent: false,
+      })
+    ).rejects.toThrowError('process exit called');
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/expo-cli/src/__tests__/accounts-test.ts
+++ b/packages/expo-cli/src/__tests__/accounts-test.ts
@@ -140,10 +140,6 @@ describe(_retryUsernamePasswordAuthWithOTPAsync, () => {
     const consoleFn = jest.fn();
     console.warn = consoleFn;
 
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process exit called');
-    });
-
     (prompt as any)
       .mockImplementationOnce(() => ({ otp: null }))
       .mockImplementation(() => {
@@ -162,12 +158,9 @@ describe(_retryUsernamePasswordAuthWithOTPAsync, () => {
         ],
         smsAutomaticallySent: false,
       })
-    ).rejects.toThrowError('process exit called');
-
-    expect(consoleFn.mock.calls[0][0]).toContain(
+    ).rejects.toThrowError(
       'No other second-factor devices set up. Ensure you have set up and certified a backup device.'
     );
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('prompts for authenticator OTP when user selects authenticator secondary', async () => {
@@ -268,10 +261,6 @@ describe(_retryUsernamePasswordAuthWithOTPAsync, () => {
         throw new Error("shouldn't happen");
       });
 
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process exit called');
-    });
-
     await expect(
       _retryUsernamePasswordAuthWithOTPAsync('blah', 'blah', {
         secondFactorDevices: [
@@ -290,8 +279,6 @@ describe(_retryUsernamePasswordAuthWithOTPAsync, () => {
         ],
         smsAutomaticallySent: false,
       })
-    ).rejects.toThrowError('process exit called');
-
-    expect(mockExit).toHaveBeenCalledWith(1);
+    ).rejects.toThrowError('Cancelled login');
   });
 });

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -112,7 +112,7 @@ export async function login(options: CommandOptions): Promise<User> {
  */
 async function _promptForOTPAsync(cancelBehavior: 'cancel' | 'menu'): Promise<string | null> {
   const enterMessage =
-    cancelBehavior === 'cancel' ? 'press enter to cancel' : 'press enter for other options';
+    cancelBehavior === 'cancel' ? 'press Enter to cancel' : 'press Enter for other options';
   const otpQuestion: Question = {
     type: 'input',
     name: 'otp',
@@ -120,7 +120,7 @@ async function _promptForOTPAsync(cancelBehavior: 'cancel' | 'menu'): Promise<st
   };
 
   const { otp } = await prompt(otpQuestion);
-  if (!otp || otp === '') {
+  if (!otp) {
     return null;
   }
 
@@ -129,7 +129,7 @@ async function _promptForOTPAsync(cancelBehavior: 'cancel' | 'menu'): Promise<st
 
 /**
  * Prompt for user to choose a backup OTP method. If selected method is SMS, a request
- * for a new  will be sent to that method. Then, prompt for the OTP, and retry the user login.
+ * for a new OTP will be sent to that method. Then, prompt for the OTP, and retry the user login.
  */
 async function _promptForBackupOTPAsync(
   username: string,
@@ -139,11 +139,11 @@ async function _promptForBackupOTPAsync(
   const nonPrimarySecondFactorDevices = secondFactorDevices.filter(device => !device.is_primary);
 
   if (nonPrimarySecondFactorDevices.length === 0) {
-    throw new Error('No other second factor devices set up for user');
+    throw new Error('No other second-factor devices set up');
   }
 
-  const hasOtherAuthenticatorSecondFactorDevice = !!nonPrimarySecondFactorDevices.find(
-    device => device.method === UserSecondFactorDeviceMethod.AUTHENTICATOR
+  const hasNonAuthenticatorSecondFactorDevice = nonPrimarySecondFactorDevices.find(
+    device => device.method !== UserSecondFactorDeviceMethod.AUTHENTICATOR
   );
 
   const smsNonPrimarySecondFactorDevices = nonPrimarySecondFactorDevices.filter(
@@ -154,11 +154,11 @@ async function _promptForBackupOTPAsync(
   const cancelChoiceSentinel = -2;
 
   const deviceChoices = smsNonPrimarySecondFactorDevices.map((device, idx) => ({
-    name: `Phone ending in ${device.sms_phone_number}`,
+    name: device.sms_phone_number!,
     value: idx,
   }));
 
-  if (hasOtherAuthenticatorSecondFactorDevice) {
+  if (hasNonAuthenticatorSecondFactorDevice) {
     deviceChoices.push({
       name: 'Authenticator',
       value: authenticatorChoiceSentinel,
@@ -173,14 +173,14 @@ async function _promptForBackupOTPAsync(
   const question: Question = {
     type: 'list',
     name: 'choice',
-    message: 'Select a second factor device:',
+    message: 'Select a second-factor device:',
     choices: deviceChoices,
     pageSize: Infinity,
   };
 
   const { choice } = await prompt(question);
   if (choice === cancelChoiceSentinel) {
-    throw new Error('User cancelled login');
+    throw new Error('Cancelled login');
   } else if (choice === authenticatorChoiceSentinel) {
     return await _promptForOTPAsync('cancel');
   }
@@ -220,13 +220,7 @@ async function _retryUsernamePasswordAuthWithOTPAsync(
     smsAutomaticallySent?: boolean;
   }
 ): Promise<User> {
-  const {
-    secondFactorDevices,
-    smsAutomaticallySent,
-  }: {
-    secondFactorDevices?: SecondFactorDevice[];
-    smsAutomaticallySent?: boolean;
-  } = metadata as any;
+  const { secondFactorDevices, smsAutomaticallySent } = metadata;
   invariant(
     secondFactorDevices !== undefined && smsAutomaticallySent !== undefined,
     'malformed OTP error metadata'
@@ -257,7 +251,7 @@ async function _retryUsernamePasswordAuthWithOTPAsync(
   }
 
   if (!otp) {
-    throw new Error('User cancelled login');
+    throw new Error('Cancelled login');
   }
 
   return await UserManager.loginAsync('user-pass', {

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -142,8 +142,8 @@ async function _promptForBackupOTPAsync(
     throw new Error('No other second-factor devices set up');
   }
 
-  const hasNonAuthenticatorSecondFactorDevice = nonPrimarySecondFactorDevices.find(
-    device => device.method !== UserSecondFactorDeviceMethod.AUTHENTICATOR
+  const hasAuthenticatorSecondFactorDevice = nonPrimarySecondFactorDevices.find(
+    device => device.method === UserSecondFactorDeviceMethod.AUTHENTICATOR
   );
 
   const smsNonPrimarySecondFactorDevices = nonPrimarySecondFactorDevices.filter(
@@ -158,7 +158,7 @@ async function _promptForBackupOTPAsync(
     value: idx,
   }));
 
-  if (hasNonAuthenticatorSecondFactorDevice) {
+  if (hasAuthenticatorSecondFactorDevice) {
     deviceChoices.push({
       name: 'Authenticator',
       value: authenticatorChoiceSentinel,
@@ -223,7 +223,7 @@ async function _retryUsernamePasswordAuthWithOTPAsync(
   const { secondFactorDevices, smsAutomaticallySent } = metadata;
   invariant(
     secondFactorDevices !== undefined && smsAutomaticallySent !== undefined,
-    'malformed OTP error metadata'
+    `Malformed OTP error metadata: ${metadata}`
   );
 
   const primaryDevice = secondFactorDevices.find(device => device.is_primary);

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -141,10 +141,10 @@ async function _promptForBackupOTPAsync(
   const nonPrimarySecondFactorDevices = secondFactorDevices.filter(device => !device.is_primary);
 
   if (nonPrimarySecondFactorDevices.length === 0) {
-    log.warn(
+    throw new CommandError(
+      'LOGIN_CANCELLED',
       'No other second-factor devices set up. Ensure you have set up and certified a backup device.'
     );
-    process.exit(1);
   }
 
   const hasAuthenticatorSecondFactorDevice = nonPrimarySecondFactorDevices.find(
@@ -253,8 +253,7 @@ export async function _retryUsernamePasswordAuthWithOTPAsync(
   }
 
   if (!otp) {
-    log.warn('Cancelled login');
-    process.exit(1);
+    throw new CommandError('LOGIN_CANCELLED', 'Cancelled login');
   }
 
   return await UserManager.loginAsync('user-pass', {

--- a/packages/expo-cli/src/commands/login.ts
+++ b/packages/expo-cli/src/commands/login.ts
@@ -10,5 +10,6 @@ export default function (program: Command) {
     .helpGroup('auth')
     .option('-u, --username [string]', 'Username')
     .option('-p, --password [string]', 'Password')
+    .option('--otp [string]', 'One-time Password')
     .asyncAction(login);
 }

--- a/packages/expo-cli/src/commands/login.ts
+++ b/packages/expo-cli/src/commands/login.ts
@@ -10,6 +10,6 @@ export default function (program: Command) {
     .helpGroup('auth')
     .option('-u, --username [string]', 'Username')
     .option('-p, --password [string]', 'Password')
-    .option('--otp [string]', 'One-time Password')
+    .option('--otp [string]', 'One-time password from your 2FA device')
     .asyncAction(login);
 }

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -39,7 +39,8 @@ export default function prompt(
 // see: https://github.com/terkelg/prompts/issues/254
 prompt.separator = (title: string): Choice => ({ title, disable: true, value: undefined });
 
-type NamelessQuestion = Omit<Question<'value'>, 'name' | 'type'>;
+export type NamelessQuestion = Omit<Question<'value'>, 'name' | 'type'>;
+
 /**
  * Create an auto complete list that can be searched and cancelled.
  *
@@ -75,7 +76,7 @@ export async function autoCompleteAsync(
 export async function selectAsync(
   questions: NamelessQuestion,
   options?: PromptOptions
-): Promise<string> {
+): Promise<any> {
   const { value } = await prompt(
     {
       limit: 11,

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -35,6 +35,7 @@ export class ApiV2Error extends ExtendableError {
   code: string;
   details?: JSONValue;
   serverStack?: string;
+  metadata?: object;
   readonly _isApiError = true;
 
   constructor(message: string, code: string = 'UNKNOWN') {
@@ -244,6 +245,7 @@ export default class ApiV2Client {
       const error = new ApiV2Error(responseError.message, responseError.code);
       error.serverStack = responseError.stack;
       error.details = responseError.details;
+      error.metadata = responseError.metadata;
       throw error;
     }
 

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -91,7 +91,7 @@ export class UserManagerInstance {
    */
   async loginAsync(
     loginType: LoginType,
-    loginArgs?: { username: string; password: string }
+    loginArgs?: { username: string; password: string; otp?: string }
   ): Promise<User> {
     if (loginType === 'user-pass') {
       if (!loginArgs) {
@@ -101,6 +101,7 @@ export class UserManagerInstance {
       const loginResp = await apiAnonymous.postAsync('auth/loginAsync', {
         username: loginArgs.username,
         password: loginArgs.password,
+        otp: loginArgs.otp,
       });
       if (loginResp.error) {
         throw new XDLError('INVALID_USERNAME_PASSWORD', loginResp['error_description']);


### PR DESCRIPTION
# Why

This adds CLI support for the upcoming two-factor authentication feature.

## Feature overview: 

Users are able to configure a set of devices to act as second factor authentication mechanisms. There are two kinds of devices: Authenticator TOTP and SMS. A user has the option to have a "primary" device. A user is also given backup codes during 2FA setup.

Currently there is no public way to set up 2FA since it is still in active development.

# How

See inline docblocks.

# Test Plan

Start server locally with https://github.com/expo/universe/pull/5733 patched.

Set up and confirm 2FA for my user in GraphiQL, adding a default authenticator and backup SMS.

```
export EXPO_LOCAL=1

> yarn expo login --username wschurman2 --password <password_in_plain_text_here> --otp 478045
Success. You are now logged in as wschurman2.

> yarn expo logout
Logged out

> yarn expo login
? Username/Email Address: wschurman2
? Password: [hidden]
One-time password from authenticator required.
? One-time Password or Backup Code (press enter for other options): 134243
Success. You are now logged in as wschurman2.

> yarn expo logout
Logged out

> yarn expo login
? Username/Email Address: wschurman2
? Password: [hidden]
One-time password from authenticator required.
? One-time Password or Backup Code (press enter for other options): <press enter, menu showing all devices is shown in next step>
? Select a device to send a one-time password: Phone ending in **74
? One-time Password or Backup Code (press enter to cancel): 769422
Success. You are now logged in as wschurman2.

> yarn expo login
? Username/Email Address: wschurman2
? Password: [hidden]
One-time password from authenticator required.
? One-time Password or Backup Code (press enter for other options):
? Select a device to send a one-time password: Cancel
User cancelled login
```

Also, run the new integration test.