### PR TITLE
[config] Disable splash screen on eject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [config] Disable splash screen applying on eject until we fix issue with @expo/configure-splash-screen versioning. [#2700](https://github.com/expo/expo-cli/pull/2700).
+
 ## [Thu, 24 Sep 2020 15:27:32 -0700](https://github.com/expo/expo-cli/commit/c76d808751c8f20203b0d3555ec3a210a37d0d1d)
 
 ### 🎉 New features

--- a/packages/config/src/android/SplashScreen.ts
+++ b/packages/config/src/android/SplashScreen.ts
@@ -32,6 +32,16 @@ export function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenCo
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
+  const splashScreenIsSupported = false; // config.sdkVersion === '39.0.0'
+  if (!splashScreenIsSupported) {
+    addWarningAndroid(
+      'splash',
+      'Unable to automatically configure splash screen. Please refer to the expo-splash-screen README for more information: https://github.com/expo/expo/tree/master/packages/expo-splash-screen'
+    );
+
+    return;
+  }
+
   const splashConfig = getSplashScreenConfig(config);
   if (!splashConfig) {
     return;

--- a/packages/config/src/ios/SplashScreen.ts
+++ b/packages/config/src/ios/SplashScreen.ts
@@ -26,6 +26,15 @@ export function getSplashScreen(config: ExpoConfig): IosSplashScreenConfig | und
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
+  const splashScreenIsSupported = false; // config.sdkVersion === '39.0.0'
+  if (!splashScreenIsSupported) {
+    addWarningIOS(
+      'splash',
+      'Unable to automatically configure splash screen. Please refer to the expo-splash-screen README for more information: https://github.com/expo/expo/tree/master/packages/expo-splash-screen'
+    );
+    return;
+  }
+
   const splashConfig = getSplashScreen(config);
 
   if (!splashConfig) {


### PR DESCRIPTION
Any single version of `@expo/configure-splash-screen` is only guaranteed to work with a single version of expo-splash-screen. We only include one version of that pkg in @expo/config at any given time.

- For now: disable splash screen to fix ejecting
- Next: find a version that works with SDK 39 and use that on SDK 39 eject, otherwise add warning and don't apply
- Future: use version of script that ships with expo-splash-screen rather than packaging a single version in @expo/config 