### PR TITLE
[config] EAS Build managed support

### DIFF
--- a/packages/config/src/android/EasBuild.ts
+++ b/packages/config/src/android/EasBuild.ts
@@ -1,0 +1,47 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import gradleScript from './EasBuildGradleScript';
+import * as Paths from './Paths';
+
+const APPLY_EAS_GRADLE = 'apply from: "./eas-build.gradle"';
+
+function hasApplyLine(content: string, applyLine: string): boolean {
+  return (
+    content
+      .split('\n')
+      // Check for both single and double quotes
+      .some(line => line === applyLine || line === applyLine.replace(/"/g, "'"))
+  );
+}
+
+export function getEasBuildGradlePath(projectDir: string): string {
+  return path.join(projectDir, 'android', 'app', 'eas-build.gradle');
+}
+
+export async function configureEasBuildAsync(projectRoot: string): Promise<void> {
+  const buildGradlePath = Paths.getAppBuildGradle(projectRoot);
+  const easGradlePath = getEasBuildGradlePath(projectRoot);
+
+  await fs.writeFile(easGradlePath, gradleScript);
+
+  const buildGradleContent = await fs.readFile(path.join(buildGradlePath), 'utf8');
+
+  const hasEasGradleApply = hasApplyLine(buildGradleContent, APPLY_EAS_GRADLE);
+
+  if (!hasEasGradleApply) {
+    await fs.writeFile(buildGradlePath, `${buildGradleContent.trim()}\n${APPLY_EAS_GRADLE}\n`);
+  }
+}
+
+export async function isEasBuildGradleConfiguredAsync(projectRoot: string): Promise<boolean> {
+  const buildGradlePath = Paths.getAppBuildGradle(projectRoot);
+  const easGradlePath = getEasBuildGradlePath(projectRoot);
+
+  const hasEasGradleFile = await fs.pathExists(easGradlePath);
+
+  const buildGradleContent = await fs.readFile(path.join(buildGradlePath), 'utf8');
+  const hasEasGradleApply = hasApplyLine(buildGradleContent, APPLY_EAS_GRADLE);
+
+  return hasEasGradleApply && hasEasGradleFile;
+}

--- a/packages/config/src/android/EasBuildGradleScript.ts
+++ b/packages/config/src/android/EasBuildGradleScript.ts
@@ -28,7 +28,7 @@ project.afterEvaluate {
     def credentialsJson = rootProject.file("../credentials.json");
 
     if (credentialsJson.exists()) {
-      if (config.storeFile) {
+      if (config.storeFile && System.getenv("EAS_BUILD") != "true") {
         println("Path to release keystore file is already set, ignoring 'credentials.json'")
       } else {
         try {

--- a/packages/config/src/android/index.ts
+++ b/packages/config/src/android/index.ts
@@ -1,6 +1,7 @@
 import * as AllowBackup from './AllowBackup';
 import * as Branch from './Branch';
 import * as Colors from './Colors';
+import * as EasBuild from './EasBuild';
 import * as Facebook from './Facebook';
 import * as GoogleMapsApiKey from './GoogleMapsApiKey';
 import * as GoogleMobileAds from './GoogleMobileAds';
@@ -26,6 +27,7 @@ import * as Version from './Version';
 
 export {
   AllowBackup,
+  EasBuild,
   Manifest,
   Branch,
   Colors,

--- a/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
@@ -53,7 +53,7 @@ export default async function configureAndroidProjectAsync(projectRoot: string) 
   await getOrPromptForPackage(projectRoot);
 
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
-  const username = await UserManager.getCurrentUsernameAsync();
+  const username = process.env.EAS_BUILD_USERNAME || (await UserManager.getCurrentUsernameAsync());
 
   await modifyBuildGradleAsync(projectRoot, (buildGradle: string) => {
     buildGradle = AndroidConfig.GoogleServices.setClassPath(exp, buildGradle);

--- a/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
@@ -14,7 +14,7 @@ export default async function configureIOSProjectAsync(projectRoot: string) {
   IOSConfig.BundleIdenitifer.setBundleIdentifierForPbxproj(projectRoot, bundleIdentifier);
 
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
-  const username = await UserManager.getCurrentUsernameAsync();
+  const username = process.env.EAS_BUILD_USERNAME || (await UserManager.getCurrentUsernameAsync());
 
   // Configure the Xcode project
   await modifyPbxprojAsync(projectRoot, async project => {


### PR DESCRIPTION
- [Android] move eas-build.gradle to @expo/config (will be required on turtle during managed build)
- [Android] check `EAS_BUILD` env (always override release keystore on turtle)
- [Android+iOS] override username with EAS_BUILD_USERNAME env variable