### PR TITLE
fix(cli): let publish command respect clear flag to clear cache

### DIFF
--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -82,6 +82,7 @@ export async function action(
     releaseChannel: options.releaseChannel,
     quiet: options.quiet,
     target,
+    resetCache: options.clear,
   });
 
   const url = result.url;


### PR DESCRIPTION
It seems `--clear` flag should work with `publish` sub command since it is documented in command description (and it is obviously useful).

```
$ expo publish --help

  Usage: publish|p [options] [path]

  Deploy a project to Expo hosting

  Options:

    -q, --quiet                          Suppress verbose output from the Metro bundler.
    -s, --send-to [dest]                 A phone number or email address to send a link to
    -c, --clear                          Clear the Metro bundler cache
    -t, --target [env]                   Target environment for which this publish is intended. Options are `managed` or `bare`.
    --max-workers [num]                  Maximum number of tasks to allow Metro to spawn.
    --release-channel <release channel>  The release channel to publish to. Default is 'default'. (default: default)
    --config [file]                      Specify a path to app.json or app.config.js
    -h, --help                           output usage information
```

Although, actually, the flag is not respected to clear the cache.

This is because `options.clear` is not passed to the publishment process.

## Testing

To test this change, I tried to build the package and execute the command below:

```
expo-cli/packages/expo-cli/bin/expo.js publish --clear
```

Then, I found this message every time I published my package.

```
Your JavaScript transform cache is empty, rebuilding (this may take a minute).
```

This message does not appear when I use the released version of the command.

I don't know it is enough to check this change works well, please let me know the further process if it's needed.

Thanks for the awesome tool 😄 
