### PR TITLE
feat(expo-cli): Add 'validate-dependencies' command

### DIFF
--- a/packages/expo-cli/e2e/__tests__/validate-dependencies-test.ts
+++ b/packages/expo-cli/e2e/__tests__/validate-dependencies-test.ts
@@ -1,0 +1,52 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs-extra';
+import path from 'path';
+import temporary from 'tempy';
+
+import { createMinimalProjectAsync, EXPO_CLI, minimumNativePkgJson } from '../TestUtils';
+
+const tempDir = temporary.directory();
+
+beforeAll(async () => {
+  jest.setTimeout(30000);
+  await fs.mkdirp(tempDir);
+});
+
+function executeCommand(cwd: string, args: string[]) {
+  const promise = spawnAsync(EXPO_CLI, args, { cwd });
+
+  if (!process.env.CI) {
+    promise.child.stdout.pipe(process.stdout);
+    promise.child.stderr.pipe(process.stderr);
+  }
+
+  return promise;
+}
+
+describe('validate-dependencies', () => {
+  it('exits with a non-zero code if project dependencies are not compatible', async () => {
+    expect.assertions(4);
+
+    const projectRoot = await createMinimalProjectAsync(tempDir, 'validate-dependencies-test');
+
+    const cleanCmd = await executeCommand(projectRoot, ['validate-dependencies']);
+    expect(cleanCmd.status).toEqual(0);
+    expect(cleanCmd.stdout).toMatch(/Dependencies appear to be compatible/);
+
+    const incompatiblePkgJson = {
+      ...minimumNativePkgJson,
+      dependencies: {
+        ...minimumNativePkgJson.dependencies,
+        'expo-application': '0.0.0',
+      },
+    };
+    fs.writeFileSync(path.join(projectRoot, 'package.json'), JSON.stringify(incompatiblePkgJson));
+
+    try {
+      await executeCommand(projectRoot, ['validate-dependencies']);
+    } catch (errorCmd) {
+      expect(errorCmd.stderr).toMatch(/your project's dependencies are not compatible/);
+      expect(errorCmd.status).toEqual(1);
+    }
+  });
+});

--- a/packages/expo-cli/src/commands/index.ts
+++ b/packages/expo-cli/src/commands/index.ts
@@ -28,6 +28,7 @@ const COMMANDS = [
   require('./upgrade'),
   require('./upload'),
   require('./url'),
+  require('./validate-dependencies'),
   require('./webhooks'),
   require('./whoami'),
 ];

--- a/packages/expo-cli/src/commands/utils/Dependencies.ts
+++ b/packages/expo-cli/src/commands/utils/Dependencies.ts
@@ -1,0 +1,84 @@
+import { ExpoConfig, PackageJSONConfig, projectHasModule } from '@expo/config';
+import JsonFile from '@expo/json-file';
+import { Versions } from '@expo/xdl';
+import chalk from 'chalk';
+import intersection from 'lodash/intersection';
+import semver from 'semver';
+
+import log from '../../log';
+
+/**
+ * Returns a promise that will be resolved with a list of dependencies which do
+ * not match the expected versions for the projects current SDK version.
+ *
+ * @param projectDir
+ * @param exp
+ * @param pkg
+ * @returns A list of incompatible dependencies
+ */
+
+export async function listIncompatibleDependencies(
+  projectDir: string,
+  exp: ExpoConfig,
+  pkg: PackageJSONConfig
+): Promise<{ moduleName: string; expectedRange: string; actualRange: string }[]> {
+  if (!Versions.gteSdkVersion(exp, '33.0.0')) {
+    return [];
+  }
+
+  const bundleNativeModulesPath = projectHasModule(
+    'expo/bundledNativeModules.json',
+    projectDir,
+    exp
+  );
+  if (!bundleNativeModulesPath) {
+    log.warn(
+      `Your project is in SDK version >= 33.0.0, but the ${chalk.underline(
+        'expo'
+      )} package version seems to be older.`
+    );
+    return [];
+  }
+
+  const bundledNativeModules = await JsonFile.readAsync(bundleNativeModulesPath);
+  const bundledNativeModulesNames = Object.keys(bundledNativeModules);
+  const projectDependencies = Object.keys(pkg.dependencies || []);
+
+  const modulesToCheck = intersection(bundledNativeModulesNames, projectDependencies);
+  const incorrectDeps = [];
+  for (const moduleName of modulesToCheck) {
+    const expectedRange = bundledNativeModules[moduleName];
+    const actualRange = pkg.dependencies[moduleName];
+    if (
+      (semver.valid(actualRange) || semver.validRange(actualRange)) &&
+      typeof expectedRange === 'string' &&
+      !semver.intersects(expectedRange, actualRange)
+    ) {
+      incorrectDeps.push({
+        moduleName,
+        expectedRange,
+        actualRange,
+      });
+    }
+  }
+  if (incorrectDeps.length > 0) {
+    log.warn(
+      "Some of your project's dependencies are not compatible with currently installed expo package version:"
+    );
+    incorrectDeps.forEach(({ moduleName, expectedRange, actualRange }) => {
+      log.warn(
+        ` - ${chalk.underline(moduleName)} - expected version range: ${chalk.underline(
+          expectedRange
+        )} - actual version installed: ${chalk.underline(actualRange)}`
+      );
+    });
+    log.warn(
+      'Your project may not work correctly until you install the correct versions of the packages.\n' +
+        `To install the correct versions of these packages, please run: ${chalk.inverse(
+          'expo install [package-name ...]'
+        )}`
+    );
+  }
+
+  return incorrectDeps;
+}

--- a/packages/expo-cli/src/commands/validate-dependencies.ts
+++ b/packages/expo-cli/src/commands/validate-dependencies.ts
@@ -1,0 +1,30 @@
+import { getConfig } from '@expo/config';
+import { Command } from 'commander';
+
+import log from '../log';
+import * as Dependencies from './utils/Dependencies';
+
+async function action(projectDir: string) {
+  const { exp, pkg } = getConfig(projectDir);
+
+  const incompatibleDependencies = await Dependencies.listIncompatibleDependencies(
+    projectDir,
+    exp,
+    pkg
+  );
+
+  if (incompatibleDependencies.length) {
+    process.exit(1);
+  }
+
+  log.nested('✅ Dependencies appear to be compatible with your current SDK version');
+  process.exit();
+}
+
+export default function (program: Command) {
+  program
+    .command('validate-dependencies [path]')
+    .description('Validates project dependencies are compatible with Expo')
+    .helpGroup('info')
+    .asyncActionProjectDir(action);
+}


### PR DESCRIPTION
# What

Adds `expo validate-dependencies`.

This command will terminate with a non-zero exit code if a dependency version is
incompatible with the projects SDK version.

# Why

It is designed to be used with automated dependency managers such as Dependabot
as part of the CI process to verify if native dependencies will be compatible
with the current Expo SDK version.

We were merging dependency updates to later finding they were causing warnings 
when running `expo start` which then meant reverting the dependency updates.
Instead with `validate-dependencies` we can fail the build on CI and prevent the PR
being merged in the first place.

# Test plan

- [ ] Automated test (e2e test in place, I have made changes to the start command however the test coverage for this command looks patchy - the e2e tests are skipped and fail on master. Would appreciate guidance from the maintainers about testing)
- [ ] Create a new expo bare minimal app with expo init
- [ ] Run `expo start` and `expo validate-dependencies` expect both to run without warnings
- [ ] Update a dependency to be incompatible 
- [ ] Run `expo start` and `expo validate-dependencies` expect both to run with stderr warnings and the exit code of `expo validate-dependencies` to be "1"
