### PR TITLE
[expo-cli] Eas Build: support for monorepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🎉 New features
 
 - [expo-cli] EAS Build: add `experimental.npmToken` to `credentials.json` [#2603](https://github.com/expo/expo-cli/pull/2603)
+- [expo-cli] EAS Build: monorepo support [#2601](https://github.com/expo/expo-cli/pull/2601)
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -63,7 +63,7 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@expo/build-tools": "^0.1.15",
+    "@expo/build-tools": "^0.1.16",
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.3.0",
     "@expo/dev-tools": "0.13.39",

--- a/packages/expo-cli/src/__mocks__/git.ts
+++ b/packages/expo-cli/src/__mocks__/git.ts
@@ -1,0 +1,13 @@
+const gitStatusAsync = jest.fn();
+const gitDiffAsync = jest.fn();
+const gitAddAsync = jest.fn();
+
+async function gitDoesRepoExistAsync(): Promise<boolean> {
+  return true;
+}
+
+async function gitRootDirectory(): Promise<string> {
+  return '.';
+}
+
+export { gitStatusAsync, gitDiffAsync, gitAddAsync, gitDoesRepoExistAsync, gitRootDirectory };

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
@@ -213,6 +213,7 @@ describe('build command', () => {
         projectUrl: mockProjectUrl,
         artifactPath: 'android/app/build/outputs/**/*.{apk,aab}',
         gradleCommand: ':app:bundleRelease',
+        projectRootDirectory: '.',
         secrets: {
           buildCredentials: {
             keystore: {
@@ -251,6 +252,7 @@ describe('build command', () => {
         type: 'generic',
         projectUrl: mockProjectUrl,
         artifactPath: 'ios/build/App.ipa',
+        projectRootDirectory: '.',
         scheme: 'testapp',
         secrets: {
           buildCredentials: {
@@ -296,6 +298,7 @@ describe('build command', () => {
         projectUrl: mockProjectUrl,
         artifactPath: 'android/app/build/outputs/**/*.{apk,aab}',
         gradleCommand: ':app:bundleRelease',
+        projectRootDirectory: '.',
         secrets: {
           buildCredentials: {
             keystore: {
@@ -319,6 +322,7 @@ describe('build command', () => {
         projectUrl: mockProjectUrl,
         artifactPath: 'ios/build/App.ipa',
         scheme: 'testapp',
+        projectRootDirectory: '.',
         secrets: {
           buildCredentials: {
             distributionCertificate: {

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -16,7 +16,7 @@ import {
   CredentialsSource,
   Workflow,
 } from '../../../../easJson';
-import { gitAddAsync } from '../../../../git';
+import { gitAddAsync, gitRootDirectory } from '../../../../git';
 import log from '../../../../log';
 import { Builder, BuilderContext } from '../../types';
 import * as gitUtils from '../../utils/git';
@@ -185,11 +185,13 @@ class AndroidBuilder implements Builder<Platform.Android> {
     archiveUrl: string,
     buildProfile: AndroidGenericBuildProfile
   ): Promise<Partial<Android.GenericJob>> {
+    const projectRootDirectory = path.relative(await gitRootDirectory(), process.cwd()) || '.';
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
       type: BuildType.Generic,
       gradleCommand: buildProfile.gradleCommand,
       artifactPath: buildProfile.artifactPath,
+      projectRootDirectory,
     };
   }
 

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 import AndroidBuilder from '../AndroidBuilder';
 
 jest.mock('fs');
+jest.mock('../../../../../git');
 jest.mock('../../../../../credentials/context', () => {
   return {
     Context: jest.fn().mockImplementation(() => ({
@@ -73,6 +74,7 @@ describe('AndroidBuilder', () => {
         projectUrl,
         artifactPath: 'android/app/build/outputs/**/*.{apk,aab}',
         gradleCommand: ':app:bundleRelease',
+        projectRootDirectory: '.',
         secrets: {
           buildCredentials: {
             keystore: {

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 import iOSBuilder from '../iOSBuilder';
 
 jest.mock('fs');
+jest.mock('../../../../../git');
 jest.mock('../../../../../credentials/context', () => {
   return {
     Context: jest.fn().mockImplementation(() => ({
@@ -87,6 +88,7 @@ describe('iOSBuilder', () => {
         projectUrl,
         scheme: 'testapp',
         artifactPath: 'ios/build/App.ipa',
+        projectRootDirectory: '.',
         secrets: {
           buildCredentials: {
             distributionCertificate: {

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import figures from 'figures';
 import sortBy from 'lodash/sortBy';
 import ora from 'ora';
+import path from 'path';
 
 import { readSecretEnvsAsync } from '../../../../credentials/credentialsJson/read';
 import iOSCredentialsProvider, {
@@ -16,6 +17,7 @@ import {
   iOSGenericBuildProfile,
   iOSManagedBuildProfile,
 } from '../../../../easJson';
+import { gitRootDirectory } from '../../../../git';
 import log from '../../../../log';
 import prompts from '../../../../prompts';
 import { Builder, BuilderContext } from '../../types';
@@ -182,11 +184,13 @@ class iOSBuilder implements Builder<Platform.iOS> {
     archiveUrl: string,
     buildProfile: iOSGenericBuildProfile
   ): Promise<Partial<iOS.GenericJob>> {
+    const projectRootDirectory = path.relative(await gitRootDirectory(), process.cwd()) || '.';
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
       type: BuildType.Generic,
       scheme: this.scheme,
       artifactPath: buildProfile.artifactPath,
+      projectRootDirectory,
     };
   }
 

--- a/packages/expo-cli/src/commands/eas-build/utils/git.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/git.ts
@@ -4,7 +4,12 @@ import fs from 'fs-extra';
 import ora from 'ora';
 
 import CommandError from '../../../CommandError';
-import { gitDiffAsync, gitDoesRepoExistAsync, gitStatusAsync } from '../../../git';
+import {
+  gitDiffAsync,
+  gitDoesRepoExistAsync,
+  gitRootDirectory,
+  gitStatusAsync,
+} from '../../../git';
 import log from '../../../log';
 import prompts from '../../../prompts';
 
@@ -60,15 +65,11 @@ class DirtyGitTreeError extends Error {}
 
 async function makeProjectTarballAsync(tarPath: string): Promise<number> {
   const spinner = ora('Making project tarball').start();
-  await spawnAsync('git', [
-    'archive',
-    '--format=tar.gz',
-    '--prefix',
-    'project/',
-    '-o',
-    tarPath,
-    'HEAD',
-  ]);
+  await spawnAsync(
+    'git',
+    ['archive', '--format=tar.gz', '--prefix', 'project/', '-o', tarPath, 'HEAD'],
+    { cwd: await gitRootDirectory() }
+  );
   spinner.succeed('Project tarball created.');
 
   const { size } = await fs.stat(tarPath);

--- a/packages/expo-cli/src/git.ts
+++ b/packages/expo-cli/src/git.ts
@@ -29,4 +29,8 @@ async function gitDoesRepoExistAsync(): Promise<boolean> {
   }
 }
 
-export { gitStatusAsync, gitDiffAsync, gitAddAsync, gitDoesRepoExistAsync };
+async function gitRootDirectory(): Promise<string> {
+  return (await spawnAsync('git', ['rev-parse', '--show-toplevel'])).stdout.trim();
+}
+
+export { gitStatusAsync, gitDiffAsync, gitAddAsync, gitDoesRepoExistAsync, gitRootDirectory };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,13 +1385,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/build-tools@^0.1.15":
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/@expo/build-tools/-/build-tools-0.1.15.tgz#6374747ab6b1a8e3a4f84b16d89ddb7263fb9a5d"
-  integrity sha512-j0mu22hWLKBIwvZYmBNMWnAklZRq5cwC6ZyG3SJ5uC2vFK/IIhr3WSstz+dUwFZflCAUUsKRvIbZ2svgBImf4w==
+"@expo/build-tools@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@expo/build-tools/-/build-tools-0.1.16.tgz#387799d40279672f8b6fdcac681b709ac368192f"
+  integrity sha512-TibRPjYxovRPMwQKUnVAiSTEE6tkeI/syY5n7XtnKXEH9lsgHkHieXLoXuxNrrOSjhEwbSyuUXX+DiXXoop6sQ==
   dependencies:
     "@expo/downloader" "0.0.8"
-    "@expo/fastlane" "0.0.13"
+    "@expo/fastlane" "0.0.14"
     "@expo/logger" "0.0.13"
     "@expo/template-file" "0.1.7"
     "@expo/turtle-spawn" "0.0.13"
@@ -1433,10 +1433,10 @@
     fs-extra "^9.0.0"
     got "^11.1.4"
 
-"@expo/fastlane@0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@expo/fastlane/-/fastlane-0.0.13.tgz#57cf2549b8b46e3a10da6a7a76d42b078f5045e2"
-  integrity sha512-3380HL0KwJdJdmUBkD75jzX8ptOC8feGWrQcFu/xEg33zSurzNE0+BEwTEpZBZKVdKyCyEglRWEslU6MEVCPNw==
+"@expo/fastlane@0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@expo/fastlane/-/fastlane-0.0.14.tgz#762dead5565db9f7c250ee451bf9661d9b976214"
+  integrity sha512-hDPffN5WsVfJ6VBfOpmjm24IexHsr1llQrxYCuIoRCVO+6C+lkLF7nC7/Swb7pNpuLhQxAkQJl3UohDwNvJOtA==
   dependencies:
     "@expo/logger" "0.0.13"
     "@expo/turtle-spawn" "0.0.13"


### PR DESCRIPTION
**[do not merge before turtle changes are deployed]**

# Why

Adds support for monorepo

# How

Upload the entire repository instead of the current directory. 
Add `projectRootDirectory` to the job that represents relative path inside tarball