### PR TITLE
[configure-splash-screen]<feat>: Make Android configuration conform to the new native API

### DIFF
--- a/packages/configure-splash-screen/src/android/__tests__/MainActivity.test.ts
+++ b/packages/configure-splash-screen/src/android/__tests__/MainActivity.test.ts
@@ -34,7 +34,9 @@ describe('MainActivity', () => {
           : `
     // SplashScreen.show(...) has to be called after super.onCreate(...)
     // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually
-    SplashScreen.show(this, SplashScreenImageResizeMode.${addSplashScreenShowWith}, ${statusBarTranslucent})${LE}`
+    SplashScreen.show(this, SplashScreenImageResizeMode.${addSplashScreenShowWith}, ReactRootView${
+              kotlin ? '::class.java' : '.class'
+            }, ${statusBarTranslucent})${LE}`
       }
   }
 `;
@@ -48,6 +50,8 @@ import android.os.Bundle${LE}
 `
 }
 import com.facebook.react.ReactActivity${LE}
+
+import com.facebook.react.ReactRootView${LE}
 ${
   !addSplashScreenShowWith
     ? ''

--- a/packages/configure-splash-screen/src/android/__tests__/fixtures/react-native-project-structure-with-splash-screen-configured.ts
+++ b/packages/configure-splash-screen/src/android/__tests__/fixtures/react-native-project-structure-with-splash-screen-configured.ts
@@ -5,6 +5,8 @@ import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
 
+import com.facebook.react.ReactRootView;
+
 import expo.modules.splashscreen.SplashScreen;
 import expo.modules.splashscreen.SplashScreenImageResizeMode;
 
@@ -14,7 +16,7 @@ public class MainActivity extends ReactActivity {
     super.onCreate(savedInstanceState);
     // SplashScreen.show(...) has to be called after super.onCreate(...)
     // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually
-    SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, false);
+    SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class, false);
   }
 
   /**


### PR DESCRIPTION
Recent change in `expo-splash-screen` https://github.com/expo/expo/commit/2770008129aef794dcdf5fcdaa35ef5056b6ff29#diff-70eefa11c7e96de30d02e5d069488fe2R35-R40
changed the native Android API.

This PR accommodates this native API change.

Resolves https://github.com/expo/expo-cli/issues/2586

#### All published versions since https://github.com/expo/expo/commit/2196cebae55bda181ccceadec809942f51ee9e39 needs this adjustment:
- [x] `0.6.x`
- [x] `0.7.x@next`

# TODOs after merge:
- [ ] publish new version of `@expo/configure-splash-screen`
- [ ] bump dependency version in `expo-splash-screen` package on `expo/expo#sdk-39` branch and publish with patch version for `0.6.x`
- [ ] bump dependency version in `expo-splash-screen` package on `expo/expo#master` branch and publish with patch version for `0.7.x@next`