### PR TITLE
[expo-cli][eject] warn about Constants.manifest and assetBundlePatterns

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -122,7 +122,9 @@ export async function ejectAsync(projectRoot: string, options?: EjectAsyncOption
     log.nested(
       `- 📁 The property ${chalk.bold(
         `'assetBundlePatterns'`
-      )} is not used in the bare-workflow. ${log.chalk.dim(learnMore('https://docs.expo.io/bare/updating-your-app/#embedding-assets'))}`
+      )} does not have the same effect in the bare workflow. ${log.chalk.dim(
+        learnMore('https://docs.expo.io/bare/updating-your-app/#embedding-assets')
+      )}`
     );
   }
 
@@ -644,11 +646,13 @@ async function warnIfDependenciesRequireAdditionalSetupAsync(
     'expo-camera': 'https://github.com/expo/expo/tree/master/packages/expo-camera',
     'expo-image-picker': 'https://github.com/expo/expo/tree/master/packages/expo-image-picker',
     'lottie-react-native': 'https://github.com/react-native-community/lottie-react-native',
-    'expo-constants': `${chalk.yellow(
+    'expo-constants': `${chalk.bold(
       'Constants.manifest'
-    )} is not available in the bare workflow. You should replace it with ${chalk.yellow(
+    )} is not available in the bare workflow. You should replace it with ${chalk.bold(
       'Updates.manifest'
-    )}: https://docs.expo.io/versions/latest/sdk/updates/#updatesmanifest`,
+    )}. ${log.chalk.dim(
+      learnMore('https://docs.expo.io/versions/latest/sdk/updates/#updatesmanifest')
+    )}`,
   };
   const packagesToWarn: string[] = Object.keys(pkg.dependencies).filter(
     pkgName => pkgName in pkgsWithExtraSetup

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -120,9 +120,9 @@ export async function ejectAsync(projectRoot: string, options?: EjectAsyncOption
 
   if (usesAssetBundlePatterns(projectRoot)) {
     log.nested(
-      `- 📁 In the bare workflow, ${chalk.yellow(
-        `${'assetBundlePatterns'}`
-      )} no longer affects your builds. To learn about assets in the bare workflow, read here: https://docs.expo.io/bare/updating-your-app/#embedding-assets`
+      `- 📁 The property ${chalk.bold(
+        `'assetBundlePatterns'`
+      )} is not used in the bare-workflow. ${log.chalk.dim(learnMore('https://docs.expo.io/bare/updating-your-app/#embedding-assets'))}`
     );
   }
 

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -126,7 +126,6 @@ export async function ejectAsync(projectRoot: string, options?: EjectAsyncOption
     );
   }
 
-  //todo remove this
   if (await usesOldExpoUpdatesAsync(projectRoot)) {
     log.nested(
       `- 🚀 ${

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -23,7 +23,6 @@ import configureAndroidProjectAsync from '../apply/configureAndroidProjectAsync'
 import configureIOSProjectAsync from '../apply/configureIOSProjectAsync';
 import * as CreateApp from '../utils/CreateApp';
 import * as GitIgnore from '../utils/GitIgnore';
-import { usesOldExpoUpdatesAsync } from '../utils/ProjectUtils';
 import { learnMore } from '../utils/TerminalLink';
 import { logConfigWarningsAndroid, logConfigWarningsIOS } from '../utils/logConfigWarnings';
 import maybeBailOnGitStatusAsync from '../utils/maybeBailOnGitStatusAsync';
@@ -123,23 +122,6 @@ export async function ejectAsync(projectRoot: string, options?: EjectAsyncOption
       `- 📁 In the bare workflow, ${chalk.yellow(
         `${'assetBundlePatterns'}`
       )} no longer affects your builds. To learn about assets in the bare workflow, read here: https://docs.expo.io/bare/updating-your-app/#embedding-assets`
-    );
-  }
-
-  //todo remove this
-  if (await usesOldExpoUpdatesAsync(projectRoot)) {
-    log.nested(
-      `- 🚀 ${
-        (terminalLink(
-          'expo-updates',
-          'https://github.com/expo/expo/blob/master/packages/expo-updates/README.md'
-        ),
-        {
-          fallback: (text: string) => text,
-        })
-      } has been configured in your project. Before you do a release build, make sure you run ${chalk.bold(
-        'expo publish'
-      )}. ${log.chalk.dim(learnMore('https://expo.fyi/release-builds-with-expo-updates'))}`
     );
   }
 

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -23,6 +23,7 @@ import configureAndroidProjectAsync from '../apply/configureAndroidProjectAsync'
 import configureIOSProjectAsync from '../apply/configureIOSProjectAsync';
 import * as CreateApp from '../utils/CreateApp';
 import * as GitIgnore from '../utils/GitIgnore';
+import { usesOldExpoUpdatesAsync } from '../utils/ProjectUtils';
 import { learnMore } from '../utils/TerminalLink';
 import { logConfigWarningsAndroid, logConfigWarningsIOS } from '../utils/logConfigWarnings';
 import maybeBailOnGitStatusAsync from '../utils/maybeBailOnGitStatusAsync';
@@ -122,6 +123,23 @@ export async function ejectAsync(projectRoot: string, options?: EjectAsyncOption
       `- 📁 In the bare workflow, ${chalk.yellow(
         `${'assetBundlePatterns'}`
       )} no longer affects your builds. To learn about assets in the bare workflow, read here: https://docs.expo.io/bare/updating-your-app/#embedding-assets`
+    );
+  }
+
+  //todo remove this
+  if (await usesOldExpoUpdatesAsync(projectRoot)) {
+    log.nested(
+      `- 🚀 ${
+        (terminalLink(
+          'expo-updates',
+          'https://github.com/expo/expo/blob/master/packages/expo-updates/README.md'
+        ),
+        {
+          fallback: (text: string) => text,
+        })
+      } has been configured in your project. Before you do a release build, make sure you run ${chalk.bold(
+        'expo publish'
+      )}. ${log.chalk.dim(learnMore('https://expo.fyi/release-builds-with-expo-updates'))}`
     );
   }
 


### PR DESCRIPTION
- We should warn about moving from `Constants.manifest` -> `Updates.manifest` when using the bare workflow
- Assets are bundled into bare workflow binaries differently (don't rely on `assetBundlePatterns`), so we should point to these new docs when you eject

screenshot of the output:
![image](https://user-images.githubusercontent.com/35579283/93258418-425ad880-f76c-11ea-8bea-48ccaf60fe5b.png)
