### PR TITLE
[expo-cli] EAS Build - handle missing credentials.json

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -47,12 +47,7 @@ class AndroidBuilder implements Builder<Platform.Android> {
     CredentialsSource.LOCAL | CredentialsSource.REMOTE | undefined
   > {
     this.credentialsPrepared = true;
-    try {
-      this.secretEnvs = await readSecretEnvsAsync(this.ctx.commandCtx.projectDir);
-    } catch {
-      // credentials.json can not exist and that is fine.
-      // TODO: handle this better than with try/catch
-    }
+    this.secretEnvs = await readSecretEnvsAsync(this.ctx.commandCtx.projectDir);
 
     if (!this.shouldLoadCredentials()) {
       return;

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -60,12 +60,7 @@ class iOSBuilder implements Builder<Platform.iOS> {
   public async ensureCredentialsAsync(): Promise<
     CredentialsSource.LOCAL | CredentialsSource.REMOTE | undefined
   > {
-    try {
-      this.secretEnvs = await readSecretEnvsAsync(this.ctx.commandCtx.projectDir);
-    } catch {
-      // credentials.json can not exist and that is fine.
-      // TODO: handle this better than with try/catch
-    }
+    this.secretEnvs = await readSecretEnvsAsync(this.ctx.commandCtx.projectDir);
 
     if (!this.shouldLoadCredentials()) {
       return;

--- a/packages/expo-cli/src/credentials/credentialsJson/read.ts
+++ b/packages/expo-cli/src/credentials/credentialsJson/read.ts
@@ -101,6 +101,9 @@ export async function readIosCredentialsAsync(projectDir: string): Promise<iOSCr
 export async function readSecretEnvsAsync(
   projectDir: string
 ): Promise<Record<string, string> | undefined> {
+  if (!(await fileExistsAsync(projectDir))) {
+    return undefined;
+  }
   const credentialsJson = await readAsync(projectDir);
   const npmToken = credentialsJson?.experimental?.npmToken;
   return npmToken ? { NPM_TOKEN: npmToken } : undefined;


### PR DESCRIPTION
# Why

missing credentials json should be handled earlier