### PR TITLE
[expo-cli] replace @expo/build-tools with @expo/eas-build-job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [expo-cli] replace @expo/build-tools with @expo/eas-build-job to reduce depencies size. [#2679](https://github.com/expo/expo-cli/pull/2679)
+
 ### 🐛 Bug fixes
 
 ## [Mon, 21 Sep 2020 19:11:42 -0700](https://github.com/expo/expo-cli/commit/d77fcb4613fa535ca809c833acc016759d93d996)

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -64,10 +64,10 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@expo/build-tools": "^0.1.16",
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.3.3",
     "@expo/dev-tools": "0.13.45",
+    "@expo/eas-build-job": "^0.1.0",
     "@expo/json-file": "8.2.24",
     "@expo/package-manager": "0.0.33",
     "@expo/plist": "0.0.10",

--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/build-tools';
+import { Platform } from '@expo/eas-build-job';
 import { ApiV2 } from '@expo/xdl';
 import chalk from 'chalk';
 import delayAsync from 'delay-async';
@@ -11,15 +11,15 @@ import { v4 as uuidv4 } from 'uuid';
 import { CredentialsSource, EasJsonReader } from '../../../easJson';
 import log from '../../../log';
 import { ensureProjectExistsAsync } from '../../../projects';
-import { UploadType, uploadAsync } from '../../../uploads';
+import { uploadAsync, UploadType } from '../../../uploads';
 import { createProgressTracker } from '../../utils/progress';
 import { platformDisplayNames } from '../constants';
 import {
   AnalyticsEvent,
   Build,
   BuildCommandPlatform,
-  BuildStatus,
   Builder,
+  BuildStatus,
   CommandContext,
 } from '../types';
 import Analytics from '../utils/analytics';

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -1,4 +1,4 @@
-import { Android, BuildType, Job, Platform, sanitizeJob } from '@expo/build-tools';
+import { Android, BuildType, Job, Platform, sanitizeJob } from '@expo/eas-build-job';
 import chalk from 'chalk';
 import figures from 'figures';
 import fs from 'fs-extra';

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -1,5 +1,5 @@
-import { BuildType, iOS, Job, Platform, sanitizeJob } from '@expo/build-tools';
 import { IOSConfig } from '@expo/config';
+import { BuildType, iOS, Job, Platform, sanitizeJob } from '@expo/eas-build-job';
 import chalk from 'chalk';
 import figures from 'figures';
 import sortBy from 'lodash/sortBy';

--- a/packages/expo-cli/src/commands/eas-build/init/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/init/action.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/build-tools';
+import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 import figures from 'figures';
 import fs from 'fs-extra';

--- a/packages/expo-cli/src/commands/eas-build/types.ts
+++ b/packages/expo-cli/src/commands/eas-build/types.ts
@@ -1,5 +1,5 @@
-import { Job, Platform } from '@expo/build-tools';
 import { ExpoConfig } from '@expo/config';
+import { Job, Platform } from '@expo/eas-build-job';
 import { User } from '@expo/xdl';
 
 import { AndroidBuildProfile, CredentialsSource, iOSBuildProfile } from '../../easJson';

--- a/packages/expo-cli/src/commands/eas-build/utils/createBuilderContext.ts
+++ b/packages/expo-cli/src/commands/eas-build/utils/createBuilderContext.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/build-tools';
+import { Platform } from '@expo/eas-build-job';
 
 import { EasConfig } from '../../../easJson';
 import { BuilderContext, CommandContext, PlatformBuildProfile } from '../types';

--- a/packages/expo-cli/src/easJson.ts
+++ b/packages/expo-cli/src/easJson.ts
@@ -1,11 +1,11 @@
-import { Platform } from '@expo/build-tools';
+import { Platform } from '@expo/eas-build-job';
 import Joi from '@hapi/joi';
 import fs from 'fs-extra';
 import path from 'path';
 
 // TODO(wkozyra95): move it to @expo/config or to separate package
 
-// Workflow is representing different value than BuildType from @expo/build-tools
+// Workflow is representing different value than BuildType from @expo/eas-build-job
 // Each workflow has a set of BuildTypes available
 // - Generic workflow allows to build 'generic' and 'generic-client'
 // - Managed workflow allows to build 'managed' and 'managed-client'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,22 +1394,6 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/build-tools@^0.1.16":
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/@expo/build-tools/-/build-tools-0.1.16.tgz#387799d40279672f8b6fdcac681b709ac368192f"
-  integrity sha512-TibRPjYxovRPMwQKUnVAiSTEE6tkeI/syY5n7XtnKXEH9lsgHkHieXLoXuxNrrOSjhEwbSyuUXX+DiXXoop6sQ==
-  dependencies:
-    "@expo/downloader" "0.0.8"
-    "@expo/fastlane" "0.0.14"
-    "@expo/logger" "0.0.13"
-    "@expo/template-file" "0.1.7"
-    "@expo/turtle-spawn" "0.0.13"
-    "@hapi/joi" "^17.1.1"
-    fs-extra "^9.0.0"
-    node-forge "^0.9.1"
-    plist "^3.0.1"
-    uuid "^3.3.3"
-
 "@expo/bunyan@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@expo/bunyan/-/bunyan-3.0.2.tgz#775680bd479a8b79ada4a5676936a58eef1579c9"
@@ -1422,40 +1406,12 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/bunyan@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@expo/bunyan/-/bunyan-3.0.4.tgz#339763713e0e23ac5ed159b64f0944ca2ea302f1"
-  integrity sha512-S+4UTK6smc9vzWXOepnzjvERhVGcp3WfHCt7iUdaAOKg5jCZXwPIV24kPfG4vGtFKa0WyzcTa9P5KYPGko6GJA==
+"@expo/eas-build-job@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.0.tgz#45fb32efd6c2456a07ec2d05429754760f689034"
+  integrity sha512-yoJhhpc1GSP7l65pIIY9kc/IlvJKgQJ9SyUHl0QCu96DCHqCp51OEKaTBy0J+wxQ/7UKbQ8YvHbtYxwKrUR7nw==
   dependencies:
-    exeunt "1.1.0"
-    uuid "^3.2.1"
-  optionalDependencies:
-    moment "^2.10.6"
-    mv "~2"
-    safe-json-stringify "~1"
-
-"@expo/downloader@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@expo/downloader/-/downloader-0.0.8.tgz#f620c29ebfc09f064c01670229ab8a224c2bf5dd"
-  integrity sha512-IsVOmgPEK8FQlxqykTNxjsyk4DeEku1XcKoZg1dEGRddNhRZv5gDDYMrR/LHgT9U9gbjB3GALz9beUe22ZajlQ==
-  dependencies:
-    fs-extra "^9.0.0"
-    got "^11.1.4"
-
-"@expo/fastlane@0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@expo/fastlane/-/fastlane-0.0.14.tgz#762dead5565db9f7c250ee451bf9661d9b976214"
-  integrity sha512-hDPffN5WsVfJ6VBfOpmjm24IexHsr1llQrxYCuIoRCVO+6C+lkLF7nC7/Swb7pNpuLhQxAkQJl3UohDwNvJOtA==
-  dependencies:
-    "@expo/logger" "0.0.13"
-    "@expo/turtle-spawn" "0.0.13"
-
-"@expo/logger@0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@expo/logger/-/logger-0.0.13.tgz#757588e31d8dc9abd7d31a7009a17a8979fe829d"
-  integrity sha512-OgCChdpojvrDn1CeCDuBaEog000HpJ+cxVDSv93q+6qYXht+CT7IZt6QlYsGa67ToGNZCHloXq0q70pDlN208w==
-  dependencies:
-    "@expo/bunyan" "^3.0.4"
+    "@hapi/joi" "^17.1.1"
 
 "@expo/ngrok-bin-darwin-ia32@2.2.8":
   version "2.2.8"
@@ -1558,14 +1514,6 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/template-file@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@expo/template-file/-/template-file-0.1.7.tgz#18cd3dba1086fd4187fdb8672a20807ccf32c079"
-  integrity sha512-hX1ETUlbk0M5ajqVp94yZNnkQ9jGCU7KXJZ9g9xyd7FGkg8ba0VDln0JtRyZGM4VUy3jcYkJZOflIdYsvFmhEg==
-  dependencies:
-    fs-extra "^9.0.0"
-    lodash.template "^4.5.0"
-
 "@expo/traveling-fastlane-darwin@1.15.1":
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.15.1.tgz#87b34e39a91377044070a55f3b03c575d00be39e"
@@ -1575,14 +1523,6 @@
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-linux/-/traveling-fastlane-linux-1.15.1.tgz#3b77e3a3d490cbe59fbcffd155068e267c2e95c8"
   integrity sha512-YaFAYYOOxImYNx9s6X3tY6fC1y6rka0KXstrs2zrS+vHyyBD8IOhNtIUvybHScM3jUL+qukgKElAb+7gzlF6Eg==
-
-"@expo/turtle-spawn@0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@expo/turtle-spawn/-/turtle-spawn-0.0.13.tgz#207604e3eab99a4e6bf17aa26d39e6572df84dcd"
-  integrity sha512-hwkvbI/nwo1Lcvv1QfEeAIjxvjUB+U11zJRgiD38hseKVyWxYn+yNbFFLlEcaIhw99KUQ3dfzodIibhTA4vHmg==
-  dependencies:
-    "@expo/logger" "0.0.13"
-    "@expo/spawn-async" "^1.5.0"
 
 "@expo/vector-icons@^10.0.2":
   version "10.0.6"
@@ -15688,11 +15628,6 @@ node-forge@0.9.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
   integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
 
-node-forge@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.1.tgz#775368e6846558ab6676858a4d8c6e8d16c677b5"
-  integrity sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==
-
 node-gyp@^5.0.2:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.0.5.tgz#f6cf1da246eb8c42b097d7cd4d6c3ce23a4163af"
@@ -21432,7 +21367,7 @@ uuid@^2.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
   integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
We've split `@expo/build-tools` into two packages: `@expo/eas-build-job` and smaller `@expo/build-tools`. The former conaints only TS types, Joi schemas, and some utils. Expo CLI doesn't anything else so this PR replaces `@expo/build-tools` with `@expo/eas-build-job` entirely. This PR doesn't change any logic. 