### PR TITLE
[expo-cli] EAS Build support `experimental.npmToken` in credentials.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [expo-cli] EAS Build: add `experimental.npmToken` to `credentials.json` [#2603](https://github.com/expo/expo-cli/pull/2603)
+
 ### 🐛 Bug fixes
 
 ## [Thu, 8 Sep 2020 14:30:14 +0200](https://github.com/expo/expo-cli/commit/f0e24ee436806c109c19329c7e161fee0d2f0c81)
@@ -32,7 +34,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [expo-cli] fix Segment context format [#2560](https://github.com/expo/expo-cli/pull/2560))
+- [expo-cli] fix Segment context format [#2560](https://github.com/expo/expo-cli/pull/2560)
 
 ### 📦 Packages updated
 

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
@@ -214,11 +214,13 @@ describe('build command', () => {
         artifactPath: 'android/app/build/outputs/**/*.{apk,aab}',
         gradleCommand: ':app:bundleRelease',
         secrets: {
-          keystore: {
-            dataBase64: keystore.base64,
-            keystorePassword: 'keystorePassword',
-            keyAlias: 'keyAlias',
-            keyPassword: 'keyPassword',
+          buildCredentials: {
+            keystore: {
+              dataBase64: keystore.base64,
+              keystorePassword: 'keystorePassword',
+              keyAlias: 'keyAlias',
+              keyPassword: 'keyPassword',
+            },
           },
         },
       });
@@ -251,11 +253,13 @@ describe('build command', () => {
         artifactPath: 'ios/build/App.ipa',
         scheme: 'testapp',
         secrets: {
-          distributionCertificate: {
-            dataBase64: cert.base64,
-            password: 'certPass',
+          buildCredentials: {
+            distributionCertificate: {
+              dataBase64: cert.base64,
+              password: 'certPass',
+            },
+            provisioningProfileBase64: pprofile.base64,
           },
-          provisioningProfileBase64: pprofile.base64,
         },
       });
     });
@@ -293,11 +297,13 @@ describe('build command', () => {
         artifactPath: 'android/app/build/outputs/**/*.{apk,aab}',
         gradleCommand: ':app:bundleRelease',
         secrets: {
-          keystore: {
-            dataBase64: keystore.base64,
-            keystorePassword: 'keystorePassword',
-            keyAlias: 'keyAlias',
-            keyPassword: 'keyPassword',
+          buildCredentials: {
+            keystore: {
+              dataBase64: keystore.base64,
+              keystorePassword: 'keystorePassword',
+              keyAlias: 'keyAlias',
+              keyPassword: 'keyPassword',
+            },
           },
         },
       });
@@ -314,11 +320,13 @@ describe('build command', () => {
         artifactPath: 'ios/build/App.ipa',
         scheme: 'testapp',
         secrets: {
-          distributionCertificate: {
-            dataBase64: cert.base64,
-            password: 'certPass',
+          buildCredentials: {
+            distributionCertificate: {
+              dataBase64: cert.base64,
+              password: 'certPass',
+            },
+            provisioningProfileBase64: pprofile.base64,
           },
-          provisioningProfileBase64: pprofile.base64,
         },
       });
     });

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
@@ -74,11 +74,13 @@ describe('AndroidBuilder', () => {
         artifactPath: 'android/app/build/outputs/**/*.{apk,aab}',
         gradleCommand: ':app:bundleRelease',
         secrets: {
-          keystore: {
-            dataBase64: keystore.base64,
-            keystorePassword: 'keystorePassword',
-            keyAlias: 'keyAlias',
-            keyPassword: 'keyPassword',
+          buildCredentials: {
+            keystore: {
+              dataBase64: keystore.base64,
+              keystorePassword: 'keystorePassword',
+              keyAlias: 'keyAlias',
+              keyPassword: 'keyPassword',
+            },
           },
         },
       });
@@ -109,11 +111,13 @@ describe('AndroidBuilder', () => {
         packageJson: { example: 'packageJson' },
         manifest: { example: 'manifest' },
         secrets: {
-          keystore: {
-            dataBase64: keystore.base64,
-            keystorePassword: 'keystorePassword',
-            keyAlias: 'keyAlias',
-            keyPassword: 'keyPassword',
+          buildCredentials: {
+            keystore: {
+              dataBase64: keystore.base64,
+              keystorePassword: 'keystorePassword',
+              keyAlias: 'keyAlias',
+              keyPassword: 'keyPassword',
+            },
           },
         },
       });

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
@@ -88,11 +88,13 @@ describe('iOSBuilder', () => {
         scheme: 'testapp',
         artifactPath: 'ios/build/App.ipa',
         secrets: {
-          distributionCertificate: {
-            dataBase64: cert.base64,
-            password: 'certPass',
+          buildCredentials: {
+            distributionCertificate: {
+              dataBase64: cert.base64,
+              password: 'certPass',
+            },
+            provisioningProfileBase64: pprofile.base64,
           },
-          provisioningProfileBase64: pprofile.base64,
         },
       });
     }, 10000);
@@ -123,11 +125,13 @@ describe('iOSBuilder', () => {
         packageJson: { example: 'packageJson' },
         manifest: { example: 'manifest' },
         secrets: {
-          distributionCertificate: {
-            dataBase64: cert.base64,
-            password: 'certPass',
+          buildCredentials: {
+            distributionCertificate: {
+              dataBase64: cert.base64,
+              password: 'certPass',
+            },
+            provisioningProfileBase64: pprofile.base64,
           },
-          provisioningProfileBase64: pprofile.base64,
         },
       });
     });

--- a/packages/expo-cli/src/credentials/credentialsJson/__tests__/read-test.ts
+++ b/packages/expo-cli/src/credentials/credentialsJson/__tests__/read-test.ts
@@ -179,4 +179,29 @@ describe('credentialsJson', () => {
       await expect(promise).rejects.toThrow("ENOENT: no such file or directory, open 'pprofile'");
     });
   });
+
+  describe('readSecretEnvsAsync', () => {
+    it('should read secretEnvs field correctly', async () => {
+      vol.fromJSON({
+        './credentials.json': JSON.stringify({
+          ios: {
+            provisioningProfilePath: 'pprofile',
+            distributionCertificate: {
+              path: 'cert.p12',
+              password: 'certPass',
+            },
+          },
+          experimental: {
+            npmToken: 'VALUE',
+          },
+        }),
+        './pprofile': 'somebinarycontent',
+        './cert.p12': 'somebinarycontent2',
+      });
+      const result = await credentialsJsonReader.readSecretEnvsAsync('.');
+      expect(result).toEqual({
+        NPM_TOKEN: 'VALUE',
+      });
+    });
+  });
 });

