### PR TITLE
[eject] Remove name prompt and static config writing

### DIFF
--- a/packages/expo-cli/e2e/__tests__/eject-test.ts
+++ b/packages/expo-cli/e2e/__tests__/eject-test.ts
@@ -76,8 +76,6 @@ it(`can eject a minimal project`, async () => {
   expect(outputPkgJson.scripts['ios']).toBe('react-native run-ios');
   expect(outputPkgJson.scripts['android']).toBe('react-native run-android');
   expect(outputPkgJson.scripts['web']).toBe('expo web');
-  // The eject command should be deleted
-  expect(outputPkgJson.scripts['eject']).not.toBeDefined();
   // The react-native fork is replaced with the upstream react-native version
   expect(outputPkgJson.dependencies['react-native']).not.toBe(
     minimumNativePkgJson.dependencies['react-native']

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -126,15 +126,17 @@ export async function ejectAsync(projectRoot: string, options?: EjectAsyncOption
     );
   }
 
-  log.newLine();
-  log.nested(`☑️  ${chalk.bold('When you are ready to run your project')}`);
-  log.nested(
-    'To compile and run your project in development, execute one of the following commands:'
-  );
+  if (!isSyncing) {
+    log.newLine();
+    log.nested(`☑️  ${chalk.bold('When you are ready to run your project')}`);
+    log.nested(
+      'To compile and run your project in development, execute one of the following commands:'
+    );
 
-  log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run ios' : 'yarn ios')}`);
-  log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run android' : 'yarn android')}`);
-  log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run web' : 'yarn web')}`);
+    log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run ios' : 'yarn ios')}`);
+    log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run android' : 'yarn android')}`);
+    log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run web' : 'yarn web')}`);
+  }
 }
 
 async function configureIOSStepAsync(projectRoot: string) {

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -325,12 +325,9 @@ function writeMetroConfig(projectRoot: string, pkg: PackageJSONConfig, tempDir: 
   }
 }
 
-async function createNativeProjectsFromTemplateAsync(projectRoot: string): Promise<void> {
-  // We need the SDK version to proceed
-  const { exp, pkg } = await ensureConfigAsync(projectRoot);
-
+async function validateBareTemplateExistsAsync(sdkVersion: string): Promise<npmPackageArg.Result> {
   // Validate that the template exists
-  const sdkMajorVersionNumber = semver.major(exp.sdkVersion!);
+  const sdkMajorVersionNumber = semver.major(sdkVersion);
   const templateSpec = npmPackageArg(`expo-template-bare-minimum@sdk-${sdkMajorVersionNumber}`);
   try {
     await pacote.manifest(templateSpec);
@@ -343,6 +340,15 @@ async function createNativeProjectsFromTemplateAsync(projectRoot: string): Promi
       throw e;
     }
   }
+
+  return templateSpec;
+}
+
+async function createNativeProjectsFromTemplateAsync(projectRoot: string): Promise<void> {
+  // We need the SDK version to proceed
+  const { exp, pkg } = await ensureConfigAsync(projectRoot);
+
+  const templateSpec = await validateBareTemplateExistsAsync(exp.sdkVersion!);
 
   /**
    * Extract the template and copy the ios and android directories over to the project directory

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -279,6 +279,7 @@ function writeMetroConfig(projectRoot: string, pkg: PackageJSONConfig, tempDir: 
    */
 
   const updatingMetroConfigStep = CreateApp.logNewSection('Adding Metro bundler configuration');
+
   try {
     const sourceConfigPath = path.join(tempDir, 'metro.config.js');
     const targetConfigPath = path.join(projectRoot, 'metro.config.js');
@@ -289,6 +290,11 @@ function writeMetroConfig(projectRoot: string, pkg: PackageJSONConfig, tempDir: 
       const targetContents = createFileHash(fs.readFileSync(sourceConfigPath, 'utf8'));
       if (contents !== targetContents) {
         throw new Error('Existing Metro configuration found; not overwriting.');
+      } else {
+        // Nothing to change, hide the step and exit.
+        updatingMetroConfigStep.stop();
+        updatingMetroConfigStep.clear();
+        return;
       }
     } else if (
       fs.existsSync(path.join(projectRoot, 'metro.config.json')) ||

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -138,19 +138,17 @@ export async function ejectAsync(projectRoot: string, options?: EjectAsyncOption
 }
 
 async function configureIOSStepAsync(projectRoot: string) {
-  log.newLine();
-  const applyingIOSConfigStep = CreateApp.logNewSection('Applying iOS configuration');
+  const applyingIOSConfigStep = CreateApp.logNewSection('iOS config syncing');
   await configureIOSProjectAsync(projectRoot);
   if (ConfigWarningAggregator.hasWarningsIOS()) {
     applyingIOSConfigStep.stopAndPersist({
       symbol: '⚠️ ',
-      text: chalk.red('iOS configuration applied with warnings that should be fixed:'),
+      text: chalk.red('iOS config synced with warnings that should be fixed:'),
     });
     logConfigWarningsIOS();
   } else {
-    applyingIOSConfigStep.succeed('All project configuration applied to iOS project');
+    applyingIOSConfigStep.succeed('iOS config synced');
   }
-  log.newLine();
 }
 
 /**
@@ -192,16 +190,16 @@ async function installNodeDependenciesAsync(
 }
 
 async function configureAndroidStepAsync(projectRoot: string) {
-  const applyingAndroidConfigStep = CreateApp.logNewSection('Applying Android configuration');
+  const applyingAndroidConfigStep = CreateApp.logNewSection('Android config syncing');
   await configureAndroidProjectAsync(projectRoot);
   if (ConfigWarningAggregator.hasWarningsAndroid()) {
     applyingAndroidConfigStep.stopAndPersist({
       symbol: '⚠️ ',
-      text: chalk.red('Android configuration applied with warnings that should be fixed:'),
+      text: chalk.red('Android config synced with warnings that should be fixed:'),
     });
     logConfigWarningsAndroid();
   } else {
-    applyingAndroidConfigStep.succeed('All project configuration applied to Android project');
+    applyingAndroidConfigStep.succeed('Android config synced');
   }
 }
 

--- a/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
+++ b/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
@@ -1,4 +1,9 @@
-import { isPkgMainExpoAppEntry, stripDashes } from '../Eject';
+import {
+  hashForDependencyMap,
+  isPkgMainExpoAppEntry,
+  shouldDeleteMainField,
+  stripDashes,
+} from '../Eject';
 
 describe('stripDashes', () => {
   it(`removes spaces and dashes from a string`, () => {
@@ -7,6 +12,28 @@ describe('stripDashes', () => {
     expect(stripDashes('-----')).toBe('');
     expect(stripDashes(' ')).toBe('');
     expect(stripDashes(' \n-\n-')).toBe('');
+  });
+});
+
+describe('hashForDependencyMap', () => {
+  it(`dependencies in any order hash to the same value`, () => {
+    expect(hashForDependencyMap({ a: '1.0.0', b: 2, c: '~3.0' })).toBe(
+      hashForDependencyMap({ c: '~3.0', b: 2, a: '1.0.0' })
+    );
+  });
+});
+
+describe('shouldDeleteMainField', () => {
+  it(`should delete non index field`, () => {
+    expect(shouldDeleteMainField(null)).toBe(false);
+    expect(shouldDeleteMainField()).toBe(false);
+    expect(shouldDeleteMainField('expo/AppEntry')).toBe(true);
+    // non-expo fields
+    expect(shouldDeleteMainField('.src/other.js')).toBe(false);
+    expect(shouldDeleteMainField('index.js')).toBe(false);
+    expect(shouldDeleteMainField('index.ios.js')).toBe(false);
+    expect(shouldDeleteMainField('index.ts')).toBe(false);
+    expect(shouldDeleteMainField('./index')).toBe(false);
   });
 });
 


### PR DESCRIPTION
- The name prompt will never be invoked because if the name is missing it will be inferred from the folder name.
- Writing an `app.json` seems unnecessary, removing this step in favor of preserving whichever config was in use before ejecting (i.e. app.config).
- Don't delete eject script
- Only delete main field if it's an expo value
- Split metro logic into its own function -- no functionality changes
- Prevent reruns from throwing metro config errors by comparing the file hashes
  - hide the metro step when nothing changes to reduce the amount of logs
- Only clean deps if new project files were added
- Only run pod install if new deps or an ios folder get added.
- Split up methods
- Reduce the amount of times that deps get rewritten