### PR TITLE
[expo-cli] Add `releaseChannel` field to the profile in `eas.json`

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -67,7 +67,7 @@
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.3.10",
     "@expo/dev-tools": "0.13.53",
-    "@expo/eas-build-job": "^0.1.0",
+    "@expo/eas-build-job": "^0.1.1",
     "@expo/json-file": "8.2.24",
     "@expo/package-manager": "0.0.33",
     "@expo/plist": "0.0.10",

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -200,6 +200,7 @@ class AndroidBuilder implements Builder<Platform.Android> {
       type: BuildType.Generic,
       gradleCommand: buildProfile.gradleCommand,
       artifactPath: buildProfile.artifactPath,
+      releaseChannel: buildProfile.releaseChannel,
       projectRootDirectory,
     };
   }

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -192,6 +192,7 @@ class iOSBuilder implements Builder<Platform.iOS> {
       type: BuildType.Generic,
       scheme: this.scheme,
       artifactPath: buildProfile.artifactPath,
+      releaseChannel: buildProfile.releaseChannel,
       projectRootDirectory,
     };
   }

--- a/packages/expo-cli/src/commands/eas-build/build/metadata.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/metadata.ts
@@ -66,6 +66,7 @@ async function collectMetadata<T extends Platform>(
     credentialsSource,
     sdkVersion: ctx.commandCtx.exp.sdkVersion,
     trackingContext: ctx.trackingCtx,
+    releaseChannel: ctx.buildProfile.releaseChannel,
   };
 }
 

--- a/packages/expo-cli/src/easJson.ts
+++ b/packages/expo-cli/src/easJson.ts
@@ -24,6 +24,7 @@ export interface AndroidManagedBuildProfile {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
   buildType?: 'apk' | 'app-bundle';
+  releaseChannel?: undefined;
 }
 
 export interface AndroidGenericBuildProfile {
@@ -32,12 +33,14 @@ export interface AndroidGenericBuildProfile {
   gradleCommand?: string;
   artifactPath?: string;
   withoutCredentials?: boolean;
+  releaseChannel?: string;
 }
 
 export interface iOSManagedBuildProfile {
   workflow: Workflow.Managed;
   credentialsSource: CredentialsSource;
   buildType?: 'archive' | 'simulator';
+  releaseChannel?: undefined;
 }
 
 export interface iOSGenericBuildProfile {
@@ -45,6 +48,7 @@ export interface iOSGenericBuildProfile {
   credentialsSource: CredentialsSource;
   scheme?: string;
   artifactPath?: string;
+  releaseChannel?: string;
 }
 
 export type AndroidBuildProfile = AndroidManagedBuildProfile | AndroidGenericBuildProfile;
@@ -88,6 +92,7 @@ const AndroidGenericSchema = Joi.object({
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   gradleCommand: Joi.string(),
   artifactPath: Joi.string(),
+  releaseChannel: Joi.string(),
   withoutCredentials: Joi.boolean(),
 });
 
@@ -101,6 +106,7 @@ const iOSGenericSchema = Joi.object({
   workflow: Joi.string().valid('generic').required(),
   credentialsSource: Joi.string().valid('local', 'remote', 'auto').default('auto'),
   scheme: Joi.string(),
+  releaseChannel: Joi.string(),
   artifactPath: Joi.string(),
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,10 +1423,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.0.tgz#45fb32efd6c2456a07ec2d05429754760f689034"
-  integrity sha512-yoJhhpc1GSP7l65pIIY9kc/IlvJKgQJ9SyUHl0QCu96DCHqCp51OEKaTBy0J+wxQ/7UKbQ8YvHbtYxwKrUR7nw==
+"@expo/eas-build-job@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.1.tgz#7b71f87ac57192ba03613e18fb0fd5f639d21b6d"
+  integrity sha512-V5zrRdz6qa45Aflh84CmsEyNcNHG95O7dyzQqpzEI73phB+Jr7ffM+AP0f3+POjy6mwNXIKHgbzH8VG3excPpA==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
Why
===
We want to be able to specify the release channel when building our app so that subsequent updates `expo-updates` can be published separately for different profiles.

How
===
I've added the `releaseChannel` field to the `jobs` and `metadata` objects which are sent to the www server when running `expo eas:build`.

Test plan
=========
I verified that the `releaseChannel` is respected by adding a new `releaseChannel` field under the profile in the `eas.json` of the turtle example app, and then running the build to make sure that tis field is received by the turtle worker as well.

Note
====
The PR depends on https://github.com/expo/turtle-v2/pull/302 since it needs changes in the `@expo/eas-build-job`. When that PR is merged and published, I'll update this PR with the latest version of the package so that it can be merged.