### PR TITLE
[config] fix entitlements functionality

### DIFF
--- a/packages/config/src/ios/Entitlements.ts
+++ b/packages/config/src/ios/Entitlements.ts
@@ -90,41 +90,67 @@ export function setAssociatedDomains(
 }
 
 export function getEntitlementsPath(projectRoot: string): string {
-  return Paths.getEntitlementsPath(projectRoot) ?? createEntitlementsFile(projectRoot);
-}
-
-function createEntitlementsFile(projectRoot: string) {
-  /**
-   * Write file from template
-   */
-  const entitlementsPath = getDefaultEntitlementsPath(projectRoot);
-  if (!fs.pathExistsSync(path.dirname(entitlementsPath))) {
-    fs.mkdirSync(path.dirname(entitlementsPath));
-  }
-  fs.writeFileSync(entitlementsPath, ENTITLEMENTS_TEMPLATE);
-  const entitlementsRelativePath = entitlementsPath.replace(`${projectRoot}/ios/`, '');
+  const paths = Paths.getAllEntitlementsPaths(projectRoot);
+  let targetPath: string | null = null;
 
   /**
    * Add file to pbxproj under CODE_SIGN_ENTITLEMENTS
    */
   const project = getPbxproj(projectRoot);
-  Object.entries(project.pbxXCBuildConfigurationSection())
-    .filter(isNotComment)
-    .filter(isBuildConfig)
-    .filter(isNotTestHost)
-    .forEach(({ 1: { buildSettings } }: any) => {
-      buildSettings.CODE_SIGN_ENTITLEMENTS = entitlementsRelativePath;
-    });
-  fs.writeFileSync(project.filepath, project.writeSync());
+  const projectName = getProjectName(projectRoot);
+  const productName = project.productName;
+
+  const entitlementsRelativePath = path.join(projectName, `${productName}.entitlements`);
+  const entitlementsPath = path.normalize(path.join(projectRoot, 'ios', entitlementsRelativePath));
+
+  const pathsToDelete: string[] = [];
+
+  while (paths.length) {
+    const last = path.normalize(paths.pop()!);
+    if (last !== entitlementsPath) {
+      pathsToDelete.push(last);
+    } else {
+      targetPath = last;
+    }
+  }
+
+  // Create a new entitlements file
+  if (!targetPath) {
+    targetPath = entitlementsPath;
+
+    // Use the default template
+    let template = ENTITLEMENTS_TEMPLATE;
+
+    // If an old entitlements file exists, copy it's contents into the new file.
+    if (pathsToDelete.length) {
+      // Get the last entitlements file and use it as the template
+      const last = pathsToDelete[pathsToDelete.length - 1]!;
+      template = fs.readFileSync(last, 'utf8');
+    }
+
+    fs.ensureDirSync(path.dirname(entitlementsPath));
+    fs.writeFileSync(entitlementsPath, template);
+
+    Object.entries(project.pbxXCBuildConfigurationSection())
+      .filter(isNotComment)
+      .filter(isBuildConfig)
+      .filter(isNotTestHost)
+      .forEach(({ 1: { buildSettings } }: any) => {
+        buildSettings.CODE_SIGN_ENTITLEMENTS = entitlementsRelativePath;
+      });
+    fs.writeFileSync(project.filepath, project.writeSync());
+  }
+
+  // Clean up others
+  deleteEntitlementsFiles(pathsToDelete);
 
   return entitlementsPath;
 }
 
