### PR TITLE
[next-adapter] Fixed ReferenceError Html is not defined

### DIFF
--- a/packages/next-adapter/document.js
+++ b/packages/next-adapter/document.js
@@ -1,6 +1,6 @@
 // Based on https://github.com/zeit/next.js/tree/canary/examples/with-react-native-web
 // and https://github.com/expo/expo-cli/blob/master/packages/webpack-config/web-default/index.html
-import NextDocument, { Head, Main, NextScript } from 'next/document';
+import NextDocument, { Html, Head, Main, NextScript } from 'next/document';
 import * as React from 'react';
 import { AppRegistry } from 'react-native';
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18282328/93553618-8eee2000-f9c7-11ea-8b87-dd3bb547107f.png)

Got this error today when trying to use Next.js
Fixed by this PR

It was caused by this PR: https://github.com/expo/expo-cli/pull/2661