### PR TITLE
[expo-cli] Allow manually provided credentials when keytool is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [expo-cli] `build:android` fix missing keytool warning if user want to specify ceredentials manually [#2662](https://github.com/expo/expo-cli/pull/2662)
+
 ## [Thu, 17 Sep 2020 13:28:59 -0700](https://github.com/expo/expo-cli/commit/f0c9270058f38cc1b58bd03765e3e1de747c7b39)
 
 ### 🛠 Breaking changes

--- a/packages/expo-cli/src/credentials/views/SetupAndroidKeystore.ts
+++ b/packages/expo-cli/src/credentials/views/SetupAndroidKeystore.ts
@@ -1,5 +1,3 @@
-import commandExists from 'command-exists';
-
 import log from '../../log';
 import { Context, IView } from '../context';
 import * as credentialsJsonReader from '../credentialsJson/read';
@@ -30,14 +28,7 @@ export class SetupAndroidKeystore implements IView {
       }
     }
 
-    if (await keytoolCommandExists()) {
-      return new UpdateKeystore(this.experienceName);
-    } else {
-      log.warn(
-        'The `keytool` utility was not found in your PATH. A new Keystore will be generated on Expo servers.'
-      );
-      return null;
-    }
+    return new UpdateKeystore(this.experienceName, { bestEffortKeystoreGeneration: true });
   }
 }
 
@@ -56,14 +47,5 @@ export class SetupAndroidBuildCredentialsFromLocal implements IView {
     }
     await ctx.android.updateKeystore(this.experienceName, localCredentials.keystore);
     return null;
-  }
-}
-
-async function keytoolCommandExists(): Promise<boolean> {
-  try {
-    await commandExists('keytool');
-    return true;
-  } catch (err) {
-    return false;
   }
 }


### PR DESCRIPTION
# Why

When keytool was missing update process was stopped before the user had a chance to select the option to manually provide credentials.

# How

Move `keytool` check to later stage

# Test plan

Remove `keytool` and run `expo build:android -c`