### PR TITLE
[xdl] Rename debug to expo raw log to avoid collision

### DIFF
--- a/packages/xdl/src/Logger.ts
+++ b/packages/xdl/src/Logger.ts
@@ -18,7 +18,7 @@ const logger = bunyan.createLogger({
   name: 'expo',
   serializers: bunyan.stdSerializers,
   streams:
-    process.env.DEBUG && process.env.NODE_ENV !== 'production'
+    process.env.EXPO_RAW_LOG && process.env.NODE_ENV !== 'production'
       ? [
           {
             type: 'raw',


### PR DESCRIPTION
This environment var might collide with the [`debug()` package](https://www.npmjs.com/package/debug), if people use it. It's fairly popular so I would imagine this might be the cause of issues like #2803.

![Screenshot 2020-10-20 at 20 12 35](https://user-images.githubusercontent.com/1203991/96627050-9a0ed580-1310-11eb-9b84-568d2084c2ef.png)
