### PR TITLE
[config] Configure splash screen for the latest SDK only

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,8 @@
   "commands": {
     "publish": {
       "ignoreChanges": [
-        "packages/config-types/**/*"
+        "packages/config-types/**/*",
+        "packages/configure-splash-screen/**/*"
       ]
     }
   }

--- a/packages/config/src/android/SplashScreen.ts
+++ b/packages/config/src/android/SplashScreen.ts
@@ -32,7 +32,7 @@ export function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenCo
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
-  const splashScreenIsSupported = false; // config.sdkVersion === '39.0.0'
+  const splashScreenIsSupported = config.sdkVersion === '39.0.0' || !config.sdkVersion;
   if (!splashScreenIsSupported) {
     addWarningAndroid(
       'splash',

--- a/packages/config/src/ios/SplashScreen.ts
+++ b/packages/config/src/ios/SplashScreen.ts
@@ -26,7 +26,7 @@ export function getSplashScreen(config: ExpoConfig): IosSplashScreenConfig | und
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
-  const splashScreenIsSupported = false; // config.sdkVersion === '39.0.0'
+  const splashScreenIsSupported = config.sdkVersion === '39.0.0' || !config.sdkVersion;
   if (!splashScreenIsSupported) {
     addWarningIOS(
       'splash',


### PR DESCRIPTION
This modifies the native splash screen configuration *only when the project being configured is on the latest SDK*. This is a workaround that is needed because we only include one version of `@expo/configure-splash-screen` in `@expo/config` at any given time. In the future, we will depend on `expo-splash-screen` providing its own config.

*Note*: I removed `@expo/configure-splash-screen` from the watched projects in lerna because we may make changes to it that aren't backwards compatible with the currently released splash screen versions, and so we need to manually bump the dependencies in `@expo/config` and release `@expo/configure-splash-screen` on its own without using the publish script.