### PR TITLE
Restore Project.startExpoServerAsync accessibility

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1649,7 +1649,7 @@ export async function stopReactNativeServerAsync(projectRoot: string): Promise<v
   });
 }
 
-async function startExpoServerAsync(projectRoot: string): Promise<void> {
+export async function startExpoServerAsync(projectRoot: string): Promise<void> {
   _assertValidProjectRoot(projectRoot);
   await stopExpoServerAsync(projectRoot);
   const app = express();


### PR DESCRIPTION
Hi, I'm a developer supporting and developing the [VSCode React Native Tools Extension](https://github.com/microsoft/vscode-react-native). For more control of the development environment, we run the React Native Packager on the extension side. This change will allow us to have more control over the Expo apps launching through the extension and launch Expo server without the packager.