### PR TITLE
[expo-cli] use correct description for openDevToolsAtStartup in the ? message

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -51,7 +51,7 @@ const printUsage = async (projectDir: string, options: Pick<StartOptions, 'webOn
   const { dev } = await ProjectSettings.readAsync(projectDir);
   const openDevToolsAtStartup = await UserSettings.getAsync('openDevToolsAtStartup', true);
   const devMode = dev ? 'development' : 'production';
-  const currentToggle = openDevToolsAtStartup ? 'disabled' : 'enabled';
+  const currentToggle = openDevToolsAtStartup ? 'enabled' : 'disabled';
 
   const isMac = process.platform === 'darwin';
 


### PR DESCRIPTION
I noticed that the message triggered by entering `?` in the `expo start` command displays the wrong value of openDevToolsAtStartup.

<details>
<summary>Here's what it shows:</summary>

````
Automatically opening DevTools disabled.
Press d to open DevTools now.

 Expo  Press ? to show a list of all available commands.

 › Press a | open Android
 › shift+a | select a device or emulator
 › Press i | open iOS simulator
 › shift+i | select a simulator
 › Press w | open web

 › Press o | open project code in your editor
 › Press c | show project QR
 › Press p | toggle build mode (development)
 › Press r | restart bundler
 › shift+r | restart and clear cache

 › Press d | open Expo DevTools
 › shift+d | toggle auto opening DevTools on startup (enabled)
 › Press e | share the app link by email
 › Press s | sign out (@sconaway)
````
</details>