### PR TITLE
[expo-cli] Fix eas gradle script not working when used with react-native-config

### DIFF
--- a/packages/config/src/android/EasBuildGradleScript.ts
+++ b/packages/config/src/android/EasBuildGradleScript.ts
@@ -17,18 +17,27 @@ android {
   }
 }
 
-project.afterEvaluate {
-  android.signingConfigs.release { config ->
-    def debug = gradle.startParameter.taskNames.any { it.toLowerCase().contains('debug') }
+def isEasBuildConfigured = false
 
-    if (debug) {
-      return
-    }
+tasks.whenTaskAdded {
+  def debug = gradle.startParameter.taskNames.any { it.toLowerCase().contains('debug') }
 
+  if (debug) {
+    return
+  }
+
+  // We only need to configure EAS build once
+  if (isEasBuildConfigured) {
+    return
+  }
+
+  isEasBuildConfigured = true;
+
+  android.signingConfigs.release {
     def credentialsJson = rootProject.file("../credentials.json");
 
     if (credentialsJson.exists()) {
-      if (config.storeFile && System.getenv("EAS_BUILD") != "true") {
+      if (storeFile && System.getenv("EAS_BUILD") != "true") {
         println("Path to release keystore file is already set, ignoring 'credentials.json'")
       } else {
         try {
@@ -47,14 +56,14 @@ project.afterEvaluate {
         }
       }
     } else {
-      if (config.storeFile == null) {
+      if (storeFile == null) {
         println("Couldn't find a 'credentials.json' file, skipping release keystore configuration")
       }
     }
   }
 
-  android.buildTypes.release { config ->
-    config.signingConfig android.signingConfigs.release
+  android.buildTypes.release {
+    signingConfig android.signingConfigs.release
   }
 }
 `;


### PR DESCRIPTION
Why
===
Currently, when a user has `react-native-config` configured, our configuration for signing config doesn't work. The resulting app gets signed with debug key instead of release key. I tried to debug but couldn't exactly figure out why it happens. Just adding the following in the `react-native-config`'s gradle script produces this behaviour (which shouldn't affect anything?):

```gradle
tasks.whenTaskAdded { task ->
    // Nothing here
}
```

The commit changes the logic to do the configuration on `whenTaskAdded` hook rather than on `afterEvaluate` hook which somehow fixes the issues, probably because then our logic executes before dotenv's script instead of after like previously. Though to be honest, this is result of many trial and errors.

Test plan
=========
I've tested by building the app both with and without the changes, with and without `react-native-config` and verified that the signing key is not the debug key when we're building release build. To test, I used the following command:

```sh
./gradlew assembleRelease
keytool -list -printcert -jarfile app/build/outputs/apk/release/app-release.apk
```

<img width="443" alt="Screen Shot 2020-10-27 at 08 56 26" src="https://user-images.githubusercontent.com/1174278/97272575-682ad100-1832-11eb-868d-ab841c05e56c.png">
