### PR TITLE
[eject] update config validation messages

### DIFF
--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -75,7 +75,6 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
 
   await attemptModification(
     projectRoot,
-    `Your iOS bundle identifier is now: ${bundleIdentifier}`,
     {
       ios: { ...(exp.ios || {}), bundleIdentifier },
     },
@@ -144,7 +143,6 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
 
   await attemptModification(
     projectRoot,
-    `Your Android package is now: ${packageName}`,
     {
       android: { ...(exp.android || {}), package: packageName },
     },
@@ -158,7 +156,6 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
 
 async function attemptModification(
   projectRoot: string,
-  modificationSuccessMessage: string,
   edits: Partial<ExpoConfig>,
   exactEdits: Partial<ExpoConfig>
 ): Promise<void> {
@@ -166,8 +163,6 @@ async function attemptModification(
     skipSDKVersionRequirement: true,
   });
   if (modification.type === 'success') {
-    log.addNewLineIfNone();
-    log(modificationSuccessMessage);
     log.newLine();
   } else {
     warnAboutConfigAndExit(modification.type, modification.message!, exactEdits);

--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -1,9 +1,9 @@
 import { ExpoConfig, getConfig, modifyConfigAsync } from '@expo/config';
 import { UserManager } from '@expo/xdl';
-import terminalLink from 'terminal-link';
 
 import log from '../../log';
 import prompt from '../../prompt';
+import { learnMore } from '../utils/TerminalLink';
 
 const noBundleIdMessage = `Your project must have a \`bundleIdentifier\` set in the Expo config (app.json or app.config.js).\nSee https://expo.fyi/bundle-identifier`;
 const noPackageMessage = `Your project must have a \`package\` set in the Expo config (app.json or app.config.js).\nSee https://expo.fyi/android-package`;
@@ -49,15 +49,11 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
 
   log.addNewLineIfNone();
   log(
-    log.chalk.cyan(
-      `Now we need to know your ${terminalLink(
-        'iOS bundle identifier',
-        'https://expo.fyi/bundle-identifier'
-      )}.\nYou can change this in the future if you need to.`
-    )
+    `${log.chalk.bold(`📝 iOS Bundle Identifier`)} ${log.chalk.dim(
+      learnMore('https://expo.fyi/bundle-identifier')
+    )}`
   );
   log.newLine();
-
   // Prompt the user for the bundle ID.
   // Even if the project is using a dynamic config we can still
   // prompt a better error message, recommend a default value, and help the user
@@ -122,10 +118,9 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
 
   log.addNewLineIfNone();
   log(
-    `Now we need to know your ${terminalLink(
-      'Android package',
-      'https://expo.fyi/android-package'
-    )}. You can change this in the future if you need to.`
+    `${log.chalk.bold(`📝 Android package`)} ${log.chalk.dim(
+      learnMore('https://expo.fyi/android-package')
+    )}`
   );
   log.newLine();
 

--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -132,7 +132,7 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
       {
         name: 'packageName',
         default: recommendedPackage,
-        message: `What would you like your Android package to be named?`,
+        message: `What would you like your Android package name to be?`,
         validate: validatePackage,
       },
     ],


### PR DESCRIPTION
# Why

- ios config message is blue and the android one is green
- ios newlines the link and android doesn't
- links are formatted poorly in the standard terminal
- messages and hints are redundant
- extra success message is logged after the prompt. I think the absence of an error message or warning is good enough for this.

### Before

<img width="923" alt="Screen Shot 2020-09-08 at 6 08 55 PM" src="https://user-images.githubusercontent.com/9664363/92502191-cd355380-f1ff-11ea-96cf-d820dfd97e47.png">

### After

<img width="507" alt="Screen Shot 2020-09-08 at 6 27 45 PM" src="https://user-images.githubusercontent.com/9664363/92503113-1043f680-f201-11ea-83bd-4e1566f05316.png">

