### PR TITLE
[config] Created AssetContents

### DIFF
--- a/packages/config/src/ios/AssetContents.ts
+++ b/packages/config/src/ios/AssetContents.ts
@@ -1,0 +1,56 @@
+import fs from 'fs-extra';
+import { join } from 'path';
+
+export type ContentsJsonImageIdiom = 'iphone' | 'ipad' | 'ios-marketing' | 'universal';
+
+export type ContentsJsonImageAppearance = {
+  appearance: 'luminosity';
+  value: 'dark';
+};
+
+export type ContentsJsonImageScale = '1x' | '2x' | '3x';
+
+export interface ContentsJsonImage {
+  appearances?: ContentsJsonImageAppearance[];
+  idiom: ContentsJsonImageIdiom;
+  size?: string;
+  scale: ContentsJsonImageScale;
+  filename?: string;
+}
+
+export interface ContentsJson {
+  images: ContentsJsonImage[];
+  info: {
+    version: number;
+    author: string;
+  };
+}
+
+/**
+ * Writes the Config.json which is used to assign images to their respective platform, dpi, and idiom.
+ *
+ * @param directory path to add the Contents.json to.
+ * @param contents image json data
+ */
+export async function writeContentsJsonAsync(
+  directory: string,
+  { images }: Pick<ContentsJson, 'images'>
+): Promise<void> {
+  await fs.ensureDir(directory);
+
+  await fs.writeFile(
+    join(directory, 'Contents.json'),
+    JSON.stringify(
+      {
+        images,
+        info: {
+          version: 1,
+          // common practice is for the tool that generated the icons to be the "author"
+          author: 'expo',
+        },
+      },
+      null,
+      2
+    )
+  );
+}

--- a/packages/config/src/ios/Icons.ts
+++ b/packages/config/src/ios/Icons.ts
@@ -4,32 +4,16 @@ import { join } from 'path';
 
 import { ExpoConfig } from '../Config.types';
 import { addWarningIOS } from '../WarningAggregator';
+import { ContentsJson, ContentsJsonImageIdiom, writeContentsJsonAsync } from './AssetContents';
 import { getProjectName } from './utils/Xcodeproj';
-
-type ContentsJsonImageIdiom = 'iphone' | 'ipad' | 'ios-marketing';
-interface ContentsJsonImage {
-  idiom: ContentsJsonImageIdiom;
-  size: string;
-  scale: string;
-  filename: string;
-}
-
-interface ContentsJson {
-  images: ContentsJsonImage[];
-  info: {
-    version: number;
-    author: string;
-  };
-}
 
 const IMAGE_CACHE_NAME = 'icons';
 const IMAGESET_PATH = 'Images.xcassets/AppIcon.appiconset';
-const CONTENTS_PATH = `${IMAGESET_PATH}/Contents.json`;
 
 // Hard-coding seemed like the clearest and safest way to implement the sizes.
 export const ICON_CONTENTS: {
   idiom: ContentsJsonImageIdiom;
-  sizes: { size: number; scales: number[] }[];
+  sizes: { size: number; scales: (1 | 2 | 3)[] }[];
 }[] = [
   {
     idiom: 'iphone',
@@ -156,6 +140,7 @@ export async function setIconsAsync(config: ExpoConfig, projectRoot: string) {
         imagesJson.push({
           idiom: platform.idiom,
           size: `${size}x${size}`,
+          // @ts-ignore: template types not supported in TS yet
           scale: `${scale}x`,
           filename,
         });
@@ -164,7 +149,7 @@ export async function setIconsAsync(config: ExpoConfig, projectRoot: string) {
   }
 
   // Finally, write the Config.json
-  await writeContentsJsonAsync(iosNamedProjectRoot, { images: imagesJson });
+  await writeContentsJsonAsync(join(iosNamedProjectRoot, IMAGESET_PATH), { images: imagesJson });
 }
 
 /**
@@ -175,33 +160,6 @@ export async function setIconsAsync(config: ExpoConfig, projectRoot: string) {
 function getIosNamedProjectPath(projectRoot: string): string {
   const projectName = getProjectName(projectRoot);
   return join(projectRoot, 'ios', projectName);
-}
-
-/**
- * Writes the Config.json which is used to assign images to their respective platform, dpi, and idiom.
- *
- * @param iosNamedProjectRoot named iOS project path
- * @param contents image json data
- */
-async function writeContentsJsonAsync(
-  iosNamedProjectRoot: string,
-  { images }: Pick<ContentsJson, 'images'>
-): Promise<void> {
-  await fs.writeFile(
-    join(iosNamedProjectRoot, CONTENTS_PATH),
-    JSON.stringify(
-      {
-        images,
-        info: {
-          version: 1,
-          // common practice is for the tool that generated the icons to be the "author"
-          author: 'expo',
-        },
-      },
-      null,
-      2
-    )
-  );
 }
 
 function getAppleIconName(size: number, scale: number): string {

--- a/packages/config/src/ios/IosConfig.types.ts
+++ b/packages/config/src/ios/IosConfig.types.ts
@@ -16,6 +16,7 @@ export type InfoPlist = {
   CFBundleIdentifier?: string;
   CFBundleName?: string;
   CFBundleURLTypes?: URLScheme[];
+  CFBundleDevelopmentRegion?: string;
   ITSAppUsesNonExemptEncryption?: boolean;
   LSApplicationQueriesSchemes?: string[];
   FacebookAppID?: string;

--- a/packages/config/src/ios/Version.ts
+++ b/packages/config/src/ios/Version.ts
@@ -13,7 +13,7 @@ export function setVersion(config: ExpoConfig, infoPlist: InfoPlist) {
 }
 
 export function getBuildNumber(config: ExpoConfig) {
-  return config.ios && config.ios.buildNumber ? config.ios.buildNumber : '1';
+  return config.ios?.buildNumber ? config.ios.buildNumber : '1';
 }
 
 export function setBuildNumber(config: ExpoConfig, infoPlist: InfoPlist) {


### PR DESCRIPTION
- moved from https://github.com/expo/expo-cli/pull/2706
- abstracts the Contents.json feature (currently for no reason).
- makes the Icons module less complex.