### PR TITLE
[expo-cli] Configure expo updates when building with eas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [expo-cli] EAS Build: Configure `expo-updates` automatically if it's installed when running `eas:build:init` [#2587](https://github.com/expo/expo-cli/pull/2587)
+
 ### 🐛 Bug fixes
 
 ## [Thu, 24 Sep 2020 16:18:06 -0700](https://github.com/expo/expo-cli/commit/8443580c8093f28550c7ebbb8d1b66bacc83a201)

--- a/packages/config/src/android/Manifest.ts
+++ b/packages/config/src/android/Manifest.ts
@@ -196,3 +196,16 @@ export function addMetaDataItemToMainApplication(
   }
   return mainApplication;
 }
+
+export function removeMetaDataItemFromMainApplication(mainApplication: any, itemName: string) {
+  if (mainApplication.hasOwnProperty('meta-data')) {
+    const index = mainApplication['meta-data'].findIndex(
+      (e: any) => e['$']['android:name'] === itemName
+    );
+
+    if (index > -1) {
+      mainApplication['meta-data'].splice(index, 1);
+    }
+  }
+  return mainApplication;
+}

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -121,7 +121,8 @@
     "untildify": "3.0.3",
     "uuid": "^8.0.0",
     "validator": "10.5.0",
-    "wordwrap": "1.0.0"
+    "wordwrap": "1.0.0",
+    "xcode": "^3.0.1"
   },
   "optionalDependencies": {
     "@expo/traveling-fastlane-darwin": "1.15.1",

--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -166,6 +166,7 @@ async function startBuildAsync<T extends Platform>(
     if (!builder.ctx.commandCtx.skipProjectConfiguration) {
       try {
         await builder.ensureProjectConfiguredAsync();
+
         Analytics.logEvent(
           AnalyticsEvent.CONFIGURE_PROJECT_SUCCESS,
           builder.ctx.trackingCtx.properties

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -1,9 +1,6 @@
 import { IOSConfig } from '@expo/config';
 import { BuildType, iOS, Job, Platform, sanitizeJob } from '@expo/eas-build-job';
-import chalk from 'chalk';
-import figures from 'figures';
 import sortBy from 'lodash/sortBy';
-import ora from 'ora';
 import path from 'path';
 
 import { readSecretEnvsAsync } from '../../../../credentials/credentialsJson/read';
@@ -21,7 +18,8 @@ import { gitRootDirectory } from '../../../../git';
 import log from '../../../../log';
 import prompts from '../../../../prompts';
 import { Builder, BuilderContext } from '../../types';
-import * as gitUtils from '../../utils/git';
+import { configureUpdatesIOSAsync, setUpdatesVersionsIOSAsync } from '../../utils/expoUpdates';
+import { modifyAndCommitAsync } from '../../utils/git';
 import { ensureCredentialsAsync } from '../credentials';
 import { getBundleIdentifier } from '../utils/ios';
 
@@ -99,10 +97,42 @@ class iOSBuilder implements Builder<Platform.iOS> {
   }
 
   public async ensureProjectConfiguredAsync(): Promise<void> {
-    await this.configureProjectAsync();
+    const { projectDir, nonInteractive, exp } = this.ctx.commandCtx;
+
+    await modifyAndCommitAsync(
+      async () => {
+        await this.configureEasBuildAsync();
+        await setUpdatesVersionsIOSAsync({ projectDir, exp });
+      },
+      {
+        startMessage: 'Making sure your Xcode project is set up properly',
+        commitMessage: 'Configure Xcode project',
+        commitSuccessMessage: 'Successfully committed the configuration changes',
+        successMessage: 'We configured your Xcode project to build it on the Expo servers',
+        nonInteractive,
+      }
+    );
   }
 
   public async configureProjectAsync(): Promise<void> {
+    const { projectDir, nonInteractive, exp } = this.ctx.commandCtx;
+
+    await modifyAndCommitAsync(
+      async () => {
+        await this.configureEasBuildAsync();
+        await configureUpdatesIOSAsync({ projectDir, exp });
+      },
+      {
+        startMessage: 'Configuring the Xcode project',
+        commitMessage: 'Configure Xcode project',
+        commitSuccessMessage: 'Successfully committed the configuration changes',
+        successMessage: 'We configured your Xcode project to build it on the Expo servers',
+        nonInteractive,
+      }
+    );
+  }
+
+  private async configureEasBuildAsync(): Promise<void> {
     if (this.ctx.buildProfile.workflow !== Workflow.Generic) {
       return;
     }
@@ -113,49 +143,20 @@ class iOSBuilder implements Builder<Platform.iOS> {
       throw new Error('Call ensureCredentialsAsync first!');
     }
 
-    const spinner = ora('Configuring the Xcode project');
+    const { projectDir, exp } = this.ctx.commandCtx;
 
-    const bundleIdentifier = await getBundleIdentifier(
-      this.ctx.commandCtx.projectDir,
-      this.ctx.commandCtx.exp
-    );
+    const bundleIdentifier = await getBundleIdentifier(projectDir, exp);
 
     const profileName = ProvisioningProfileUtils.readProfileName(
       this.credentials.provisioningProfile
     );
     const appleTeam = ProvisioningProfileUtils.readAppleTeam(this.credentials.provisioningProfile);
 
-    const { projectDir } = this.ctx.commandCtx;
     IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(projectDir, bundleIdentifier, false);
     IOSConfig.ProvisioningProfile.setProvisioningProfileForPbxproj(projectDir, {
       profileName,
       appleTeamId: appleTeam.teamId,
     });
-
-    try {
-      await gitUtils.ensureGitStatusIsCleanAsync();
-      spinner.succeed();
-    } catch (err) {
-      if (err instanceof gitUtils.DirtyGitTreeError) {
-        spinner.succeed('We configured the Xcode project to build it on the Expo servers');
-        log.newLine();
-
-        try {
-          await gitUtils.reviewAndCommitChangesAsync('Configure Xcode project', {
-            nonInteractive: this.ctx.commandCtx.nonInteractive,
-          });
-
-          log(`${chalk.green(figures.tick)} Successfully committed the configuration changes.`);
-        } catch (e) {
-          throw new Error(
-            "Aborting, run the command again once you're ready. Make sure to commit any changes you've made."
-          );
-        }
-      } else {
-        spinner.fail();
-        throw err;
-      }
-    }
   }
 
   private async prepareJobCommonAsync(archiveUrl: string): Promise<Partial<CommonJobProperties>> {

--- a/packages/expo-cli/src/commands/eas-build/init/__tests__/init-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/init/__tests__/init-test.ts
@@ -15,7 +15,13 @@ jest.mock('../../../../projects', () => {
     ensureProjectExistsAsync: () => 'fakeProjectId',
   };
 });
-jest.mock('../../utils/git');
+jest.mock('../../utils/git', () => {
+  return {
+    ensureGitRepoExistsAsync: jest.fn(),
+    ensureGitStatusIsCleanAsync: jest.fn(),
+    modifyAndCommitAsync: cb => cb(),
+  };
+});
 jest.mock('../../build/builders/iOSBuilder');
 jest.mock('../../../../git');
 jest.mock('@expo/image-utils', () => ({

--- a/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/android.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/android.ts
@@ -1,0 +1,232 @@
+import { AndroidConfig, ExpoConfig, projectHasModule } from '@expo/config';
+import { UserManager } from '@expo/xdl';
+import * as fs from 'fs-extra';
+import path from 'path';
+
+import CommandError from '../../../../CommandError';
+import getConfigurationOptionsAsync from './getConfigurationOptions';
+import isExpoUpdatesInstalled from './isExpoUpdatesInstalled';
+
+function getAndroidBuildScript(projectDir: string, exp: ExpoConfig) {
+  const androidBuildScriptPath = projectHasModule(
+    'expo-updates/scripts/create-manifest-android.gradle',
+    projectDir,
+    exp
+  );
+
+  if (!androidBuildScriptPath) {
+    throw new Error(
+      "Could not find the build script for Android. This could happen in case of outdated 'node_modules'. Run 'npm install' to make sure that it's up-to-date."
+    );
+  }
+
+  return `apply from: ${JSON.stringify(
+    path.relative(path.join(projectDir, 'android', 'app'), androidBuildScriptPath)
+  )}`;
+}
+
+export async function setUpdatesVersionsAndroidAsync({
+  projectDir,
+  exp,
+}: {
+  projectDir: string;
+  exp: ExpoConfig;
+}) {
+  if (!isExpoUpdatesInstalled(projectDir)) {
+    return;
+  }
+
+  const isUpdatesConfigured = await isUpdatesConfiguredAndroidAsync(projectDir);
+
+  if (!isUpdatesConfigured) {
+    throw new CommandError(
+      '"expo-updates" is installed, but not configured in the project. Please run "expo eas:build:init" first to configure "expo-updates"'
+    );
+  }
+
+  const {
+    path: androidManifestPath,
+    data: androidManifestJSON,
+  } = await getAndroidManifestJSONAsync(projectDir);
+
+  const runtimeVersion = AndroidConfig.Updates.getRuntimeVersion(exp);
+  const sdkVersion = AndroidConfig.Updates.getSDKVersion(exp);
+
+  const currentRuntimeVersion = getAndroidMetadataValue(
+    androidManifestJSON,
+    AndroidConfig.Updates.Config.RUNTIME_VERSION
+  );
+
+  const currentSdkVersion = getAndroidMetadataValue(
+    androidManifestJSON,
+    AndroidConfig.Updates.Config.SDK_VERSION
+  );
+
+  if (
+    (runtimeVersion && runtimeVersion === currentRuntimeVersion) ||
+    (sdkVersion && sdkVersion === currentSdkVersion)
+  ) {
+    return;
+  }
+
+  const result = await AndroidConfig.Updates.setVersionsConfig(exp, androidManifestJSON);
+
+  await AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, result);
+}
+
+export async function configureUpdatesAndroidAsync({
+  projectDir,
+  exp,
+}: {
+  projectDir: string;
+  exp: ExpoConfig;
+}) {
+  if (!isExpoUpdatesInstalled(projectDir)) {
+    return;
+  }
+
+  const username = await UserManager.getCurrentUsernameAsync();
+  const buildGradlePath = getAndroidBuildGradlePath(projectDir);
+  const buildGradleContent = await getAndroidBuildGradleContentAsync(buildGradlePath);
+
+  if (!hasBuildScriptApply(buildGradleContent, projectDir, exp)) {
+    const androidBuildScript = getAndroidBuildScript(projectDir, exp);
+
+    await fs.writeFile(
+      buildGradlePath,
+      `${buildGradleContent}\n// Integration with Expo updates\n${androidBuildScript}\n`
+    );
+  }
+
+  const {
+    path: androidManifestPath,
+    data: androidManifestJSON,
+  } = await getAndroidManifestJSONAsync(projectDir);
+
+  if (!isMetadataSetAndroid(androidManifestJSON, exp, username)) {
+    const result = await AndroidConfig.Updates.setUpdatesConfig(exp, androidManifestJSON, username);
+
+    await AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, result);
+  }
+}
+
+async function isUpdatesConfiguredAndroidAsync(projectDir: string) {
+  if (!isExpoUpdatesInstalled(projectDir)) {
+    return true;
+  }
+
+  const { exp, username } = await getConfigurationOptionsAsync(projectDir);
+
+  const buildGradlePath = getAndroidBuildGradlePath(projectDir);
+  const buildGradleContent = await getAndroidBuildGradleContentAsync(buildGradlePath);
+
+  if (!hasBuildScriptApply(buildGradleContent, projectDir, exp)) {
+    return false;
+  }
+
+  const { data: androidManifestJSON } = await getAndroidManifestJSONAsync(projectDir);
+
+  if (!isMetadataSetAndroid(androidManifestJSON, exp, username)) {
+    return false;
+  }
+
+  return true;
+}
+
+function getAndroidBuildGradlePath(projectDir: string) {
+  const buildGradlePath = path.join(projectDir, 'android', 'app', 'build.gradle');
+
+  return buildGradlePath;
+}
+
+async function getAndroidBuildGradleContentAsync(buildGradlePath: string) {
+  if (!(await fs.pathExists(buildGradlePath))) {
+    throw new Error(`Couldn't find gradle build script at ${buildGradlePath}`);
+  }
+
+  const buildGradleContent = await fs.readFile(buildGradlePath, 'utf-8');
+
+  return buildGradleContent;
+}
+
+function hasBuildScriptApply(
+  buildGradleContent: string,
+  projectDir: string,
+  exp: ExpoConfig
+): boolean {
+  const androidBuildScript = getAndroidBuildScript(projectDir, exp);
+
+  return (
+    buildGradleContent
+      .split('\n')
+      // Check for both single and double quotes
+      .some(line => line === androidBuildScript || line === androidBuildScript.replace(/"/g, "'"))
+  );
+}
+
+async function getAndroidManifestJSONAsync(projectDir: string) {
+  const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
+
+  if (!androidManifestPath) {
+    throw new Error(`Could not find AndroidManifest.xml in project directory: "${projectDir}"`);
+  }
+
+  const androidManifestJSON = await AndroidConfig.Manifest.readAndroidManifestAsync(
+    androidManifestPath
+  );
+
+  return {
+    path: androidManifestPath,
+    data: androidManifestJSON,
+  };
+}
+
+function isMetadataSetAndroid(
+  androidManifestJSON: AndroidConfig.Manifest.Document,
+  exp: ExpoConfig,
+  username: string | null
+): boolean {
+  const currentUpdateUrl = AndroidConfig.Updates.getUpdateUrl(exp, username);
+
+  const setUpdateUrl = getAndroidMetadataValue(
+    androidManifestJSON,
+    AndroidConfig.Updates.Config.UPDATE_URL
+  );
+
+  return Boolean(
+    isVersionsSetAndroid(androidManifestJSON) &&
+      currentUpdateUrl &&
+      setUpdateUrl === currentUpdateUrl
+  );
+}
+
+function isVersionsSetAndroid(androidManifestJSON: AndroidConfig.Manifest.Document): boolean {
+  const runtimeVersion = getAndroidMetadataValue(
+    androidManifestJSON,
+    AndroidConfig.Updates.Config.RUNTIME_VERSION
+  );
+
+  const sdkVersion = getAndroidMetadataValue(
+    androidManifestJSON,
+    AndroidConfig.Updates.Config.SDK_VERSION
+  );
+
+  return Boolean(runtimeVersion || sdkVersion);
+}
+
+function getAndroidMetadataValue(
+  androidManifestJSON: AndroidConfig.Manifest.Document,
+  name: string
+): string | undefined {
+  const mainApplication = androidManifestJSON.manifest?.application?.filter(
+    (e: any) => e['$']['android:name'] === '.MainApplication'
+  )[0];
+
+  if (mainApplication?.hasOwnProperty('meta-data')) {
+    const item = mainApplication?.['meta-data']?.find((e: any) => e.$['android:name'] === name);
+
+    return item?.$['android:value'];
+  }
+
+  return undefined;
+}

--- a/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/getConfigurationOptions.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/getConfigurationOptions.ts
@@ -1,0 +1,18 @@
+import { ExpoConfig, getConfig } from '@expo/config';
+import { UserManager } from '@expo/xdl';
+
+export default async function getConfigurationOptionsAsync(
+  projectDir: string
+): Promise<{ exp: ExpoConfig; username: string | null }> {
+  const username = await UserManager.getCurrentUsernameAsync();
+
+  const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+
+  if (!exp.runtimeVersion && !exp.sdkVersion) {
+    throw new Error(
+      "Couldn't find either 'runtimeVersion' or 'sdkVersion' to configure 'expo-updates'. Please specify at least one of these properties under the 'expo' key in 'app.json'"
+    );
+  }
+
+  return { exp, username };
+}

--- a/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/index.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/index.ts
@@ -1,0 +1,2 @@
+export { configureUpdatesAndroidAsync, setUpdatesVersionsAndroidAsync } from './android';
+export { configureUpdatesIOSAsync, setUpdatesVersionsIOSAsync } from './ios';

--- a/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/ios.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/ios.ts
@@ -1,0 +1,232 @@
+import { ExpoConfig, IOSConfig, projectHasModule } from '@expo/config';
+import plist from '@expo/plist';
+import { UserManager } from '@expo/xdl';
+import * as fs from 'fs-extra';
+import glob from 'glob';
+import path from 'path';
+import xcode from 'xcode';
+
+import CommandError from '../../../../CommandError';
+import { gitAddAsync } from '../../../../git';
+import getConfigurationOptionsAsync from './getConfigurationOptions';
+import isExpoUpdatesInstalled from './isExpoUpdatesInstalled';
+
+function getIOSBuildScript(projectDir: string, exp: ExpoConfig) {
+  const iOSBuildScriptPath = projectHasModule(
+    'expo-updates/scripts/create-manifest-ios.sh',
+    projectDir,
+    exp
+  );
+
+  if (!iOSBuildScriptPath) {
+    throw new Error(
+      "Could not find the build script for iOS. This could happen in case of outdated 'node_modules'. Run 'npm install' to make sure that it's up-to-date."
+    );
+  }
+
+  return path.relative(path.join(projectDir, 'ios'), iOSBuildScriptPath);
+}
+
+export async function setUpdatesVersionsIOSAsync({
+  projectDir,
+  exp,
+}: {
+  projectDir: string;
+  exp: ExpoConfig;
+}) {
+  if (!isExpoUpdatesInstalled(projectDir)) {
+    return;
+  }
+
+  const isUpdatesConfigured = await isUpdatesConfiguredIOSAsync(projectDir);
+
+  if (!isUpdatesConfigured) {
+    throw new CommandError(
+      '"expo-updates" is installed, but not configured in the project. Please run "expo eas:build:init" first to configure "expo-updates"'
+    );
+  }
+
+  await modifyExpoPlistAsync(projectDir, expoPlist => {
+    const runtimeVersion = IOSConfig.Updates.getRuntimeVersion(exp);
+    const sdkVersion = IOSConfig.Updates.getSDKVersion(exp);
+
+    if (
+      (runtimeVersion && expoPlist[IOSConfig.Updates.Config.RUNTIME_VERSION] === runtimeVersion) ||
+      (sdkVersion && expoPlist[IOSConfig.Updates.Config.SDK_VERSION] === sdkVersion)
+    ) {
+      return expoPlist;
+    }
+
+    return IOSConfig.Updates.setVersionsConfig(exp, expoPlist);
+  });
+}
+
+export async function configureUpdatesIOSAsync({
+  projectDir,
+  exp,
+}: {
+  projectDir: string;
+  exp: ExpoConfig;
+}) {
+  if (!isExpoUpdatesInstalled(projectDir)) {
+    return;
+  }
+
+  const username = await UserManager.getCurrentUsernameAsync();
+  const pbxprojPath = await getPbxprojPathAsync(projectDir);
+  const project = await getXcodeProjectAsync(pbxprojPath);
+  const bundleReactNative = await getBundleReactNativePhaseAsync(project);
+  const iOSBuildScript = getIOSBuildScript(projectDir, exp);
+
+  if (!bundleReactNative.shellScript.includes(iOSBuildScript)) {
+    bundleReactNative.shellScript = `${bundleReactNative.shellScript.replace(
+      /"$/,
+      ''
+    )}${iOSBuildScript}\\n"`;
+  }
+
+  await fs.writeFile(pbxprojPath, project.writeSync());
+
+  await modifyExpoPlistAsync(projectDir, expoPlist => {
+    return IOSConfig.Updates.setUpdatesConfig(exp, expoPlist, username);
+  });
+}
+
+async function modifyExpoPlistAsync(projectDir: string, callback: (expoPlist: any) => any) {
+  const pbxprojPath = await getPbxprojPathAsync(projectDir);
+  const expoPlistPath = getExpoPlistPath(projectDir, pbxprojPath);
+
+  let expoPlist = {};
+
+  if (await fs.pathExists(expoPlistPath)) {
+    const expoPlistContent = await fs.readFile(expoPlistPath, 'utf8');
+    expoPlist = plist.parse(expoPlistContent);
+  }
+
+  const updatedExpoPlist = callback(expoPlist);
+
+  if (updatedExpoPlist === expoPlist) {
+    return;
+  }
+
+  const expoPlistContent = plist.build(updatedExpoPlist);
+
+  await fs.mkdirp(path.dirname(expoPlistPath));
+  await fs.writeFile(expoPlistPath, expoPlistContent);
+  await gitAddAsync(expoPlistPath, { intentToAdd: true });
+}
+
+async function isUpdatesConfiguredIOSAsync(projectDir: string) {
+  if (!isExpoUpdatesInstalled(projectDir)) {
+    return true;
+  }
+
+  const { exp, username } = await getConfigurationOptionsAsync(projectDir);
+
+  const pbxprojPath = await getPbxprojPathAsync(projectDir);
+  const project = await getXcodeProjectAsync(pbxprojPath);
+  const bundleReactNative = await getBundleReactNativePhaseAsync(project);
+  const iOSBuildScript = getIOSBuildScript(projectDir, exp);
+
+  if (!bundleReactNative.shellScript.includes(iOSBuildScript)) {
+    return false;
+  }
+
+  const expoPlistPath = getExpoPlistPath(projectDir, pbxprojPath);
+
+  if (!(await fs.pathExists(expoPlistPath))) {
+    return false;
+  }
+
+  const expoPlist = await fs.readFile(expoPlistPath, 'utf8');
+  const expoPlistData = plist.parse(expoPlist);
+
+  return isMetadataSetIOS(expoPlistData, exp, username);
+}
+
+function isMetadataSetIOS(expoPlistData: any, exp: ExpoConfig, username: string | null) {
+  const currentUpdateUrl = IOSConfig.Updates.getUpdateUrl(exp, username);
+
+  if (
+    isVersionsSetIOS(expoPlistData) &&
+    currentUpdateUrl &&
+    expoPlistData[IOSConfig.Updates.Config.UPDATE_URL] === currentUpdateUrl
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function isVersionsSetIOS(expoPlistData: any) {
+  if (
+    expoPlistData[IOSConfig.Updates.Config.RUNTIME_VERSION] ||
+    expoPlistData[IOSConfig.Updates.Config.SDK_VERSION]
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+async function getPbxprojPathAsync(projectDir: string) {
+  const pbxprojPaths = await new Promise<string[]>((resolve, reject) =>
+    glob('ios/*/project.pbxproj', { absolute: true, cwd: projectDir }, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    })
+  );
+
+  const pbxprojPath = pbxprojPaths.length > 0 ? pbxprojPaths[0] : undefined;
+
+  if (!pbxprojPath) {
+    throw new Error(`Could not find Xcode project in project directory: "${projectDir}"`);
+  }
+
+  return pbxprojPath;
+}
+
+async function getXcodeProjectAsync(pbxprojPath: string) {
+  const project = xcode.project(pbxprojPath);
+
+  await new Promise((resolve, reject) =>
+    project.parse(err => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    })
+  );
+
+  return project;
+}
+
+function getExpoPlistPath(projectDir: string, pbxprojPath: string) {
+  const xcodeprojPath = path.resolve(pbxprojPath, '..');
+  const expoPlistPath = path.resolve(
+    projectDir,
+    'ios',
+    path.basename(xcodeprojPath).replace(/\.xcodeproj$/, ''),
+    'Supporting',
+    'Expo.plist'
+  );
+
+  return expoPlistPath;
+}
+
+async function getBundleReactNativePhaseAsync(project: xcode.XcodeProject) {
+  const scriptBuildPhase = project.hash.project.objects.PBXShellScriptBuildPhase;
+  const bundleReactNative = Object.values(scriptBuildPhase).find(
+    buildPhase => buildPhase.name === '"Bundle React Native code and images"'
+  );
+
+  if (!bundleReactNative) {
+    throw new Error(`Couldn't find a build phase script for "Bundle React Native code and images"`);
+  }
+
+  return bundleReactNative;
+}

--- a/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/isExpoUpdatesInstalled.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/expoUpdates/isExpoUpdatesInstalled.ts
@@ -1,0 +1,7 @@
+import { getPackageJson } from '@expo/config';
+
+export default function isExpoUpdatesInstalled(projectDir: string) {
+  const packageJson = getPackageJson(projectDir);
+
+  return packageJson.dependencies && 'expo-updates' in packageJson.dependencies;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22383,6 +22383,14 @@ xcode@^3.0.0:
     simple-plist "^1.1.0"
     uuid "^7.0.3"
 
+xcode@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-3.0.1.tgz#3efb62aac641ab2c702458f9a0302696146aa53c"
+  integrity sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==
+  dependencies:
+    simple-plist "^1.1.0"
+    uuid "^7.0.3"
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"


### PR DESCRIPTION
Why
===

We want to automatically configure required config such as runtime version for expo updates so that it's always uptodate with the app's runtime version.

What
====

Running `expo eas:build:init` will now check if `expo-updates` is in `package.json` and make following changes:

1. On iOS, set `sdkVersion`, `runtimeVersion`, `updateUrl` etc in `Expo.plist`. by reading from `exp` config
2. On iOS, add build phase script for assets in XCode project
1. On Android, set `sdkVersion`, `runtimeVersion`, `updateUrl` etc in `AndroidManifest.xml`. by reading from `exp` config
2. On Android, add build phase script for assets in `build.gradle`

Running `expo eas:build` will now do the following: 

1. Check if either `runtimeVersion` or `sdkversion` are correctly set, and will set them if not
2. Check if project is configured for `expo-updates`, if not, throw an error

Test plan
=========

1. Create a new expo bare minimal app with `expo init`
2. Run `expo eas:build:init` and verify that it made the changes necessary for `expo-updates`
3. Run `expo build --platform <android|ios>` and verify that it schedules a build and
 builds pass on v2 dashboard
4. Add `runtimeVersion` field in `app.json` and verify that `expo build --platform <android|ios>` updates the related configuration before build
5. Remove a necessary configuration such as build script and verify that `expo build --platform <android|ios>` throws an error saying `expo-updates` is not configured