### PR TITLE
[cli] Only create index.js on eject when it is needed - when we change pkg.main

### DIFF
--- a/packages/expo-cli/e2e/TestUtils.ts
+++ b/packages/expo-cli/e2e/TestUtils.ts
@@ -37,6 +37,7 @@ export async function tryRunAsync(args: string[], options?: SpawnOptions): Promi
 
 // TODO(Bacon): This is too much stuff
 export const minimumNativePkgJson = {
+  main: 'node_modules/expo/AppEntry.js',
   dependencies: {
     expo: '37.0.11',
     react: '16.9.0',

--- a/packages/expo-cli/e2e/__tests__/eject-test.ts
+++ b/packages/expo-cli/e2e/__tests__/eject-test.ts
@@ -72,6 +72,8 @@ it(`can eject a minimal project`, async () => {
 
   const outputPkgJson = await JsonFile.readAsync(path.join(projectRoot, 'package.json'));
 
+  // Remove main
+  expect(outputPkgJson.main).toBe(undefined);
   // Scripts should be rewritten to use react-native-community/cli
   expect(outputPkgJson.scripts['ios']).toBe('react-native run-ios');
   expect(outputPkgJson.scripts['android']).toBe('react-native run-android');

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -503,6 +503,17 @@ export function hashForDependencyMap(deps: DependenciesMap): string {
   return createFileHash(depsString);
 }
 
+export function getTargetPaths(pkg: PackageJSONConfig) {
+  const targetPaths = ['ios', 'android'];
+
+  // Only create index.js if we are going to replace the app "main" entry point
+  if (shouldDeleteMainField(pkg.main)) {
+    targetPaths.push('index.js');
+  }
+
+  return targetPaths;
+}
+
 /**
  * Extract the template and copy the ios and android directories over to the project directory.
  *
@@ -526,12 +537,8 @@ async function cloneNativeDirectoriesAsync({
   const creatingNativeProjectStep = CreateApp.logNewSection(
     'Creating native project directories (./ios and ./android) and updating .gitignore'
   );
-  const targetPaths = ['ios', 'android'];
 
-  // Only create index.js if we are going to replace the app "main" entry point
-  if (shouldDeleteMainField(pkg.main)) {
-    targetPaths.push('index.js');
-  }
+  const targetPaths = getTargetPaths(pkg);
 
   let copiedPaths: string[] = [];
   let skippedPaths: string[] = [];

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -512,10 +512,12 @@ async function cloneNativeDirectoriesAsync({
   projectRoot,
   tempDir,
   exp,
+  pkg,
 }: {
   projectRoot: string;
   tempDir: string;
   exp: Pick<ExpoConfig, 'name' | 'sdkVersion'>;
+  pkg: PackageJSONConfig;
 }): Promise<string[]> {
   const templateSpec = await validateBareTemplateExistsAsync(exp.sdkVersion!);
 
@@ -524,7 +526,13 @@ async function cloneNativeDirectoriesAsync({
   const creatingNativeProjectStep = CreateApp.logNewSection(
     'Creating native project directories (./ios and ./android) and updating .gitignore'
   );
-  const targetPaths = ['ios', 'android', 'index.js'];
+  const targetPaths = ['ios', 'android'];
+
+  // Only create index.js if we are going to replace the app "main" entry point
+  if (shouldDeleteMainField(pkg.main)) {
+    targetPaths.push('index.js');
+  }
+
   let copiedPaths: string[] = [];
   let skippedPaths: string[] = [];
   try {
@@ -579,7 +587,7 @@ async function createNativeProjectsFromTemplateAsync(
 ): Promise<
   { hasNewProjectFiles: boolean; needsPodInstall: boolean } & DependenciesModificationResults
 > {
-  const copiedPaths = await cloneNativeDirectoriesAsync({ projectRoot, tempDir, exp });
+  const copiedPaths = await cloneNativeDirectoriesAsync({ projectRoot, tempDir, exp, pkg });
 
   writeMetroConfig({ projectRoot, pkg, tempDir });
 

--- a/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
+++ b/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
@@ -1,4 +1,5 @@
 import {
+  getTargetPaths,
   hashForDependencyMap,
   isPkgMainExpoAppEntry,
   shouldDeleteMainField,
@@ -20,6 +21,20 @@ describe('hashForDependencyMap', () => {
     expect(hashForDependencyMap({ a: '1.0.0', b: 2, c: '~3.0' })).toBe(
       hashForDependencyMap({ c: '~3.0', b: 2, a: '1.0.0' })
     );
+  });
+});
+
+describe('getTargetPaths', () => {
+  it(`should include index.js when pkg.main should be deleted`, () => {
+    expect(getTargetPaths({ main: 'node_modules/expo/AppEntry.js' })).toEqual([
+      'ios',
+      'android',
+      'index.js',
+    ]);
+  });
+
+  it(`should not include index.js when pkg.main is left alone`, () => {
+    expect(getTargetPaths({ main: './src/index.js' })).toEqual(['ios', 'android']);
   });
 });
 


### PR DESCRIPTION
We want to switch away from using the Expo node_modules/expo/AppEntry when ejecting, but if the user already is not using that, we don't need to do anything. We don't need to create index.js or delete their `pkg.main`. We previously already handled the latter but not the former, this PR addresses that.

Fixes https://github.com/expo/expo-cli/issues/2748