### PR TITLE
[xdl] Support beta versions when EXPO_BETA=1

### DIFF
--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -36,14 +36,8 @@ async function action(
 
   // Set EXPO_VIEW_DIR to universe/exponent to pull expo view code locally instead of from S3 for ExpoKit
   if (Versions.lteSdkVersion(exp, '36.0.0')) {
-    // Don't show a warning if we haven't released SDK 37 yet
-    const latestReleasedVersion = await Versions.newestReleasedSdkVersionAsync();
-    if (Versions.lteSdkVersion({ sdkVersion: latestReleasedVersion.version }, '36.0.0')) {
+    if (options.force || (await userWantsToEjectWithoutUpgradingAsync())) {
       await LegacyEject.ejectAsync(projectDir, options as LegacyEject.EjectAsyncOptions);
-    } else {
-      if (options.force || (await userWantsToEjectWithoutUpgradingAsync())) {
-        await LegacyEject.ejectAsync(projectDir, options as LegacyEject.EjectAsyncOptions);
-      }
     }
   } else {
     await Eject.ejectAsync(projectDir, options as Eject.EjectAsyncOptions);
@@ -61,6 +55,7 @@ export default function (program: Command) {
       'Create Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.'
     )
     .helpGroup('eject')
+    .option('--force', 'Skip legacy eject warnings.')
     .option('--no-install', 'Skip installing npm packages and CocoaPods.')
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .asyncActionProjectDir(action);

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -35,6 +35,7 @@ async function action(
   }
 
   // Set EXPO_VIEW_DIR to universe/exponent to pull expo view code locally instead of from S3 for ExpoKit
+  // TODO: remove LegacyEject when SDK 36 is no longer supported: after SDK 40 is released.
   if (Versions.lteSdkVersion(exp, '36.0.0')) {
     if (options.force || (await userWantsToEjectWithoutUpgradingAsync())) {
       await LegacyEject.ejectAsync(projectDir, options as LegacyEject.EjectAsyncOptions);
@@ -55,7 +56,7 @@ export default function (program: Command) {
       'Create Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.'
     )
     .helpGroup('eject')
-    .option('--force', 'Skip legacy eject warnings.')
+    .option('--force', 'Skip legacy eject warnings.') // TODO: remove the force flag when SDK 36 is no longer supported: after SDK 40 is released.
     .option('--no-install', 'Skip installing npm packages and CocoaPods.')
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .asyncActionProjectDir(action);

--- a/packages/xdl/src/Versions.ts
+++ b/packages/xdl/src/Versions.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { JSONObject } from '@expo/json-file';
+import getenv from 'getenv';
 import pickBy from 'lodash/pickBy';
 import path from 'path';
 import semver from 'semver';
@@ -27,6 +28,7 @@ export type SDKVersion = {
   androidClientUrl?: string;
   androidClientVersion?: string;
   relatedPackages?: { [name: string]: string };
+  beta?: boolean;
 };
 
 export type SDKVersions = { [version: string]: SDKVersion };
@@ -146,7 +148,10 @@ export async function newestReleasedSdkVersionAsync(): Promise<{
   let result = null;
   let highestMajorVersion = '0.0.0';
   for (const [version, data] of Object.entries(sdkVersions)) {
-    if (semver.major(version) > semver.major(highestMajorVersion) && data.releaseNoteUrl) {
+    if (
+      semver.major(version) > semver.major(highestMajorVersion) &&
+      (data.releaseNoteUrl || (data.beta && getenv.boolish('EXPO_BETA', false)))
+    ) {
       highestMajorVersion = version;
       result = data;
     }
@@ -157,6 +162,9 @@ export async function newestReleasedSdkVersionAsync(): Promise<{
   };
 }
 
+/**
+ * Be careful when using this! It can include unreleased and beta SDK versions.
+ */
 export async function newestSdkVersionAsync(): Promise<{
   version: string;
   data: SDKVersion | null;

--- a/packages/xdl/src/Versions.ts
+++ b/packages/xdl/src/Versions.ts
@@ -144,13 +144,19 @@ export async function newestReleasedSdkVersionAsync(): Promise<{
   version: string;
   data: SDKVersion | null;
 }> {
+  const betaOptInEnabled = getenv.boolish('EXPO_BETA', false);
   const sdkVersions = await sdkVersionsAsync();
+
   let result = null;
   let highestMajorVersion = '0.0.0';
+
   for (const [version, data] of Object.entries(sdkVersions)) {
+    const hasReleaseNotes = !!data.releaseNoteUrl;
+    const isBeta = !!data.beta;
+
     if (
       semver.major(version) > semver.major(highestMajorVersion) &&
-      (data.releaseNoteUrl || (data.beta && getenv.boolish('EXPO_BETA', false)))
+      (hasReleaseNotes || (isBeta && betaOptInEnabled))
     ) {
       highestMajorVersion = version;
       result = data;


### PR DESCRIPTION
This PR changes `Versions.newestReleasedSdkVersionAsync()`:

- Currently a "released" version is defined as being a version that has a `releaseNoteUrl` field attached to it on the versions endpoint
- For beta releases, we will add a boolean `beta` field.
- We only want to return beta releases as the newest released version when the user opts in to it.
- Users are able to opt-in by setting `EXPO_BETA=1` in their environment.

This small change has the following intended impacts:

- `EXPO_BETA=1 expo upgrade` will now be able to upgrade to a beta version
- `EXPO_BETA=1 expo client:install:[ios/android]` outside of a project directory will install the beta version of the client