### PR TITLE
[config] Fix Android scandir error when ejecting on windows

### DIFF
--- a/packages/config/src/android/Package.ts
+++ b/packages/config/src/android/Package.ts
@@ -25,7 +25,9 @@ function getMainApplicationPath({
     cwd: packageRoot,
   });
   // If there's more than one, we'll probably have a problem.
-  return mainApplications[0];
+  // Also, glob always returns a posix formatted path (even on windows),
+  // lets normalize that so we can use it with `.split(path.sep)`
+  return path.normalize(mainApplications[0]);
 }
 
 function getCurrentPackageName(projectRoot: string) {

--- a/packages/config/src/android/Package.ts
+++ b/packages/config/src/android/Package.ts
@@ -34,7 +34,7 @@ function getCurrentPackageName(projectRoot: string) {
   const packageRoot = getPackageRoot(projectRoot);
   const mainApplicationPath = getMainApplicationPath({ projectRoot, packageRoot });
   const packagePath = path.dirname(mainApplicationPath);
-  const packagePathParts = packagePath.replace(packageRoot, '').split(path.sep).filter(Boolean);
+  const packagePathParts = path.relative(packageRoot, packagePath).split(path.sep).filter(Boolean);
 
   return packagePathParts.join('.');
 }


### PR DESCRIPTION
Fixes #2711

The issue originates (once again) from `glob`. This _always returns_ a posix formatted path, even on Windows. This messes up the `path.sep` because that's different on Windows. I think it's a good thing to normalize paths when using glob, it changes the format of the path to the expected one on Windows.

It's also good to use `path.relative` more when stripping root paths. It takes all differences into account related to windows/posix paths and just returns you the path you need.