### PR TITLE
[expo-cli] Add a EAS_OUTPUT_JOB_JSON environment variable to output JSON for the job

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/build/action.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/action.ts
@@ -58,6 +58,12 @@ async function buildAction(projectDir: string, options: BuildOptions): Promise<v
     );
   }
 
+  if (process.env.EAS_OUTPUT_JOB_JSON === '1' && requestedPlatform === BuildCommandPlatform.ALL) {
+    throw new Error(
+      `You can build for only one platform at a time when EAS_OUTPUT_JOB_JSON=true is set`
+    );
+  }
+
   const trackingCtx = {
     tracking_id: uuidv4(),
     requested_platform: options.platform,
@@ -204,6 +210,11 @@ async function startBuildAsync<T extends Platform>(
     });
     const job = await builder.prepareJobAsync(archiveUrl);
     log(`Starting ${platformDisplayNames[job.platform]} build`);
+
+    if (process.env.EAS_OUTPUT_JOB_JSON === '1') {
+      process.stdout.write(`JSON for the job:\n${JSON.stringify(job)}\n`);
+      process.exit(0);
+    }
 
     try {
       const { buildId, deprecationInfo } = await client.postAsync(`projects/${projectId}/builds`, {


### PR DESCRIPTION
Why
===
We want to be able to build projects with EAS without having to spin off multiple watchers and servers. We can pass the JSON for the job directly to turtle workers, but currently there's no way to access the JOSN easily.

This commit checks if `EAS_OUTPUT_JOB_JSON` is set to `true` and if yes, prints the JSON to `stdout` and exits the command. The [`eas-build-cli`](https://github.com/expo/eas-build-cli) can then read this JSON to call respective builders directly.

Example usage:

```sh
EAS_OUTPUT_JOB_JSON=1 expo eas:build --platform android | sed -n '/JSON for the job:/,$p' | tail -n +2 | eas-build-cli | bunyan -o short
```

Test plan
=========
I have tested that it works with `eas-build-cli` by triggering a new build for Android and ensuring that the build completes.

![eas-build-cli](https://user-images.githubusercontent.com/1174278/95699292-5fd47280-0c44-11eb-94ab-dce8922f93fe.gif)
