### PR TITLE
[config] Fix relative module resolution for config files

### DIFF
--- a/packages/config/src/__tests__/ConfigParsing-test.js
+++ b/packages/config/src/__tests__/ConfigParsing-test.js
@@ -62,6 +62,15 @@ describe('getConfig', () => {
       expect(exp.foo).toBe('bar');
       expect(exp.name).toBe('cool+export-json_app.config');
     });
+    it('parses a js config with import', () => {
+      const projectRoot = path.resolve(__dirname, './fixtures/language-support/js');
+      const configPath = path.resolve(projectRoot, 'with-import_app.config.js');
+      setCustomConfigPath(projectRoot, configPath);
+      const { exp } = getConfig(projectRoot, {
+        skipSDKVersionRequirement: true,
+      });
+      expect(exp.foo).toBe('bar');
+    });
     xit('parses a yaml config', () => {
       const projectRoot = path.resolve(__dirname, './fixtures/language-support/yaml');
       const { exp } = getConfig(projectRoot, {

--- a/packages/config/src/__tests__/fixtures/language-support/js/with-import_app.config.js
+++ b/packages/config/src/__tests__/fixtures/language-support/js/with-import_app.config.js
@@ -1,0 +1,6 @@
+const { foo } = require('./export-json_app.config');
+
+module.exports = function ({ config }) {
+  config.foo = foo;
+  return config;
+};

--- a/packages/config/src/evalConfig.ts
+++ b/packages/config/src/evalConfig.ts
@@ -35,7 +35,7 @@ export function evalConfig(
     presets: [preset],
   });
 
-  let result = requireString(code);
+  let result = requireString(code, configFile);
   if (result.default != null) {
     result = result.default;
   }


### PR DESCRIPTION
I have a number of different app configs and was receiving a `Failed to read config` / `MODULE_NOT_FOUND` error on `expo start` since they import shared config variables. This sets `configFile` as the `filename` argument to `require-from-string` so relative modules can be resolved properly