### PR TITLE
Add support for escaped names in eject and bare init

### DIFF
--- a/packages/expo-cli/e2e/__tests__/eject-test.ts
+++ b/packages/expo-cli/e2e/__tests__/eject-test.ts
@@ -63,8 +63,7 @@ it(`can eject a minimal project`, async () => {
   await res;
 
   // Test that native folders were generated
-  // TODO(Bacon): test that the native file names match
-  expect(fileExists(projectName, 'ios/hworld.xcworkspace')).toBe(true);
+  expect(fileExists(projectName, 'ios/hworld.xcodeproj')).toBe(true);
   expect(fileExists(projectName, 'android')).toBe(true);
 
   // Test extra generated files were created

--- a/packages/expo-cli/e2e/__tests__/eject-test.ts
+++ b/packages/expo-cli/e2e/__tests__/eject-test.ts
@@ -49,9 +49,12 @@ function executeDefaultAsync(cwd: string, args: string[]) {
 
 // Test that the default case works (`expo eject`)
 it(`can eject a minimal project`, async () => {
-  const projectName = 'default-eject-minimal-&<world/>';
-
-  const projectRoot = await createMinimalProjectAsync(tempDir, projectName);
+  const projectName = 'default-eject-minimal-world';
+  const projectRoot = await createMinimalProjectAsync(tempDir, projectName, {
+    expo: {
+      name: 'h"&<world/>🚀',
+    },
+  });
 
   // Run a standard eject command
   const res = executeDefaultAsync(projectRoot, ['eject']);
@@ -61,7 +64,7 @@ it(`can eject a minimal project`, async () => {
 
   // Test that native folders were generated
   // TODO(Bacon): test that the native file names match
-  expect(fileExists(projectName, 'ios')).toBe(true);
+  expect(fileExists(projectName, 'ios/hworld.xcworkspace')).toBe(true);
   expect(fileExists(projectName, 'android')).toBe(true);
 
   // Test extra generated files were created

--- a/packages/expo-cli/e2e/__tests__/eject-test.ts
+++ b/packages/expo-cli/e2e/__tests__/eject-test.ts
@@ -49,7 +49,7 @@ function executeDefaultAsync(cwd: string, args: string[]) {
 
 // Test that the default case works (`expo eject`)
 it(`can eject a minimal project`, async () => {
-  const projectName = 'default-eject-minimal';
+  const projectName = 'default-eject-minimal-&<world/>';
 
   const projectRoot = await createMinimalProjectAsync(tempDir, projectName);
 

--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -20,11 +20,11 @@ xtest('init', async () => {
   jest.setTimeout(60000);
   const cwd = temporary.directory();
   const { stdout } = await runAsync(
-    ['init', 'hello-world', '--template', 'blank', '--name', 'Hello'],
+    ['init', 'hello-world', '--template', 'blank', '--name', 'hello-&<world/>'],
     { cwd, env: { ...process.env, YARN_CACHE_FOLDER: path.join(cwd, 'yarn-cache') } }
   );
   expect(stdout).toMatch(`Your project is ready!`);
   const appJson = await JsonFile.readAsync(path.join(cwd, 'hello-world/app.json'));
-  expect(appJson).toHaveProperty(['expo', 'name'], 'Hello');
+  expect(appJson).toHaveProperty(['expo', 'name'], 'hello-&<world/>');
   expect(appJson).toHaveProperty(['expo', 'slug'], 'hello-world');
 });

--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -53,24 +53,39 @@ function sanitizedName(name: string) {
     .replace(/[\u0300-\u036f]/g, '');
 }
 
-class Transformer extends Minipass {
-  data: string;
-  config: TemplateConfig;
+function escapeXMLCharacters(original: string): string {
+  const noAmps = original.replace('&', '&amp;');
+  const noLt = noAmps.replace('<', '&lt;');
+  const noGt = noLt.replace('>', '&gt;');
+  const noApos = noGt.replace('"', '\\"');
+  return noApos.replace("'", "\\'");
+}
 
-  constructor(config: TemplateConfig) {
+class Transformer extends Minipass {
+  data = '';
+
+  constructor(public config: TemplateConfig, private settings: { extension: string }) {
     super();
-    this.data = '';
-    this.config = config;
   }
+
   write(data: string) {
     this.data += data;
     return true;
   }
+
+  getNormalizedName(): string {
+    if (['.xml', '.plist'].includes(this.settings.extension)) {
+      return escapeXMLCharacters(this.config.name);
+    }
+    return this.config.name;
+  }
+
   end() {
+    const name = this.getNormalizedName();
     const replaced = this.data
-      .replace(/Hello App Display Name/g, this.config.name)
-      .replace(/HelloWorld/g, sanitizedName(this.config.name))
-      .replace(/helloworld/g, sanitizedName(this.config.name.toLowerCase()));
+      .replace(/Hello App Display Name/g, name)
+      .replace(/HelloWorld/g, sanitizedName(name))
+      .replace(/helloworld/g, sanitizedName(name.toLowerCase()));
     super.write(replaced);
     return super.end();
   }
@@ -81,8 +96,9 @@ const binaryExtensions = ['.png', '.jar', '.keystore', '.otf', '.ttf'];
 
 function createFileTransform(config: TemplateConfig) {
   return function transformFile(entry: ReadEntry) {
-    if (!binaryExtensions.includes(path.extname(entry.path)) && config.name) {
-      return new Transformer(config);
+    const extension = path.extname(entry.path);
+    if (!binaryExtensions.includes(extension) && config.name) {
+      return new Transformer(config, { extension });
     }
     return undefined;
   };


### PR DESCRIPTION
Apps with special characters would break the strings.xml and Info.plist files when added because they weren't being escaped. 

To repro, set the name of your app.json to `&<world/>` and run `expo eject`.