### PR TITLE
[expo-cli] fix eslint warnings

### DIFF
--- a/packages/expo-cli/src/commands/__tests__/export-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/export-test.ts
@@ -29,20 +29,6 @@ mockExpoXDL({
   },
 });
 
-function getDirFromFS(fsJSON: Record<string, string | null>, rootDir: string) {
-  return Object.entries(fsJSON)
-    .filter(([path, value]) => value !== null && path.startsWith(rootDir))
-    .reduce<Record<string, string>>(
-      (acc, [path, fileContent]) => ({
-        ...acc,
-        [path.substring(rootDir.length).startsWith('/')
-          ? path.substring(rootDir.length + 1)
-          : path.substring(rootDir.length)]: fileContent,
-      }),
-      {}
-    );
-}
-
 it(`throws a coded error when prompted in non interactive`, async () => {
   program.nonInteractive = true;
   await expect(promptPublicUrlAsync()).rejects.toThrow('public-url');

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -195,7 +195,6 @@ class IOSBuilder extends BaseBuilder {
 
   async _setupDistCert(ctx: Context, appLookupParams: AppLookupParams): Promise<void> {
     try {
-      const nonInteractive = this.options.parent && this.options.parent.nonInteractive;
       const distCertFromParams = await getDistCertFromParams(this.options);
       if (distCertFromParams) {
         await useDistCertFromParams(ctx, appLookupParams, distCertFromParams);
@@ -210,7 +209,6 @@ class IOSBuilder extends BaseBuilder {
 
   async _setupPushCert(ctx: Context, appLookupParams: AppLookupParams): Promise<void> {
     try {
-      const nonInteractive = this.options.parent && this.options.parent.nonInteractive;
       const pushKeyFromParams = await getPushKeyFromParams(this.options);
       if (pushKeyFromParams) {
         await usePushKeyFromParams(ctx, appLookupParams, pushKeyFromParams);
@@ -225,7 +223,6 @@ class IOSBuilder extends BaseBuilder {
 
   async _setupProvisioningProfile(ctx: Context, appLookupParams: AppLookupParams) {
     try {
-      const nonInteractive = this.options.parent && this.options.parent.nonInteractive;
       const provisioningProfileFromParams = await getProvisioningProfileFromParams(
         this.options.provisioningProfilePath
       );

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -37,7 +37,7 @@ async function action(projectRoot: string): Promise<void> {
   console.log(lines.join('\n') + '\n');
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('diagnostics [path]')
     .description('Log environment info to the console')

--- a/packages/expo-cli/src/commands/eas-build/init/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/init/action.ts
@@ -4,7 +4,6 @@ import figures from 'figures';
 import fs from 'fs-extra';
 import ora from 'ora';
 import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 
 import { EasJsonReader } from '../../../easJson';
 import { gitAddAsync } from '../../../git';

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -565,61 +565,6 @@ function isNonExistentOrEmptyDir(dir: string) {
   }
 }
 
-async function promptForBareConfig(
-  parentDir: string,
-  dirName: string | undefined,
-  options: Options
-): Promise<BareAppConfig> {
-  let projectName: string;
-  if (dirName) {
-    const validationResult = validateProjectName(dirName);
-    if (validationResult !== true) {
-      throw new CommandError('INVALID_PROJECT_NAME', validationResult);
-    }
-    projectName = dirName;
-  } else {
-    ({ projectName } = await prompt({
-      name: 'projectName',
-      message: 'What would you like to name your app?',
-      default: 'MyApp',
-      filter: (name: string) => name.trim(),
-      validate: (name: string) => validateProjectName(name),
-    }));
-  }
-
-  return {
-    name: projectName,
-    expo: {
-      name: options.name || projectName,
-      slug: projectName,
-    },
-  };
-}
-
-async function promptForManagedConfig(
-  parentDir: string,
-  dirName: string | undefined,
-  options: Options
-): Promise<{ expo: Pick<ExpoConfig, 'name' | 'slug'> }> {
-  let slug;
-  if (dirName) {
-    slug = dirName;
-  } else {
-    ({ slug } = await prompt({
-      name: 'slug',
-      message: 'What would you like to name your app?',
-      default: 'my-app',
-      filter: (name: string) => name.trim(),
-      validate: (name: string) => validateName(parentDir, name),
-    }));
-  }
-  const expo = { name: slug, slug };
-  if (options.name) {
-    expo.name = options.name;
-  }
-  return { expo };
-}
-
 export default function (program: Command) {
   program
     .command('init [path]')

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -1,6 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
 
-import CommandError from '../../CommandError';
 import log from '../../log';
 import prompt from '../../prompt';
 import { displayAndroidAppCredentials } from '../actions/list';


### PR DESCRIPTION
# Why

Eslint warnings, mostly unused code or imports `yarn eslint packages/expo-cli/ --ext js,ts`