### PR TITLE
[config] Force ios entitlement paths to be in posix

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -45,6 +45,7 @@
     "require-from-string": "^2.0.2",
     "resolve-from": "^5.0.0",
     "semver": "^7.1.3",
+    "slash": "^3.0.0",
     "slugify": "^1.3.4",
     "xcode": "^2.1.0",
     "xml2js": "^0.4.23"

--- a/packages/config/src/ios/Entitlements.ts
+++ b/packages/config/src/ios/Entitlements.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import slash from 'slash';
 
 import { ExpoConfig } from '../Config.types';
 import { addWarningIOS } from '../WarningAggregator';
@@ -101,13 +102,16 @@ export function getEntitlementsPath(projectRoot: string): string {
   const projectName = getProjectName(projectRoot);
   const productName = getProductName(project);
 
-  const entitlementsRelativePath = path.join(projectName, `${productName}.entitlements`);
-  const entitlementsPath = path.normalize(path.join(projectRoot, 'ios', entitlementsRelativePath));
+  // Use posix formatted path, even on Windows
+  const entitlementsRelativePath = slash(path.join(projectName, `${productName}.entitlements`));
+  const entitlementsPath = slash(
+    path.normalize(path.join(projectRoot, 'ios', entitlementsRelativePath))
+  );
 
   const pathsToDelete: string[] = [];
 
   while (paths.length) {
-    const last = path.normalize(paths.pop()!);
+    const last = slash(path.normalize(paths.pop()!));
     if (last !== entitlementsPath) {
       pathsToDelete.push(last);
     } else {


### PR DESCRIPTION
This is a fix that doesn't do a lot currently, since we disabled ejecting iOS on windows. But this, in combination [with this `xcode` fork](https://github.com/byCedric/cordova-node-xcode/tree/fix/windows-issues), actually fixes all differences in the iOS files we get from ejecting the same app on both platforms.

I'll try to push the fork to upstream, [but there isn't a lot of activity in the repo](https://github.com/apache/cordova-node-xcode/issues/116). So we probably need to fork and republish instead.

This would fix (partially, the fork changes arent in here yet) #2675 if we enable ejecting ios on windows again.