### PR TITLE
[config] Updated Android Facebook module to better accommodate plugins

### DIFF
--- a/packages/config/src/Errors.ts
+++ b/packages/config/src/Errors.ts
@@ -1,3 +1,5 @@
+import nodeAssert from 'assert';
+
 import { ConfigErrorCode } from './Config.types';
 
 /**
@@ -39,4 +41,9 @@ export function errorToJSON(error: any): any {
     name: error.name,
     stack: error.stack,
   };
+}
+
+export function assert(value: any, message?: string | Error): asserts value {
+  // TODO: Upgrade node? TypeScript isn't properly asserting values without this wrapper.
+  return nodeAssert(value, message);
 }

--- a/packages/config/src/android/Facebook.ts
+++ b/packages/config/src/android/Facebook.ts
@@ -1,18 +1,44 @@
-import { Parser } from 'xml2js';
-
 import { ExpoConfig } from '../Config.types';
+import { assert } from '../Errors';
 import {
   addMetaDataItemToMainApplication,
-  Document,
+  AndroidManifest,
   getMainApplication,
+  ManifestActivity,
+  ManifestApplication,
   removeMetaDataItemFromMainApplication,
 } from './Manifest';
-import { readResourcesXMLAsync, ResourceItemXML } from './Resources';
+import { buildResourceItem, readResourcesXMLAsync, ResourceXML } from './Resources';
 import { getProjectStringsXMLPathAsync, removeStringItem, setStringItem } from './Strings';
 import { writeXMLAsync } from './XML';
 
-const facebookSchemeActivity = (scheme: string) => `
-<activity
+function buildXMLItem({
+  head,
+  children,
+}: {
+  head: Record<string, string>;
+  children?: Record<string, string | any[]>;
+}) {
+  return { ...(children ?? {}), $: head };
+}
+
+function buildAndroidHead(head: Record<string, string>) {
+  // prefix all head keys with `android:`
+  return Object.entries(head).reduce(
+    (prev, [key, curr]) => ({ ...prev, [`android:${key}`]: curr }),
+    {}
+  );
+}
+
+function buildAndroidItem(datum: string | Record<string, any>) {
+  const item = typeof datum === 'string' ? { name: datum } : datum;
+  const head = buildAndroidHead(item);
+  return buildXMLItem({ head });
+}
+
+function getFacebookSchemeActivity(scheme: string) {
+  /**
+ <activity
     android:name="com.facebook.CustomTabActivity"
     android:exported="true">
     <intent-filter>
@@ -22,7 +48,26 @@ const facebookSchemeActivity = (scheme: string) => `
         <data android:scheme="${scheme}" />
     </intent-filter>
 </activity>
-`;
+   */
+  return buildXMLItem({
+    head: buildAndroidHead({
+      name: 'com.facebook.CustomTabActivity',
+      exported: 'true',
+    }),
+    children: {
+      'intent-filter': [
+        {
+          action: [buildAndroidItem('android.intent.action.VIEW')],
+          category: [
+            buildAndroidItem('android.intent.category.DEFAULT'),
+            buildAndroidItem('android.intent.category.BROWSABLE'),
+          ],
+          data: [buildAndroidItem({ scheme })],
+        },
+      ],
+    },
+  }) as ManifestActivity;
+}
 
 export function getFacebookScheme(config: ExpoConfig) {
   return config.facebookScheme ?? null;
@@ -47,60 +92,57 @@ export function getFacebookAdvertiserIDCollection(config: ExpoConfig) {
   return config.facebookAdvertiserIDCollectionEnabled ?? null;
 }
 
-function removeFacebookCustomTabActivities(mainApplication: any) {
-  // Remove all Facebook CustomTabActivities first
-  if ('activity' in mainApplication) {
-    mainApplication['activity'] = mainApplication['activity'].filter(
-      (activity: Record<string, any>) => {
-        return activity['$']?.['android:name'] !== 'com.facebook.CustomTabActivity';
-      }
-    );
-  }
-}
-
-async function ensureFacebookActivityAsync({
+function ensureFacebookActivity({
   mainApplication,
   scheme,
 }: {
-  mainApplication: any;
-  scheme: string;
+  mainApplication: ManifestApplication;
+  scheme: string | null;
 }) {
-  const facebookSchemeActivityXML = facebookSchemeActivity(scheme);
-  const parser = new Parser();
-  const facebookSchemeActivityJSON = (await parser.parseStringPromise(facebookSchemeActivityXML))
-    .activity;
-
-  if (!Array.isArray(mainApplication.activity)) {
+  if (Array.isArray(mainApplication.activity)) {
+    // Remove all Facebook CustomTabActivities first
+    mainApplication.activity = mainApplication.activity.filter(activity => {
+      return activity['$']?.['android:name'] !== 'com.facebook.CustomTabActivity';
+    });
+  } else {
     mainApplication.activity = [];
   }
-  mainApplication.activity.push(facebookSchemeActivityJSON);
+
+  // If a new scheme is defined, append it to the activity.
+  if (scheme) {
+    mainApplication.activity.push(getFacebookSchemeActivity(scheme));
+  }
+  return mainApplication;
 }
 
 export async function setFacebookAppIdString(config: ExpoConfig, projectDirectory: string) {
-  const appId = getFacebookAppId(config);
-
   const stringsPath = await getProjectStringsXMLPathAsync(projectDirectory);
-  if (!stringsPath) {
-    throw new Error(`There was a problem setting your Facebook App ID in ${stringsPath}.`);
-  }
+  assert(stringsPath, `There was a problem setting your Facebook App ID in "${stringsPath}"`);
 
   let stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
-  if (appId) {
-    const stringItemToAdd: ResourceItemXML[] = [{ _: appId, $: { name: 'facebook_app_id' } }];
-    stringsJSON = setStringItem(stringItemToAdd, stringsJSON);
-  } else {
-    stringsJSON = removeStringItem('facebook_app_id', stringsJSON);
-  }
+  stringsJSON = applyFacebookAppIdString(config, stringsJSON);
 
   try {
     await writeXMLAsync({ path: stringsPath, xml: stringsJSON });
-  } catch (e) {
-    throw new Error(`Error setting facebookAppId. Cannot write strings.xml to ${stringsPath}.`);
+  } catch {
+    throw new Error(`Error setting facebookAppId. Cannot write strings.xml to "${stringsPath}"`);
   }
   return true;
 }
 
-export async function setFacebookConfig(config: ExpoConfig, manifestDocument: Document) {
+function applyFacebookAppIdString(config: ExpoConfig, stringsJSON: ResourceXML) {
+  const appId = getFacebookAppId(config);
+
+  if (appId) {
+    return setStringItem(
+      [buildResourceItem({ name: 'facebook_app_id', value: appId })],
+      stringsJSON
+    );
+  }
+  return removeStringItem('facebook_app_id', stringsJSON);
+}
+
+export function setFacebookConfig(config: ExpoConfig, androidManifest: AndroidManifest) {
   const scheme = getFacebookScheme(config);
 
   const appId = getFacebookAppId(config);
@@ -109,13 +151,11 @@ export async function setFacebookConfig(config: ExpoConfig, manifestDocument: Do
   const autoLogAppEvents = getFacebookAutoLogAppEvents(config);
   const advertiserIdCollection = getFacebookAdvertiserIDCollection(config);
 
-  let mainApplication = getMainApplication(manifestDocument);
+  let mainApplication = getMainApplication(androidManifest);
 
-  removeFacebookCustomTabActivities(mainApplication);
+  assert(mainApplication != null, 'Main application is not defined in the AndroidManifest.xml');
 
-  if (scheme) {
-    await ensureFacebookActivityAsync({ scheme, mainApplication });
-  }
+  mainApplication = ensureFacebookActivity({ scheme, mainApplication });
 
   if (appId) {
     mainApplication = addMetaDataItemToMainApplication(
@@ -178,5 +218,5 @@ export async function setFacebookConfig(config: ExpoConfig, manifestDocument: Do
     );
   }
 
-  return manifestDocument;
+  return androidManifest;
 }

--- a/packages/config/src/android/Manifest.ts
+++ b/packages/config/src/android/Manifest.ts
@@ -89,7 +89,7 @@ export type ManifestUsesLibrary = {
   };
 };
 
-type ManifestApplication = {
+export type ManifestApplication = {
   $: ManifestApplicationAttributes;
   activity?: ManifestActivity[];
   service?: ManifestService[];
@@ -116,7 +116,7 @@ type ManifestUsesFeature = {
   };
 };
 
-export type Document = {
+export type AndroidManifest = {
   manifest: {
     // Probably more, but this is currently all we'd need for most cases in Expo.
     $: { 'xmlns:android': string; package?: string; [key: string]: string | undefined };
@@ -127,22 +127,24 @@ export type Document = {
   };
 };
 
+export type Document = AndroidManifest;
+
 export type InputOptions = {
   manifestPath?: string | null;
   projectRoot?: string | null;
-  manifest?: Document | null;
+  manifest?: AndroidManifest | null;
 };
 
 export async function writeAndroidManifestAsync(
   manifestPath: string,
-  manifest: Document
+  manifest: AndroidManifest
 ): Promise<void> {
   const manifestXml = XML.format(manifest);
   await fs.ensureDir(path.dirname(manifestPath));
   await fs.writeFile(manifestPath, manifestXml);
 }
 
-export async function readAndroidManifestAsync(manifestPath: string): Promise<Document> {
+export async function readAndroidManifestAsync(manifestPath: string): Promise<AndroidManifest> {
   const xml = await XML.readXMLAsync({ path: manifestPath });
   if (!isManifest(xml)) {
     throw new Error('Invalid manifest found at: ' + manifestPath);
@@ -150,12 +152,12 @@ export async function readAndroidManifestAsync(manifestPath: string): Promise<Do
   return xml;
 }
 
-function isManifest(xml: XML.XMLObject): xml is Document {
+function isManifest(xml: XML.XMLObject): xml is AndroidManifest {
   // TODO: Maybe more validation
   return !!xml.manifest;
 }
 
-export function getMainApplication(manifest: Document): ManifestApplication | null {
+export function getMainApplication(manifest: AndroidManifest): ManifestApplication | null {
   return (
     manifest?.manifest?.application?.filter(
       e => e?.['$']?.['android:name'] === '.MainApplication'
@@ -163,7 +165,7 @@ export function getMainApplication(manifest: Document): ManifestApplication | nu
   );
 }
 
-export function getMainActivity(manifest: Document): ManifestActivity | null {
+export function getMainActivity(manifest: AndroidManifest): ManifestActivity | null {
   const mainActivity = manifest?.manifest?.application?.[0]?.activity?.filter?.(
     (e: any) => e['$']['android:name'] === '.MainActivity'
   );
@@ -217,7 +219,7 @@ export function findMetaDataItem(mainApplication: any, itemName: string): number
 }
 
 export function getMainApplicationMetaDataValue(
-  androidManifest: Document,
+  androidManifest: AndroidManifest,
   name: string
 ): string | null {
   const mainApplication = getMainApplication(androidManifest);

--- a/packages/config/src/android/__tests__/Facebook-test.js
+++ b/packages/config/src/android/__tests__/Facebook-test.js
@@ -92,9 +92,9 @@ describe('Android facebook config', () => {
       facebookAutoInitEnabled: true,
       facebookAdvertiserIDCollectionEnabled: false,
     };
-    androidManifestJson = await setFacebookConfig(facebookConfig, androidManifestJson);
+    androidManifestJson = setFacebookConfig(facebookConfig, androidManifestJson);
     // Run this twice to ensure copies don't get added.
-    androidManifestJson = await setFacebookConfig(facebookConfig, androidManifestJson);
+    androidManifestJson = setFacebookConfig(facebookConfig, androidManifestJson);
 
     const mainApplication = getMainApplication(androidManifestJson);
 
@@ -145,7 +145,7 @@ describe('Android facebook config', () => {
     let androidManifestJson = await parser.parseStringPromise(filledManifest);
 
     const facebookConfig = {};
-    androidManifestJson = await setFacebookConfig(facebookConfig, androidManifestJson);
+    androidManifestJson = setFacebookConfig(facebookConfig, androidManifestJson);
 
     const mainApplication = getMainApplication(androidManifestJson);
 


### PR DESCRIPTION
- `Document` -> `AndroidManifest`
- Support a proper `assert` function
- Create a typed object instead of parsing a string (async)
- Split `applyFacebookAppIdString` out