-function getDefaultEntitlementsPath(projectRoot: string) {
-  const projectName = getProjectName(projectRoot);
-  const project = getPbxproj(projectRoot);
-  const productName = project.productName;
-  return path.join(projectRoot, 'ios', projectName, `${productName}.entitlements`);
+function deleteEntitlementsFiles(entitlementsPaths: string[]) {
+  for (const path of entitlementsPaths) {
+    fs.removeSync(path);
+  }
 }
 
 const ENTITLEMENTS_TEMPLATE = `

--- a/packages/config/src/ios/Paths.ts
+++ b/packages/config/src/ios/Paths.ts
@@ -23,6 +23,7 @@ export function getAppDelegate(projectRoot: string): { path: string; language: '
     warnMultipleFiles({
       tag: 'app-delegate',
       fileName: 'AppDelegate',
+      projectRoot,
       using,
       extra,
     });
@@ -72,6 +73,7 @@ export function getXcodeProjectPath(projectRoot: string): string {
     warnMultipleFiles({
       tag: 'xcodeproj',
       fileName: '*.xcodeproj',
+      projectRoot,
       using,
       extra,
     });
@@ -101,6 +103,7 @@ export function getPBXProjectPath(projectRoot: string): string {
     warnMultipleFiles({
       tag: 'project-pbxproj',
       fileName: 'project.pbxproj',
+      projectRoot,
       using,
       extra,
     });
@@ -131,6 +134,7 @@ export function getInfoPlistPath(projectRoot: string): string {
     warnMultipleFiles({
       tag: 'info-plist',
       fileName: 'Info.plist',
+      projectRoot,
       using,
       extra,
     });
@@ -139,22 +143,28 @@ export function getInfoPlistPath(projectRoot: string): string {
   return using;
 }
 
+export function getAllEntitlementsPaths(projectRoot: string): string[] {
+  const paths = globSync('ios/*/*.entitlements', {
+    absolute: true,
+    cwd: projectRoot,
+    ignore: ignoredPaths,
+  });
+  return paths;
+}
+
 /**
  * Get the entitlements file path if it exists.
  *
  * @param projectRoot
  */
 export function getEntitlementsPath(projectRoot: string): string | null {
-  const [using, ...extra] = globSync('ios/*/.entitlements', {
-    absolute: true,
-    cwd: projectRoot,
-    ignore: ignoredPaths,
-  });
+  const [using, ...extra] = getAllEntitlementsPaths(projectRoot);
 
   if (extra.length) {
     warnMultipleFiles({
       tag: 'entitlements',
       fileName: '*.entitlements',
+      projectRoot,
       using,
       extra,
     });
@@ -166,18 +176,22 @@ export function getEntitlementsPath(projectRoot: string): string | null {
 function warnMultipleFiles({
   tag,
   fileName,
+  projectRoot,
   using,
   extra,
 }: {
   tag: string;
   fileName: string;
+  projectRoot?: string;
   using: string;
   extra: string[];
 }) {
+  const usingPath = projectRoot ? path.relative(projectRoot, using) : using;
+  const extraPaths = projectRoot ? extra.map(v => path.relative(projectRoot, v)) : extra;
   addWarningIOS(
     `paths-${tag}`,
-    `Found multiple ${fileName} file paths, using "${using}". Ignored paths: ${JSON.stringify(
-      extra
+    `Found multiple ${fileName} file paths, using "${usingPath}". Ignored paths: ${JSON.stringify(
+      extraPaths
     )}`
   );
 }

--- a/packages/config/src/ios/__tests__/Entitlements-test.ts
+++ b/packages/config/src/ios/__tests__/Entitlements-test.ts
@@ -1,0 +1,76 @@
+import plist from '@expo/plist';
+import * as fs from 'fs-extra';
+import { vol } from 'memfs';
+import * as path from 'path';
+
+import { getEntitlementsPath } from '../Entitlements';
+
+const actualFs = jest.requireActual('fs') as typeof fs;
+
+jest.mock('fs');
+
+afterAll(() => {
+  jest.unmock('fs');
+});
+
+describe(getEntitlementsPath, () => {
+  const projectRoot = '/app';
+  const projectRootNone = '/no-config';
+  beforeAll(async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': actualFs.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject/old.entitlements': `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>special</key>
+	<true/>
+</dict>
+</plist>`,
+        'ios/testproject/AppDelegate.m': '',
+      },
+      projectRoot
+    );
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': actualFs.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject/AppDelegate.m': '',
+      },
+      projectRootNone
+    );
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it('creates a new entitlements file when none exists', async () => {
+    const entitlementsPath = getEntitlementsPath(projectRootNone);
+    expect(entitlementsPath).toBe('/no-config/ios/testproject/testproject.entitlements');
+
+    // New file has the contents of the old entitlements file
+    const data = plist.parse(await fs.readFile(entitlementsPath, 'utf8'));
+    expect(data).toStrictEqual({
+      /* empty object by default */
+    });
+  });
+
+  it('creates a new entitlements file and copies the contents of the older one before deleting it', async () => {
+    const entitlementsPath = getEntitlementsPath(projectRoot);
+    expect(entitlementsPath).toBe('/app/ios/testproject/testproject.entitlements');
+
+    // New file has the contents of the old entitlements file
+    const data = plist.parse(await fs.readFile(entitlementsPath, 'utf8'));
+    expect(data).toStrictEqual({ special: true });
+
+    // Old file is deleted
+    expect(await fs.pathExists('/app/ios/testproject/old.entitlements')).toBe(false);
+  });
+});

--- a/packages/config/src/ios/__tests__/Paths-test.ts
+++ b/packages/config/src/ios/__tests__/Paths-test.ts
@@ -65,7 +65,7 @@ describe(getXcodeProjectPath, () => {
     expect(getXcodeProjectPath('/multiple')).toBe('/multiple/ios/otherproject.xcodeproj');
     expect(addWarningIOS).toHaveBeenLastCalledWith(
       'paths-xcodeproj',
-      'Found multiple *.xcodeproj file paths, using "/multiple/ios/otherproject.xcodeproj". Ignored paths: ["/multiple/ios/testproject.xcodeproj"]'
+      'Found multiple *.xcodeproj file paths, using "ios/otherproject.xcodeproj". Ignored paths: ["ios/testproject.xcodeproj"]'
     );
   });
 });
@@ -156,7 +156,7 @@ describe(getAppDelegate, () => {
     });
     expect(addWarningIOS).toHaveBeenLastCalledWith(
       'paths-app-delegate',
-      'Found multiple AppDelegate file paths, using "/confusing/ios/testproject/AppDelegate.m". Ignored paths: ["/confusing/ios/testproject/AppDelegate.swift"]'
+      'Found multiple AppDelegate file paths, using "ios/testproject/AppDelegate.m". Ignored paths: ["ios/testproject/AppDelegate.swift"]'
     );
   });
 });


### PR DESCRIPTION
- Implement a system for deleting all .entitlements files, moving one of them (basically at random (there should never be more than one)) into the new entitlements path if it doesn't exist.
- Log file warnings relative to the project root
- Fix https://github.com/expo/expo-cli/issues/2688
- Test this new complex functionality