### PR TITLE
Use subprocess to populate dynamic config cache, add function to clear it

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -23,6 +23,8 @@ import { getRootPackageJsonPath, projectHasModule } from './Modules';
 import { getExpoSDKVersion } from './Project';
 import { getDynamicConfig, getStaticConfig } from './getConfig';
 
+export { clearDynamicConfigCache } from './getConfig';
+
 export const isDynamicEvalEnabled = boolish('EXPO_HOT_CONFIG', false);
 
 /**

--- a/packages/config/src/__tests__/ConfigParsing-test.js
+++ b/packages/config/src/__tests__/ConfigParsing-test.js
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { getConfig, setCustomConfigPath } from '../Config';
+import { clearDynamicConfigCache, getConfig, setCustomConfigPath } from '../Config';
 
 const fixtures = {
   customLocationJson: path.resolve(__dirname, 'fixtures/behavior/custom-location-json'),
@@ -16,6 +16,7 @@ describe('getConfig', () => {
     beforeEach(() => {
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/js');
       setCustomConfigPath(projectRoot, undefined);
+      clearDynamicConfigCache();
     });
     it('parses a ts config', () => {
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/ts');

--- a/packages/config/src/__tests__/fixtures/behavior/dynamic-hot/after/app.config.js
+++ b/packages/config/src/__tests__/fixtures/behavior/dynamic-hot/after/app.config.js
@@ -1,0 +1,3 @@
+export default {
+  name: 'after',
+};

--- a/packages/config/src/__tests__/fixtures/behavior/dynamic-hot/before/app.config.js
+++ b/packages/config/src/__tests__/fixtures/behavior/dynamic-hot/before/app.config.js
@@ -1,0 +1,3 @@
+export default {
+  name: 'before',
+};

--- a/packages/config/src/__tests__/fixtures/language-support/toml/package.json
+++ b/packages/config/src/__tests__/fixtures/language-support/toml/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "js-config-test",
+  "name": "toml-config-test",
   "version": "1.0.0"
 }

--- a/packages/config/src/__tests__/fixtures/language-support/yaml/package.json
+++ b/packages/config/src/__tests__/fixtures/language-support/yaml/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "js-config-test",
+  "name": "yaml-config-test",
   "version": "1.0.0"
 }


### PR DESCRIPTION
This approach makes a bit easier to understand (`@babel/register` is a black box for me) and has the bonus of making it easy for us to expose functionality to let users clear the config cache without restarting expo-cli.

Note that the base branch is `@evanbacon/config/add-support-for-toggling-config-evaluation-modes`