### PR TITLE
[lint] Enforce no lint warnings in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           fetch-depth: 1
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn lerna run prepare --stream
+      - run: yarn lint --max-warnings=0
       - uses: actions/cache@v1
         id: cache-build
         with:

--- a/packages/config/src/ios/Scheme.ts
+++ b/packages/config/src/ios/Scheme.ts
@@ -2,11 +2,12 @@ import { ExpoConfig } from '../Config.types';
 import { InfoPlist, URLScheme } from './IosConfig.types';
 import { findSchemeNames } from './utils/Xcodeproj';
 
+function validate(value: any): value is string {
+  return typeof value === 'string';
+}
+
 export function getScheme(config: { scheme?: string | string[] }): string[] {
   if (Array.isArray(config.scheme)) {
-    function validate(value: any): value is string {
-      return typeof value === 'string';
-    }
     return config.scheme.filter<string>(validate);
   } else if (typeof config.scheme === 'string') {
     return [config.scheme];

--- a/packages/expo-cli/.eslintrc.js
+++ b/packages/expo-cli/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   rules: {
-    'no-console': 'warn',
+    'no-console': 'error',
   },
 };

--- a/packages/expo-cli/.eslintrc.js
+++ b/packages/expo-cli/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'no-console': 'warn',
+  },
+};

