### PR TITLE
Fix: Asset batch uploading

### DIFF
--- a/packages/xdl/src/ProjectAssets.ts
+++ b/packages/xdl/src/ProjectAssets.ts
@@ -246,23 +246,21 @@ async function uploadAssetsAsync(projectRoot: string, assets: Asset[]) {
   const keyChunks = chunk(missing, 5);
 
   // Upload them!
-  await Promise.all(
-    keyChunks.map(async keys => {
-      const formData = new FormData();
-      for (const key of keys) {
-        const pathName = paths[key];
+  for (const keys of keyChunks) {
+    const formData = new FormData();
+    for (const key of keys) {
+      const pathName = paths[key];
 
-        logAssetTask(projectRoot, 'uploading', pathName);
+      logAssetTask(projectRoot, 'uploading', pathName);
 
-        formData.append(key, fs.createReadStream(pathName), pathName);
-      }
+      formData.append(key, fs.createReadStream(pathName), pathName);
+    }
 
-      // TODO: Document what's going on
-      const user = await UserManager.ensureLoggedInAsync();
-      const api = ApiV2.clientForUser(user);
-      await api.uploadFormDataAsync('assets/upload', formData);
-    })
-  );
+    // TODO: Document what's going on
+    const user = await UserManager.ensureLoggedInAsync();
+    const api = ApiV2.clientForUser(user);
+    await api.uploadFormDataAsync('assets/upload', formData);
+  }
 }
 
 function collectAssetPaths(assets: Asset[]): Record<string, string> {

--- a/packages/xdl/src/ProjectAssets.ts
+++ b/packages/xdl/src/ProjectAssets.ts
@@ -245,7 +245,7 @@ async function uploadAssetsAsync(projectRoot: string, assets: Asset[]) {
 
   const keyChunks = chunk(missing, 5);
 
-  // Upload them!
+  // Upload them in chunks of 5 to prevent network and system issues.
   for (const keys of keyChunks) {
     const formData = new FormData();
     for (const key of keys) {


### PR DESCRIPTION
Fix: Asset batch uploading
Assets were divided into chunks of 5 for uploading, using await promise.all to upload all the chunks at once causes network and system resources issues for big number of assets, instead with this change chunks are uploaded sequentially.
Reference for issue: https://stackoverflow.com/a/30823708