### PR TITLE
[config][cli] feat: add locales for android

### DIFF
--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -665,6 +665,16 @@ export interface Android {
    * Determines how the software keyboard will impact the layout of your application. This maps to the `android:windowSoftInputMode` property. Defaults to `resize`. Valid values: `resize`, `pan`.
    */
   softwareKeyboardLayoutMode?: 'resize' | 'pan';
+  /**
+   * Provide overrides by locale for string values
+   */
+  locales?: {
+    [k: string]:
+      | string
+      | {
+          [k: string]: any;
+        };
+  };
 }
 export interface AndroidIntentFiltersData {
   /**

--- a/packages/config/src/android/Locales.ts
+++ b/packages/config/src/android/Locales.ts
@@ -2,14 +2,14 @@ import JsonFile from '@expo/json-file';
 import { join } from 'path';
 
 import { ExpoConfig } from '../Config.types';
+import { addWarningAndroid } from '../WarningAggregator';
 import { buildResourceItem, readResourcesXMLAsync } from './Resources';
 import { getProjectStringsXMLPathAsync, setStringItem } from './Strings';
-import { addWarningAndroid } from '../WarningAggregator';
 import { writeXMLAsync } from './XML';
 
 type LocaleJson = Record<string, string>;
 type ResolvedLocalesJson = Record<string, LocaleJson>;
-type ExpoConfigLocales = NonNullable<ExpoConfig['android']['locales']>;
+type ExpoConfigLocales = NonNullable<ExpoConfig['android']>['locales'];
 
 export function getLocales(config: ExpoConfig): Record<string, string | LocaleJson> | null {
   return config.android.locales ?? null;
@@ -27,12 +27,15 @@ export async function setLocalesAsync(
   const localesMap = await getResolvedLocalesAsync(projectDirectory, locales);
 
   for (const [lang, localizationObj] of Object.entries(localesMap)) {
-    const stringsPath = await getProjectStringsXMLPathAsync(projectDirectory, { kind: `values-${lang}` });
+    const stringsPath = await getProjectStringsXMLPathAsync(projectDirectory, {
+      kind: `values-${lang}`,
+    });
+
     if (!stringsPath) {
-      throw new Error(`There was a problem setting your locale in ${stringsPath}.`);
+      throw new Error(`There was a problem setting the locale in ${stringsPath}.`);
     }
 
-    let stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
+    const stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
 
     for (const [name, value] of Object.entries(localizationObj)) {
       setStringItem([buildResourceItem({ name, value })], stringsJSON);

--- a/packages/config/src/android/Locales.ts
+++ b/packages/config/src/android/Locales.ts
@@ -12,7 +12,7 @@ type ResolvedLocalesJson = Record<string, LocaleJson>;
 type ExpoConfigLocales = NonNullable<ExpoConfig['android']>['locales'];
 
 export function getLocales(config: ExpoConfig): Record<string, string | LocaleJson> | null {
-  return config.android.locales ?? null;
+  return (config.android && config.android.locales) ?? null;
 }
 
 export async function setLocalesAsync(

--- a/packages/config/src/android/Locales.ts
+++ b/packages/config/src/android/Locales.ts
@@ -1,0 +1,76 @@
+import JsonFile from '@expo/json-file';
+import { join } from 'path';
+
+import { ExpoConfig } from '../Config.types';
+import { buildResourceItem, readResourcesXMLAsync } from './Resources';
+import { getProjectStringsXMLPathAsync, setStringItem } from './Strings';
+import { addWarningAndroid } from '../WarningAggregator';
+import { writeXMLAsync } from './XML';
+
+type LocaleJson = Record<string, string>;
+type ResolvedLocalesJson = Record<string, LocaleJson>;
+type ExpoConfigLocales = NonNullable<ExpoConfig['android']['locales']>;
+
+export function getLocales(config: ExpoConfig): Record<string, string | LocaleJson> | null {
+  return config.android.locales ?? null;
+}
+
+export async function setLocalesAsync(
+  config: ExpoConfig,
+  projectDirectory: string
+): Promise<boolean> {
+  const locales = getLocales(config);
+  if (!locales) {
+    return false;
+  }
+
+  const localesMap = await getResolvedLocalesAsync(projectDirectory, locales);
+
+  for (const [lang, localizationObj] of Object.entries(localesMap)) {
+    const stringsPath = await getProjectStringsXMLPathAsync(projectDirectory, { kind: `values-${lang}` });
+    if (!stringsPath) {
+      throw new Error(`There was a problem setting your locale in ${stringsPath}.`);
+    }
+
+    let stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
+
+    for (const [name, value] of Object.entries(localizationObj)) {
+      setStringItem([buildResourceItem({ name, value })], stringsJSON);
+    }
+
+    try {
+      await writeXMLAsync({ path: stringsPath, xml: stringsJSON });
+    } catch (e) {
+      throw new Error(`Error setting locale. Cannot write strings.xml to ${stringsPath}.`);
+    }
+  }
+
+  return true;
+}
+
+export async function getResolvedLocalesAsync(
+  projectRoot: string,
+  input: ExpoConfigLocales
+): Promise<ResolvedLocalesJson> {
+  const locales: ResolvedLocalesJson = {};
+  for (const [lang, localeJsonPath] of Object.entries(input)) {
+    if (typeof localeJsonPath === 'string') {
+      try {
+        locales[lang] = await JsonFile.readAsync(join(projectRoot, localeJsonPath));
+      } catch (e) {
+        // Add a warning when a json file cannot be parsed.
+        addWarningAndroid(
+          `locales-${lang}`,
+          `Failed to parse JSON of locale file for language: ${lang}`,
+          'https://docs.expo.io/distribution/app-stores/#localizing-your-android-app'
+        );
+      }
+    } else {
+      // In the off chance that someone defined the locales json in the config, pass it directly to the object.
+      // We do this to make the types more elegant.
+      locales[lang] = localeJsonPath;
+    }
+  }
+
+  return locales;
+}

--- a/packages/config/src/android/Resources.ts
+++ b/packages/config/src/android/Resources.ts
@@ -25,8 +25,9 @@ export type ResourceItemXML = {
 };
 /**
  * Name of the resource folder.
+ * Values after the dash are qualifiers: https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources
  */
-export type ResourceKind = 'values' | 'values-night' | 'values-v23';
+export type ResourceKind = 'values' | 'values-night' | 'values-v23' | string;
 
 const fallbackResourceString = `<?xml version="1.0" encoding="utf-8"?><resources></resources>`;
 

--- a/packages/config/src/android/__tests__/Locales-test.ts
+++ b/packages/config/src/android/__tests__/Locales-test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs-extra';
+import { vol } from 'memfs';
+
+import { getLocales, setLocalesAsync } from '../Locales';
+import { getDirFromFS } from './utils/getDirFromFS';
+
+jest.mock('fs');
+
+jest.mock('../../WarningAggregator');
+const { addWarningAndroid } = require('../../WarningAggregator');
+
+export const sampleStringsXML = `
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<resources>
+  <string name="app_name">expo &amp;bo&lt;y&gt;'</string>
+</resources>`;
+
+describe('android Locales', () => {
+  it(`returns null if no values are provided`, () => {
+    expect(getLocales({})).toBeNull();
+  });
+
+  it(`returns the android locales object`, () => {
+    expect(
+      getLocales({
+        android:  {
+          locales: [{}],
+        }
+      })
+    ).toStrictEqual([{}]);
+  });
+});
+
+describe('e2e: android locales', () => {
+  const projectRoot = '/app';
+  beforeAll(async () => {
+    const directoryJSON = {
+      'android/app/src/main/res/values/strings.xml': sampleStringsXML,
+      'lang/fr.json': JSON.stringify({
+        app_name: 'french-name',
+      }),
+    };
+    vol.fromJSON(directoryJSON, projectRoot);
+
+    await setLocalesAsync(
+      {
+        slug: 'testproject',
+        version: '1',
+        name: 'testproject',
+        platforms: ['ios', 'android'],
+        android: {
+          locales: {
+            fr: 'lang/fr.json',
+            // doesn't exist
+            xx: 'lang/xx.json',
+            // partially support inlining the JSON so our Expo Config type doesn't conflict with the resolved manifest type.
+            es: { app_name: 'spanish-name' },
+          },
+        },
+      },
+      projectRoot,
+    );
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it('writes all the language files expected', async () => {
+    const after = getDirFromFS(vol.toJSON(), projectRoot);
+    const locales = Object.keys(after).filter(value => {
+      return value.startsWith('android/app/src/main/res/values-');
+    });
+
+    expect(locales.length).toBe(2);
+    expect(after[locales[0]]).toMatchSnapshot();
+    // Test that the inlined locale is resolved.
+    expect(after[locales[1]]).toMatch(/spanish-name/);
+    // Test a warning is thrown for an invalid locale JSON file.
+    expect(addWarningAndroid).toHaveBeenCalledWith(
+      'locales-xx',
+      'Failed to parse JSON of locale file for language: xx',
+      'https://docs.expo.io/distribution/app-stores/#localizing-your-android-app'
+    );
+  });
+});

--- a/packages/config/src/android/__tests__/utils/getDirFromFS.ts
+++ b/packages/config/src/android/__tests__/utils/getDirFromFS.ts
@@ -1,0 +1,13 @@
+export function getDirFromFS(fsJSON: Record<string, string | null>, rootDir: string) {
+  return Object.entries(fsJSON)
+    .filter(([path, value]) => value !== null && path.startsWith(rootDir))
+    .reduce<Record<string, string>>(
+      (acc, [path, fileContent]) => ({
+        ...acc,
+        [path.substring(rootDir.length).startsWith('/')
+          ? path.substring(rootDir.length + 1)
+          : path.substring(rootDir.length)]: fileContent,
+      }),
+      {}
+    );
+}

--- a/packages/config/src/android/index.ts
+++ b/packages/config/src/android/index.ts
@@ -7,6 +7,7 @@ import * as GoogleMapsApiKey from './GoogleMapsApiKey';
 import * as GoogleMobileAds from './GoogleMobileAds';
 import * as GoogleServices from './GoogleServices';
 import * as Icon from './Icon';
+import * as Locales from './Locales';
 import * as IntentFilters from './IntentFilters';
 import * as Manifest from './Manifest';
 import * as Name from './Name';
@@ -36,6 +37,7 @@ export {
   GoogleMobileAds,
   GoogleServices,
   Icon,
+  Locales,
   IntentFilters,
   Name,
   NavigationBar,

--- a/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
@@ -127,6 +127,7 @@ export default async function configureAndroidProjectAsync(projectRoot: string) 
   // Modify strings.xml
   await AndroidConfig.Facebook.setFacebookAppIdString(exp, projectRoot);
   await AndroidConfig.Name.setName(exp, projectRoot);
+  await AndroidConfig.Locales.setLocalesAsync(exp, projectRoot);
 
   // add google-services.json to project
   await AndroidConfig.GoogleServices.setGoogleServicesFile(exp, projectRoot);


### PR DESCRIPTION
The locales will be written to `res/values-{lang}/strings.xml`

These are called [alternative resources](https://developer.android.com/guide/topics/resources/localization#creating-alternatives) and allow for the localization of the app name.

A more specific `locales` key was created under `android`.

```
  "expo" : {
    ...
    "android" : {
      "locales": {
        "ru": {
          "app_name": "Привет"
        }
      }
    }
  }
```