### PR TITLE
[expo-cli] Support --platform option for eas:build:init

### DIFF
--- a/packages/expo-cli/src/commands/eas-build/index.ts
+++ b/packages/expo-cli/src/commands/eas-build/index.ts
@@ -16,6 +16,11 @@ export default function (program: Command) {
     .command('eas:build:init [path]')
     .description('Initialize build configuration for the project')
     .helpGroup('eas')
+    .option(
+      '-p --platform <platform>',
+      'Platform to configure: ios, android, all',
+      /^(all|android|ios)$/i
+    )
     .option('--skip-credentials-check', 'Skip checking credentials', false)
     .asyncActionProjectDir(initAction, { checkConfig: true, skipSDKVersionRequirement: true });
 


### PR DESCRIPTION
Why
===
We want to be able to configure eas build for specific platforms incase we're not ready to configure all platforms yet.