### PR TITLE
Extract introspect out of expo-cli

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -12,6 +12,7 @@
     "start": "yarn run prepare && yarn run watch",
     "build": "tsc --emitDeclarationOnly && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
     "watch": "tsc --watch",
+    "introspect": "ts-node ./scripts/introspect.ts",
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "preversion": "node ./scripts/preversion.js",

--- a/packages/expo-cli/scripts/introspect.ts
+++ b/packages/expo-cli/scripts/introspect.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env ts-node-script
+import '../build/exp.js';
+
+import program, { Command, Option } from 'commander';
+
+import { registerCommands } from '../build/commands/index.js';
+
+// import side-effects
+type OptionData = {
+  flags: string;
+  required: boolean;
+  description: string;
+  default: any;
+};
+
+type CommandData = {
+  name: string;
+  description: string;
+  alias?: string;
+  options: OptionData[];
+};
+
+// Sets up commander with a minimal setup for inspecting commands and extracting
+// data from them.
+function generateCommandJSON() {
+  program.name('expo');
+  registerCommands(program);
+  return program.commands.map(commandAsJSON);
+}
+
+// The type definition for Option seems to be wrong - doesn't include defaultValue
+function optionAsJSON(option: Option & { defaultValue: any }): OptionData {
+  return {
+    flags: option.flags,
+    required: option.required,
+    description: option.description,
+    default: option.defaultValue,
+  };
+}
+
+function commandAsJSON(command: Command): CommandData {
+  return {
+    name: command.name(),
+    description: command.description(),
+    alias: command.alias(),
+    options: command.options.map(optionAsJSON),
+  };
+}
+
+function sanitizeFlags(flags: string) {
+  return flags.replace('<', '[').replace('>', ']');
+}
+
+function formatOptionAsMarkdown(option: OptionData) {
+  return `| \`${sanitizeFlags(option.flags)}\` | ${option.description} |`;
+}
+
+function formatOptionsAsMarkdown(options: OptionData[]) {
+  if (!options || !options.length) {
+    return 'This command does not take any options.';
+  }
+
+  return [
+    `| Option         | Description             |`,
+    `| ------------ | ----------------------- |`,
+    ...options.map(formatOptionAsMarkdown),
+    '',
+  ].join('\n');
+}
+
+function formatCommandAsMarkdown(command: CommandData): string {
+  return [
+    `<details>`,
+    `<summary>`,
+    `<h3>expo ${command.name}</h3>`,
+    `<p>${command.description}</p>`,
+    `</summary>`,
+    `<p>`,
+    ...(command.alias ? ['', `Alias: \`expo ${command.alias}\``] : []),
+    '',
+    formatOptionsAsMarkdown(command.options),
+    '',
+    '</p>',
+    '</details>',
+    '',
+  ].join('\n');
+}
+
+function formatCommandsAsMarkdown(commands: CommandData[]) {
+  return commands.map(formatCommandAsMarkdown).join('\n');
+}
+
+const commands = generateCommandJSON();
+
+console.log('');
+if (['markdown', 'md'].includes(process.argv[2])) {
+  console.info(formatCommandsAsMarkdown(commands));
+} else {
+  console.info(JSON.stringify(commands));
+}

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -19,7 +19,7 @@ import {
 } from '@expo/xdl';
 import boxen from 'boxen';
 import chalk from 'chalk';
-import program, { Command, Option } from 'commander';
+import program, { Command } from 'commander';
 import fs from 'fs';
 import getenv from 'getenv';
 import leven from 'leven';
@@ -684,101 +684,10 @@ async function writePathAsync() {
   await Binaries.writePathToUserSettingsAsync();
 }
 
-type OptionData = {
-  flags: string;
-  required: boolean;
-  description: string;
-  default: any;
-};
-
-type CommandData = {
-  name: string;
-  description: string;
-  alias?: string;
-  options: OptionData[];
-};
-
-// Sets up commander with a minimal setup for inspecting commands and extracting
-// data from them.
-function generateCommandJSON() {
-  program.name('expo');
-  registerCommands(program);
-  return program.commands.map(commandAsJSON);
-}
-
-// The type definition for Option seems to be wrong - doesn't include defaultValue
-function optionAsJSON(option: Option & { defaultValue: any }): OptionData {
-  return {
-    flags: option.flags,
-    required: option.required,
-    description: option.description,
-    default: option.defaultValue,
-  };
-}
-
-function commandAsJSON(command: Command): CommandData {
-  return {
-    name: command.name(),
-    description: command.description(),
-    alias: command.alias(),
-    options: command.options.map(optionAsJSON),
-  };
-}
-
-function sanitizeFlags(flags: string) {
-  return flags.replace('<', '[').replace('>', ']');
-}
-
-function formatOptionAsMarkdown(option: OptionData) {
-  return `| \`${sanitizeFlags(option.flags)}\` | ${option.description} |`;
-}
-
-function formatOptionsAsMarkdown(options: OptionData[]) {
-  if (!options || !options.length) {
-    return 'This command does not take any options.';
-  }
-
-  return `| Option         | Description             |
-| ------------ | ----------------------- |
-${options.map(formatOptionAsMarkdown).join('\n')}
-`;
-}
-
-function formatCommandAsMarkdown(command: CommandData) {
-  return `
-<details><summary><h3>expo ${command.name}</h3><p>${command.description}</p></summary>
-<p>${
-    command.alias
-      ? `
-
-Alias: \`expo ${command.alias}\``
-      : ''
-  }
-
-${formatOptionsAsMarkdown(command.options)}
-
-</p>
-</details>
-  `;
-}
-
-function formatCommandsAsMarkdown(commands: CommandData[]) {
-  return commands.map(formatCommandAsMarkdown).join('\n');
-}
-
 // This is the entry point of the CLI
 export function run(programName: string) {
   (async function () {
-    if (process.argv[2] === 'introspect') {
-      const commands = generateCommandJSON();
-      if (process.argv[3] && process.argv[3].includes('markdown')) {
-        log(formatCommandsAsMarkdown(commands));
-      } else {
-        log(JSON.stringify(commands));
-      }
-    } else {
-      await Promise.all([writePathAsync(), runAsync(programName)]);
-    }
+    await Promise.all([writePathAsync(), runAsync(programName)]);
   })().catch(e => {
     console.error('Uncaught Error', e);
     process.exit(1);


### PR DESCRIPTION
Move `expo introspect` to a script that can be run from `packages/expo-cli` as `yarn introspect`. Helps to reduce the production bundle and public interface of expo-cli.

resolves https://github.com/expo/expo-cli/issues/2593