### PR TITLE
Transpile expo/config in expo-optimize

### DIFF
--- a/packages/babel-preset-cli/index.js
+++ b/packages/babel-preset-cli/index.js
@@ -1,7 +1,7 @@
 module.exports = () => ({
   presets: [
     [
-      require.resolve('@babel/preset-env'),
+      require('@babel/preset-env'),
       {
         targets: {
           node: '8.9.0',
@@ -9,17 +9,17 @@ module.exports = () => ({
         modules: false,
       },
     ],
-    require.resolve('@babel/preset-typescript'),
+    require('@babel/preset-typescript'),
   ],
   plugins: [
-    require.resolve('@babel/plugin-proposal-class-properties'),
+    require('@babel/plugin-proposal-class-properties'),
     [
-      require.resolve('@babel/plugin-transform-modules-commonjs'),
+      require('@babel/plugin-transform-modules-commonjs'),
       {
         lazy: /* istanbul ignore next */ source => true,
       },
     ],
-    require.resolve('@babel/plugin-proposal-optional-chaining'),
-    require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
+    require('@babel/plugin-proposal-optional-chaining'),
+    require('@babel/plugin-proposal-nullish-coalescing-operator'),
   ],
 });

--- a/packages/config/src/evalConfig.ts
+++ b/packages/config/src/evalConfig.ts
@@ -22,13 +22,14 @@ export function evalConfig(
   request: ConfigContext | null
 ): DynamicConfigResults {
   const babel = require('@babel/core');
+  const preset = require('@expo/babel-preset-cli');
   const { code } = babel.transformFileSync(require.resolve(configFile), {
     only: [configFile],
     cwd: request?.projectRoot || process.cwd(),
     babelrc: false,
     ignore: [/node_modules/],
     filename: 'unknown',
-    presets: [require.resolve('@expo/babel-preset-cli')],
+    presets: [preset],
   });
 
   let result = requireString(code);

--- a/packages/expo-optimize/package.json
+++ b/packages/expo-optimize/package.json
@@ -28,16 +28,14 @@
     "prepare": "yarn run clean && yarn run build:prod",
     "lint": "eslint .",
     "watch": "yarn run build -w",
-    "build": "ncc build ./src/index.ts -o build/ -e @expo/config",
-    "build:prod": "ncc build ./src/index.ts -o build/ --minify --no-cache --no-source-map-register -e @expo/config",
+    "build": "ncc build ./src/index.ts -o build/",
+    "build:prod": "ncc build ./src/index.ts -o build/ --minify --no-cache --no-source-map-register",
     "clean": "rimraf ./build/"
-  },
-  "dependencies": {
-    "@expo/config": "3.3.0"
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.17",
     "@expo/image-utils": "0.3.5",
+    "@expo/config": "3.3.0",
     "@expo/json-file": "8.2.22",
     "@types/node": "^12.6.8",
     "@zeit/ncc": "^0.20.5",


### PR DESCRIPTION
Now that the external script is gone we can transpile expo/config in expo-optimize which should drastically reduce npx time. Probably wanna wait to see if we need to revert the config stuff before merging this.

Tested locally and it works as expected when the `require.resolve`s are removed.