### PR TITLE
Log about upload after build:ios completes

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -380,7 +380,11 @@ ${job.id}
       const artifactUrl = completedJob.artifactId
         ? UrlUtils.constructArtifactUrl(completedJob.artifactId)
         : completedJob.artifacts.url;
+      log.addNewLineIfNone();
       log(`${chalk.green('Successfully built standalone app:')} ${chalk.underline(artifactUrl)}`);
+      log.newLine();
+      log(`You can publish to the App Store with ${chalk.bold('expo upload:ios')}`);
+      log.newLine();
     } else {
       log('Alternatively, run `expo build:status` to monitor it from the command line.');
     }

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -382,8 +382,10 @@ ${job.id}
         : completedJob.artifacts.url;
       log.addNewLineIfNone();
       log(`${chalk.green('Successfully built standalone app:')} ${chalk.underline(artifactUrl)}`);
-      log.newLine();
-      log(`You can publish to the App Store with ${chalk.bold('expo upload:ios')}`);
+      if (process.platform === 'darwin') {
+        log.newLine();
+        log(`You can publish to the App Store with ${chalk.bold('expo upload:ios')}`);
+      }
       log.newLine();
     } else {
       log('Alternatively, run `expo build:status` to monitor it from the command line.');


### PR DESCRIPTION
resolve #1916 

After `expo build:ios` completes successfully, log about using `expo upload:ios`