### PR TITLE
Added better logs for invalid custom config paths

### DIFF
--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -131,7 +131,7 @@ async function resolveProjectRootAsync(input?: string): Promise<string> {
     log.nested('Please choose your app name:');
     log.nested(`  ${log.chalk.green(`${program.name()} init`)} ${log.chalk.cyan('<app-name>')}`);
     log.newLine();
-    log.nested(`Run ${log.chalk.green(`${program.name()} init --help`)} for more info.`);
+    log.nested(`Run ${log.chalk.green(`${program.name()} init --help`)} for more info`);
     log.newLine();
     process.exit(1);
   }

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -346,9 +346,30 @@ Command.prototype.asyncActionProjectDir = function (
     }
 
     if (opts.config) {
+      // @ts-ignore: This guards against someone passing --config without a path.
+      if (opts.config === true) {
+        log.addNewLineIfNone();
+        log('Please specify your custom config path:');
+        log(log.chalk.green(`  expo ${this.name()} --config ${log.chalk.cyan(`<app-config>`)}`));
+        log.newLine();
+        process.exit(1);
+      }
+
       const pathToConfig = path.resolve(process.cwd(), opts.config);
+      // Warn the user when the custom config path they provided does not exist.
       if (!fs.existsSync(pathToConfig)) {
-        throw new Error(`File at provided config path does not exist: ${pathToConfig}`);
+        const relativeInput = path.relative(process.cwd(), opts.config);
+        const formattedPath = log.chalk
+          .reset(pathToConfig)
+          .replace(relativeInput, log.chalk.bold(relativeInput));
+        log.addNewLineIfNone();
+        log.nestedWarn(`Custom config file does not exist:\n${formattedPath}`);
+        log.newLine();
+        const helpCommand = log.chalk.green(`expo ${this.name()} --help`);
+        log(`Run ${helpCommand} for more info`);
+        log.newLine();
+        process.exit(1);
+        // throw new Error(`File at provided config path does not exist: ${pathToConfig}`);
       }
       ConfigUtils.setCustomConfigPath(projectDir, pathToConfig);
     }


### PR DESCRIPTION
## Before

<img width="673" alt="custom-config-error-before" src="https://user-images.githubusercontent.com/9664363/92920953-744e0100-f433-11ea-96d5-632499e594d5.png">

## After

<img width="673" alt="custom-config-error-after" src="https://user-images.githubusercontent.com/9664363/92920962-787a1e80-f433-11ea-8d4b-b51bb97e7722.png">
