### PR TITLE
[expo-cli] add --config flag to credentials:manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
-- [expo-cli] EAS Build: Improve errors and wanrings when deprecating API [#2639](https://github.com/expo/expo-cli/pull/2639)
+- [expo-cli] EAS Build: Improve errors and warnings when deprecating API [#2639](https://github.com/expo/expo-cli/pull/2639)
+- [expo-cli] support `--config` flag in `expo credentials:manager` [#2641](https://github.com/expo/expo-cli/pull/2641)
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -105,15 +105,15 @@ export class Context {
     this._appleCtxOptions = pick(options, ['appleId', 'appleIdPassword', 'teamId']);
     this._nonInteractive = options.nonInteractive;
 
-    // Check if we are in project context by looking for a manifest
-    const status = await Doctor.validateWithoutNetworkAsync(projectDir, {
-      skipSDKVersionRequirement: true,
-    });
-    if (status !== Doctor.FATAL) {
+    // try to acccess project context
+    try {
       const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
       this._manifest = exp;
       this._hasProjectContext = true;
       this.logOwnerAndProject();
+    } catch (error) {
+      // ignore error
+      // startcredentials manager without project context
     }
   }
 }


### PR DESCRIPTION
# Why

Support credentials manager for people that have multiple projects on a single codebase. For those cases, all credentials management had to be done via build command.

# How

Support config flag. I couldn't use logic from `exp.ts` because that code requires a valid project and in the case of `credentials:manager` command it's optional 