### PR TITLE
[config] only serialize the expo object

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -9,6 +9,7 @@ import {
   AppJSONConfig,
   ConfigFilePaths,
   ExpoConfig,
+  ExportedConfig,
   ExpRc,
   GetConfigOptions,
   PackageJSONConfig,
@@ -28,14 +29,18 @@ import { getDynamicConfig, getStaticConfig } from './getConfig';
  *
  * @param config Input config object to reduce
  */
-function reduceExpoObject(config?: any): ExpoConfig | null {
-  if (!config) return config === undefined ? null : config;
+function reduceExpoObject(config?: any): ExportedConfig {
+  if (!config) {
+    return config === undefined ? null : config;
+  }
 
   if (typeof config.expo === 'object') {
     // TODO: We should warn users in the future that if there are more values than "expo", those values outside of "expo" will be omitted in favor of the "expo" object.
-    return config.expo as ExpoConfig;
+    return {
+      expo: config.expo as ExpoConfig,
+    };
   }
-  return config;
+  return { expo: config };
 }
 
 /**
@@ -69,7 +74,7 @@ function getSupportedPlatforms(
  * module.exports = function({ config }) {
  *   // mutate the config before returning it.
  *   config.slug = 'new slug'
- *   return config;
+ *   return { expo: config };
  * }
  *
  * **Supports**
@@ -89,18 +94,18 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
   const rootConfig = (rawStaticConfig || {}) as AppJSONConfig;
   const staticConfig = reduceExpoObject(rawStaticConfig) || {};
 
-  const jsonFileWithNodeModulesPath = reduceExpoObject(rootConfig) as ExpoConfig;
+  const jsonFileWithNodeModulesPath = reduceExpoObject(rootConfig);
   // Can only change the package.json location if an app.json or app.config.json exists with nodeModulesPath
   const [packageJson, packageJsonPath] = getPackageJsonAndPath(
     projectRoot,
-    jsonFileWithNodeModulesPath
+    jsonFileWithNodeModulesPath.expo
   );
 
-  function fillAndReturnConfig(config: any, dynamicConfigObjectType: string | null) {
+  function fillAndReturnConfig(config: ExportedConfig, dynamicConfigObjectType: string | null) {
     return {
       ...ensureConfigHasDefaultValues(
         projectRoot,
-        config,
+        config.expo,
         packageJson,
         options.skipSDKVersionRequirement
       ),
@@ -112,8 +117,8 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
   }
 
   // Fill in the static config
-  function getContextConfig(config: any = {}) {
-    return ensureConfigHasDefaultValues(projectRoot, config, packageJson, true).exp;
+  function getContextConfig(config: ExportedConfig) {
+    return ensureConfigHasDefaultValues(projectRoot, config.expo, packageJson, true).exp;
   }
 
   if (paths.dynamicConfigPath) {
@@ -147,8 +152,11 @@ export function getPackageJson(
 
 function getPackageJsonAndPath(
   projectRoot: string,
-  config: Partial<Pick<ExpoConfig, 'nodeModulesPath'>> = {}
+  config: Partial<Pick<ExpoConfig, 'nodeModulesPath'>> | null = {}
 ): [PackageJSONConfig, string] {
+  if (!config) {
+    config = {};
+  }
   const packageJsonPath = getRootPackageJsonPath(projectRoot, config);
   return [JsonFile.read(packageJsonPath), packageJsonPath];
 }
@@ -385,10 +393,13 @@ const APP_JSON_EXAMPLE = JSON.stringify({
 
 function ensureConfigHasDefaultValues(
   projectRoot: string,
-  exp: Partial<ExpoConfig>,
+  exp: Partial<ExpoConfig> | null,
   pkg: JSONObject,
   skipSDKVersionRequirement: boolean = false
 ): { exp: ExpoConfig; pkg: PackageJSONConfig } {
+  if (!exp) {
+    exp = {};
+  }
   // Defaults for package.json fields
   const pkgName = typeof pkg.name === 'string' ? pkg.name : path.basename(projectRoot);
   const pkgVersion = typeof pkg.version === 'string' ? pkg.version : '1.0.0';

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -1,5 +1,10 @@
 import { ExpoConfig } from '@expo/config-types';
 
+// TODO: Migrate ProjectConfig to using expo instead if exp
+export interface ExportedConfig {
+  expo: ExpoConfig;
+}
+
 export { ExpoConfig };
 export type PackageJSONConfig = { [key: string]: any };
 export type ProjectConfig = {

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -1,9 +1,6 @@
 import { ExpoConfig } from '@expo/config-types';
 
 // TODO: Migrate ProjectConfig to using expo instead if exp
-export interface ExportedConfig {
-  expo: ExpoConfig;
-}
 
 export { ExpoConfig };
 export type PackageJSONConfig = { [key: string]: any };

--- a/packages/config/src/__tests__/fixtures/behavior/dynamic-and-static/app.config.js
+++ b/packages/config/src/__tests__/fixtures/behavior/dynamic-and-static/app.config.js
@@ -1,1 +1,14 @@
-export default {};
+export default {
+  // Should be serialized
+  expo: {
+    name() {
+      return 'my-app';
+    },
+  },
+  // Shouldn't be serialized
+  other: {
+    name() {
+      return 'my-app';
+    },
+  },
+};

--- a/packages/config/src/__tests__/getConfig-test.js
+++ b/packages/config/src/__tests__/getConfig-test.js
@@ -63,6 +63,15 @@ describe('getDynamicConfig', () => {
     );
   });
 
+  it(`only serializes expo object`, async () => {
+    const { config } = await getDynamicConfig(
+      join(__dirname, 'fixtures/behavior/dynamic-and-static/app.config.js')
+    );
+    expect(config.expo.name).toBe('my-app');
+    expect(typeof config.other.name).toBe('function');
+    expect(config.other.name()).toBe('my-app');
+  });
+
   describe('process.cwd in a child process', () => {
     const originalCwd = process.cwd();
     const projectRoot = join(__dirname, 'fixtures/behavior/dynamic-cwd');

--- a/packages/config/src/evalConfig.ts
+++ b/packages/config/src/evalConfig.ts
@@ -48,5 +48,13 @@ export function evalConfig(
     throw new ConfigError(`Config file ${configFile} cannot return a Promise.`, 'INVALID_CONFIG');
   }
 
-  return { config: serializeAndEvaluate(result), exportedObjectType };
+  // If the expo object exists, only serialize that, otherwise serialize the entire object.
+  // This preserves the functions in the pack config for further evaluation.
+  if (result?.expo) {
+    result.expo = serializeAndEvaluate(result.expo);
+  } else {
+    result = serializeAndEvaluate(result);
+  }
+
+  return { config: result, exportedObjectType };
 }


### PR DESCRIPTION
- moved from https://github.com/expo/expo-cli/pull/2789
- only serialize the expo object if present, this allows for a more dynamic config to be added in `app.config.js`.