### PR TITLE
[xdl] Remove xde-recent-exps

### DIFF
--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -195,18 +195,6 @@ async function extractTemplateAppAsyncImpl(
   });
 }
 
-export async function saveRecentExpRootAsync(root: string) {
-  root = path.resolve(root);
-
-  // Write the recent Exps JSON file
-  const recentExpsJsonFile = UserSettings.recentExpsJsonFile();
-  let recentExps = await recentExpsJsonFile.readAsync();
-  // Filter out copies of this so we don't get dupes in this list
-  recentExps = recentExps.filter((dir: string) => dir !== root);
-  recentExps.unshift(root);
-  return await recentExpsJsonFile.writeAsync(recentExps.slice(0, 100));
-}
-
 export async function sendAsync(recipient: string, url_: string, allowUnauthed: boolean = true) {
   const user = await UserManager.ensureLoggedInAsync();
   const api = ApiV2.clientForUser(user);

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1705,7 +1705,6 @@ export async function startExpoServerAsync(projectRoot: string): Promise<void> {
     const port = info.port;
     ProjectUtils.logDebug(projectRoot, 'expo', `Local server listening at http://${host}:${port}`);
   });
-  await Exp.saveRecentExpRootAsync(projectRoot);
 }
 
 async function stopExpoServerAsync(projectRoot: string): Promise<void> {

--- a/packages/xdl/src/UserSettings.ts
+++ b/packages/xdl/src/UserSettings.ts
@@ -49,15 +49,6 @@ function userSettingsJsonFile(): JsonFile<UserSettingsData> {
   });
 }
 
-function recentExpsJsonFile() {
-  // TODO(ville): Add array support to JsonFile.
-  // @ts-ignore JsonFile doesn't officially support arrays, only objects
-  return new JsonFile<string[]>(path.join(dotExpoHomeDirectory(), 'xde-recent-exps.json'), {
-    jsonParseErrorDefault: [],
-    cantReadFileDefault: [],
-  });
-}
-
 var mkdirped = false;
 function dotExpoHomeDirectory() {
   let dirPath;
@@ -115,7 +106,6 @@ function accessToken(): string | null {
 
 const UserSettings = Object.assign(userSettingsJsonFile(), {
   dotExpoHomeDirectory,
-  recentExpsJsonFile,
   userSettingsFile,
   userSettingsJsonFile,
   accessToken,


### PR DESCRIPTION
We don't use this anymore. It was used by XDE. We should possibly remove the `PATH` file too - we used that with XDE.