### PR TITLE
Add "client" copy to Android and iOS open option

### DIFF
--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -18,10 +18,10 @@ export type URLOptions = {
 
 function addOptions(program: Command) {
   program
-    .option('-a, --android', 'Opens your app in Expo on a connected Android device')
+    .option('-a, --android', 'Opens your app in Expo client on a connected Android device')
     .option(
       '-i, --ios',
-      'Opens your app in Expo in a currently running iOS simulator on your computer'
+      'Opens your app in Expo client in a currently running iOS simulator on your computer'
     )
     .option('-w, --web', 'Opens your app in a web browser')
     .option(


### PR DESCRIPTION
Handles: https://github.com/expo/expo-cli/pull/2763#issuecomment-705264151