### PR TITLE
[expo-cli] Validate the credentials for android keystore

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -116,7 +116,7 @@
     "slash": "1.0.0",
     "strip-ansi": "^6.0.0",
     "tar": "^6.0.5",
-    "tempy": "^0.3.0",
+    "tempy": "^0.7.1",
     "terminal-link": "^2.1.1",
     "untildify": "3.0.3",
     "uuid": "^8.0.0",

--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -61,6 +61,7 @@ export default class AndroidBuilder extends BaseBuilder {
 
   async collectAndValidateCredentials(): Promise<void> {
     const nonInteractive = this.options.parent?.nonInteractive;
+    const skipCredentialsCheck = this.options.skipCredentialsCheck === true;
 
     const ctx = new Context();
     await ctx.init(this.projectDir, { nonInteractive });
@@ -78,13 +79,18 @@ export default class AndroidBuilder extends BaseBuilder {
 
     const paramKeystore = await getKeystoreFromParams(this.options);
     if (paramKeystore) {
-      await useKeystore(ctx, experienceName, paramKeystore);
+      await useKeystore(ctx, {
+        experienceName,
+        keystore: paramKeystore,
+        skipKeystoreValidation: skipCredentialsCheck,
+      });
     } else {
       await runCredentialsManager(
         ctx,
         new SetupAndroidKeystore(experienceName, {
           nonInteractive,
           allowMissingKeystore: true,
+          skipKeystoreValidation: skipCredentialsCheck,
         })
       );
     }

--- a/packages/expo-cli/src/commands/build/BaseBuilder.types.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.types.ts
@@ -31,6 +31,7 @@ export type AndroidOptions = CommonOptions & {
   keystorePath?: string;
   keystoreAlias?: string;
   generateKeystore: boolean;
+  skipCredentialsCheck?: boolean;
 };
 
 export type BuilderOptions = Omit<Partial<IosOptions> & Partial<AndroidOptions>, 'type'> & {

--- a/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/__tests__/build-test.ts
@@ -12,6 +12,8 @@ const mockedUser = {
 
 const mockProjectUrl = 'http://fakeurl.com';
 const mockPostAsync = jest.fn();
+
+jest.mock('@expo/spawn-async');
 jest.mock('@expo/config', () => {
   const pkg = jest.requireActual('@expo/config');
   return {
@@ -40,6 +42,7 @@ jest.mock('../../../../projects', () => {
 });
 jest.mock('../../utils/git');
 jest.mock('../../../../git');
+jest.mock('../../../../credentials/utils/validateKeystore');
 jest.mock('../../../../uploads', () => ({
   UploadType: {},
   uploadAsync: () => mockProjectUrl,

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -67,7 +67,10 @@ class AndroidBuilder implements Builder<Platform.Android> {
         projectName: this.ctx.commandCtx.projectName,
         accountName: this.ctx.commandCtx.accountName,
       },
-      { nonInteractive: this.ctx.commandCtx.nonInteractive }
+      {
+        nonInteractive: this.ctx.commandCtx.nonInteractive,
+        skipCredentialsCheck: this.ctx.commandCtx.skipCredentialsCheck,
+      }
     );
     await provider.initAsync();
     const credentialsSource = await ensureCredentialsAsync(

--- a/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/__tests__/AndroidBuilder-test.ts
@@ -2,8 +2,10 @@ import { vol } from 'memfs';
 
 import AndroidBuilder from '../AndroidBuilder';
 
+jest.mock('@expo/spawn-async');
 jest.mock('fs');
 jest.mock('../../../../../git');
+jest.mock('../../../../../credentials/utils/validateKeystore');
 jest.mock('../../../../../credentials/context', () => {
   return {
     Context: jest.fn().mockImplementation(() => ({

--- a/packages/expo-cli/src/commands/eas-build/credentialsSync/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/credentialsSync/action.ts
@@ -92,7 +92,10 @@ async function updateRemoteCredentialsAsync(
   if ([BuildCommandPlatform.ALL, BuildCommandPlatform.ANDROID].includes(platform)) {
     try {
       const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
-      await runCredentialsManager(ctx, new SetupAndroidBuildCredentialsFromLocal(experienceName));
+      await runCredentialsManager(
+        ctx,
+        new SetupAndroidBuildCredentialsFromLocal(experienceName, { skipKeystoreValidation: false })
+      );
       Analytics.logEvent(AnalyticsEvent.CREDENTIALS_SYNC_UPDATE_REMOTE_SUCCESS, {
         ...trackingCtx,
         platform: 'android',

--- a/packages/expo-cli/src/commands/eas-build/init/__tests__/init-test.ts
+++ b/packages/expo-cli/src/commands/eas-build/init/__tests__/init-test.ts
@@ -24,6 +24,7 @@ jest.mock('../../utils/git', () => {
 });
 jest.mock('../../build/builders/iOSBuilder');
 jest.mock('../../../../git');
+jest.mock('../../../../credentials/utils/validateKeystore');
 jest.mock('@expo/image-utils', () => ({
   generateImageAsync(input, { src }) {
     const fs = require('fs');

--- a/packages/expo-cli/src/credentials/provider/__tests__/AndroidCredentialsProvider-test.ts
+++ b/packages/expo-cli/src/credentials/provider/__tests__/AndroidCredentialsProvider-test.ts
@@ -25,6 +25,8 @@ jest.mock('../../context', () => {
     })),
   };
 });
+jest.mock('../../utils/validateKeystore');
+
 beforeEach(() => {
   mockFetchKeystore.mockReset();
   vol.reset();

--- a/packages/expo-cli/src/credentials/utils/validateKeystore.ts
+++ b/packages/expo-cli/src/credentials/utils/validateKeystore.ts
@@ -1,0 +1,48 @@
+import spawnAsync from '@expo/spawn-async';
+import commandExists from 'command-exists';
+import temporary from 'tempy';
+import terminalLink from 'terminal-link';
+
+import log from '../../log';
+
+export default async function validateKeystoreAsync({
+  keystore: keystoreBase64,
+  keystorePassword,
+  keyAlias,
+}: {
+  keystore: string;
+  keystorePassword: string;
+  keyAlias: string;
+}) {
+  try {
+    await commandExists('keytool');
+  } catch (e) {
+    log.warn(
+      `Couldn't validate the provided Android keystore because the 'keytool' command is not available. Make sure that you have a Java Development Kit installed. See ${terminalLink(
+        'https://openjdk.java.net',
+        'https://openjdk.java.net'
+      )} to install OpenJDK.`
+    );
+    return;
+  }
+
+  try {
+    await temporary.write.task(Buffer.from(keystoreBase64, 'base64'), async keystorePath => {
+      await spawnAsync('keytool', [
+        '-list',
+        '-keystore',
+        keystorePath,
+        '-storepass',
+        keystorePassword,
+        '-alias',
+        keyAlias,
+      ]);
+    });
+  } catch (e) {
+    throw new Error(
+      `An error occurred when validating the Android keystore: ${
+        e.stdout || e.message
+      }\nMake sure that you provided correct credentials in 'credentials.json' and the path provided under 'keystorePath' points to a valid keystore file.`
+    );
+  }
+}

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -47,7 +47,7 @@ class ExperienceView implements IView {
   handleAction(context: Context, selected: string): IView | null {
     switch (selected) {
       case 'update-keystore':
-        return new UpdateKeystore(this.experienceName);
+        return new UpdateKeystore(this.experienceName, { skipKeystoreValidation: false });
       case 'remove-keystore':
         return new RemoveKeystore(this.experienceName);
       case 'update-fcm-key':

--- a/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/AndroidKeystore-Update-test.ts
@@ -6,6 +6,7 @@ import { UpdateKeystore } from '../AndroidKeystore';
 
 jest.mock('../../actions/list');
 jest.mock('../../../prompts');
+jest.mock('../../utils/validateKeystore');
 jest.mock('fs-extra');
 mockExpoXDL({
   AndroidCredentials: {
@@ -31,7 +32,7 @@ describe('UpdateKeystore', () => {
           throw new Error("shouldn't happen");
         });
 
-      const view = new UpdateKeystore(testExperienceName);
+      const view = new UpdateKeystore(testExperienceName, { skipKeystoreValidation: true });
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
@@ -47,7 +48,7 @@ describe('UpdateKeystore', () => {
         .mockImplementationOnce(() => ({ answer: true })) // user specified
         .mockImplementation(() => ({ input: 'test' })); // keystore credentials
 
-      const view = new UpdateKeystore(testExperienceName);
+      const view = new UpdateKeystore(testExperienceName, { skipKeystoreValidation: true });
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
@@ -70,7 +71,7 @@ describe('UpdateKeystore', () => {
           throw new Error("shouldn't happen");
         });
 
-      const view = new UpdateKeystore(testExperienceName);
+      const view = new UpdateKeystore(testExperienceName, { skipKeystoreValidation: true });
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);
@@ -90,7 +91,7 @@ describe('UpdateKeystore', () => {
         .mockImplementationOnce(() => ({ answer: true })) // user specified
         .mockImplementation(() => ({ input: 'test' })); // keystore credentials
 
-      const view = new UpdateKeystore(testExperienceName);
+      const view = new UpdateKeystore(testExperienceName, { skipKeystoreValidation: true });
       const lastView = await view.open(ctx);
 
       expect(lastView).toBe(null);

--- a/packages/expo-cli/src/credentials/views/__tests__/SetupAndroidBuildCredentialsFromLocal-test.ts
+++ b/packages/expo-cli/src/credentials/views/__tests__/SetupAndroidBuildCredentialsFromLocal-test.ts
@@ -36,7 +36,9 @@ describe('SetupAndroidBuildCredentialsFromLocal', () => {
     await fs.writeFile('keystore.jks', Buffer.from(testKeystore.keystore, 'base64'));
 
     const ctx = getCtxMock();
-    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName);
+    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName, {
+      skipKeystoreValidation: true,
+    });
     const lastView = await view.open(ctx);
 
     expect(lastView).toBe(null);
@@ -58,7 +60,9 @@ describe('SetupAndroidBuildCredentialsFromLocal', () => {
     await fs.writeFile('keystore.jks', Buffer.from(testKeystore.keystore, 'base64'));
 
     const ctx = getCtxMock();
-    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName);
+    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName, {
+      skipKeystoreValidation: true,
+    });
     await expect(view.open(ctx)).rejects.toThrowError();
   });
   it('should fail if keystore file (specified in credentials.json) does not exist', async () => {
@@ -76,7 +80,9 @@ describe('SetupAndroidBuildCredentialsFromLocal', () => {
     });
 
     const ctx = getCtxMock();
-    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName);
+    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName, {
+      skipKeystoreValidation: true,
+    });
     await expect(view.open(ctx)).rejects.toThrowError();
   });
   it('should fail if there are missing fields in ios config in credentials.json', async () => {
@@ -98,7 +104,9 @@ describe('SetupAndroidBuildCredentialsFromLocal', () => {
     await fs.writeFile('keystore.jks', Buffer.from(testKeystore.keystore, 'base64'));
 
     const ctx = getCtxMock();
-    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName);
+    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName, {
+      skipKeystoreValidation: true,
+    });
     await expect(view.open(ctx)).rejects.toThrowError();
   });
   it('should update keystore on www if provisioningProfile and distribuiton certificate are missing', async () => {
@@ -124,7 +132,9 @@ describe('SetupAndroidBuildCredentialsFromLocal', () => {
     await fs.writeFile('keystore.jks', Buffer.from(testKeystore.keystore, 'base64'));
 
     const ctx = getCtxMock();
-    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName);
+    const view = new SetupAndroidBuildCredentialsFromLocal(testExperienceName, {
+      skipKeystoreValidation: true,
+    });
     const lastView = await view.open(ctx);
 
     expect(lastView).toBe(null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7538,6 +7538,11 @@ crypto-random-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -8079,6 +8084,20 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+del@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
+  integrity sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==
+  dependencies:
+    globby "^11.0.1"
+    graceful-fs "^4.2.4"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.2"
+    p-map "^4.0.0"
+    rimraf "^3.0.2"
+    slash "^3.0.0"
 
 delay-async@1.2.0:
   version "1.2.0"
@@ -12075,7 +12094,7 @@ is-path-cwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
   integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
 
-is-path-cwd@^2.0.0:
+is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
@@ -12107,6 +12126,11 @@ is-path-inside@^2.1.0:
   integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
   dependencies:
     path-is-inside "^1.0.2"
+
+is-path-inside@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
+  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -20364,6 +20388,11 @@ temp-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
 
+temp-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
+  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
 temp-write@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.4.0.tgz#8cff630fb7e9da05f047c74ce4ce4d685457d492"
@@ -20391,7 +20420,7 @@ temp@^0.8.1:
   dependencies:
     rimraf "~2.6.2"
 
-tempy@0.3.0, tempy@^0.3.0:
+tempy@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8"
   integrity sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==
@@ -20399,6 +20428,17 @@ tempy@0.3.0, tempy@^0.3.0:
     temp-dir "^1.0.0"
     type-fest "^0.3.1"
     unique-string "^1.0.0"
+
+tempy@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.7.1.tgz#5a654e6dbd1747cdd561efb112350b55cd9c1d46"
+  integrity sha512-vXPxwOyaNVi9nyczO16mxmHGpl6ASC5/TVhRRHpqeYHvKQm58EaWNvZXxAhR0lYYnBOQFjXjhzeLsaXdjxLjRg==
+  dependencies:
+    del "^6.0.0"
+    is-stream "^2.0.0"
+    temp-dir "^2.0.0"
+    type-fest "^0.16.0"
+    unique-string "^2.0.0"
 
 term-size@^1.2.0:
   version "1.2.0"
@@ -20859,6 +20899,11 @@ type-fest@^0.12.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.12.0.tgz#f57a27ab81c68d136a51fd71467eff94157fa1ee"
   integrity sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==
 
+type-fest@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.16.0.tgz#3240b891a78b0deae910dbeb86553e552a148860"
+  integrity sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==
+
 type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
@@ -21124,6 +21169,13 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+unique-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
 
 universal-user-agent@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Why
===
We want to ensure that the user provided correct keystore file and credentials before starting the build. It'll let us avoid cases such as when users downloade some file from Google play and mistakenly thought that it's a keystore file.

How
===
1. When reading the credentials for Android from 'credentials.json' or when user enters keystore password when prompted for providing own keystore, validate the keystore file with 'keytool' by using the provided credentials, unless '--skip-credentials-check' is specified.
1. If 'keytool' is not present, print an warning and skip the verification.

Test plan
=========
1. Run `expo credentials:manager > android > Update upload Keystore` and ensure that an error is thrown upon entering incorrect credentials.
1. Run `expo build:android` without any remote credentials and ensure that an error is thrown upon entering incorrect credentials when user is prompted for credentials.
1. Specify incorrect credentials in 'credentials.json' and ensure that an error is thrown when trying to build the app with `expo eas:build --platform android`, and the error is ignored when specifying `--skip-credentials-check`

Tested with the 'keytool' from both Oracle JDK and OpenJDK to make sure it works in both cases.

Screenshots from the test with `expo eas:build --platform android`:

When `keytool` is not present:
<img width="682" alt="Screen Shot 2020-10-05 at 15 28 04" src="https://user-images.githubusercontent.com/1174278/95085418-7d26af80-071f-11eb-8bb4-671e2b28f1c0.png">

When not using a valid keystore:
<img width="682" alt="Screen Shot 2020-10-05 at 15 44 53" src="https://user-images.githubusercontent.com/1174278/95087279-c7109500-0721-11eb-9ed7-6610ae5904ed.png">

When keystore password is incorrect:
<img width="682" alt="Screen Shot 2020-10-05 at 14 13 18" src="https://user-images.githubusercontent.com/1174278/95087345-db549200-0721-11eb-967b-8c07366ed1e8.png">

When alias is incorrect:
<img width="682" alt="Screen Shot 2020-10-05 at 14 12 29" src="https://user-images.githubusercontent.com/1174278/95087392-e8718100-0721-11eb-860e-968c8ae37ce9.png">

