### PR TITLE
use learn more link

### DIFF
--- a/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
@@ -1,6 +1,7 @@
 import log from '../../../../log';
 import prompt from '../../../../prompt';
 import { existingFile } from '../../../../validators';
+import { learnMore } from '../../../utils/TerminalLink';
 
 enum ServiceAccountSourceType {
   path,
@@ -54,9 +55,8 @@ async function askForServiceAccountPathAsync(): Promise<string> {
     `${log.chalk.bold(
       'A Google Service Account JSON key is required to upload your app to Google Play Store'
     )}.\n` +
-      `If you're not sure what this is or how to create one, ${log.terminalLink(
-        'learn more here',
-        'https://expo.fyi/creating-google-service-account'
+      `If you're not sure what this is or how to create one, ${log.chalk.dim(
+        learnMore('https://expo.fyi/creating-google-service-account')
       )}.`
   );
   const { filePath } = await prompt({

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
@@ -1,4 +1,5 @@
 import log from '../../../../log';
+import { learnMore } from '../../../utils/TerminalLink';
 import { SubmissionError } from '../SubmissionService.types';
 
 enum SubmissionErrorCode {
@@ -19,15 +20,15 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
     "We couldn't figure out what went wrong. Please see logs to learn more.",
   [SubmissionErrorCode.ANDROID_FIRST_UPLOAD_ERROR]:
     "You haven't submitted this app to Google Play Store yet. The first submission of the app needs to be performed manually.\n" +
-    `${log.terminalLink('Learn more here', 'https://expo.fyi/first-android-submission')}.`,
+    `${log.chalk.dim(learnMore('https://expo.fyi/first-android-submission'))}.`,
   [SubmissionErrorCode.ANDROID_OLD_VERSION_CODE_ERROR]:
     "You've already submitted this version of the app.\n" +
     'Versions are identified by Android version code (expo.android.versionCode in app.json).\n' +
     "If you're submitting a managed Expo project, increment the version code in app.json and build the project with expo build:android.\n" +
-    `${log.terminalLink('Learn more here', 'https://expo.fyi/bumping-android-version-code')}.`,
+    `${log.chalk.dim(learnMore('https://expo.fyi/bumping-android-version-code'))}.`,
   [SubmissionErrorCode.ANDROID_MISSING_PRIVACY_POLICY]:
     'The app has permissions that require a privacy policy set for the app.\n' +
-    `${log.terminalLink('Learn more here', 'https://expo.fyi/missing-privacy-policy')}.`,
+    `${log.chalk.dim(learnMore('https://expo.fyi/missing-privacy-policy'))}.`,
 };
 
 function printSubmissionError(error: SubmissionError): boolean {


### PR DESCRIPTION
standardize the styling around the repo. This uses:

- iTerm: `[Learn more](...)`
- default: `Learn more: ...`

Instead of the verbose `Learn more ( ... )`