### PR TITLE
[xdl][expo-cli] add the "target" warning for export

### DIFF
--- a/packages/expo-cli/src/commands/__tests__/publish-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-test.ts
@@ -2,6 +2,7 @@ import { vol } from 'memfs';
 
 import log from '../../log';
 import { isInvalidReleaseChannel, logExpoUpdatesWarnings, logOptimizeWarnings } from '../publish';
+import { logBareWorkflowWarnings } from '../utils/logConfigWarnings';
 
 jest.mock('fs');
 jest.mock('../../log', () => ({
@@ -41,6 +42,18 @@ describe('warnings', () => {
   it(`warns about expo-updates not working in ExpoKit`, () => {
     (log.nestedWarn as jest.Mock).mockReset();
     logExpoUpdatesWarnings({ dependencies: { 'expo-updates': '1.0.0', expokit: '1.0.0' } });
+    expect(log.nestedWarn).toBeCalledTimes(1);
+  });
+
+  it(`skips bare workflow warnings if expo is not installed in a bare project`, () => {
+    (log.nestedWarn as jest.Mock).mockReset();
+    logBareWorkflowWarnings({}, 'publish');
+    expect(log.nestedWarn).toBeCalledTimes(0);
+  });
+
+  it(`warns about publishing in a bare workflow project when expo is installed`, () => {
+    (log.nestedWarn as jest.Mock).mockReset();
+    logBareWorkflowWarnings({ dependencies: { expo: '1.0.0' } }, 'publish');
     expect(log.nestedWarn).toBeCalledTimes(1);
   });
 

--- a/packages/expo-cli/src/commands/__tests__/publish-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-test.ts
@@ -1,12 +1,7 @@
 import { vol } from 'memfs';
 
 import log from '../../log';
-import {
-  isInvalidReleaseChannel,
-  logBareWorkflowWarnings,
-  logExpoUpdatesWarnings,
-  logOptimizeWarnings,
-} from '../publish';
+import { isInvalidReleaseChannel, logExpoUpdatesWarnings, logOptimizeWarnings } from '../publish';
 
 jest.mock('fs');
 jest.mock('../../log', () => ({
@@ -46,18 +41,6 @@ describe('warnings', () => {
   it(`warns about expo-updates not working in ExpoKit`, () => {
     (log.nestedWarn as jest.Mock).mockReset();
     logExpoUpdatesWarnings({ dependencies: { 'expo-updates': '1.0.0', expokit: '1.0.0' } });
-    expect(log.nestedWarn).toBeCalledTimes(1);
-  });
-
-  it(`skips bare workflow warnings if expo is not installed in a bare project`, () => {
-    (log.nestedWarn as jest.Mock).mockReset();
-    logBareWorkflowWarnings({});
-    expect(log.nestedWarn).toBeCalledTimes(0);
-  });
-
-  it(`warns about publishing in a bare workflow project when expo is installed`, () => {
-    (log.nestedWarn as jest.Mock).mockReset();
-    logBareWorkflowWarnings({ dependencies: { expo: '1.0.0' } });
     expect(log.nestedWarn).toBeCalledTimes(1);
   });
 

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -1,4 +1,4 @@
-import { ProjectTarget } from '@expo/config';
+import { getDefaultTarget, getPackageJson, ProjectTarget } from '@expo/config';
 import { Project, UrlUtils } from '@expo/xdl';
 import program, { Command } from 'commander';
 import crypto from 'crypto';
@@ -11,6 +11,7 @@ import log from '../log';
 import prompt from '../prompts';
 import * as CreateApp from './utils/CreateApp';
 import { downloadAndDecompressAsync } from './utils/Tar';
+import { logBareWorkflowWarnings } from './utils/logConfigWarnings';
 
 type Options = {
   outputDir: string;
@@ -162,6 +163,14 @@ function collect<T>(val: T, memo: T[]): T[] {
 export async function action(projectDir: string, options: Options) {
   // Ensure URL
   options.publicUrl = await ensurePublicUrlAsync(options.publicUrl, options.dev);
+
+  // Warn about publishing in bare without a target
+  const target = options.target ?? getDefaultTarget(projectDir);
+  if (!options.target && target === 'bare') {
+    log.newLine();
+    logBareWorkflowWarnings(getPackageJson(projectDir), 'export');
+  }
+  options.target = target;
 
   // Ensure the output directory is created
   const outputPath = path.resolve(projectDir, options.outputDir);

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -1,4 +1,4 @@
-import { getDefaultTarget, ProjectTarget } from '@expo/config';
+import { ProjectTarget } from '@expo/config';
 import { Project, UrlUtils } from '@expo/xdl';
 import program, { Command } from 'commander';
 import crypto from 'crypto';
@@ -84,7 +84,7 @@ async function exportFilesAsync(
     isDev: options.dev,
     publishOptions: {
       resetCache: !!options.clear,
-      target: options.target ?? getDefaultTarget(projectRoot),
+      target: options.target,
     },
   };
   const absoluteOutputDir = path.resolve(process.cwd(), options.outputDir);

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -64,15 +64,9 @@ export async function action(
 
   logOptimizeWarnings({ projectRoot: projectDir });
 
-  if (!options.target && target === 'bare') {
-    logBareWorkflowWarnings(pkg);
-  }
-
   log.addNewLineIfNone();
 
   // Build and publish the project.
-
-  log(`Building optimized bundles and generating sourcemaps...`);
 
   if (options.quiet) {
     simpleSpinner.start();
@@ -81,7 +75,7 @@ export async function action(
   const result = await Project.publishAsync(projectDir, {
     releaseChannel: options.releaseChannel,
     quiet: options.quiet,
-    target,
+    target: options.target,
     resetCache: options.clear,
   });
 
@@ -114,8 +108,6 @@ export async function action(
       await sendTo.sendUrlAsync(websiteUrl, recipient);
     }
   }
-
-  log.newLine();
 
   return result;
 }
@@ -264,39 +256,6 @@ export function logOptimizeWarnings({ projectRoot }: { projectRoot: string }): v
         `npx expo-optimize`
       )}`,
       'https://docs.expo.io/distribution/optimizing-updates/#optimize-images'
-    )
-  );
-}
-
-/**
- * Warn users if they attempt to publish in a bare project that may also be
- * using Expo client and does not If the developer does not have the Expo
- * package installed then we do not need to warn them as there is no way that
- * it will run in Expo client in development even. We should revisit this with
- * dev client, and possibly also by excluding SDK version for bare
- * expo-updates usage in the future (and then surfacing this as an error in
- * the Expo client app instead)
- *
- * Related: https://github.com/expo/expo/issues/9517
- *
- * @param pkg package.json
- */
-export function logBareWorkflowWarnings(pkg: PackageJSONConfig) {
-  const hasExpoInstalled = pkg.dependencies?.['expo'];
-  if (!hasExpoInstalled) {
-    return;
-  }
-
-  log.nestedWarn(
-    formatNamedWarning(
-      'Workflow target',
-      `This is a ${chalk.bold(
-        'bare workflow'
-      )} project. The resulting publish will only run properly inside of a native build of your project. If you want to publish a version of your app that will run in Expo client, please use ${chalk.bold(
-        'expo publish --target managed'
-      )}. You can skip this warning by explicitly running ${chalk.bold(
-        'expo publish --target bare'
-      )} in the future.`
     )
   );
 }

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -10,7 +10,7 @@ import CommandError from '../CommandError';
 import log from '../log';
 import * as sendTo from '../sendTo';
 import * as TerminalLink from './utils/TerminalLink';
-import { formatNamedWarning } from './utils/logConfigWarnings';
+import { formatNamedWarning, logBareWorkflowWarnings } from './utils/logConfigWarnings';
 
 type Options = {
   clear?: boolean;
@@ -64,9 +64,15 @@ export async function action(
 
   logOptimizeWarnings({ projectRoot: projectDir });
 
+  if (!options.target && target === 'bare') {
+    logBareWorkflowWarnings(pkg, 'publish');
+  }
+
   log.addNewLineIfNone();
 
   // Build and publish the project.
+
+  log(`Building optimized bundles and generating sourcemaps...`);
 
   if (options.quiet) {
     simpleSpinner.start();
@@ -75,7 +81,7 @@ export async function action(
   const result = await Project.publishAsync(projectDir, {
     releaseChannel: options.releaseChannel,
     quiet: options.quiet,
-    target: options.target,
+    target,
     resetCache: options.clear,
   });
 
@@ -108,6 +114,8 @@ export async function action(
       await sendTo.sendUrlAsync(websiteUrl, recipient);
     }
   }
+
+  log.newLine();
 
   return result;
 }

--- a/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
@@ -1,4 +1,5 @@
 import { WarningAggregator } from '@expo/config-plugins';
+import { PackageJSONConfig } from '@expo/config';
 import chalk from 'chalk';
 
 import log from '../../log';
@@ -38,4 +39,36 @@ function getSpacer(text: string) {
   } else {
     return '. ';
   }
+}
+
+/**
+ * Warn users if they attempt to publish in a bare project that may also be
+ * using Expo client and does not If the developer does not have the Expo
+ * package installed then we do not need to warn them as there is no way that
+ * it will run in Expo client in development even. We should revisit this with
+ * dev client, and possibly also by excluding SDK version for bare
+ * expo-updates usage in the future (and then surfacing this as an error in
+ * the Expo client app instead)
+ *
+ * Related: https://github.com/expo/expo/issues/9517
+ *
+ * @param pkg package.json
+ */
+export function logBareWorkflowWarnings(pkg: PackageJSONConfig, commandName: string) {
+  const hasExpoInstalled = pkg.dependencies?.['expo'];
+  if (!hasExpoInstalled) {
+    return;
+  }
+  log.nestedWarn(
+    formatNamedWarning(
+      'Workflow target',
+      `This is a ${chalk.bold(
+        'bare workflow'
+      )} project. The resulting ${commandName} will only run properly inside of a native build of your project. If you want to ${commandName} a version of your app that will run in the Expo client, please use ${chalk.bold(
+        `expo ${commandName} --target managed`
+      )}. You can skip this warning by explicitly running ${chalk.bold(
+        `expo ${commandName} --target bare`
+      )} in the future.`
+    )
+  );
 }

--- a/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
@@ -1,5 +1,5 @@
-import { WarningAggregator } from '@expo/config-plugins';
 import { PackageJSONConfig } from '@expo/config';
+import { WarningAggregator } from '@expo/config-plugins';
 import chalk from 'chalk';
 
 import log from '../../log';

--- a/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
@@ -42,17 +42,17 @@ function getSpacer(text: string) {
 }
 
 /**
- * Warn users if they attempt to publish in a bare project that may also be
- * using Expo client and does not If the developer does not have the Expo
- * package installed then we do not need to warn them as there is no way that
- * it will run in Expo client in development even. We should revisit this with
- * dev client, and possibly also by excluding SDK version for bare
- * expo-updates usage in the future (and then surfacing this as an error in
- * the Expo client app instead)
+ * Warn users if they attempt to export or publish in a bare project that may also
+ * be using the Expo client and does not if the developer does not have the Expo
+ * package installed (without it, there is no way the project will run in the Expo
+ * client. We should revisit this with dev client, and possibly also by excluding SDK
+ * version for bare expo-updates usage in the future (and then surfacing this
+ * as an error in the Expo client app instead)
  *
  * Related: https://github.com/expo/expo/issues/9517
  *
- * @param pkg package.json
+ * @param pkg         package.json
+ * @param commandName name of the command to warn about
  */
 export function logBareWorkflowWarnings(pkg: PackageJSONConfig, commandName: string) {
   const hasExpoInstalled = pkg.dependencies?.['expo'];

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -388,7 +388,6 @@ export async function exportForAppHosting(
 
   logger.global.info('Finished saving JS Bundles.');
 
-  // save the assets
   const { assets } = await exportAssetsAsync({
     projectRoot,
     exp,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -355,8 +355,15 @@ export async function exportForAppHosting(
     publishOptions?: PublishOptions;
   } = {}
 ): Promise<void> {
-  const defaultTarget = getDefaultTarget(projectRoot);
-  const target = options.publishOptions?.target ?? defaultTarget;
+  // Get project config
+  const publishOptions = options.publishOptions || {};
+  const { exp, pkg, hooks } = await _getPublishExpConfigAsync(projectRoot, publishOptions);
+
+  const target = options.publishOptions?.target ?? getDefaultTarget(projectRoot);
+
+  if (!publishOptions.target && target === 'bare') {
+    logBareWorkflowWarnings(pkg);
+  }
 
   // build the bundles
   // make output dirs if not exists
@@ -365,10 +372,7 @@ export async function exportForAppHosting(
   const bundlesPathToWrite = path.resolve(projectRoot, path.join(outputDir, 'bundles'));
   await fs.ensureDir(bundlesPathToWrite);
 
-  const publishOptions = options.publishOptions || {};
-  const { exp, pkg, hooks } = await _getPublishExpConfigAsync(projectRoot, publishOptions);
-
-  const bundles = await buildPublishBundlesAsync(projectRoot, options.publishOptions, {
+  const bundles = await buildPublishBundlesAsync(projectRoot, publishOptions, {
     dev: options.isDev,
     useDevServer: shouldUseDevServer(exp),
   });
@@ -388,6 +392,7 @@ export async function exportForAppHosting(
 
   logger.global.info('Finished saving JS Bundles.');
 
+  // save the assets
   const { assets } = await exportAssetsAsync({
     projectRoot,
     exp,
@@ -604,8 +609,7 @@ export async function publishAsync(
   projectRoot: string,
   options: PublishOptions = {}
 ): Promise<PublishedProjectResult> {
-  options.target = options.target ?? getDefaultTarget(projectRoot);
-  const target = options.target;
+  const target = options.target ?? getDefaultTarget(projectRoot);
   const user = await UserManager.ensureLoggedInAsync();
 
   Analytics.logEvent('Publish', {
@@ -628,6 +632,12 @@ export async function publishAsync(
   if (exp.isKernel && user.kind === 'robot') {
     throw new XDLError('ROBOT_ACCOUNT_ERROR', 'Kernel builds are not available for robot users');
   }
+
+  if (!options.target && target === 'bare') {
+    logBareWorkflowWarnings(pkg);
+  }
+
+  logger.global.info(`Building optimized bundles and generating sourcemaps...`);
 
   // TODO: refactor this out to a function, throw error if length doesn't match
   const validPostPublishHooks: LoadedHook[] = prepareHooks(hooks, 'postPublish', projectRoot, exp);
@@ -1852,3 +1862,32 @@ export async function stopAsync(projectDir: string): Promise<void> {
 }
 
 export { startTunnelsAsync, stopTunnelsAsync };
+
+/**
+ * Warn users if they attempt to publish in a bare project that may also be
+ * using Expo client and does not If the developer does not have the Expo
+ * package installed then we do not need to warn them as there is no way that
+ * it will run in Expo client in development even. We should revisit this with
+ * dev client, and possibly also by excluding SDK version for bare
+ * expo-updates usage in the future (and then surfacing this as an error in
+ * the Expo client app instead)
+ *
+ * Related: https://github.com/expo/expo/issues/9517
+ *
+ * @param pkg package.json
+ */
+export function logBareWorkflowWarnings(pkg: PackageJSONConfig) {
+  const hasExpoInstalled = pkg.dependencies?.['expo'];
+  if (!hasExpoInstalled) {
+    return;
+  }
+  logger.global.warn(
+    `\n- ${chalk.bold('Workflow target')}: This is a ${chalk.bold(
+      'bare workflow'
+    )} project. The resulting publish will only run properly inside of a native build of your project. If you want to publish a version of your app that will run in Expo client, please use ${chalk.bold(
+      'expo publish --target managed'
+    )}. You can skip this warning by explicitly running ${chalk.bold(
+      'expo publish --target bare'
+    )} in the future.\n`
+  );
+}


### PR DESCRIPTION
## Why

we warn if you run `expo publish` in a bare project without the `--target` flag. So we should do the same for `expo export` 

to keep things in one place, i moved the `logBareWorkflowWarnings` code from `expo-cli/publish.ts` to `xdl/Project.ts`, since that's where we do the relevant publishing/exporting work. This also prevents us from calling `getConfig` (which is expensive) more times than we need to

Tested in a bare project:
- `expo export` logs warning ✅ 
- `expo publish` logs warning ✅ 
- `expo export --target bare` does not log warning ✅ 
- `expo publish --target bare` does not log warning ✅ 
- remove `expo` from dependencies in package.json, does not log warning ✅ 

Tested in a managed project:
- never logs warning✅ 