### PR TITLE
[xdl] Configure splash screen for standalone apps according to @expo/config

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1,3 +1,4 @@
+import { AndroidConfig } from '@expo/config';
 import fs from 'fs-extra';
 import { sync as globSync } from 'glob';
 import path from 'path';
@@ -1029,6 +1030,11 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       })
     );
   }
+
+  await AndroidConfig.SplashScreen.setSplashScreenAsync(
+    manifest,
+    isRunningInUserContext ? context.data.projectPath : path.join(shellPath, '..')
+  );
 
   await AssetBundle.bundleAsync(
     context,

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1,4 +1,4 @@
-import { AndroidConfig } from '@expo/config';
+import { AndroidConfig, WarningAggregator } from '@expo/config';
 import fs from 'fs-extra';
 import { sync as globSync } from 'glob';
 import path from 'path';
@@ -1326,6 +1326,22 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       '<meta-data android:name="com.facebook.sdk.AdvertiserIDCollectionEnabled" android:value="true"/>',
       path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
     );
+  }
+
+  // Log Android warnings from @expo/config
+  const warningsAndroid = WarningAggregator.flushWarningsAndroid();
+  if (warningsAndroid.length) {
+    const getSpacer = text => {
+      if (text.endsWith('.')) {
+        return ' ';
+      } else {
+        return '. ';
+      }
+    };
+
+    warningsAndroid.forEach(([property, warning, link]) => {
+      console.warn(`- ${property}: ${warning}${link ? `${getSpacer(warning)}${link}` : ''}`);
+    });
   }
 }
 


### PR DESCRIPTION
I haven't tested it yet, but if I understand the API correctly this should fix https://github.com/expo/expo/issues/10382. I've used `@expo/config` as it exposed easier API for SplashScreen modification than `@expo/configure-splash-screen` (a single method to which I can pass manifest and path both I already have defined there).

I have also added `@expo/config` warnings integration to `runShellAppModificationsAsync`.