### PR TITLE
[configure-splash-screen]<feat>: Accommodate Android singletons.SplashScreen import from the subpackage

### DIFF
--- a/packages/configure-splash-screen/src/android/MainActivity.ts
+++ b/packages/configure-splash-screen/src/android/MainActivity.ts
@@ -68,8 +68,8 @@ export default async function configureMainActivity(
     // importing SplashScreen
     .applyAction(content => {
       const [succeeded, newContent] = replace(content, {
-        replacePattern: /^import expo\.modules\.splashscreen\.SplashScreen.*?\nimport expo\.modules\.splashscreen\.SplashScreenImageResizeMode.*?$/m,
-        replaceContent: `import expo.modules.splashscreen.SplashScreen${LE}
+        replacePattern: /^import expo\.modules\.splashscreen\..*?SplashScreen.*?\nimport expo\.modules\.splashscreen\.SplashScreenImageResizeMode.*?$/m,
+        replaceContent: `import expo.modules.splashscreen.singletons.SplashScreen${LE}
 import expo.modules.splashscreen.SplashScreenImageResizeMode${LE}`,
       });
       return [newContent, 'replacedSplashImports', succeeded];
@@ -80,7 +80,7 @@ import expo.modules.splashscreen.SplashScreenImageResizeMode${LE}`,
       }
       const [succeeded, newContent] = insert(content, {
         insertPattern: isJava ? /(?=public class .* extends .* {.*$)/m : /(?=class .* : .* {.*$)/m,
-        insertContent: `import expo.modules.splashscreen.SplashScreen${LE}
+        insertContent: `import expo.modules.splashscreen.singletons.SplashScreen${LE}
 import expo.modules.splashscreen.SplashScreenImageResizeMode${LE}
 
 `,

--- a/packages/configure-splash-screen/src/android/__tests__/MainActivity.test.ts
+++ b/packages/configure-splash-screen/src/android/__tests__/MainActivity.test.ts
@@ -56,7 +56,7 @@ ${
   !addSplashScreenShowWith
     ? ''
     : `
-import expo.modules.splashscreen.SplashScreen${LE}
+import expo.modules.splashscreen.singletons.SplashScreen${LE}
 import expo.modules.splashscreen.SplashScreenImageResizeMode${LE}
 `
 }

--- a/packages/configure-splash-screen/src/android/__tests__/fixtures/react-native-project-structure-with-splash-screen-configured.ts
+++ b/packages/configure-splash-screen/src/android/__tests__/fixtures/react-native-project-structure-with-splash-screen-configured.ts
@@ -7,7 +7,7 @@ import com.facebook.react.ReactActivity;
 
 import com.facebook.react.ReactRootView;
 
-import expo.modules.splashscreen.SplashScreen;
+import expo.modules.splashscreen.singletons.SplashScreen;
 import expo.modules.splashscreen.SplashScreenImageResizeMode;
 
 public class MainActivity extends ReactActivity {


### PR DESCRIPTION
_don't merge before https://github.com/expo/expo-cli/pull/2698_

Follow up of https://github.com/expo/expo-cli/pull/2698
Follow up of https://github.com/expo/expo/pull/10294

This is supplementary change that accommodates Android API change from expo/expo#10294

# TODOs after merge:
- [ ] publish new version of `@expo/configure-splash-screen`
- [ ] bump dependency version in `expo-splash-screen` package on `expo/expo#sdk-39` branch and publish with patch version for `0.6.x`
- [ ] bump dependency version in `expo-splash-screen` package on `expo/expo#master` branch and publish with patch version for `0.7.x@next`
