### PR TITLE
fix android circle cropping images with sharp

### DIFF
--- a/packages/image-utils/src/Image.ts
+++ b/packages/image-utils/src/Image.ts
@@ -73,13 +73,9 @@ async function resizeAsync(imageOptions: ImageOptions): Promise<Buffer> {
 
     if (imageOptions.borderRadius) {
       const mask = Buffer.from(
-        `<svg><rect x="0" y="0" width="${width}" height="${height}" 
-        rx="${imageOptions.borderRadius}" ry="${imageOptions.borderRadius}" 
-        fill="${
-          backgroundColor && backgroundColor !== 'transparent' ? backgroundColor : 'none'
-        }" /></svg>`
+        `<svg><circle cx="${imageOptions.borderRadius}" cy="${imageOptions.borderRadius}" r="${imageOptions.borderRadius}" /></svg>`
       );
-      sharpBuffer.composite([{ input: mask, blend: 'dest-over' }]);
+      sharpBuffer.composite([{ input: mask, blend: 'dest-in' }]);
     }
 
     return await sharpBuffer.png().toBuffer();

--- a/packages/image-utils/src/Image.ts
+++ b/packages/image-utils/src/Image.ts
@@ -25,7 +25,7 @@ async function resizeAsync(imageOptions: ImageOptions): Promise<Buffer> {
   const { width, height, backgroundColor, resizeMode } = imageOptions;
   if (!sharp) {
     const inputOptions: any = { input: imageOptions.src, quality: 100 };
-    const jimp = await Jimp.resize(inputOptions, {
+    let jimp = await Jimp.resize(inputOptions, {
       width,
       height,
       fit: resizeMode,
@@ -35,12 +35,18 @@ async function resizeAsync(imageOptions: ImageOptions): Promise<Buffer> {
     if (imageOptions.removeTransparency) {
       jimp.colorType(2);
     }
+
+    let mime: string;
     if (imageOptions.borderRadius) {
+      await jimp.rgba(true);
+      mime = 'image/png';
       // TODO: support setting border radius with Jimp. Currently only support making the image a circle
-      await Jimp.circleAsync(jimp);
+      jimp = await Jimp.circleAsync(jimp);
+    } else {
+      mime = jimp.getMIME();
     }
 
-    const imgBuffer = await jimp.getBufferAsync(jimp.getMIME());
+    const imgBuffer = await jimp.getBufferAsync(mime);
     return imgBuffer;
   }
   try {


### PR DESCRIPTION
Run `expo apply` with sharp installed globally.
Also fixes circle cropping for jpeg images in jimp.


## Before

![ic_launcher](https://user-images.githubusercontent.com/9664363/92504408-e986bf80-f202-11ea-9793-1e00ed203cfe.png)

## After

![ic_launcher_round](https://user-images.githubusercontent.com/9664363/92504392-e4c20b80-f202-11ea-8278-1be21af50493.png)