--- a/packages/expo-cli/src/credentials/credentialsJson/read.ts
+++ b/packages/expo-cli/src/credentials/credentialsJson/read.ts
@@ -20,6 +20,9 @@ interface CredentialsJson {
       password: string;
     };
   };
+  experimental?: {
+    npmToken?: string;
+  };
 }
 
 const CredentialsJsonSchema = Joi.object({
@@ -37,6 +40,9 @@ const CredentialsJsonSchema = Joi.object({
       path: Joi.string().required(),
       password: Joi.string().required(),
     }).required(),
+  }),
+  experimental: Joi.object({
+    npmToken: Joi.string(),
   }),
 });
 
@@ -90,6 +96,14 @@ export async function readIosCredentialsAsync(projectDir: string): Promise<iOSCr
       certPassword: credentialsJson.ios.distributionCertificate.password,
     },
   };
+}
+
+export async function readSecretEnvsAsync(
+  projectDir: string
+): Promise<Record<string, string> | undefined> {
+  const credentialsJson = await readAsync(projectDir);
+  const npmToken = credentialsJson?.experimental?.npmToken;
+  return npmToken ? { NPM_TOKEN: npmToken } : undefined;
 }
 
 async function readAsync(projectDir: string): Promise<CredentialsJson> {


### PR DESCRIPTION
**[do not merge before turtle changes are deployed]**

# Why

Support for private packages 

# How

add `experimental.npmToken` field to credentials.json