### PR TITLE
[expo-cli] EAS Build deprecation info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [expo-cli] EAS Build: Improve errors and wanrings when deprecating API [#2639](https://github.com/expo/expo-cli/pull/2639)
+
 ### 🐛 Bug fixes
 
 ## [Thu, 9 Sep 2020 16:32:14 +0200](https://github.com/expo/expo-cli/commit/58ac4c43d0b3e7cb8db5b2c46d8602bf101e33db)

--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -29,7 +29,7 @@ import {
   ensureGitStatusIsCleanAsync,
   makeProjectTarballAsync,
 } from '../utils/git';
-import { printBuildResults, printLogsUrls } from '../utils/misc';
+import { printBuildResults, printDeprecationWarnings, printLogsUrls } from '../utils/misc';
 import AndroidBuilder from './builders/AndroidBuilder';
 import iOSBuilder from './builders/iOSBuilder';
 import { collectMetadata } from './metadata';
@@ -204,10 +204,11 @@ async function startBuildAsync<T extends Platform>(
     log(`Starting ${platformDisplayNames[job.platform]} build`);
 
     try {
-      const { buildId } = await client.postAsync(`projects/${projectId}/builds`, {
+      const { buildId, deprecationInfo } = await client.postAsync(`projects/${projectId}/builds`, {
         job,
         metadata,
       } as any);
+      printDeprecationWarnings(deprecationInfo);
       Analytics.logEvent(AnalyticsEvent.BUILD_REQUEST_SUCCESS, builder.ctx.trackingCtx.properties);
       return buildId;
     } catch (error) {
@@ -215,6 +216,9 @@ async function startBuildAsync<T extends Platform>(
         ...builder.ctx.trackingCtx,
         reason: error.message,
       });
+      if (error.code === 'TURTLE_DEPRECATED_JOB_FORMAT') {
+        log.error('EAS Build API changed, upgrade to latest expo-cli');
+      }
       throw error;
     }
   } finally {

--- a/packages/expo-cli/src/commands/eas-build/utils/misc.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/misc.ts
@@ -5,6 +5,11 @@ import * as UrlUtils from '../../utils/url';
 import { platformDisplayNames } from '../constants';
 import { Build } from '../types';
 
+export interface DeprecationInfo {
+  type: 'user-facing' | 'internal';
+  message: string;
+}
+
 async function printLogsUrls(
   accountName: string,
   builds: { platform: 'android' | 'ios'; buildId: string }[]
@@ -46,4 +51,23 @@ async function printBuildResults(builds: (Build | null)[]): Promise<void> {
   }
 }
 
-export { printLogsUrls, printBuildResults };
+function printDeprecationWarnings(deprecationInfo?: DeprecationInfo): void {
+  if (!deprecationInfo) {
+    return;
+  }
+  if (deprecationInfo.type === 'internal') {
+    log.warn('This command is using API that soon will be deprecated, please update expo-cli.');
+    log.warn("Changes won't affect your project confiuration.");
+    log.warn(deprecationInfo.message);
+  } else if (deprecationInfo.type === 'user-facing') {
+    log.warn('This command is using API that soon will be deprecated, please update expo-cli.');
+    log.warn(
+      'There might be some changes necessary to your project configuration, latest expo-cli will provide more specific error messages.'
+    );
+    log.warn(deprecationInfo.message);
+  } else {
+    log(deprecationInfo); // should not happen
+  }
+}
+
+export { printLogsUrls, printBuildResults, printDeprecationWarnings };

--- a/packages/expo-cli/src/commands/eas-build/utils/misc.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/misc.ts
@@ -66,7 +66,8 @@ function printDeprecationWarnings(deprecationInfo?: DeprecationInfo): void {
     );
     log.warn(deprecationInfo.message);
   } else {
-    log(deprecationInfo); // should not happen
+    log.warn('An unexpected warning was encountered. Please report it as a bug:');
+    log.warn(deprecationInfo);
   }
 }
 


### PR DESCRIPTION
# Why

Better error messages when deprecating parts of api in EAS Build