### PR TITLE
Fix: Next warning Expected Document Component Html was not rendered

### DIFF
--- a/packages/next-adapter/document.js
+++ b/packages/next-adapter/document.js
@@ -56,7 +56,7 @@ export class Document extends NextDocument {
   static getInitialProps = getInitialProps;
   render() {
     return (
-      <html>
+      <Html>
         <Head>
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
         </Head>
@@ -64,7 +64,7 @@ export class Document extends NextDocument {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }


### PR DESCRIPTION
Since next 9.5.3 the html element in _document.js should be Html instead. This error is rendered:

```
Expected Document Component Html was not rendered. Make sure you render them in your custom `_document`
See more info here https://err.sh/next.js/missing-document-component
```

See also https://github.com/vercel/next.js/discussions/16908