### PR TITLE
[pkcs12] return null if pkcs keystore has no cert under friendly name

### DIFF
--- a/packages/pkcs12/src/__tests__/index-test.ts
+++ b/packages/pkcs12/src/__tests__/index-test.ts
@@ -105,9 +105,10 @@ describe('reading PKCS#12 files', () => {
     const certificate = getX509CertificateByFriendlyName(p12, alias);
     expect(certificate).toMatchSnapshot();
   });
-  it('fails to read X.509 certificates from conventional p12 files using #getX509CertificateByFriendlyName', async () => {
+  it('returns null if there are no X.509 certificates under friendly name for p12 keystores using #getX509CertificateByFriendlyName', async () => {
     const { base64EncodedP12, password } = conventionalP12;
     const p12 = parsePKCS12(base64EncodedP12, password);
-    expect(() => getX509CertificateByFriendlyName(p12, 'ruhroh')).toThrow();
+    const certificate = getX509CertificateByFriendlyName(p12, 'no keystore here :(');
+    expect(certificate).toBe(null);
   });
 });

--- a/packages/pkcs12/src/index.ts
+++ b/packages/pkcs12/src/index.ts
@@ -35,11 +35,11 @@ export function getX509Certificate(p12: forge.pkcs12.Pkcs12Pfx): forge.pki.Certi
 export function getX509CertificateByFriendlyName(
   p12: forge.pkcs12.Pkcs12Pfx,
   friendlyName: string
-): forge.pki.Certificate {
+): forge.pki.Certificate | null {
   const certBagType = forge.pki.oids.certBag;
   const bags = p12.getBags({ friendlyName, bagType: certBagType }).friendlyName;
   if (!bags || bags.length === 0) {
-    throw new Error(`PKCS12: No certificates found under friendlyName: ${friendlyName}`);
+    return null;
   }
   const certificate = bags[0].cert;
   if (!certificate) {


### PR DESCRIPTION
# why
a common mistake users make is uploading a pkcs keystore and providing the wrong alias (friendly name) that their credentials are stored under. It'll make it easier if we just returned `null` in this case rather than throwing an error in this package so the client (www) can handle this case and wrap it in an error with more context.

# tests

- [x] amended tests pass