### PR TITLE
[xdl] Build iOS shell app artifact to current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- [xdl] Build iOS shell app artifact in the current directory (instead of one level up).
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -353,11 +353,11 @@ async function buildAndCopyArtifactAsync(args) {
     context.build.ios.workspaceSourcePath,
     context.build.configuration,
     type,
-    path.relative(context.build.ios.workspaceSourcePath, '../shellAppBase'),
+    path.relative(context.build.ios.workspaceSourcePath, './shellAppBase'),
     verbose,
     parseSdkMajorVersion(args.shellAppSdkVersion) > 33
   );
-  const artifactDestPath = path.join('../shellAppBase-builds', type, context.build.configuration);
+  const artifactDestPath = path.join('./shellAppBase-builds', type, context.build.configuration);
   logger.info(`\nFinished building, copying artifact to ${path.resolve(artifactDestPath)}...`);
   if (fs.existsSync(artifactDestPath)) {
     await spawnAsyncThrowError('/bin/rm', ['-rf', artifactDestPath]);


### PR DESCRIPTION
While moving iOS shell app code from `tools-public` to `expotools` I haven't noticed that XDL outputs build artifacts to a directory relative to current directory, so from `../` from `tools-public` was `expo` root. Now with `expotools` it's out of repository, which required this change to get the `tar` packaging the tarball —https://github.com/expo/expo/commit/b42aba261f6d1ac54b33d780a09ffe282931c36e.

It's not the prettiest, but it works.

See the failed job at https://github.com/expo/expo/runs/1086951550.