### PR TITLE
[xdl] Add expo-random to SDK39+ iOS shell apps

### DIFF
--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -422,6 +422,11 @@ function _renderUnversionedUniversalModulesDependencies(
       excludedUnimodules.push('expo-splash-screen', 'expo-updates');
     }
 
+    const expoModulesThatAreNotUnimodules = [];
+    if (sdkMajorVersion >= 39) {
+      expoModulesThatAreNotUnimodules.push(`pod 'EXRandom', path: '../packages/expo-random/ios'`);
+    }
+
     return indentString(
       `
 # Install unimodules
@@ -431,7 +436,11 @@ use_unimodules!(
   exclude: [
     ${excludedUnimodules.map(module => `'${module}'`).join(',\n    ')}
   ],
-)`,
+)
+
+# Expo modules that are not unimodules
+${expoModulesThatAreNotUnimodules.join('\n')}
+`,
       2
     );
   } else {


### PR DESCRIPTION
Random screen currently soft crashes the standalone iOS apps on SDK39 and for a good reason — `expo-random` native module is not included.