### PR TITLE
[cli] add missing owner query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🐛 Bug fixes
 
 - [configure-splash-screen] Fix error when project's name contains only numeric characters [#2657](https://github.com/expo/expo-cli/pull/2657)
+- [expo-cli] Fix credential fetching for team members acting on behalf of a project owner [#2660](https://github.com/expo/expo-cli/pull/2660)
 
 ## [Wed, 9 Sep 2020 13:28:10 -0700](https://github.com/expo/expo-cli/commit/7b9b00b12095ce6ea5c02c03f793fcc6bf0f55a7)
 

--- a/packages/expo-cli/src/credentials/api/IosApiV2Wrapper.ts
+++ b/packages/expo-cli/src/credentials/api/IosApiV2Wrapper.ts
@@ -41,7 +41,7 @@ export default class ApiClient {
     id: number,
     accountName: string
   ): Promise<IosDistCredentials | IosPushCredentials> {
-    return await this.api.getAsync(`credentials/ios/userCredentials/${id}`);
+    return await this.api.getAsync(`credentials/ios/userCredentials/${id}`, { owner: accountName });
   }
 
   public async createDistCertApi(


### PR DESCRIPTION
# why
This PR fixes a bug reported by our users.

We've set up all our credentials endpoints to accept an `owner` parameter so we can fetch the correct credentials and perform permissioning checks.

When a team member tries to get the project owner's user credentials, the `owner` parameter must be set in the API call otherwise the server will return a permissioning error. 

