### PR TITLE
[@expo/json-file] add option to create directory on write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [json-file] Add `ensureDir` option [#2664](https://github.com/expo/expo-cli/pull/2664)
+
 ### 🐛 Bug fixes
 
 ## [Thu, 17 Sep 2020 13:28:59 -0700](https://github.com/expo/expo-cli/commit/f0c9270058f38cc1b58bd03765e3e1de747c7b39)


### PR DESCRIPTION
# Why

Currently, there are two options two ensure directory is created,
- run `mkdir` on start of the application
- wrap entire JsonFIle api

# How

add option `ensureDirOnWrite`

# Test plan

Run `setAsync` when file does not exists
