### PR TITLE
[config] minor plugin updates

### DIFF
--- a/packages/config/src/android/Facebook.ts
+++ b/packages/config/src/android/Facebook.ts
@@ -1,7 +1,12 @@
 import { Parser } from 'xml2js';
 
 import { ExpoConfig } from '../Config.types';
-import { addMetaDataItemToMainApplication, Document, getMainApplication } from './Manifest';
+import {
+  addMetaDataItemToMainApplication,
+  Document,
+  getMainApplication,
+  removeMetaDataItemFromMainApplication,
+} from './Manifest';
 import { readResourcesXMLAsync, ResourceItemXML } from './Resources';
 import { getProjectStringsXMLPathAsync, removeStringItem, setStringItem } from './Strings';
 import { writeXMLAsync } from './XML';
@@ -98,7 +103,7 @@ export async function setFacebookAppIdString(config: ExpoConfig, projectDirector
   return true;
 }
 
-export async function setFacebookConfig(config: ExpoConfig, manifestDocument: Document) {
+export function setFacebookConfig(config: ExpoConfig, manifestDocument: Document) {
   const scheme = getFacebookScheme(config);
   const appId = getFacebookAppId(config);
   const displayName = getFacebookDisplayName(config);
@@ -176,18 +181,4 @@ export async function setFacebookConfig(config: ExpoConfig, manifestDocument: Do
   }
 
   return manifestDocument;
-}
-
-// TODO: Use Manifest version after https://github.com/expo/expo-cli/pull/2587 lands
-function removeMetaDataItemFromMainApplication(mainApplication: any, itemName: string) {
-  if (mainApplication.hasOwnProperty('meta-data')) {
-    const index = mainApplication['meta-data'].findIndex(
-      (e: any) => e['$']['android:name'] === itemName
-    );
-
-    if (index > -1) {
-      mainApplication['meta-data'].splice(index, 1);
-    }
-  }
-  return mainApplication;
 }

--- a/packages/config/src/android/Icon.ts
+++ b/packages/config/src/android/Icon.ts
@@ -263,7 +263,7 @@ async function createAdaptiveIconXmlFiles(projectRoot: string, icLauncherXmlStri
 
 async function removeBackgroundImageFilesAsync(projectRoot: string) {
   Promise.all(
-    Object.values(dpiValues).map(async ({ folderName, scale }) => {
+    Object.values(dpiValues).map(async ({ folderName }) => {
       const dpiFolderPath = path.resolve(projectRoot, ANDROID_RES_PATH, folderName);
       await fs.remove(path.resolve(dpiFolderPath, IC_LAUNCHER_BACKGROUND_PNG));
     })

--- a/packages/config/src/ios/DeviceFamily.ts
+++ b/packages/config/src/ios/DeviceFamily.ts
@@ -1,7 +1,6 @@
-import * as fs from 'fs-extra';
+import { XcodeProject } from 'xcode';
 
 import { ExpoConfig } from '../Config.types';
-import { getPbxproj } from './utils/Xcodeproj';
 
 export function getSupportsTablet(config: ExpoConfig): boolean {
   return !!config.ios?.supportsTablet;
@@ -38,10 +37,12 @@ export function formatDeviceFamilies(deviceFamilies: number[]): string {
 /**
  * Add to pbxproj under TARGETED_DEVICE_FAMILY
  */
-export function setDeviceFamily(config: ExpoConfig, projectRoot: string) {
+export function setDeviceFamily(
+  config: ExpoConfig,
+  { project }: { project: XcodeProject }
+): XcodeProject {
   const deviceFamilies = formatDeviceFamilies(getDeviceFamilies(config));
 
-  const project = getPbxproj(projectRoot);
   const configurations = project.pbxXCBuildConfigurationSection();
   // @ts-ignore
   for (const { buildSettings } of Object.values(configurations || {})) {
@@ -52,5 +53,5 @@ export function setDeviceFamily(config: ExpoConfig, projectRoot: string) {
     }
   }
 
-  fs.writeFileSync(project.filepath, project.writeSync());
+  return project;
 }

--- a/packages/config/src/ios/Google.ts
+++ b/packages/config/src/ios/Google.ts
@@ -1,11 +1,12 @@
 import fs from 'fs-extra';
 import path from 'path';
+import { XcodeProject } from 'xcode';
 
 import { ExpoConfig } from '../Config.types';
 import { InfoPlist } from './IosConfig.types';
 import { getSourceRoot } from './Paths';
 import { appendScheme } from './Scheme';
-import { addFileToGroup, getPbxproj, getProjectName } from './utils/Xcodeproj';
+import { addFileToGroup, getProjectName } from './utils/Xcodeproj';
 
 export function getGoogleMapsApiKey(config: ExpoConfig) {
   return config.ios?.config?.googleMapsApiKey ?? null;
@@ -82,10 +83,13 @@ export function setGoogleConfig(config: ExpoConfig, infoPlist: InfoPlist): InfoP
   return infoPlist;
 }
 
-export function setGoogleServicesFile(config: ExpoConfig, projectRoot: string) {
+export function setGoogleServicesFile(
+  config: ExpoConfig,
+  { projectRoot, project }: { project: XcodeProject; projectRoot: string }
+): XcodeProject {
   const googleServicesFileRelativePath = getGoogleServicesFile(config);
   if (googleServicesFileRelativePath === null) {
-    return;
+    return project;
   }
 
   const googleServiceFilePath = path.resolve(projectRoot, googleServicesFileRelativePath);
@@ -94,8 +98,7 @@ export function setGoogleServicesFile(config: ExpoConfig, projectRoot: string) {
     path.join(getSourceRoot(projectRoot), 'GoogleService-Info.plist')
   );
 
-  let project = getPbxproj(projectRoot);
   const projectName = getProjectName(projectRoot);
   project = addFileToGroup(`${projectName}/GoogleService-Info.plist`, projectName, project);
-  fs.writeFileSync(project.filepath, project.writeSync());
+  return project;
 }

--- a/packages/config/src/ios/__tests__/DeviceFamily-test.ts
+++ b/packages/config/src/ios/__tests__/DeviceFamily-test.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from '@expo/config-types';
 import { fs, vol } from 'memfs';
 import * as path from 'path';
 
@@ -8,6 +9,7 @@ import {
   getSupportsTablet,
   setDeviceFamily,
 } from '../DeviceFamily';
+import { getPbxproj } from '../utils/Xcodeproj';
 
 const actualFs = jest.requireActual('fs') as typeof fs;
 
@@ -99,8 +101,14 @@ describe(setDeviceFamily, () => {
   });
 
   it('updates device families without throwing', async () => {
-    setDeviceFamily({ name: '', slug: '', ios: {} }, projectRoot);
-    setDeviceFamily({ name: '', slug: '', ios: { supportsTablet: true } }, projectRoot);
-    setDeviceFamily({ name: '', slug: '', ios: { isTabletOnly: true } }, projectRoot);
+    setDeviceFamilyForRoot({ name: '', slug: '', ios: {} }, projectRoot);
+    setDeviceFamilyForRoot({ name: '', slug: '', ios: { supportsTablet: true } }, projectRoot);
+    setDeviceFamilyForRoot({ name: '', slug: '', ios: { isTabletOnly: true } }, projectRoot);
   });
 });
+
+function setDeviceFamilyForRoot(config: ExpoConfig, projectRoot: string) {
+  let project = getPbxproj(projectRoot);
+  project = setDeviceFamily(config, { project });
+  fs.writeFileSync(project.filepath, project.writeSync());
+}

--- a/packages/config/src/ios/__tests__/Locales-test.ts
+++ b/packages/config/src/ios/__tests__/Locales-test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 import { addWarningIOS } from '../../WarningAggregator';
 import { getLocales, setLocalesAsync } from '../Locales';
+import { getPbxproj } from '../utils/Xcodeproj';
 const actualFs = jest.requireActual('fs') as typeof fs;
 
 jest.mock('fs');
@@ -61,7 +62,9 @@ describe('e2e: iOS locales', () => {
       projectRoot
     );
 
-    await setLocalesAsync(
+    let project = getPbxproj(projectRoot);
+
+    project = await setLocalesAsync(
       {
         slug: 'testproject',
         version: '1',
@@ -75,8 +78,10 @@ describe('e2e: iOS locales', () => {
           es: { CFBundleDisplayName: 'spanish-name' },
         },
       },
-      projectRoot
+      { project, projectRoot }
     );
+    // Sync the Xcode project with the changes.
+    fs.writeFileSync(project.filepath, project.writeSync());
   });
 
   afterAll(() => {


### PR DESCRIPTION
- changes pulled from https://github.com/expo/expo-cli/pull/2669
- unify facebook metadata removal method
- create `modifyPbxprojAsync` and migrate Locales, DeviceFamilies, and Google to use it.