### PR TITLE
[cli] improve init

### DIFF
--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -13,7 +13,8 @@ test('init --help', async () => {
 test('init (no dir name)', async () => {
   const { status, stderr } = await tryRunAsync(['init']);
   expect(status).not.toBe(0);
-  expect(stderr).toMatch('The project dir argument is required in non-interactive mode.');
+
+  expect(stderr).toMatch(/Pass the project name using the first argument/);
 });
 
 xtest('init', async () => {

--- a/packages/expo-cli/src/commands/__tests__/export-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/export-test.ts
@@ -3,12 +3,7 @@ import { vol } from 'memfs';
 
 import { mockExpoXDL } from '../../__tests__/mock-utils';
 import { jester } from '../../credentials/test-fixtures/mocks-constants';
-import {
-  assertFolderEmptyAsync,
-  collectMergeSourceUrlsAsync,
-  ensurePublicUrlAsync,
-  promptPublicUrlAsync,
-} from '../export';
+import { collectMergeSourceUrlsAsync, ensurePublicUrlAsync, promptPublicUrlAsync } from '../export';
 
 jest.mock('fs');
 jest.mock('resolve-from');
@@ -104,57 +99,5 @@ describe('collectMergeSourceUrlsAsync', () => {
 
     // Ensure the tmp directory was created and the file was added
     expect(vol.existsSync(directories[0])).toBe(true);
-  });
-});
-
-describe('assertFolderEmptyAsync', () => {
-  const projectRoot = '/alpha';
-  const projectRootEmpty = '/beta';
-
-  beforeEach(() => {
-    vol.fromJSON({
-      [projectRoot + '/LICENSE']: 'noop',
-      [projectRoot + '/bundles/app.js']: 'noop',
-      [projectRootEmpty + '/LICENSE']: 'noop',
-    });
-  });
-
-  afterEach(() => {
-    vol.reset();
-  });
-
-  const originalWarn = console.warn;
-  const originalLog = console.log;
-  beforeEach(() => {
-    console.warn = jest.fn();
-    console.log = jest.fn();
-  });
-  afterAll(() => {
-    console.warn = originalWarn;
-    console.log = originalLog;
-  });
-
-  it(`returns false when conflicts are found and they cannot be removed`, async () => {
-    // Should return false indicating that the CLI must exit.
-    expect(await assertFolderEmptyAsync({ projectRoot: '/alpha', overwrite: false })).toBe(false);
-    const after = getDirFromFS(vol.toJSON(), projectRoot);
-    // Ensure that no files were deleted.
-    expect(after).toStrictEqual({ LICENSE: 'noop', 'bundles/app.js': 'noop' });
-  });
-
-  it(`returns true when no conflicts are found`, async () => {
-    expect(await assertFolderEmptyAsync({ projectRoot: projectRootEmpty, overwrite: false })).toBe(
-      true
-    );
-    const after = getDirFromFS(vol.toJSON(), projectRootEmpty);
-    // Ensure that no files were deleted.
-    expect(after).toStrictEqual({ LICENSE: 'noop' });
-  });
-
-  it(`returns true when conflicts are found and deleted`, async () => {
-    expect(await assertFolderEmptyAsync({ projectRoot: '/alpha', overwrite: true })).toBe(true);
-    const after = getDirFromFS(vol.toJSON(), projectRoot);
-    // Ensure that the tolerable files were not deleted, and the others were
-    expect(after).toStrictEqual({ LICENSE: 'noop' });
   });
 });

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -4,22 +4,20 @@ import spawnAsync from '@expo/spawn-async';
 import { Exp, IosPlist, UserManager } from '@expo/xdl';
 import chalk from 'chalk';
 import program, { Command } from 'commander';
-import fs from 'fs';
-import getenv from 'getenv';
-import yaml from 'js-yaml';
+import fs from 'fs-extra';
 import padEnd from 'lodash/padEnd';
 import trimStart from 'lodash/trimStart';
 import npmPackageArg from 'npm-package-arg';
-import ora from 'ora';
 import pacote from 'pacote';
 import path from 'path';
-import semver from 'semver';
 import terminalLink from 'terminal-link';
 import wordwrap from 'wordwrap';
 
 import CommandError from '../CommandError';
 import log from '../log';
 import prompt from '../prompt';
+import prompts from '../prompts';
+import * as CreateApp from './utils/CreateApp';
 import { usesOldExpoUpdatesAsync } from './utils/ProjectUtils';
 
 type Options = {
@@ -64,8 +62,16 @@ const FEATURED_TEMPLATES = [
 const BARE_WORKFLOW_TEMPLATES = ['expo-template-bare-minimum', 'expo-template-bare-typescript'];
 const isMacOS = process.platform === 'darwin';
 
-async function action(projectDir: string, command: Command) {
-  const options: Options = {
+function assertValidName(folderName: string) {
+  const validation = CreateApp.validateName(folderName);
+  if (typeof validation === 'string') {
+    log.error(`Cannot create an app named ${chalk.red(`"${folderName}"`)}. ${validation}`);
+    process.exit(1);
+  }
+}
+
+function parseOptions(command: Command): Options {
+  return {
     yes: !!command.yes,
     yarn: !!command.yarn,
     npm: !!command.npm,
@@ -75,35 +81,102 @@ async function action(projectDir: string, command: Command) {
     // option is not set, `command.name` will point to `Command.prototype.name`.
     name: typeof command.name === 'string' ? ((command.name as unknown) as string) : undefined,
   };
-  if (options.yes) {
-    projectDir = '.';
-    if (!options.template) {
-      options.template = 'blank';
+}
+
+async function assertFolderEmptyAsync(projectRoot: string, folderName?: string) {
+  if (!(await CreateApp.assertFolderEmptyAsync({ projectRoot, folderName, overwrite: false }))) {
+    log.newLine();
+    log.nested('Try using a new directory name, or moving these files.');
+    log.newLine();
+    process.exit(1);
+  }
+}
+
+async function resolveProjectRootAsync(input?: string): Promise<string> {
+  let name = input?.trim();
+
+  if (!name) {
+    const { answer } = await prompts({
+      type: 'text',
+      name: 'answer',
+      message: 'What would you like to name your app?',
+      initial: 'my-app',
+      validate: name => {
+        const validation = CreateApp.validateName(path.basename(path.resolve(name)));
+        if (typeof validation === 'string') {
+          return 'Invalid project name: ' + validation;
+        }
+        return true;
+      },
+    });
+
+    if (typeof answer === 'string') {
+      name = answer.trim();
     }
   }
 
-  let parentDir;
-  let dirName;
-  if (projectDir) {
-    const root = path.resolve(projectDir);
-    parentDir = path.dirname(root);
-    dirName = path.basename(root);
-    const validationResult = validateName(parentDir, dirName);
-    if (validationResult !== true) {
-      throw new CommandError('INVALID_PROJECT_DIR', validationResult);
-    }
-  } else if (command.parent?.nonInteractive) {
-    throw new CommandError(
-      'NON_INTERACTIVE',
-      'The project dir argument is required in non-interactive mode.'
-    );
+  if (!name) {
+    log.newLine();
+    log.nested('Please choose your app name:');
+    // todo: ensure expo and not expo-cli
+    log.nested(`  ${log.chalk.green(program.name())} ${log.chalk.magenta('<app-name>')}`);
+    log.newLine();
+    log.nested(`Run ${log.chalk.green(`${program.name()} --help`)} for more info.`);
+    process.exit(1);
+  }
+
+  const projectRoot = path.resolve(name);
+  const folderName = path.basename(projectRoot);
+
+  assertValidName(folderName);
+
+  await fs.ensureDir(projectRoot);
+
+  await assertFolderEmptyAsync(projectRoot, folderName);
+
+  return projectRoot;
+}
+
+function getChangeDirectoryPath(projectRoot: string): string {
+  const cdPath = path.relative(process.cwd(), projectRoot);
+  if (cdPath.length <= projectRoot.length) {
+    return cdPath;
+  }
+  return projectRoot;
+}
+
+async function action(projectDir: string, command: Command) {
+  const options = parseOptions(command);
+
+  // Resolve the name, and projectRoot
+  // TODO: Account for --name
+  let projectRoot: string;
+  if (!projectDir && options.yes) {
+    projectRoot = path.resolve(process.cwd());
+    const folderName = path.basename(projectRoot);
+    assertValidName(folderName);
+    await assertFolderEmptyAsync(projectRoot, folderName);
   } else {
-    parentDir = process.cwd();
+    projectRoot = await resolveProjectRootAsync(projectDir || options.name);
+  }
+
+  let resolvedTemplate: string | null = options.template ?? null;
+  // @ts-ignore: This guards against someone passing --template without a name after it.
+  if (resolvedTemplate === true) {
+    console.log();
+    console.log('Please specify the template');
+    console.log();
+    process.exit(1);
+  }
+
+  // TODO: is this right?
+  if (options.yes && !resolvedTemplate) {
+    resolvedTemplate = 'blank';
   }
 
   let templateSpec;
-  if (options.template) {
-    templateSpec = npmPackageArg(options.template);
+  if (resolvedTemplate) {
+    templateSpec = npmPackageArg(resolvedTemplate);
 
     // For backwards compatibility, 'blank' and 'tabs' are aliases for
     // 'expo-template-blank' and 'expo-template-tabs', respectively.
@@ -154,43 +227,26 @@ async function action(projectDir: string, command: Command) {
     templateSpec = npmPackageArg(template);
   }
 
-  let initialConfig;
+  const projectName = path.basename(projectRoot);
+  const initialConfig: Record<string, any> & { expo: any } = {
+    expo: {
+      name: projectName,
+      slug: projectName,
+    },
+  };
   const templateManifest = await pacote.manifest(templateSpec);
+  // TODO: Use presence of ios/android folder instead.
   const isBare = BARE_WORKFLOW_TEMPLATES.includes(templateManifest.name);
   if (isBare) {
-    initialConfig = await promptForBareConfig(parentDir, dirName, options);
-  } else {
-    initialConfig = await promptForManagedConfig(parentDir, dirName, options);
+    initialConfig.name = projectName;
   }
 
-  let packageManager: 'npm' | 'yarn' = 'npm';
-  if (options.install) {
-    if (options.yarn) {
-      packageManager = 'yarn';
-    } else if (options.npm) {
-      packageManager = 'npm';
-    } else if (PackageManager.shouldUseYarn()) {
-      packageManager = 'yarn';
-      log.newLine();
-      log('🧶 Using Yarn to install packages. You can pass --npm to use npm instead.');
-      log.newLine();
-    } else {
-      packageManager = 'npm';
-      log.newLine();
-      log('📦 Using npm to install packages. You can pass --yarn to use Yarn instead.');
-      log.newLine();
-    }
-  }
-
-  const extractTemplateStep = logNewSection('Downloading and extracting project files.');
+  const extractTemplateStep = CreateApp.logNewSection('Downloading and extracting project files.');
   let projectPath;
   try {
     projectPath = await Exp.extractAndPrepareTemplateAppAsync(
       templateSpec,
-      path.join(
-        parentDir,
-        dirName || ('expo' in initialConfig ? initialConfig.expo.slug : initialConfig.name)
-      ),
+      projectRoot,
       initialConfig
     );
     extractTemplateStep.succeed('Downloaded and extracted project files.');
@@ -201,71 +257,59 @@ async function action(projectDir: string, command: Command) {
     throw e;
   }
 
+  // Install dependencies
+
+  const packageManager = resolvePackageManager(options);
+
+  // TODO: not this
+  const workflow = isBare ? 'bare' : 'managed';
+
+  let podsInstalled: boolean = false;
+  const needsPodsInstalled = await fs.existsSync(path.join(projectRoot, 'ios'));
   if (options.install) {
-    const installJsDepsStep = logNewSection('Installing JavaScript dependencies.');
-    try {
-      await installDependenciesAsync(projectPath, packageManager, { silent: true });
-      installJsDepsStep.succeed('Installed JavaScript dependencies.');
-    } catch {
-      installJsDepsStep.fail(
-        `Something when wrong installing JavaScript dependencies. Check your ${packageManager} logs. Continuing to initialize the app.`
-      );
+    await installNodeDependenciesAsync(projectRoot, packageManager);
+    if (needsPodsInstalled) {
+      podsInstalled = await CreateApp.installCocoaPodsAsync(projectRoot);
     }
   }
 
-  let cdPath = path.relative(process.cwd(), projectPath);
-  if (cdPath.length > projectPath.length) {
-    cdPath = projectPath;
-  }
+  // Configure updates (?)
+
+  const cdPath = getChangeDirectoryPath(projectRoot);
+
+  let showPublishBeforeBuildWarning: boolean | undefined;
+  let didConfigureUpdatesProjectFiles: boolean = false;
+  let username: string | null = null;
+
   if (isBare) {
-    let podsInstalled = false;
-    if (options.install) {
-      try {
-        podsInstalled = await installPodsAsync(projectPath);
-      } catch (_) {}
-    }
-
-    let didConfigureUpdatesProjectFiles = false;
-    const username = await UserManager.getCurrentUsernameAsync();
+    username = await UserManager.getCurrentUsernameAsync();
     if (username) {
       try {
-        await configureUpdatesProjectFilesAsync(
-          projectPath,
-          initialConfig as BareAppConfig,
-          username
-        );
+        await configureUpdatesProjectFilesAsync(projectPath, initialConfig as any, username);
         didConfigureUpdatesProjectFiles = true;
       } catch {}
     }
-
-    log.newLine();
-    const showPublishBeforeBuildWarning = await usesOldExpoUpdatesAsync(projectPath);
-    await logProjectReadyAsync({
-      cdPath,
-      packageManager,
-      workflow: 'bare',
-      showPublishBeforeBuildWarning,
-      didConfigureUpdatesProjectFiles,
-      username,
-    });
-    if (!podsInstalled && isMacOS) {
-      log.newLine();
-      log.nested(
-        `⚠️  Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:`
-      );
-      log.nested('');
-      log.nested(`  cd ${cdPath ?? '.'}/ios`);
-      log.nested(`  pod install`);
-      log.nested('');
-    }
-  } else {
-    log.newLine();
-    await logProjectReadyAsync({ cdPath, packageManager, workflow: 'managed' });
+    showPublishBeforeBuildWarning = await usesOldExpoUpdatesAsync(projectPath);
   }
+
+  // Log info
+
+  log.addNewLineIfNone();
+  await logProjectReadyAsync({
+    cdPath,
+    packageManager,
+    workflow,
+    showPublishBeforeBuildWarning,
+    didConfigureUpdatesProjectFiles,
+    username,
+  });
 
   // Log a warning about needing to install node modules
   if (!options.install) {
     logNodeInstallWarning(cdPath, packageManager);
+  }
+  if (needsPodsInstalled && !podsInstalled) {
+    logCocoaPodsWarning(cdPath);
   }
 
   // Initialize Git at the end to ensure all lock files are committed.
@@ -282,38 +326,44 @@ async function action(projectDir: string, command: Command) {
   }
 }
 
-export async function installDependenciesAsync(
+type PackageManagerName = 'npm' | 'yarn';
+
+// TODO: Use in eject as well
+function resolvePackageManager(
+  options: Pick<Options, 'yarn' | 'npm' | 'install'>
+): PackageManagerName {
+  let packageManager: PackageManagerName = 'npm';
+  if (options.yarn || (!options.npm && PackageManager.shouldUseYarn())) {
+    packageManager = 'yarn';
+  } else {
+    packageManager = 'npm';
+  }
+  if (options.install) {
+    log.addNewLineIfNone();
+    log(
+      packageManager === 'yarn'
+        ? '🧶 Using Yarn to install packages. You can pass --npm to use npm instead.'
+        : '📦 Using npm to install packages.'
+    );
+    log.newLine();
+  }
+
+  return packageManager;
+}
+
+async function installNodeDependenciesAsync(
   projectRoot: string,
   packageManager: 'yarn' | 'npm',
   flags: { silent: boolean } = { silent: false }
 ) {
-  const options = { cwd: projectRoot, silent: flags.silent };
-  if (packageManager === 'yarn') {
-    const yarn = new PackageManager.YarnPackageManager(options);
-    const version = await yarn.versionAsync();
-    const nodeLinker = await yarn.getConfigAsync('nodeLinker');
-    if (semver.satisfies(version, '>=2.0.0-rc.24') && nodeLinker !== 'node-modules') {
-      const yarnRc = path.join(projectRoot, '.yarnrc.yml');
-      let yamlString = '';
-      try {
-        yamlString = fs.readFileSync(yarnRc, 'utf8');
-      } catch (error) {
-        if (error.code !== 'ENOENT') {
-          throw error;
-        }
-      }
-      const config = yamlString ? yaml.safeLoad(yamlString) : {};
-      config.nodeLinker = 'node-modules';
-      !flags.silent &&
-        log.warn(
-          `Yarn v${version} detected, enabling experimental Yarn v2 support using the node-modules plugin.`
-        );
-      !flags.silent && log(`Writing ${yarnRc}...`);
-      fs.writeFileSync(yarnRc, yaml.safeDump(config));
-    }
-    await yarn.installAsync();
-  } else {
-    await new PackageManager.NpmPackageManager(options).installAsync();
+  const installJsDepsStep = CreateApp.logNewSection('Installing JavaScript dependencies.');
+  try {
+    await CreateApp.installNodeDependenciesAsync(projectRoot, packageManager, flags);
+    installJsDepsStep.succeed('Installed JavaScript dependencies.');
+  } catch {
+    installJsDepsStep.fail(
+      `Something when wrong installing JavaScript dependencies. Check your ${packageManager} logs. Continuing to initialize the app.`
+    );
   }
 }
 
@@ -353,15 +403,38 @@ export async function initGitRepoAsync(
   }
 }
 
+// TODO: Use in eject
 function logNodeInstallWarning(cdPath: string, packageManager: 'yarn' | 'npm'): void {
   log.newLine();
   log.nested(`⚠️  Before running your app, make sure you have node modules installed:`);
   log.nested('');
-  log.nested(`  cd ${cdPath ?? '.'}/`);
+  if (cdPath) {
+    // In the case of --yes the project can be created in place so there would be no need to change directories.
+    log.nested(`  cd ${cdPath}/`);
+  }
   log.nested(`  ${packageManager === 'npm' ? 'npm install' : 'yarn'}`);
   log.nested('');
 }
 
+// TODO: Use in eject
+function logCocoaPodsWarning(cdPath: string): void {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+  log.newLine();
+  log.nested(
+    `⚠️  Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:`
+  );
+  log.nested('');
+  if (cdPath) {
+    // In the case of --yes the project can be created in place so there would be no need to change directories.
+    log.nested(`  cd ${cdPath}/`);
+  }
+  log.nested(`  npx pod-install`);
+  log.nested('');
+}
+
+// TODO: Use in eject
 function logProjectReadyAsync({
   cdPath,
   packageManager,
@@ -485,66 +558,6 @@ async function configureUpdatesProjectFilesAsync(
   } finally {
     await IosPlist.cleanBackupAsync(supportingDirectory, 'Expo', false);
   }
-}
-
-async function installPodsAsync(projectRoot: string) {
-  let step = logNewSection('Installing CocoaPods.');
-  if (!isMacOS) {
-    step.succeed('Skipped installing CocoaPods because operating system is not on macOS.');
-    return false;
-  }
-  const packageManager = new PackageManager.CocoaPodsPackageManager({
-    cwd: path.join(projectRoot, 'ios'),
-    log,
-    silent: getenv.boolish('EXPO_DEBUG', true),
-  });
-
-  if (!(await packageManager.isCLIInstalledAsync())) {
-    try {
-      step.text = 'CocoaPods CLI not found in your PATH, installing it now.';
-      step.render();
-      await PackageManager.CocoaPodsPackageManager.installCLIAsync({
-        nonInteractive: program.nonInteractive,
-        spawnOptions: packageManager.options,
-      });
-      step.succeed('Installed CocoaPods CLI');
-      step = logNewSection('Running `pod install` in the `ios` directory.');
-    } catch (e) {
-      step.stopAndPersist({
-        symbol: '⚠️ ',
-        text: chalk.red(
-          'Unable to install the CocoaPods CLI. Continuing with initializing the project, you can install CocoaPods afterwards.'
-        ),
-      });
-      if (e.message) {
-        log(`- ${e.message}`);
-      }
-      return false;
-    }
-  }
-
-  try {
-    await packageManager.installAsync();
-    step.succeed('Installed pods and initialized Xcode workspace.');
-    return true;
-  } catch (e) {
-    step.stopAndPersist({
-      symbol: '⚠️ ',
-      text: chalk.red(
-        'Something when wrong running `pod install` in the `ios` directory. Continuing with initializing the project, you can debug this afterwards.'
-      ),
-    });
-    if (e.message) {
-      log(`- ${e.message}`);
-    }
-    return false;
-  }
-}
-
-function logNewSection(title: string) {
-  const spinner = ora(chalk.bold(title));
-  spinner.start();
-  return spinner;
 }
 
 function validateName(parentDir: string, name: string | undefined) {

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -97,19 +97,24 @@ async function resolveProjectRootAsync(input?: string): Promise<string> {
 
   if (!name) {
     try {
-      const { answer } = await prompts({
-        type: 'text',
-        name: 'answer',
-        message: 'What would you like to name your app?',
-        initial: 'my-app',
-        validate: name => {
-          const validation = CreateApp.validateName(path.basename(path.resolve(name)));
-          if (typeof validation === 'string') {
-            return 'Invalid project name: ' + validation;
-          }
-          return true;
+      const { answer } = await prompts(
+        {
+          type: 'text',
+          name: 'answer',
+          message: 'What would you like to name your app?',
+          initial: 'my-app',
+          validate: name => {
+            const validation = CreateApp.validateName(path.basename(path.resolve(name)));
+            if (typeof validation === 'string') {
+              return 'Invalid project name: ' + validation;
+            }
+            return true;
+          },
         },
-      });
+        {
+          nonInteractiveHelp: 'Pass the project name using the first argument `expo init <name>`',
+        }
+      );
 
       if (typeof answer === 'string') {
         name = answer.trim();

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -144,14 +144,6 @@ async function resolveProjectRootAsync(input?: string): Promise<string> {
   return projectRoot;
 }
 
-function getChangeDirectoryPath(projectRoot: string): string {
-  const cdPath = path.relative(process.cwd(), projectRoot);
-  if (cdPath.length <= projectRoot.length) {
-    return cdPath;
-  }
-  return projectRoot;
-}
-
 async function action(projectDir: string, command: Command) {
   const options = parseOptions(command);
 
@@ -282,7 +274,7 @@ async function action(projectDir: string, command: Command) {
 
   // Configure updates (?)
 
-  const cdPath = getChangeDirectoryPath(projectRoot);
+  const cdPath = CreateApp.getChangeDirectoryPath(projectRoot);
 
   let showPublishBeforeBuildWarning: boolean | undefined;
   let didConfigureUpdatesProjectFiles: boolean = false;

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -120,6 +120,14 @@ export function logNewSection(title: string) {
   return spinner;
 }
 
+export function getChangeDirectoryPath(projectRoot: string): string {
+  const cdPath = path.relative(process.cwd(), projectRoot);
+  if (cdPath.length <= projectRoot.length) {
+    return cdPath;
+  }
+  return projectRoot;
+}
+
 export async function installCocoaPodsAsync(projectRoot: string) {
   log.addNewLineIfNone();
   let step = logNewSection('Installing CocoaPods.');

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -1,0 +1,74 @@
+import fs from 'fs-extra';
+import * as path from 'path';
+
+import log from '../../log';
+
+export function validateName(name?: string): string | true {
+  if (typeof name !== 'string' || name === '') {
+    return 'The project name can not be empty.';
+  }
+  if (!/^[a-z0-9@.\-_]+$/i.test(name)) {
+    return 'The project name can only contain URL-friendly characters.';
+  }
+  return true;
+}
+
+// Any of these files are allowed to exist in the projectRoot
+const TOLERABLE_FILES = [
+  // System
+  '.DS_Store',
+  'Thumbs.db',
+  // Git
+  '.git',
+  '.gitattributes',
+  '.gitignore',
+  // Project
+  '.npmignore',
+  '.travis.yml',
+  'LICENSE',
+  'docs',
+  '.idea',
+  // Package manager
+  'npm-debug.log',
+  'yarn-debug.log',
+  'yarn-error.log',
+];
+
+export function getConflictsForDirectory(
+  projectRoot: string,
+  tolerableFiles: string[] = TOLERABLE_FILES
+): string[] {
+  return fs
+    .readdirSync(projectRoot)
+    .filter((file: string) => !(/\.iml$/.test(file) || tolerableFiles.includes(file)));
+}
+
+export async function assertFolderEmptyAsync({
+  projectRoot,
+  folderName = path.dirname(projectRoot),
+  overwrite,
+}: {
+  projectRoot: string;
+  folderName?: string;
+  overwrite: boolean;
+}): Promise<boolean> {
+  const conflicts = getConflictsForDirectory(projectRoot);
+  if (conflicts.length) {
+    log.addNewLineIfNone();
+    log.nested(`The directory ${log.chalk.green(folderName)} has files that might be overwritten:`);
+    log.newLine();
+    for (const file of conflicts) {
+      log.nested(`  ${file}`);
+    }
+
+    if (overwrite) {
+      log.newLine();
+      log.nested(`Removing existing files from ${log.chalk.green(folderName)}`);
+      await Promise.all(conflicts.map(conflict => fs.remove(path.join(projectRoot, conflict))));
+      return true;
+    }
+
+    return false;
+  }
+  return true;
+}

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -14,7 +14,7 @@ export function validateName(name?: string): string | true {
     return 'The project name can not be empty.';
   }
   if (!/^[a-z0-9@.\-_]+$/i.test(name)) {
-    return 'The project name can only contain URL-friendly characters.';
+    return 'The project name can only contain URL-friendly characters (alphanumeric and @ . -  _)';
   }
   return true;
 }

--- a/packages/expo-cli/src/commands/utils/__tests__/CreateApp-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/CreateApp-test.ts
@@ -1,14 +1,6 @@
-import program from 'commander';
 import { vol } from 'memfs';
 
-import { mockExpoXDL } from '../../__tests__/mock-utils';
-import { jester } from '../../credentials/test-fixtures/mocks-constants';
-import {
-  assertFolderEmptyAsync,
-  collectMergeSourceUrlsAsync,
-  ensurePublicUrlAsync,
-  promptPublicUrlAsync,
-} from '../export';
+import { assertFolderEmptyAsync, getConflictsForDirectory } from '../CreateApp';
 
 jest.mock('fs');
 jest.mock('resolve-from');
@@ -18,21 +10,6 @@ jest.mock('@expo/image-utils', () => ({
     return { source: fs.readFileSync(src) };
   },
 }));
-jest.mock('../utils/Tar', () => ({
-  async downloadAndDecompressAsync(url: string, destination: string): Promise<string> {
-    return destination;
-  },
-}));
-
-mockExpoXDL({
-  UserManager: {
-    ensureLoggedInAsync: jest.fn(() => jester),
-    getCurrentUserAsync: jest.fn(() => jester),
-  },
-  ApiV2: {
-    clientForUser: jest.fn(),
-  },
-});
 
 function getDirFromFS(fsJSON: Record<string, string | null>, rootDir: string) {
   return Object.entries(fsJSON)
@@ -48,62 +25,23 @@ function getDirFromFS(fsJSON: Record<string, string | null>, rootDir: string) {
     );
 }
 
-it(`throws a coded error when prompted in non interactive`, async () => {
-  program.nonInteractive = true;
-  await expect(promptPublicUrlAsync()).rejects.toThrow('public-url');
-});
-
-describe('ensurePublicUrlAsync', () => {
-  const originalWarn = console.warn;
-  const originalLog = console.log;
-  beforeEach(() => {
-    console.warn = jest.fn();
-    console.log = jest.fn();
-  });
-  afterAll(() => {
-    console.warn = originalWarn;
-    console.log = originalLog;
-  });
-
-  it(`throws when a URL is not HTTPS in prod`, async () => {
-    await expect(ensurePublicUrlAsync('bacon', false)).rejects.toThrow('must be a valid HTTPS URL');
-    await expect(ensurePublicUrlAsync('ssh://bacon.io', false)).rejects.toThrow(
-      'must be a valid HTTPS URL'
-    );
-  });
-  it(`does not throw when an invalid URL is used in dev mode`, async () => {
-    await expect(ensurePublicUrlAsync('bacon', true)).resolves.toBe('bacon');
-    await expect(ensurePublicUrlAsync('ssh://bacon.io', true)).resolves.toBe('ssh://bacon.io');
-    // Ensure we warn about the invalid URL in dev mode.
-    expect(console.warn).toBeCalledTimes(2);
-  });
-
-  it(`validates a URL`, async () => {
-    await expect(ensurePublicUrlAsync('https://expo.io', true)).resolves.toBe('https://expo.io');
-    // No warnings thrown
-    expect(console.warn).toBeCalledTimes(0);
-  });
-});
-
-describe('collectMergeSourceUrlsAsync', () => {
+describe('getConflictsForDirectory', () => {
   const projectRoot = '/alpha';
 
   beforeAll(() => {
-    vol.fromJSON({});
+    vol.fromJSON({
+      [projectRoot + '/LICENSE']: 'noop',
+      [projectRoot + '/app.js']: 'noop',
+    });
   });
 
   afterAll(() => {
     vol.reset();
   });
 
-  it(`downloads tar files`, async () => {
-    const directories = await collectMergeSourceUrlsAsync(projectRoot, ['expo.io/app.tar.gz']);
-    expect(directories.length).toBe(1);
-    // Ensure the file was downloaded with the expected name
-    expect(directories[0]).toMatch(/\/alpha\/\.tmp\/app_/);
-
-    // Ensure the tmp directory was created and the file was added
-    expect(vol.existsSync(directories[0])).toBe(true);
+  it(`skips tolerable files`, async () => {
+    expect(getConflictsForDirectory(projectRoot, ['LICENSE'])).toStrictEqual(['app.js']);
+    expect(getConflictsForDirectory(projectRoot, [])).toStrictEqual(['LICENSE', 'app.js']);
   });
 });
 


### PR DESCRIPTION
We have some conflicting logic across different commands which have copy/pasted features. This is an initial push to unify some of these features. This PR also implements some logic from our package `create-react-native-app`. I'll address template issues in another PR after this one lands.

- Prompts for the name before prompting for the template since there is a higher probability that the name will fail. This results in less steps for subprime flows. 
  - We did this in the past because we were attempting to prevent the usage of dashes and numbers in bare project names. We normalize the names though, and iOS + Android both support numbers and dashes so this isn't even an issue afaict.
- Custom abort message for name prompt. Fails more gracefully instead of just quitting.
- Change slug prompt to name prompt in managed, and reuse across bare/managed init.
- Skip prompting to `cd` when the project was created in place (like with `--yes`). This applies to node modules and cocoapods.
- Reuse the conflicting files check / prompt from `expo export` in `expo init`, this is a much better UX for cases when the user attempts to bootstrap a project in a directory with conflicting files.
  - We no longer validate the project directory while the user is typing the project name. Instead, if the user enters a project name that points to a folder with conflicting files, they'd get the same error as when passing a name via `expo init <name>` or `expo init --name <name>`. This is more predictable and has less cases to test and consider.
- Unify CocoaPods installation step across eject and init, this is a good example of a ton of copy/pasted code. This will bring support for `EXPO_DEBUG=false` to silence installs in the eject ⌘. 
- Fix bug where `--no-install` would tell user to `npm start` after init ⌘. Now it favors using yarn when possible.
  - side-note: we should try to remove the `--yarn` flag and default to using yarn like we do in CRNA.
    - side-side-note: we should remove the `--name` flag since it's irrelevant.
- Unify the `logNewSection` logic.
- Unify the duplicative logic across workflows at the end of the init ⌘. We shouldn't be treating the bootstrapping process different based on something fragile like template names. 