### PR TITLE
[configure-splash-screen] do not export color-string types

### DIFF
--- a/packages/configure-splash-screen/src/SplashScreenConfig.ts
+++ b/packages/configure-splash-screen/src/SplashScreenConfig.ts
@@ -1,6 +1,6 @@
-import { Color } from 'color-string';
-
 import { SplashScreenImageResizeModeType, SplashScreenStatusBarStyleType } from './constants';
+
+export type Color = [number, number, number, number];
 
 /**
  * iOS SplashScreen config.

--- a/packages/configure-splash-screen/src/android/Colors.xml.ts
+++ b/packages/configure-splash-screen/src/android/Colors.xml.ts
@@ -1,7 +1,8 @@
-import colorString, { Color } from 'color-string';
+import colorString from 'color-string';
 import path from 'path';
 import { Element } from 'xml-js';
 
+import { Color } from '../SplashScreenConfig';
 import {
   readXmlFile,
   writeXmlFile,

--- a/packages/configure-splash-screen/src/android/Styles.xml.ts
+++ b/packages/configure-splash-screen/src/android/Styles.xml.ts
@@ -1,7 +1,7 @@
-import { Color } from 'color-string';
 import path from 'path';
 import { Element } from 'xml-js';
 
+import { Color } from '../SplashScreenConfig';
 import { SplashScreenStatusBarStyle, SplashScreenStatusBarStyleType } from '../constants';
 import {
   readXmlFile,

--- a/packages/configure-splash-screen/src/ios/BackgroundAsset.ts
+++ b/packages/configure-splash-screen/src/ios/BackgroundAsset.ts
@@ -1,8 +1,8 @@
-import { Color } from 'color-string';
 import fs from 'fs-extra';
 import path from 'path';
 import { PNG } from 'pngjs';
 
+import { Color } from '../SplashScreenConfig';
 import { writeContentsJsonFile } from './Contents.json';
 
 const PNG_FILENAME = 'background.png';


### PR DESCRIPTION
# Why

When adding `@expo/config` to `eas-cli` `color-string` types are missing.

# Test plan

Didn't test if it fixes the issue