### PR TITLE
[xdl][cli] Add support for --latest flag in client:install:x

### DIFF
--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -379,7 +379,15 @@ export async function downloadApkAsync(
   return apkPath;
 }
 
-export async function installExpoAsync({ device, url }: { device: Device; url?: string }) {
+export async function installExpoAsync({
+  device,
+  url,
+  version,
+}: {
+  device: Device;
+  url?: string;
+  version?: string;
+}) {
   const bar = new ProgressBar('Downloading the Expo client app [:bar] :percent :etas', {
     total: 100,
     width: 64,
@@ -403,7 +411,11 @@ export async function installExpoAsync({ device, url }: { device: Device; url?: 
   const path = await downloadApkAsync(url, progress => bar.tick(1, progress));
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
 
-  Logger.global.info(`Installing Expo client on device`);
+  if (version) {
+    Logger.global.info(`Installing Expo client ${version} on device`);
+  } else {
+    Logger.global.info(`Installing Expo client on device`);
+  }
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
   warningTimer = setWarningTimer();
   const result = await getAdbOutputAsync(adbPidArgs(device.pid, 'install', path));
@@ -444,7 +456,12 @@ export async function uninstallExpoAsync(device: Device): Promise<string | undef
   }
 }
 
-export async function upgradeExpoAsync(url?: string): Promise<boolean> {
+export async function upgradeExpoAsync(options?: {
+  url?: string;
+  version?: string;
+}): Promise<boolean> {
+  const { url, version } = options || {};
+
   try {
     const devices = await getAttachedDevicesAsync();
     if (!devices.length) {
@@ -457,7 +474,7 @@ export async function upgradeExpoAsync(url?: string): Promise<boolean> {
     }
 
     await uninstallExpoAsync(device);
-    await installExpoAsync({ device, url });
+    await installExpoAsync({ device, url, version });
     if (_lastUrl) {
       Logger.global.info(`Opening ${_lastUrl} in Expo.`);
       await getAdbOutputAsync([

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -429,9 +429,11 @@ export async function _downloadSimulatorAppAsync(
 export async function installExpoOnSimulatorAsync({
   url,
   simulator,
+  version,
 }: {
   simulator: Pick<SimControl.Device, 'name' | 'udid'>;
   url?: string;
+  version?: string;
 }) {
   const bar = new ProgressBar(
     `Installing the Expo client app on ${simulator.name} [:bar] :percent :etas`,
@@ -461,7 +463,12 @@ export async function installExpoOnSimulatorAsync({
   const dir = await _downloadSimulatorAppAsync(url, progress => bar.tick(1, progress));
   Logger.notifications.info({ code: NotificationCode.STOP_LOADING });
 
-  Logger.global.info(`Installing Expo client on ${simulator.name}`);
+  if (version) {
+    Logger.global.info(`Installing Expo client ${version} on ${simulator.name}`);
+  } else {
+    Logger.global.info(`Installing Expo client on ${simulator.name}`);
+  }
+
   Logger.notifications.info({ code: NotificationCode.START_LOADING });
   warningTimer = setWarningTimer();
 
@@ -495,6 +502,7 @@ export async function upgradeExpoAsync(
   options: {
     udid?: string;
     url?: string;
+    version?: string;
   } = {}
 ): Promise<boolean> {
   if (!(await isSimulatorInstalledAsync())) {
@@ -504,7 +512,11 @@ export async function upgradeExpoAsync(
   const simulator = await ensureSimulatorOpenAsync(options);
 
   await uninstallExpoAppFromSimulatorAsync(simulator);
-  const installResult = await installExpoOnSimulatorAsync({ url: options.url, simulator });
+  const installResult = await installExpoOnSimulatorAsync({
+    url: options.url,
+    version: options.version,
+    simulator,
+  });
   if (installResult.status !== 0) {
     return false;
   }


### PR DESCRIPTION
This PR makes it possible to run:

- `expo client:install:ios --latest`
- `expo client:install:android --latest`

This is useful to skip any prompts and just grab and install the latest client. These are convenient commands we can copy/paste in a variety of situations without providing any additional instructions around the cwd of the terminal, eg: `EXPO_BETA=1 expo client:install:ios --latest`.

A drive-by improvement I made here was to include the client version in the "Installing Expo client" message.

![Screen Shot 2020-10-16 at 6 16 02 PM](https://user-images.githubusercontent.com/90494/96325308-a8d94d80-0fdb-11eb-82ae-504236b8d19b.png)
