### PR TITLE
Remove extra config read when resolving entry point

### DIFF
--- a/packages/config/src/paths/paths.ts
+++ b/packages/config/src/paths/paths.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import { getConfig } from '../Config';
+import { ProjectConfig } from '../Config.types';
 import { resolveModule } from '../Modules';
 import { getManagedExtensions } from './extensions';
 
@@ -37,19 +38,21 @@ export function getAbsolutePathWithProjectRoot(
 export function getEntryPoint(
   projectRoot: string,
   entryFiles: string[],
-  platforms: string[]
+  platforms: string[],
+  projectConfig?: ProjectConfig
 ): string | null {
   const extensions = getManagedExtensions(platforms);
-  return getEntryPointWithExtensions(projectRoot, entryFiles, extensions);
+  return getEntryPointWithExtensions(projectRoot, entryFiles, extensions, projectConfig);
 }
 
 // Used to resolve the main entry file for a project.
 export function getEntryPointWithExtensions(
   projectRoot: string,
   entryFiles: string[],
-  extensions: string[]
+  extensions: string[],
+  projectConfig?: ProjectConfig
 ): string {
-  const { exp, pkg } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const { exp, pkg } = projectConfig ?? getConfig(projectRoot, { skipSDKVersionRequirement: true });
 
   // This will first look in the `app.json`s `expo.entryPoint` field for a potential main file.
   // We check the Expo config first in case you want your project to start differently with Expo then in a standalone environment.

--- a/packages/xdl/src/Exp.ts
+++ b/packages/xdl/src/Exp.ts
@@ -1,4 +1,4 @@
-import { BareAppConfig, ExpoConfig } from '@expo/config';
+import { BareAppConfig, ExpoConfig, ProjectConfig } from '@expo/config';
 import { getEntryPoint } from '@expo/config/paths';
 import JsonFile from '@expo/json-file';
 import fs from 'fs-extra';
@@ -21,7 +21,11 @@ type TemplateConfig = { name: string };
 const supportedPlatforms = ['ios', 'android', 'web'];
 
 /** @deprecated use getEntryPoint from @expo/config/paths */
-export function determineEntryPoint(projectRoot: string, platform?: string): string {
+export function determineEntryPoint(
+  projectRoot: string,
+  platform?: string,
+  projectConfig?: ProjectConfig
+): string {
   if (platform && !supportedPlatforms.includes(platform)) {
     throw new Error(
       `Failed to resolve the project's entry file: The platform "${platform}" is not supported.`
@@ -31,7 +35,7 @@ export function determineEntryPoint(projectRoot: string, platform?: string): str
   // const platforms = [platform, 'native'].filter(Boolean) as string[];
   const platforms: string[] = [];
 
-  const entry = getEntryPoint(projectRoot, ['./index'], platforms);
+  const entry = getEntryPoint(projectRoot, ['./index'], platforms, projectConfig);
   if (!entry)
     throw new Error(
       `The project entry file could not be resolved. Please either define it in the \`package.json\` (main), \`app.json\` (expo.entryPoint), create an \`index.js\`, or install the \`expo\` package.`


### PR DESCRIPTION
reducing the reload time for client reloads. There are still 5 reads taking place each time.