### PR TITLE
[eject] Added no-install and npm args to eject

### DIFF
--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -19,7 +19,7 @@ async function userWantsToEjectWithoutUpgradingAsync() {
 
 async function action(
   projectDir: string,
-  options: LegacyEject.EjectAsyncOptions | Eject.EjectAsyncOptions
+  options: (LegacyEject.EjectAsyncOptions | Eject.EjectAsyncOptions) & { npm?: boolean }
 ) {
   let exp: ExpoConfig;
   try {
@@ -29,6 +29,10 @@ async function action(
     console.log(chalk.red(error.message));
     console.log();
     process.exit(1);
+  }
+
+  if (options.npm) {
+    options.packageManager = 'npm';
   }
 
   // Set EXPO_VIEW_DIR to universe/exponent to pull expo view code locally instead of from S3 for ExpoKit
@@ -67,5 +71,7 @@ export default function (program: Command) {
       '-f --force',
       'Will attempt to generate an iOS project even when the system is not running macOS. Unsafe and may fail.'
     )
+    .option('--no-install', 'Skip installing npm packages and CocoaPods.')
+    .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .asyncActionProjectDir(action);
 }

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -166,13 +166,17 @@ async function installNodeDependenciesAsync(
   packageManager: 'yarn' | 'npm',
   { clean = true }: { clean: boolean }
 ) {
-  const installJsDepsStep = CreateApp.logNewSection('Installing JavaScript dependencies.');
-
   if (clean) {
+    // This step can take a couple seconds, if the installation logs are enabled (with EXPO_DEBUG) then it
+    // ends up looking odd to see "Installing JavaScript dependencies" for ~5 seconds before the logs start showing up.
+    const cleanJsDepsStep = CreateApp.logNewSection('Cleaning JavaScript dependencies.');
     // nuke the node modules
     // TODO: this is substantially slower, we should find a better alternative to ensuring the modules are installed.
     await fse.remove('node_modules');
+    cleanJsDepsStep.succeed('Cleaned JavaScript dependencies.');
   }
+
+  const installJsDepsStep = CreateApp.logNewSection('Installing JavaScript dependencies.');
 
   try {
     await CreateApp.installNodeDependenciesAsync(projectRoot, packageManager);

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -1,5 +1,4 @@
 import { AndroidConfig, BareAppConfig, ExpoConfig, IOSConfig, getConfig } from '@expo/config';
-import * as PackageManager from '@expo/package-manager';
 import spawnAsync from '@expo/spawn-async';
 import { Exp, IosPlist, UserManager } from '@expo/xdl';
 import chalk from 'chalk';
@@ -263,7 +262,7 @@ async function action(projectDir: string, command: Command) {
 
   // Install dependencies
 
-  const packageManager = resolvePackageManager(options);
+  const packageManager = CreateApp.resolvePackageManager(options);
 
   // TODO: not this
   const workflow = isBare ? 'bare' : 'managed';
@@ -330,39 +329,10 @@ async function action(projectDir: string, command: Command) {
   }
 }
 
-type PackageManagerName = 'npm' | 'yarn';
-
-// TODO: Use in eject as well
-function resolvePackageManager(
-  options: Pick<Options, 'yarn' | 'npm' | 'install'>
-): PackageManagerName {
-  let packageManager: PackageManagerName = 'npm';
-  if (options.yarn || (!options.npm && PackageManager.shouldUseYarn())) {
-    packageManager = 'yarn';
-  } else {
-    packageManager = 'npm';
-  }
-  if (options.install) {
-    log.addNewLineIfNone();
-    log(
-      packageManager === 'yarn'
-        ? '🧶 Using Yarn to install packages. You can pass --npm to use npm instead.'
-        : '📦 Using npm to install packages.'
-    );
-    log.newLine();
-  }
-
-  return packageManager;
-}
-
-async function installNodeDependenciesAsync(
-  projectRoot: string,
-  packageManager: 'yarn' | 'npm',
-  flags: { silent: boolean } = { silent: true }
-) {
+async function installNodeDependenciesAsync(projectRoot: string, packageManager: 'yarn' | 'npm') {
   const installJsDepsStep = CreateApp.logNewSection('Installing JavaScript dependencies.');
   try {
-    await CreateApp.installNodeDependenciesAsync(projectRoot, packageManager, flags);
+    await CreateApp.installNodeDependenciesAsync(projectRoot, packageManager);
     installJsDepsStep.succeed('Installed JavaScript dependencies.');
   } catch {
     installJsDepsStep.fail(

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -105,12 +105,14 @@ export function resolvePackageManager(options: {
   return packageManager;
 }
 
+const EXPO_DEBUG = getenv.boolish('EXPO_DEBUG', false);
+
 export async function installNodeDependenciesAsync(
   projectRoot: string,
   packageManager: PackageManagerName,
   flags: { silent: boolean } = {
     // default to silent
-    silent: getenv.boolish('EXPO_DEBUG', true),
+    silent: !EXPO_DEBUG,
   }
 ) {
   const options = { cwd: projectRoot, silent: flags.silent };
@@ -169,7 +171,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
     log,
-    silent: getenv.boolish('EXPO_DEBUG', true),
+    silent: !EXPO_DEBUG,
   });
 
   if (!(await packageManager.isCLIInstalledAsync())) {


### PR DESCRIPTION
- Added `--no-install` flag to `expo eject` which can be used to skip node module installation and cocoapods installation. This follows the same pattern we use for initializing a bare workflow project.
- Added `--npm` flag to `expo eject` which shares the same logic as init for using npm to install modules.
- Added "Cleaning JavaScript dependencies" spinner because the step takes ~5 seconds on my fast computer. Also when the yarn logs are enabled it looks off to see "installing deps.." for a few seconds before you start seeing the logs.
- Added back support for showing the installation logs with `EXPO_DEBUG=true`
- Fix cocoapods logs only showing with `EXPO_DEBUG=false`
- Make spinners automatically unmount from the logs module.
- Make spinners support `newLineIfNone`.
- Unify the node module installation step across init and eject -- adds support for yarn v2 to eject I guess.