### PR TITLE
Upgrade @expo/configure-splash-screen version used in @expo/config

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "7.9.0",
     "@expo/babel-preset-cli": "0.2.18",
     "@expo/config-types": "^40.0.0-beta.1",
-    "@expo/configure-splash-screen": "0.2.1",
+    "@expo/configure-splash-screen": "0.3.0",
     "@expo/image-utils": "0.3.7",
     "@expo/json-file": "8.2.24",
     "@expo/plist": "0.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,10 +1406,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/configure-splash-screen@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.2.1.tgz#de29b781990d32d9f48d630b912aaf017afccbf3"
-  integrity sha512-6n7ji1WKDCdLe2Mto4u4W72kTLhAbhXhC7ydVk1HxDYCcbewNLfgiwhchPtPGyUMnSDizVWph5aDoiKxqVHqNQ==
+"@expo/configure-splash-screen@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.3.0.tgz#37f52cf084078e2ba847f01a9977b8bc3f887021"
+  integrity sha512-Bglih9V0XQyHOtBYcsZBgTmNksr8bGBQ9CKXWod9aICQSyyim5Kmb3BtOaE/PJN7FcNCYBtueb33YkfNu1t1MQ==
   dependencies:
     "@react-native-community/cli-platform-android" "^4.10.0"
     "@react-native-community/cli-platform-ios" "^4.10.0"


### PR DESCRIPTION
Update to `0.3.0`. I need this in `eas-cli` because the type definition is broken in `0.2.1`.

It seems that this version number doesn't get updated automatically during releases now that `configure-splash-screen` is in `unlinked-packages`, but maybe that's OK.

Not sure how to best test this change, but CHANGELOG didn't show anything alarming.