### PR TITLE
[expo-cli] support multiple Segment projects

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@expo/build-tools';
-import { Analytics, ApiV2 } from '@expo/xdl';
+import { ApiV2 } from '@expo/xdl';
 import chalk from 'chalk';
 import delayAsync from 'delay-async';
 import fs from 'fs-extra';
@@ -22,6 +22,7 @@ import {
   Builder,
   CommandContext,
 } from '../types';
+import Analytics from '../utils/analytics';
 import createBuilderContext from '../utils/createBuilderContext';
 import createCommandContextAsync from '../utils/createCommandContextAsync';
 import {

--- a/packages/expo-cli/src/commands/eas-build/credentialsSync/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/credentialsSync/action.ts
@@ -1,5 +1,5 @@
 import { getConfig } from '@expo/config';
-import { Analytics, UserManager } from '@expo/xdl';
+import { UserManager } from '@expo/xdl';
 import { v4 as uuidv4 } from 'uuid';
 
 import CommandError from '../../../CommandError';
@@ -13,6 +13,7 @@ import { ensureProjectExistsAsync } from '../../../projects';
 import prompts from '../../../prompts';
 import { getBundleIdentifier } from '../build/utils/ios';
 import { AnalyticsEvent, BuildCommandPlatform, TrackingContext } from '../types';
+import Analytics from '../utils/analytics';
 
 interface Options {
   parent: {

--- a/packages/expo-cli/src/commands/eas-build/status/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/status/action.ts
@@ -1,11 +1,12 @@
 import { getConfig } from '@expo/config';
-import { Analytics, ApiV2, UserManager } from '@expo/xdl';
+import { ApiV2, UserManager } from '@expo/xdl';
 import ora from 'ora';
 
 import log from '../../../log';
 import { ensureProjectExistsAsync } from '../../../projects';
 import { printTableJsonArray } from '../../utils/cli-table';
 import { AnalyticsEvent, Build, BuildCommandPlatform, BuildStatus } from '../types';
+import Analytics from '../utils/analytics';
 
 interface BuildStatusOptions {
   platform: BuildCommandPlatform;

--- a/packages/expo-cli/src/commands/eas-build/utils/analytics.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/analytics.ts
@@ -1,0 +1,15 @@
+import { AnalyticsClient } from '@expo/xdl';
+
+const packageJSON = require('../../../../package.json');
+
+const client = new AnalyticsClient();
+
+client.setSegmentNodeKey(
+  process.env.EXPO_LOCAL || process.env.EXPO_STAGING
+    ? '9qenkcMBJllh4gXYSN4BfJjJNPT7PULm'
+    : 'TbWjTSn84LrRhfVEAfS6PG1wQoSCUYGp'
+);
+
+client.setVersionName(packageJSON.version);
+
+export default client;

--- a/packages/xdl/src/Analytics.ts
+++ b/packages/xdl/src/Analytics.ts
@@ -3,71 +3,90 @@ import os from 'os';
 
 import ip from './ip';
 
-let _segmentNodeInstance: Segment | undefined;
-let _userId: string | undefined;
-let _version: string | undefined;
 const PLATFORM_TO_ANALYTICS_PLATFORM: { [platform: string]: string } = {
   darwin: 'Mac',
   win32: 'Windows',
   linux: 'Linux',
 };
 
-export function flush() {
-  if (_segmentNodeInstance) _segmentNodeInstance.flush();
-}
+let _userId: string | undefined;
+let _userTraits: any;
 
-export function setSegmentNodeKey(key: string) {
-  // Do not wait before flushing, we want node to close immediately if the programs ends
-  _segmentNodeInstance = new Segment(key, { flushInterval: 300 });
-}
+export class AnalyticsClient {
+  private segmentNodeInstance: Segment | undefined;
+  private version: string | undefined;
+  private userIdentifyCalled: boolean = false;
 
-export function setUserProperties(userId: string, traits: any) {
-  _userId = userId;
-
-  if (_segmentNodeInstance) {
-    _segmentNodeInstance.identify({
-      userId,
-      traits,
-      context: _getContext(),
-    });
+  public flush() {
+    if (this.segmentNodeInstance) {
+      this.segmentNodeInstance.flush();
+    }
   }
-}
 
-export function setVersionName(version: string) {
-  _version = version;
-}
-
-export function logEvent(name: string, properties: any = {}) {
-  if (_segmentNodeInstance && _userId) {
-    _segmentNodeInstance.track({
-      userId: _userId,
-      event: name,
-      properties,
-      context: _getContext(),
-    });
+  public setSegmentNodeKey(key: string) {
+    // Do not wait before flushing, we want node to close immediately if the programs ends
+    this.segmentNodeInstance = new Segment(key, { flushInterval: 300 });
   }
-}
 
-function _getContext() {
-  const platform = PLATFORM_TO_ANALYTICS_PLATFORM[os.platform()] || os.platform();
-  const context = {
-    ip: ip.address(),
-    device: {
-      model: platform,
-      brand: platform,
-    },
-    os: {
-      name: platform,
-      version: os.release(),
-    },
-    app: {},
-  };
+  public setUserProperties(userId: string, traits: any) {
+    _userId = userId;
+    _userTraits = traits;
 
-  if (_version) {
-    context.app = {
-      version: _version,
+    this.ensureUserIdentified();
+  }
+
+  public setVersionName(version: string) {
+    this.version = version;
+  }
+
+  public logEvent(name: string, properties: any = {}) {
+    if (this.segmentNodeInstance && _userId) {
+      this.ensureUserIdentified();
+      this.segmentNodeInstance.track({
+        userId: _userId,
+        event: name,
+        properties,
+        context: this.getContext(),
+      });
+    }
+  }
+
+  private ensureUserIdentified() {
+    if (this.segmentNodeInstance && !this.userIdentifyCalled && _userId) {
+      this.segmentNodeInstance.identify({
+        userId: _userId,
+        traits: _userTraits,
+        context: this.getContext(),
+      });
+      this.userIdentifyCalled = true;
+    }
+  }
+
+  private getContext() {
+    const platform = PLATFORM_TO_ANALYTICS_PLATFORM[os.platform()] || os.platform();
+    const context = {
+      ip: ip.address(),
+      device: {
+        model: platform,
+        brand: platform,
+      },
+      os: {
+        name: platform,
+        version: os.release(),
+      },
+      app: {},
     };
-  }
 
-  return context;
+    if (this.version) {
+      context.app = {
+        version: this.version,
+      };
+    }
+
+    return context;
+  }
 }
+
+const defaultClient = new AnalyticsClient();
+
+export default defaultClient;

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -10,7 +10,7 @@ import ProgressBar from 'progress';
 import prompts from 'prompts';
 import semver from 'semver';
 
-import * as Analytics from './Analytics';
+import Analytics from './Analytics';
 import Api from './Api';
 import * as Binaries from './Binaries';
 import Logger from './Logger';
@@ -203,10 +203,7 @@ async function startEmulatorAsync(device: Device): Promise<Device> {
 export async function getAttachedDevicesAsync(): Promise<Device[]> {
   const output = await getAdbOutputAsync(['devices', '-l']);
 
-  const splitItems = output
-    .trim()
-    .replace(/\n$/, '')
-    .split(os.EOL);
+  const splitItems = output.trim().replace(/\n$/, '').split(os.EOL);
   // First line is `"List of devices attached"`, remove it
   // @ts-ignore: todo
   const attachedDevices: {

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -41,7 +41,7 @@ import urljoin from 'url-join';
 import { promisify } from 'util';
 import uuid from 'uuid';
 
-import * as Analytics from './Analytics';
+import Analytics from './Analytics';
 import * as Android from './Android';
 import ApiV2 from './ApiV2';
 import Config from './Config';
@@ -387,17 +387,11 @@ export async function exportForAppHosting(
   const iosBundle = bundles.ios.code;
   const androidBundle = bundles.android.code;
 
-  const iosBundleHash = crypto
-    .createHash('md5')
-    .update(iosBundle)
-    .digest('hex');
+  const iosBundleHash = crypto.createHash('md5').update(iosBundle).digest('hex');
   const iosBundleUrl = `ios-${iosBundleHash}.js`;
   const iosJsPath = path.join(outputDir, 'bundles', iosBundleUrl);
 
-  const androidBundleHash = crypto
-    .createHash('md5')
-    .update(androidBundle)
-    .digest('hex');
+  const androidBundleHash = crypto.createHash('md5').update(androidBundle).digest('hex');
   const androidBundleUrl = `android-${androidBundleHash}.js`;
   const androidJsPath = path.join(outputDir, 'bundles', androidBundleUrl);
 

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -9,7 +9,7 @@ import ProgressBar from 'progress';
 import prompts from 'prompts';
 import semver from 'semver';
 
-import * as Analytics from './Analytics';
+import Analytics from './Analytics';
 import Api from './Api';
 import Logger from './Logger';
 import NotificationCode from './NotificationCode';

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -2,7 +2,7 @@ import camelCase from 'lodash/camelCase';
 import isEmpty from 'lodash/isEmpty';
 import snakeCase from 'lodash/snakeCase';
 
-import * as Analytics from './Analytics';
+import Analytics from './Analytics';
 import ApiV2Client from './ApiV2';
 import Config from './Config';
 import Logger from './Logger';

--- a/packages/xdl/src/project/ManifestHandler.ts
+++ b/packages/xdl/src/project/ManifestHandler.ts
@@ -4,7 +4,7 @@ import http from 'http';
 import os from 'os';
 import { URL } from 'url';
 
-import * as Analytics from '../Analytics';
+import Analytics from '../Analytics';
 import ApiV2 from '../ApiV2';
 import Config from '../Config';
 import * as Exp from '../Exp';

--- a/packages/xdl/src/project/ProjectUtils.ts
+++ b/packages/xdl/src/project/ProjectUtils.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import path from 'path';
 
-import * as Analytics from '../Analytics';
+import Analytics from '../Analytics';
 import Logger, { Log, LogStream } from '../Logger';
 
 const MAX_MESSAGE_LENGTH = 200;

--- a/packages/xdl/src/xdl.ts
+++ b/packages/xdl/src/xdl.ts
@@ -1,6 +1,6 @@
 import { install as installSourceMapSupport } from 'source-map-support';
 
-import * as Analytics from './Analytics';
+import Analytics, { AnalyticsClient } from './Analytics';
 import * as Android from './Android';
 import Api from './Api';
 import ApiV2 from './ApiV2';
@@ -55,7 +55,7 @@ const IosWorkspace = require('./detach/IosWorkspace');
 if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   installSourceMapSupport();
 }
-export { Analytics };
+export { Analytics, AnalyticsClient };
 export { Android };
 
 export { AndroidShellApp };


### PR DESCRIPTION
# Why

Amplitude charts can only contain data from a single project, so if we want to show data from multiple services we would need to pipe all XDL events to the project. Supporting multiple Segment projects is solving that issue.

# How

Extracted current implementation to class and instantiate it for Eas Build commands with different  write key
- user information is shared globally(only one instance needs to call `setUserProperties`)
- EAS Build instance have separate projects for production and non-production builds

# Test plan

Run build locally and checked with Segment debugger that events are registered