### PR TITLE
[configure-splash-screen] Use proper bin paths to files

### DIFF
--- a/unlinked-packages/configure-splash-screen/package.json
+++ b/unlinked-packages/configure-splash-screen/package.json
@@ -3,8 +3,8 @@
   "version": "0.3.0",
   "description": "Supplementary module for 'expo-splash-screen' providing cli configuration command",
   "bin": {
-    "configure-splash-screen": "./build/src/index-cli.js",
-    "expo-splash-screen": "./build/src/index-cli.js"
+    "configure-splash-screen": "./build/index-cli.js",
+    "expo-splash-screen": "./build/index-cli.js"
   },
   "main": "./build/index.js",
   "scripts": {


### PR DESCRIPTION
I noticed these weren't matching after I linked it with `yarn link`. Maybe we should include this folder in the `yarn workspace` so installs are easier?