--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -19,6 +19,7 @@ var supportedVersions =
 
 // If newer than the current release
 if (major > 14) {
+  // eslint-disable-next-line no-console
   console.warn(
     yellow(
       'WARNING: expo-cli has not yet been tested against Node.js ' +
@@ -30,6 +31,7 @@ if (major > 14) {
     )
   );
 } else if (!((major === 10 && minor >= 13) || (major === 12 && minor >= 13) || major === 14)) {
+  // eslint-disable-next-line no-console
   console.error(
     red('ERROR: Node.js ' + process.version + ' is no longer supported.\n\n' + supportedVersions)
   );

--- a/packages/expo-cli/jest.config.js
+++ b/packages/expo-cli/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   rootDir: path.resolve(__dirname),
   displayName: require('./package').name,
   roots: ['__mocks__', 'src', 'e2e'],
+  setupFilesAfterEnv: ['<rootDir>/jest/setup.ts'],
 };

--- a/packages/expo-cli/jest/setup.ts
+++ b/packages/expo-cli/jest/setup.ts
@@ -1,0 +1,15 @@
+/* eslint-disable no-console */
+
+const originalError = console.error;
+const originalWarn = console.warn;
+const originalLog = console.log;
+beforeAll(() => {
+  console.error = jest.fn();
+  console.warn = jest.fn();
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.error = originalError;
+  console.warn = originalWarn;
+  console.log = originalLog;
+});

--- a/packages/expo-cli/scripts/preversion.js
+++ b/packages/expo-cli/scripts/preversion.js
@@ -2,6 +2,7 @@ const boxen = require('boxen');
 const { bold } = require('chalk');
 const prompts = require('prompts');
 
+// eslint-disable-next-line no-console
 console.log(
   boxen(bold("Please complete these checks before publishing the 'expo-cli' package:"), {
     padding: 1,
@@ -39,6 +40,7 @@ prompts({
   initial: false,
 }).then(answer => {
   if (!answer.completed) {
+    // eslint-disable-next-line no-console
     console.error('Please complete all the checks before continuing.');
     process.exit(1);
   }

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -237,14 +237,14 @@ async function _retryUsernamePasswordAuthWithOTPAsync(
       primaryDevice,
       'OTP should only automatically be sent when there is a primary device'
     );
-    console.log(
+    log(
       `One-time password was sent to the phone number ending in ${primaryDevice.sms_phone_number}.`
     );
     otp = await _promptForOTPAsync('menu');
   }
 
   if (primaryDevice?.method === UserSecondFactorDeviceMethod.AUTHENTICATOR) {
-    console.log(`One-time password from authenticator required.`);
+    log(`One-time password from authenticator required.`);
     otp = await _promptForOTPAsync('menu');
   }
 
@@ -322,7 +322,7 @@ async function _usernamePasswordAuth(
   }
 
   if (user) {
-    console.log(`\nSuccess. You are now logged in as ${chalk.green(user.username)}.`);
+    log(`\nSuccess. You are now logged in as ${chalk.green(user.username)}.`);
     return user;
   } else {
     throw new Error('Unexpected Error: No user returned from the API');
@@ -330,7 +330,7 @@ async function _usernamePasswordAuth(
 }
 
 export async function register(): Promise<User> {
-  console.log(
+  log(
     `
 Thanks for signing up for Expo!
 Just a few questions:
@@ -391,6 +391,6 @@ Just a few questions:
   ];
   const answers = await prompt(questions);
   const registeredUser = await UserManager.registerAsync(answers as RegistrationData);
-  console.log('\nThanks for signing up!');
+  log('\nThanks for signing up!');
   return registeredUser;
 }

--- a/packages/expo-cli/src/askUser.ts
+++ b/packages/expo-cli/src/askUser.ts
@@ -1,10 +1,11 @@
 import { UserSettings } from '@expo/xdl';
 
+import log from './log';
 import prompt from './prompt';
 
 async function askForSendToAsync(): Promise<string> {
   const cachedValue = await UserSettings.getAsync('sendTo', null);
-  console.log("Enter an email address and we'll send a link to your phone.");
+  log("Enter an email address and we'll send a link to your phone.");
   const answers = await prompt(
     [
       {

--- a/packages/expo-cli/src/commands/__tests__/publish-info-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-info-test.ts
@@ -55,17 +55,6 @@ describe('publish details', () => {
     vol.reset();
   });
 
-  const originalWarn = console.warn;
-  const originalLog = console.log;
-  beforeAll(() => {
-    console.warn = jest.fn();
-    console.log = jest.fn();
-  });
-  afterAll(() => {
-    console.warn = originalWarn;
-    console.log = originalLog;
-  });
-
   it('Get publication details', async () => {
     const detailOptions = {
       publishId: 'test-uuid',

--- a/packages/expo-cli/src/commands/__tests__/publish-modify-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-modify-test.ts
@@ -39,17 +39,6 @@ describe('publish details', () => {
     vol.reset();
   });
 
-  const originalWarn = console.warn;
-  const originalLog = console.log;
-  beforeAll(() => {
-    console.warn = jest.fn();
-    console.log = jest.fn();
-  });
-  afterAll(() => {
-    console.warn = originalWarn;
-    console.log = originalLog;
-  });
-
   it('Set publication to channel', async () => {
     const setOptions = {
       releaseChannel: 'test-channel',

--- a/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
@@ -1,6 +1,7 @@
 import { vol } from 'memfs';
 
 import { mockExpoXDL } from '../../__tests__/mock-utils';
+import log from '../../log';
 import {
   getDependenciesFromBundledNativeModules,
   maybeFormatSdkVersion,
@@ -9,6 +10,7 @@ import {
 
 jest.mock('fs');
 jest.mock('resolve-from');
+jest.mock('../../log');
 
 describe('maybeFormatSdkVersion', () => {
   it(`returns null`, () => {
@@ -25,16 +27,7 @@ describe('maybeFormatSdkVersion', () => {
 });
 
 describe('getDependenciesFromBundledNativeModules', () => {
-  const originalWarn = console.warn;
-  beforeEach(() => {
-    console.warn = jest.fn();
-  });
-  afterAll(() => {
-    console.warn = originalWarn;
-  });
-
   it(`warns when the target SDK versions aren't provided`, () => {
-    console.warn = jest.fn();
     getDependenciesFromBundledNativeModules({
       projectDependencies: {},
       bundledNativeModules: {},
@@ -43,7 +36,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
       targetSdkVersion: null,
     });
 
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledTimes(1);
   });
 
   describe('priority', () => {
@@ -151,17 +144,6 @@ describe('getDependenciesFromBundledNativeModules', () => {
 });
 
 xdescribe('upgradeAsync', () => {
-  const originalWarn = console.warn;
-  const originalLog = console.log;
-  beforeEach(() => {
-    console.warn = jest.fn();
-    console.log = jest.fn();
-  });
-  afterAll(() => {
-    console.warn = originalWarn;
-    console.log = originalLog;
-  });
-
   beforeEach(() => {
     jest.mock('commander', () => {
       return {

--- a/packages/expo-cli/src/commands/apply.ts
+++ b/packages/expo-cli/src/commands/apply.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import path from 'path';
 
+import log from '../log';
 import configureAndroidProjectAsync from './apply/configureAndroidProjectAsync';
 import configureIOSProjectAsync from './apply/configureIOSProjectAsync';
 import { logConfigWarningsAndroid, logConfigWarningsIOS } from './utils/logConfigWarnings';
@@ -29,9 +30,9 @@ async function ensureConfigExistsAsync(projectRoot: string): Promise<void> {
     }
   } catch (error) {
     // TODO(Bacon): Currently this is already handled in the command
-    console.log();
-    console.log(chalk.red(error.message));
-    console.log();
+    log();
+    log(chalk.red(error.message));
+    log();
     process.exit(1);
   }
 }

--- a/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
+++ b/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
@@ -106,20 +106,6 @@ describe('build ios', () => {
     vol.reset();
   });
 
-  const originalWarn = console.warn;
-  const originalLog = console.log;
-  const originalError = console.error;
-  beforeAll(() => {
-    console.warn = jest.fn();
-    console.log = jest.fn();
-    console.error = jest.fn();
-  });
-  afterAll(() => {
-    console.warn = originalWarn;
-    console.log = originalLog;
-    console.error = originalError;
-  });
-
   afterEach(() => {
     const mockedXDLModuleObjects = Object.values(mockedXDLModules);
     for (const module of mockedXDLModuleObjects) {

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -195,7 +195,6 @@ class IOSBuilder extends BaseBuilder {
 
   async _setupDistCert(ctx: Context, appLookupParams: AppLookupParams): Promise<void> {
     try {
-      const nonInteractive = this.options.parent && this.options.parent.nonInteractive;
       const distCertFromParams = await getDistCertFromParams(this.options);
       if (distCertFromParams) {
         await useDistCertFromParams(ctx, appLookupParams, distCertFromParams);
@@ -210,7 +209,6 @@ class IOSBuilder extends BaseBuilder {
 
   async _setupPushCert(ctx: Context, appLookupParams: AppLookupParams): Promise<void> {
     try {
-      const nonInteractive = this.options.parent && this.options.parent.nonInteractive;
       const pushKeyFromParams = await getPushKeyFromParams(this.options);
       if (pushKeyFromParams) {
         await usePushKeyFromParams(ctx, appLookupParams, pushKeyFromParams);
@@ -225,7 +223,6 @@ class IOSBuilder extends BaseBuilder {
 
   async _setupProvisioningProfile(ctx: Context, appLookupParams: AppLookupParams) {
     try {
-      const nonInteractive = this.options.parent && this.options.parent.nonInteractive;
       const provisioningProfileFromParams = await getProvisioningProfileFromParams(
         this.options.provisioningProfilePath
       );

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -139,7 +139,7 @@ export async function action(projectDir: string = './', options: Options = { for
     choices: values,
   });
   if (!answer) {
-    console.log('\n\u203A Exiting...\n');
+    log('\n\u203A Exiting...\n');
     return;
   }
   await generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder });

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -3,6 +3,8 @@ import { Command } from 'commander';
 // @ts-ignore
 import envinfo from 'envinfo';
 
+import log from '../log';
+
 const packageJSON = require('../../package.json');
 
 async function action(projectRoot: string): Promise<void> {
@@ -34,10 +36,10 @@ async function action(projectRoot: string): Promise<void> {
   const lines = info.split('\n');
   lines.pop();
   lines.push(`    Expo Workflow: ${workflow}`);
-  console.log(lines.join('\n') + '\n');
+  log(lines.join('\n') + '\n');
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('diagnostics [path]')
     .description('Log environment info to the console')

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
@@ -150,17 +150,6 @@ function setupProjectConfig(overrideConfig: any) {
   vol.writeFileSync('/projectdir/pprofile', pprofile.content);
 }
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
-
 beforeEach(() => {
   vol.reset();
   mockPostAsync.mockReset();

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/credentials-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/credentials-test.ts
@@ -5,17 +5,6 @@ import { ensureCredentialsAsync } from '../credentials';
 
 jest.mock('../../../../prompts');
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
-
 function createMockCredentialsProvider({
   hasRemote,
   hasLocal,

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
@@ -35,16 +35,6 @@ function setupCredentialsConfig() {
   });
 }
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   vol.reset();
 });

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/iOSBuilder-test.ts
@@ -46,16 +46,6 @@ function setupCredentialsConfig() {
   });
 }
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   vol.reset();
 });

--- a/packages/expo-cli/src/commands/eas-build/init/__tests__/init-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/init/__tests__/init-test.ts
@@ -104,17 +104,6 @@ function setupProjectConfig(overrideConfig: any) {
   vol.writeFileSync('/projectdir/pprofile', pprofile.content);
 }
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
-
 beforeEach(() => {
   vol.reset();
 });

--- a/packages/expo-cli/src/commands/eas-build/init/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/init/action.ts
@@ -4,7 +4,6 @@ import figures from 'figures';
 import fs from 'fs-extra';
 import ora from 'ora';
 import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 
 import { EasJsonReader } from '../../../easJson';
 import { gitAddAsync } from '../../../git';

--- a/packages/expo-cli/src/commands/eas-build/status/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/status/action.ts
@@ -117,7 +117,7 @@ function printBuildTable(builds: Build[]) {
 
   const buildTable = printTableJsonArray(headers, refactoredBuilds, colWidths);
 
-  console.log(buildTable);
+  log(buildTable);
 }
 
 export default statusAction;

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -3,6 +3,7 @@ import { Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import { Command } from 'commander';
 
+import log from '../log';
 import prompt from '../prompt';
 import * as Eject from './eject/Eject';
 import * as LegacyEject from './eject/LegacyEject';
@@ -25,9 +26,9 @@ async function action(
   try {
     exp = getConfig(projectDir).exp;
   } catch (error) {
-    console.log();
-    console.log(chalk.red(error.message));
-    console.log();
+    log();
+    log(chalk.red(error.message));
+    log();
     process.exit(1);
   }
 

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -249,9 +249,9 @@ async function createNativeProjectsFromTemplateAsync(projectRoot: string): Promi
     }
   } catch (error) {
     // TODO(Bacon): Currently this is already handled in the command
-    console.log();
-    console.log(chalk.red(error.message));
-    console.log();
+    log();
+    log(chalk.red(error.message));
+    log();
     process.exit(1);
   }
 

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -95,7 +95,7 @@ export async function action(projectDir: string, options: Options) {
   if (!options.dev && !UrlUtils.isHttps(options.publicUrl)) {
     throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
   } else if (!validator.isURL(options.publicUrl, { protocols: ['http', 'https'] })) {
-    console.warn(`Dev Mode: publicUrl ${options.publicUrl} does not conform to HTTP format.`);
+    log.warn(`Dev Mode: publicUrl ${options.publicUrl} does not conform to HTTP format.`);
   }
 
   // Make outputDir an absolute path if it isnt already

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -1,5 +1,6 @@
 import dateFormat from 'dateformat';
 
+import log from '../log';
 import {
   DetailOptions,
   HistoryOptions,
@@ -39,7 +40,7 @@ export default (program: any) => {
         const result = await getPublishHistoryAsync(projectDir, options);
 
         if (options.raw) {
-          console.log(JSON.stringify(result));
+          log(JSON.stringify(result));
           return;
         }
 
@@ -52,7 +53,7 @@ export default (program: any) => {
             },
             'General Info'
           );
-          console.log(generalTableString);
+          log(generalTableString);
 
           // Print info specific to each publication
           const headers = [
@@ -79,7 +80,7 @@ export default (program: any) => {
             publishedTime: dateFormat(publication.publishedTime, 'ddd mmm dd yyyy HH:MM:ss Z'),
           }));
           const tableString = table.printTableJsonArray(headers, resultRows, colWidths);
-          console.log(tableString);
+          log(tableString);
         } else {
           throw new Error('No records found matching your query.');
         }

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -47,7 +47,7 @@ export default function (program: Command) {
             'Channel Set Status ',
             'SUCCESS'
           );
-          console.log(tableString);
+          log(tableString);
         } catch (e) {
           log.error(e);
         }

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -2,7 +2,6 @@ import { PackageJSONConfig, ProjectTarget, getConfig, getDefaultTarget } from '@
 import simpleSpinner from '@expo/simple-spinner';
 import { Project } from '@expo/xdl';
 import chalk from 'chalk';
-import clipboard from 'clipboardy';
 import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
@@ -145,14 +144,6 @@ function logManifestUrl({ url, sdkVersion }: { url: string; sdkVersion?: string 
       TerminalLink.learnMore('https://expo.fyi/manifest-url')
     )}`
   );
-}
-
-function copyToClipboard(value: string): boolean {
-  try {
-    clipboard.writeSync(value);
-    return true;
-  } catch {}
-  return false;
 }
 
 /**

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -105,9 +105,9 @@ export default function (program: Command) {
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
 
     .on('--help', function () {
-      console.log('Available languages:');
-      console.log(`  ${LANGUAGES.join(', ')}`);
-      console.log();
+      log('Available languages:');
+      log(`  ${LANGUAGES.join(', ')}`);
+      log();
     })
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: IosPlatformOptions) => {

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
@@ -306,7 +306,7 @@ function printSummary(summary: Summary): void {
     const displayValue = SummaryHumanReadableValues[key as keyof Summary]?.(value) ?? value;
     table.push([displayKey, displayValue]);
   }
-  console.info(table.toString());
+  log(table.toString());
 }
 
 export default AndroidSubmitter;

--- a/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
@@ -43,16 +43,13 @@ describe(AndroidSubmitCommand, () => {
     '/google-service-account.json': JSON.stringify({ service: 'account' }),
   };
 
-  const originalConsoleInfo = console.info;
   beforeAll(() => {
-    console.info = jest.fn();
     vol.fromJSON({
       ...testProject.projectTree,
       ...fakeFiles,
     });
   });
   afterAll(() => {
-    console.info = originalConsoleInfo;
     vol.reset();
   });
 

--- a/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/ServiceAccountSource-test.ts
@@ -11,18 +11,12 @@ jest.mock('fs');
 jest.mock('../../../../../prompt');
 
 describe(getServiceAccountAsync, () => {
-  const originalConsoleWarn = console.warn;
-  const originalConsoleLog = console.log;
   beforeAll(() => {
-    console.warn = jest.fn();
-    console.log = jest.fn();
     vol.fromJSON({
       '/google-service-account.json': JSON.stringify({ service: 'account' }),
     });
   });
   afterAll(() => {
-    console.warn = originalConsoleWarn;
-    console.log = originalConsoleLog;
     vol.reset();
   });
 

--- a/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveFileSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveFileSource.ts
@@ -171,7 +171,7 @@ async function handleBuildIdSourceAsync(
       slug,
     });
   } catch (err) {
-    console.error(err);
+    log.error(err);
     throw err;
   }
 

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -245,7 +245,7 @@ export async function printPublicationDetailAsync(
   options: DetailOptions
 ) {
   if (options.raw) {
-    console.log(JSON.stringify(detail));
+    log(JSON.stringify(detail));
     return;
   }
 
@@ -254,9 +254,9 @@ export async function printPublicationDetailAsync(
 
   // Print general release info
   const generalTableString = table.printTableJson(detail, 'Release Description');
-  console.log(generalTableString);
+  log(generalTableString);
 
   // Print manifest info
   const manifestTableString = table.printTableJson(manifest, 'Manifest Details');
-  console.log(manifestTableString);
+  log(manifestTableString);
 }

--- a/packages/expo-cli/src/credentials/__tests__/api-android-basic-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-android-basic-test.ts
@@ -10,16 +10,6 @@ import {
 } from '../test-fixtures/mocks-android';
 import { testExperienceName, testJester2ExperienceName } from '../test-fixtures/mocks-constants';
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {});
 
 describe('AndroidApi - Basic Tests', () => {

--- a/packages/expo-cli/src/credentials/__tests__/api-ios-basic-test.ts
+++ b/packages/expo-cli/src/credentials/__tests__/api-ios-basic-test.ts
@@ -13,17 +13,6 @@ import {
   testPushKey,
 } from '../test-fixtures/mocks-ios';
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
-
 describe('IosApi - Basic Tests', () => {
   let iosApi;
   let apiMock;

--- a/packages/expo-cli/src/credentials/credentialsJson/__tests__/update-test.ts
+++ b/packages/expo-cli/src/credentials/credentialsJson/__tests__/update-test.ts
@@ -11,20 +11,6 @@ import * as credentialsJsonUpdateUtils from '../update';
 jest.mock('fs');
 jest.mock('../../../prompts');
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-const originalError = console.error;
-beforeAll(() => {
-  console.error = jest.fn();
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-  console.error = originalError;
-});
-
 beforeEach(() => {
   vol.reset();
   (prompts as any).mockReset();

--- a/packages/expo-cli/src/credentials/provider/__tests__/AndroidCredentialsProvider-test.ts
+++ b/packages/expo-cli/src/credentials/provider/__tests__/AndroidCredentialsProvider-test.ts
@@ -13,17 +13,6 @@ const cliOptions = {
 
 const mockFetchKeystore = jest.fn();
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
-
 jest.mock('fs');
 jest.mock('../../route');
 jest.mock('../../context', () => {

--- a/packages/expo-cli/src/credentials/provider/__tests__/iOSCredentialsProvider-test.ts
+++ b/packages/expo-cli/src/credentials/provider/__tests__/iOSCredentialsProvider-test.ts
@@ -18,17 +18,6 @@ const providerOptions = {
 const mockGetDistCert = jest.fn();
 const mockGetProvisioningProfile = jest.fn();
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
-
 jest.mock('fs');
 jest.mock('../../route');
 jest.mock('../../context', () => {

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -1,6 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
 
-import CommandError from '../../CommandError';
 import log from '../../log';
 import prompt from '../../prompt';
 import { displayAndroidAppCredentials } from '../actions/list';

--- a/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
@@ -211,7 +211,7 @@ async function getKeystoreFromParams(options: {
   }
 
   if (!keystorePath || !keyAlias || !keystorePassword || !keyPassword) {
-    console.log(keystorePath, keyAlias, keystorePassword, keyPassword);
+    log(keystorePath, keyAlias, keystorePassword, keyPassword);
     throw new Error(
       'In order to provide a Keystore through the CLI parameters, you have to pass --keystore-alias, --keystore-path parameters and set EXPO_ANDROID_KEY_PASSWORD and EXPO_ANDROID_KEYSTORE_PASSWORD environment variables.'
     );

--- a/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Remove-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Remove-test.ts
@@ -20,16 +20,6 @@ mockExpoXDL({
   },
 });
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   (prompt as any).mockReset();
   (prompt as any).mockImplementation(() => {

--- a/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
@@ -13,16 +13,6 @@ mockExpoXDL({
   },
 });
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   (prompts as any).mockReset();
   (prompts as any).mockImplementation(() => {

--- a/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosDistCert-test.ts
@@ -17,16 +17,6 @@ jest.mock('../../../appleApi', () => {
 
 jest.mock('../../actions/list');
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   mockDistCertManagerCreate.mockClear();
   mockDistCertManagerList.mockClear();

--- a/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosProvisioningProfile-test.ts
@@ -25,16 +25,6 @@ jest.mock('../../../appleApi', () => {
 
 jest.mock('../../actions/list');
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   mockProvProfManagerCreate.mockClear();
   mockProvProfManagerUseExisting.mockClear();

--- a/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/IosPushCredentials-test.ts
@@ -17,16 +17,6 @@ jest.mock('../../../appleApi', () => {
 
 jest.mock('../../actions/list');
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   mockPushKeyManagerCreate.mockClear();
   mockPushKeyManagerList.mockClear();

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupAndroidBuildCredentialsFromLocal-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupAndroidBuildCredentialsFromLocal-test.ts
@@ -15,20 +15,6 @@ jest.mock('fs');
   return true;
 });
 
-const originalError = console.error;
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.error = jest.fn();
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.error = originalError;
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
-
 beforeEach(() => {
   vol.reset();
 });

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupAndroidKeystore-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupAndroidKeystore-test.ts
@@ -12,16 +12,6 @@ jest.mock('command-exists');
   return true;
 });
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {});
 
 describe('SetupAndroidKeystore', () => {

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosBuildCredentialsFromLocal-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosBuildCredentialsFromLocal-test.ts
@@ -16,20 +16,6 @@ jest.mock('fs');
   return true;
 });
 
-const originalError = console.error;
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.error = jest.fn();
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.error = originalError;
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
-
 beforeEach(() => {
   vol.reset();
 });

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosDist-test.ts
@@ -17,16 +17,6 @@ jest.mock('../../../appleApi', () => {
 
 jest.mock('../../actions/list');
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   mockDistCertManagerCreate.mockClear();
   mockDistCertManagerList.mockClear();

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupIosPush-test.ts
@@ -17,16 +17,6 @@ jest.mock('../../../appleApi', () => {
 
 jest.mock('../../actions/list');
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   mockPushKeyManagerCreate.mockClear();
   mockPushKeyManagerList.mockClear();

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupProvisioningProfile-test.ts
@@ -22,16 +22,6 @@ jest.mock('../../../appleApi', () => {
 
 jest.mock('../../actions/list');
 
-const originalWarn = console.warn;
-const originalLog = console.log;
-beforeAll(() => {
-  console.warn = jest.fn();
-  console.log = jest.fn();
-});
-afterAll(() => {
-  console.warn = originalWarn;
-  console.log = originalLog;
-});
 beforeEach(() => {
   mockProvProfManagerCreate.mockClear();
   mockProvProfManagerUseExisting.mockClear();

--- a/packages/expo-cli/src/exit.ts
+++ b/packages/expo-cli/src/exit.ts
@@ -1,6 +1,8 @@
 import { Project } from '@expo/xdl';
 import chalk from 'chalk';
 
+import log from './log';
+
 export function installExitHooks(
   projectDir: string,
   onStop: (projectDir: string) => Promise<void> = Project.stopAsync
@@ -8,9 +10,9 @@ export function installExitHooks(
   const killSignals: ['SIGINT', 'SIGTERM'] = ['SIGINT', 'SIGTERM'];
   for (const signal of killSignals) {
     process.on(signal, () => {
-      console.log(chalk.blue('\nStopping packager...'));
+      log(chalk.blue('\nStopping packager...'));
       onStop(projectDir).then(() => {
-        console.log(chalk.green('Packager stopped.'));
+        log(chalk.green('Packager stopped.'));
         process.exit();
       });
     });

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -606,7 +606,7 @@ function runAsync(programName: string) {
       program.help();
     }
   } catch (e) {
-    console.error(e);
+    log.error(e);
     throw e;
   }
 }
@@ -780,7 +780,7 @@ export function run(programName: string) {
       await Promise.all([writePathAsync(), runAsync(programName)]);
     }
   })().catch(e => {
-    console.error('Uncaught Error', e);
+    log.error('Uncaught Error', e);
     process.exit(1);
   });
 }

--- a/packages/expo-cli/src/log.ts
+++ b/packages/expo-cli/src/log.ts
@@ -25,7 +25,7 @@ function _updateIsLastLineNewLine(args: any[]) {
 function _maybePrintNewLine() {
   if (_printNewLineBeforeNextLog) {
     _printNewLineBeforeNextLog = false;
-    console.log();
+    console.log(); // eslint-disable-line no-console
   }
 }
 
@@ -33,21 +33,21 @@ function consoleLog(...args: any[]) {
   _maybePrintNewLine();
   _updateIsLastLineNewLine(args);
 
-  console.log(...args);
+  console.log(...args); // eslint-disable-line no-console
 }
 
 function consoleWarn(...args: any[]) {
   _maybePrintNewLine();
   _updateIsLastLineNewLine(args);
 
-  console.warn(...args);
+  console.warn(...args); // eslint-disable-line no-console
 }
 
 function consoleError(...args: any[]) {
   _maybePrintNewLine();
   _updateIsLastLineNewLine(args);
 
-  console.error(...args);
+  console.error(...args); // eslint-disable-line no-console
 }
 
 function respectProgressBars(commitLogs: () => void) {

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -4,6 +4,7 @@ import indentString from 'indent-string';
 import qrcodeTerminal from 'qrcode-terminal';
 
 import CommandError from './CommandError';
+import log from './log';
 
 export type URLOptions = {
   android?: boolean;
@@ -66,7 +67,7 @@ async function optsAsync(projectDir: string, options: any) {
 }
 
 function printQRCode(url: string) {
-  qrcodeTerminal.generate(url, code => console.log(`${indentString(code, 2)}\n`));
+  qrcodeTerminal.generate(url, code => log(`${indentString(code, 2)}\n`));
 }
 
 async function handleMobileOptsAsync(

--- a/packages/expo-cli/src/validators.ts
+++ b/packages/expo-cli/src/validators.ts
@@ -1,5 +1,7 @@
 import fs from 'fs-extra';
 
+import log from './log';
+
 function nonEmptyInput(val: string) {
   return val !== '';
 }
@@ -10,7 +12,7 @@ const existingFile = async (filePath: string, verbose = true) => {
     return stats.isFile();
   } catch (e) {
     if (verbose) {
-      console.log('\nFile does not exist.');
+      log('\nFile does not exist.');
     }
     return false;
   }

--- a/packages/webpack-config/web-default/expo-service-worker.js
+++ b/packages/webpack-config/web-default/expo-service-worker.js
@@ -37,7 +37,8 @@ self.addEventListener('push', event => {
     data,
   };
   options.icon = data._icon || payload.icon || self.notificationIcon || null;
-  options.image = data._richContent && data._richContent.image ? options.data._richContent.image : payload.image;
+  options.image =
+    data._richContent && data._richContent.image ? options.data._richContent.image : payload.image;
   options.tag = data._tag || payload.collapseKey;
   if (options.tag) {
     options.renotify = data._renotify;

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -203,10 +203,7 @@ async function startEmulatorAsync(device: Device): Promise<Device> {
 export async function getAttachedDevicesAsync(): Promise<Device[]> {
   const output = await getAdbOutputAsync(['devices', '-l']);
 
-  const splitItems = output
-    .trim()
-    .replace(/\n$/, '')
-    .split(os.EOL);
+  const splitItems = output.trim().replace(/\n$/, '').split(os.EOL);
   // First line is `"List of devices attached"`, remove it
   // @ts-ignore: todo
   const attachedDevices: {

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -414,17 +414,11 @@ export async function exportForAppHosting(
   const iosBundle = bundles.ios.code;
   const androidBundle = bundles.android.code;
 
-  const iosBundleHash = crypto
-    .createHash('md5')
-    .update(iosBundle)
-    .digest('hex');
+  const iosBundleHash = crypto.createHash('md5').update(iosBundle).digest('hex');
   const iosBundleUrl = `ios-${iosBundleHash}.js`;
   const iosJsPath = path.join(outputDir, 'bundles', iosBundleUrl);
 
-  const androidBundleHash = crypto
-    .createHash('md5')
-    .update(androidBundle)
-    .digest('hex');
+  const androidBundleHash = crypto.createHash('md5').update(androidBundle).digest('hex');
   const androidBundleUrl = `android-${androidBundleHash}.js`;
   const androidJsPath = path.join(outputDir, 'bundles', androidBundleUrl);
 

--- a/packages/xdl/src/Xcode.ts
+++ b/packages/xdl/src/Xcode.ts
@@ -1,6 +1,4 @@
-import * as osascript from '@expo/osascript';
-import spawnAsync, { SpawnOptions } from '@expo/spawn-async';
-import path from 'path';
+import spawnAsync from '@expo/spawn-async';
 
 import Logger from './Logger';
 

--- a/packages/xdl/src/__tests__/fixtures/publish-test-app/App.js
+++ b/packages/xdl/src/__tests__/fixtures/publish-test-app/App.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React from 'react';
 import { Text, View } from 'react-native';
 

--- a/scripts/build-packages-toc.js
+++ b/scripts/build-packages-toc.js
@@ -2,10 +2,6 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-function toCamel(s) {
-  return s.replace(/(-\w)/g, m => m[1].toUpperCase());
-}
-
 /**
  * @param {string} cell
  * @param {number} width


### PR DESCRIPTION
# Why

Follow-up of https://github.com/expo/expo-cli/pull/2629. I noticed there were some other warnings. This PR aligns this repo with our other repos so that CI fails when there are lint issues. That way they can't be committed.

# How

Add CI lint step. Fix all remaining lint warnings.

# Test Plan

Wait for CI