### PR TITLE
[configure-splash-sceen]<feat>: Add missing `--version, -V`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [configure-splash-screen] Added `--version, -V` option for version printing. ([#2785](https://github.com/expo/expo-cli/pull/2785))
 - [pkcs12] new package for PKCS#12 utility functions
 
 ### 🐛 Bug fixes

--- a/packages/configure-splash-screen/package.json
+++ b/packages/configure-splash-screen/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.1",
   "description": "Supplementary module for 'expo-splash-screen' providing cli configuration command",
   "bin": {
-    "configure-splash-screen": "./build/index-cli.js",
-    "expo-splash-screen": "./build/index-cli.js"
+    "configure-splash-screen": "./build/src/index-cli.js",
+    "expo-splash-screen": "./build/src/index-cli.js"
   },
   "main": "./build/index.js",
   "scripts": {

--- a/packages/configure-splash-screen/src/cli-command.ts
+++ b/packages/configure-splash-screen/src/cli-command.ts
@@ -1,6 +1,5 @@
 import { Command } from 'commander';
 
-import packageJSON from '../package.json';
 import { AndroidSplashScreenConfigJSON, IosSplashScreenConfigJSON } from './SplashScreenConfig';
 import configureAndroid from './android';
 import {
@@ -135,7 +134,7 @@ export default () =>
     .description(
       'Idempotent operation that configures native splash screens using provided backgroundColor and optional .png file. Supports light and dark modes configuration. Dark mode is supported only on iOS 13+ and Android 10+.'
     )
-    .version(packageJSON.version)
+    .version(require('../package.json').version)
     .allowUnknownOption(false)
     .passCommandToAction(false)
     .option(

--- a/packages/configure-splash-screen/src/cli-command.ts
+++ b/packages/configure-splash-screen/src/cli-command.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 
+import packageJSON from '../package.json';
 import { AndroidSplashScreenConfigJSON, IosSplashScreenConfigJSON } from './SplashScreenConfig';
 import configureAndroid from './android';
 import {
@@ -134,6 +135,7 @@ export default () =>
     .description(
       'Idempotent operation that configures native splash screens using provided backgroundColor and optional .png file. Supports light and dark modes configuration. Dark mode is supported only on iOS 13+ and Android 10+.'
     )
+    .version(packageJSON.version)
     .allowUnknownOption(false)
     .passCommandToAction(false)
     .option(

--- a/packages/configure-splash-screen/tsconfig.json
+++ b/packages/configure-splash-screen/tsconfig.json
@@ -4,10 +4,11 @@
     "target": "ES2018",
     "module": "CommonJS",
     "lib": ["es2018", "es2020.string"],
-    "rootDir": ".",
+    "rootDir": "./src",
     "outDir": "./build",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": false
   },
-  "include": ["src/**/*", "./package.json"],
+  "include": ["src/**/*"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }

--- a/packages/configure-splash-screen/tsconfig.json
+++ b/packages/configure-splash-screen/tsconfig.json
@@ -4,10 +4,10 @@
     "target": "ES2018",
     "module": "CommonJS",
     "lib": ["es2018", "es2020.string"],
-    "rootDir": "./src",
+    "rootDir": ".",
     "outDir": "./build",
     "esModuleInterop": true
   },
-  "include": ["./src"],
+  "include": ["src/**/*", "./package.json"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }


### PR DESCRIPTION
I observed that the `yarn expo-splash-screen` was missing a `version` option and therefore it was really hard to tell what version of this command the user is running.

I've fetched the version from the `package.json` as this is the most reliable source.

~Unfortunately I had to change tsc project structure, because tsc was complaining.~

_edit_: I've had to adjust the `tsconfig` file to ignore `json`s, because importing the file from outside the `rootDir` (specified in `tsconfig`, and `package.json` is outside the `src` directory) would change the `build` folder layout and will copy over the `package.json` file and that `package.json` file duplication is not playing well with `lerna` and other other tooling (CI was failing)