### PR TITLE
[xdl] fix: expo-notifications android standalone configuration

### DIFF
--- a/packages/xdl/src/detach/AndroidIcons.ts
+++ b/packages/xdl/src/detach/AndroidIcons.ts
@@ -233,24 +233,22 @@ async function createAndWriteIconsToPathAsync(
   }
 
   // Notification icon
-  if (notificationIconUrl) {
-    globSync('**/shell_notification_icon.png', {
-      cwd: resPath,
-      absolute: true,
-    }).forEach(filePath => {
-      fs.removeSync(filePath);
-    });
+  globSync('**/shell_notification_icon.png', {
+    cwd: resPath,
+    absolute: true,
+  }).forEach(filePath => {
+    fs.removeSync(filePath);
+  });
 
-    await _resizeIconsAsync(
-      context,
-      resPath,
-      'drawable-',
-      24,
-      'shell_notification_icon.png',
-      notificationIconUrl,
-      isDetached
-    );
-  }
+  await _resizeIconsAsync(
+    context,
+    resPath,
+    'drawable-',
+    24,
+    'shell_notification_icon.png',
+    notificationIconUrl ?? iconUrl,
+    isDetached
+  );
 }
 
 export { createAndWriteIconsToPathAsync };

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1056,6 +1056,15 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
     isRunningInUserContext
   );
 
+  // Notifications
+  if (manifest.notification.color) {
+    await regexFileAsync(
+      '"notification_icon_color">#005eff',
+      `"notification_icon_color">${manifest.notification.color}`,
+      path.join(shellPath, 'app', 'src', 'main', 'res', 'values', 'colors.xml')
+    );
+  }
+
   // Splash Background
   if (backgroundImages && backgroundImages.length > 0) {
     // Delete the placeholder images

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1057,13 +1057,11 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
   );
 
   // Notifications
-  if (manifest.notification.color) {
-    await regexFileAsync(
-      '"notification_icon_color">#005eff',
-      `"notification_icon_color">${manifest.notification.color}`,
-      path.join(shellPath, 'app', 'src', 'main', 'res', 'values', 'colors.xml')
-    );
-  }
+  await regexFileAsync(
+    '"notification_icon_color">#005eff',
+    `"notification_icon_color">${manifest.notification?.color ?? '#ffffff'}`,
+    path.join(shellPath, 'app', 'src', 'main', 'res', 'values', 'colors.xml')
+  );
 
   // Splash Background
   if (backgroundImages && backgroundImages.length > 0) {


### PR DESCRIPTION
## First and second commits

Apply changes to the `notification_icon_color`, which (paired with THIS PR will fix https://github.com/expo/expo/issues/10469). Defaults to white.

## Third commit

We currently leave the `shell_notification_icon` drawable assets unchanged unless the user specifies one. With the changes introduced in the third commit, we get rid of our Expo icon assets no matter what (no more standalone apps with Expo's notification icon 👍) _and_ we fallback to using the app icon if no `notification.icon` was provided. This isn't recommended since the notification icon really should be all white with a transparent background, but that's well documented as of https://github.com/expo/expo/pull/10828 and defaulting to something is better than nothing (worst case scenario, it will just show a blank square as the icon). 

