### PR TITLE
[expo start] remove extra config reads

### DIFF
--- a/packages/dev-tools/server/dev-server.ts
+++ b/packages/dev-tools/server/dev-server.ts
@@ -11,8 +11,8 @@ const PORT = 3333;
 
 async function run(): Promise<void> {
   try {
-    const projectDir = process.argv[2];
-    if (!projectDir) {
+    const projectRoot = process.argv[2];
+    if (!projectRoot) {
       throw new Error('No project dir specified.\nUsage: yarn dev [path]');
     }
 
@@ -39,9 +39,9 @@ async function run(): Promise<void> {
       httpServer.once('listening', resolve);
       httpServer.listen(PORT, 'localhost');
     });
-    startGraphQLServer(projectDir, httpServer, authenticationContext);
+    startGraphQLServer(projectRoot, httpServer, authenticationContext);
     console.log('Starting project...');
-    await Project.startAsync(projectDir);
+    await Project.startAsync(projectRoot);
     const url = `http://localhost:${PORT}`;
     console.log(`Development server running at ${url}`);
     openBrowser(url);

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -144,7 +144,7 @@ function parseStartOptions(options: NormalizedOptions): Project.StartOptions {
 async function startWebAction(projectDir: string, options: NormalizedOptions): Promise<void> {
   const { exp, rootPath } = await configureProjectAsync(projectDir, options);
   const startOpts = parseStartOptions(options);
-  await Project.startAsync(rootPath, exp, startOpts);
+  await Project.startAsync(rootPath, { ...startOpts, exp });
   await urlOpts.handleMobileOptsAsync(projectDir, options);
 
   if (!options.nonInteractive && !exp.isDetached) {
@@ -160,7 +160,7 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
 
   const startOpts = parseStartOptions(options);
 
-  await Project.startAsync(rootPath, exp, startOpts);
+  await Project.startAsync(rootPath, { ...startOpts, exp });
 
   const url = await UrlUtils.constructManifestUrlAsync(projectDir);
 

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -52,25 +52,6 @@ function getBooleanArg(rawArgs: string[], argName: string): boolean {
   }
 }
 
-/**
- * If the project config `platforms` only contains the "web" field.
- * If no `platforms` array is defined this could still resolve true because platforms
- * will be inferred from the existence of `react-native-web` and `react-native`.
- *
- * @param projectRoot
- */
-function isWebOnly(projectRoot: string): boolean {
-  // TODO(Bacon): Limit the amount of times that the config is evaluated
-  // currently we read it the first time without the SDK version then later read it with the SDK version if react-native is installed.
-  const { exp } = getConfig(projectRoot, {
-    skipSDKVersionRequirement: true,
-  });
-  if (Array.isArray(exp.platforms) && exp.platforms.length === 1) {
-    return exp.platforms[0] === 'web';
-  }
-  return false;
-}
-
 // The main purpose of this function is to take existing options object and
 // support boolean args with as defined in the hasBooleanArg and getBooleanArg
 // functions.
@@ -80,7 +61,7 @@ async function normalizeOptionsAsync(
 ): Promise<NormalizedOptions> {
   const opts: NormalizedOptions = {
     ...options, // This is necessary to ensure we don't drop any options
-    webOnly: options.webOnly ?? isWebOnly(projectDir),
+    webOnly: options.webOnly,
     nonInteractive: options.parent?.nonInteractive,
   };
 
@@ -163,7 +144,7 @@ function parseStartOptions(options: NormalizedOptions): Project.StartOptions {
 async function startWebAction(projectDir: string, options: NormalizedOptions): Promise<void> {
   const { exp, rootPath } = await configureProjectAsync(projectDir, options);
   const startOpts = parseStartOptions(options);
-  await Project.startAsync(rootPath, startOpts);
+  await Project.startAsync(rootPath, exp, startOpts);
   await urlOpts.handleMobileOptsAsync(projectDir, options);
 
   if (!options.nonInteractive && !exp.isDetached) {
@@ -179,7 +160,7 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
 
   const startOpts = parseStartOptions(options);
 
-  await Project.startAsync(rootPath, startOpts);
+  await Project.startAsync(rootPath, exp, startOpts);
 
   const url = await UrlUtils.constructManifestUrlAsync(projectDir);
 

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -380,7 +380,7 @@ Please reload the project in the Expo app for the change to take effect.`
         } else {
           log('Restarting Metro bundler...');
         }
-        Project.startAsync(projectRoot, undefined, { ...options, reset });
+        Project.startAsync(projectRoot, { ...options, reset });
         break;
       }
       case 's': {

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -380,7 +380,7 @@ Please reload the project in the Expo app for the change to take effect.`
         } else {
           log('Restarting Metro bundler...');
         }
-        Project.startAsync(projectRoot, { ...options, reset });
+        Project.startAsync(projectRoot, undefined, { ...options, reset });
         break;
       }
       case 's': {

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -551,7 +551,10 @@ export async function upgradeAsync(
 
   const clearingCacheStep = logNewSection('Clearing the packager cache.');
   try {
-    await Project.startReactNativeServerAsync(projectRoot, { reset: true, nonPersistent: true });
+    await Project.startReactNativeServerAsync({
+      projectRoot,
+      options: { reset: true, nonPersistent: true },
+    });
   } catch (e) {
     clearingCacheStep.fail(`Failed to clear packager cache with error: ${e.message}`);
   } finally {

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -64,7 +64,7 @@ export type PublicationDetail = {
 const VERSION = 2;
 
 export async function getPublishHistoryAsync(
-  projectDir: string,
+  projectRoot: string,
   options: HistoryOptions
 ): Promise<any> {
   if (options.count && (isNaN(options.count) || options.count < 1 || options.count > 100)) {
@@ -73,14 +73,14 @@ export async function getPublishHistoryAsync(
 
   // TODO(ville): handle the API result for not authenticated user instead of checking upfront
   const user = await UserManager.ensureLoggedInAsync();
-  const { exp } = getConfig(projectDir, {
+  const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
 
   const api = ApiV2.clientForUser(user);
   return await api.postAsync('publish/history', {
     owner: exp.owner,
-    slug: await Project.getSlugAsync(projectDir),
+    slug: await Project.getSlugAsync({ projectRoot, exp }),
     version: VERSION,
     releaseChannel: options.releaseChannel,
     count: options.count,
@@ -90,7 +90,7 @@ export async function getPublishHistoryAsync(
 }
 
 export async function setPublishToChannelAsync(
-  projectDir: string,
+  projectRoot: string,
   options: SetOptions
 ): Promise<any> {
   const user = await UserManager.ensureLoggedInAsync();
@@ -98,7 +98,7 @@ export async function setPublishToChannelAsync(
   return await api.postAsync('publish/set', {
     releaseChannel: options.releaseChannel,
     publishId: options.publishId,
-    slug: await Project.getSlugAsync(projectDir),
+    slug: await Project.getSlugAsync({ projectRoot }),
   });
 }
 
@@ -216,15 +216,15 @@ async function _printAndConfirm(
 }
 
 export async function getPublicationDetailAsync(
-  projectDir: string,
+  projectRoot: string,
   options: DetailOptions
 ): Promise<PublicationDetail> {
   // TODO(ville): handle the API result for not authenticated user instead of checking upfront
   const user = await UserManager.ensureLoggedInAsync();
-  const { exp } = getConfig(projectDir, {
+  const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
-  const slug = await Project.getSlugAsync(projectDir);
+  const slug = await Project.getSlugAsync({ projectRoot, exp });
 
   const api = ApiV2.clientForUser(user);
   const result = await api.postAsync('publish/details', {

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -171,8 +171,13 @@ function _requireFromProject(modulePath: string, projectRoot: string, exp: ExpoC
 }
 
 // TODO: Move to @expo/config
-export async function getSlugAsync(projectRoot: string): Promise<string> {
-  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+export async function getSlugAsync({
+  projectRoot,
+  exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
+}: {
+  projectRoot: string;
+  exp?: Pick<ExpoConfig, 'slug'>;
+}): Promise<string> {
   if (exp.slug) {
     return exp.slug;
   }
@@ -194,7 +199,7 @@ export async function getLatestReleaseAsync(
   const api = ApiV2.clientForUser(user);
   const result = await api.postAsync('publish/history', {
     owner: options.owner,
-    slug: await getSlugAsync(projectRoot),
+    slug: await getSlugAsync({ projectRoot }),
     releaseChannel: options.releaseChannel,
     count: 1,
     platform: options.platform,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -387,17 +387,11 @@ export async function exportForAppHosting(
   const iosBundle = bundles.ios.code;
   const androidBundle = bundles.android.code;
 
-  const iosBundleHash = crypto
-    .createHash('md5')
-    .update(iosBundle)
-    .digest('hex');
+  const iosBundleHash = crypto.createHash('md5').update(iosBundle).digest('hex');
   const iosBundleUrl = `ios-${iosBundleHash}.js`;
   const iosJsPath = path.join(outputDir, 'bundles', iosBundleUrl);
 
-  const androidBundleHash = crypto
-    .createHash('md5')
-    .update(androidBundle)
-    .digest('hex');
+  const androidBundleHash = crypto.createHash('md5').update(androidBundle).digest('hex');
   const androidBundleUrl = `android-${androidBundleHash}.js`;
   const androidJsPath = path.join(outputDir, 'bundles', androidBundleUrl);
 
@@ -1974,11 +1968,11 @@ export async function getUrlAsync(projectRoot: string, options: object = {}): Pr
 
 export async function startAsync(
   projectRoot: string,
+  exp: ExpoConfig = getConfig(projectRoot).exp,
   options: StartOptions = {},
   verbose: boolean = true
 ): Promise<ExpoConfig> {
   _assertValidProjectRoot(projectRoot);
-  const { exp } = getConfig(projectRoot);
   Analytics.logEvent('Start Project', {
     projectRoot,
     developerTool: Config.developerTool,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -392,11 +392,17 @@ export async function exportForAppHosting(
   const iosBundle = bundles.ios.code;
   const androidBundle = bundles.android.code;
 
-  const iosBundleHash = crypto.createHash('md5').update(iosBundle).digest('hex');
+  const iosBundleHash = crypto
+    .createHash('md5')
+    .update(iosBundle)
+    .digest('hex');
   const iosBundleUrl = `ios-${iosBundleHash}.js`;
   const iosJsPath = path.join(outputDir, 'bundles', iosBundleUrl);
 
-  const androidBundleHash = crypto.createHash('md5').update(androidBundle).digest('hex');
+  const androidBundleHash = crypto
+    .createHash('md5')
+    .update(androidBundle)
+    .digest('hex');
   const androidBundleUrl = `android-${androidBundleHash}.js`;
   const androidJsPath = path.join(outputDir, 'bundles', androidBundleUrl);
 
@@ -1977,8 +1983,7 @@ export async function getUrlAsync(projectRoot: string, options: object = {}): Pr
 
 export async function startAsync(
   projectRoot: string,
-  exp: ExpoConfig = getConfig(projectRoot).exp,
-  options: StartOptions = {},
+  { exp = getConfig(projectRoot).exp, ...options }: StartOptions & { exp?: ExpoConfig } = {},
   verbose: boolean = true
 ): Promise<ExpoConfig> {
   _assertValidProjectRoot(projectRoot);


### PR DESCRIPTION
- Reading the config is getting expensive. 
- The "only start webpack when react-native-web is installed and react-native is not installed" feature isn't very useful. The `expo web` / `expo start:web` command is more appropriate.
- Add optional ability to pass an expo config to `Project.startAsync` 