### PR TITLE
Add windows tests for expo cli only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,27 +109,22 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    needs: build
     strategy:
       fail-fast: false
       matrix:
-        node: ['10', '12']
-        package:
-          - expo-cli
-    name: Test ${{ matrix.package }} on Node ${{ matrix.node }} (Windows)
+        node: ['12']
+    name: Windows e2e on Node ${{ matrix.node }}
     steps:
-      - uses: actions/cache@v1
-        id: restore-build
+      - uses: actions/checkout@v2
         with:
-          path: '.'
-          key: ${{ github.sha }}-${{ matrix.node }}
+          fetch-depth: 1
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - name: Verify dependencies
+      - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Test ${{ matrix.package }}
-        working-directory: packages\${{ matrix.package }}
-        run: yarn test
+      - name: Test Expo CLI
+        working-directory: packages\expo-cli
+        run: yarn test e2e
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Build dependencies
+        run: yarn lerna run prepare --stream
       - name: Test Expo CLI
         working-directory: packages\expo-cli
         run: yarn test e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,33 +29,36 @@ jobs:
           path: '.'
           key: ${{ github.sha }}-${{ matrix.node }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build
     strategy:
       fail-fast: false
       matrix:
         node: ['10', '12']
+        os: [ubuntu-latest]
         package:
-          [
-            electron-adapter,
-            dev-tools,
-            babel-preset-cli,
-            config,
-            dev-server,
-            expo-cli,
-            expo-codemod,
-            image-utils,
-            json-file,
-            metro-config,
-            package-manager,
-            plist,
-            pwa,
-            schemer,
-            uri-scheme,
-            webpack-config,
-            xdl,
-          ]
-    name: Test ${{ matrix.package }} on Node ${{ matrix.node }}
+          - electron-adapter
+          - dev-tools
+          - babel-preset-cli
+          - config
+          - dev-server
+          - expo-cli
+          - expo-codemod
+          - image-utils
+          - json-file
+          - metro-config
+          - package-manager
+          - plist
+          - pwa
+          - schemer
+          - uri-scheme
+          - webpack-config
+          - xdl
+        include:
+          - node: '12'
+            os: windows-latest
+            package: expo-cli
+    name: Test ${{ matrix.package }} on Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/cache@v1
         id: restore-build
@@ -67,10 +70,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Test ${{ matrix.package }}
-        run: cd packages/${{ matrix.package }} && yarn test
-        # run: cd packages/${{ matrix.package }} && yarn test --coverage
-        env:
-          CI: true
+        working-directory: packages/${{ matrix.package }}
+        run: yarn test
+        # run: yarn test --coverage
       # - name: Get Test Flag Name
       #   id: cov-flag-name
       #   run: echo "::set-output name=flag::$(echo ${{ matrix.package }} | perl -pe 's/[^a-z]+([a-z])/\U\1/gi;s/^([A-Z])/\l\1/')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,12 @@ jobs:
           path: '.'
           key: ${{ github.sha }}-${{ matrix.node }}
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       fail-fast: false
       matrix:
         node: ['10', '12']
-        os: [ubuntu-latest]
         package:
           - electron-adapter
           - dev-tools
@@ -54,11 +53,7 @@ jobs:
           - uri-scheme
           - webpack-config
           - xdl
-        include:
-          - node: '12'
-            os: windows-latest
-            package: expo-cli
-    name: Test ${{ matrix.package }} on Node ${{ matrix.node }} (${{ matrix.os }})
+    name: Test ${{ matrix.package }} on Node ${{ matrix.node }}
     steps:
       - uses: actions/cache@v1
         id: restore-build
@@ -111,5 +106,30 @@ jobs:
       - name: Test building Webpack
         working-directory: packages/webpack-config
         run: yarn test:e2e:build
-        env:
-          CI: true
+
+  windows:
+    runs-on: windows-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['10', '12']
+        package:
+          - expo-cli
+    name: Test ${{ matrix.package }} on Node ${{ matrix.node }} (Windows)
+    steps:
+      - uses: actions/cache@v1
+        id: restore-build
+        with:
+          path: '.'
+          key: ${{ github.sha }}-${{ matrix.node }}
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Verify dependencies
+        run: yarn install --frozen-lockfile
+      - name: Test ${{ matrix.package }}
+        working-directory: packages\${{ matrix.package }}
+        run: yarn test
+


### PR DESCRIPTION
This would catch issues like #2711.

It adds windows as OS in the matrix build but also overwrites the `package`'s to test. Windows is really slow compared to the other OSes, and because we have E2E in `expo-cli` I think this is the only one that should run for now. 

As a side note, I removed the `CI: true` env var ([because it's set by default](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables)) and refactored the list to a yaml multiline array.

Also, we can't reuse the cache from the build step. It looks like caching are based on Linux/MacOS based paths, [which fails on windows](https://github.com/expo/expo-cli/runs/1232944843?check_suite_focus=true#step:2:7). So I skipped this and only scoped the windows tests to `expo-cli`'s `e2e` tests, with only building the `expo-cli`.