### PR TITLE
[cli] Use exact @expo/eas-build-job version, update it, and fix related TS errors

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -67,7 +67,7 @@
     "@expo/bunyan": "3.0.2",
     "@expo/config": "3.3.12",
     "@expo/dev-tools": "0.13.56",
-    "@expo/eas-build-job": "^0.1.1",
+    "@expo/eas-build-job": "0.1.2",
     "@expo/json-file": "8.2.24",
     "@expo/package-manager": "0.0.33",
     "@expo/plist": "0.0.10",

--- a/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/AndroidBuilder.ts
@@ -1,5 +1,5 @@
 import { AndroidConfig } from '@expo/config';
-import { Android, BuildType, Job, Platform, sanitizeJob } from '@expo/eas-build-job';
+import { Android, Job, Platform, sanitizeJob, Workflow } from '@expo/eas-build-job';
 import path from 'path';
 
 import CommandError from '../../../../CommandError';
@@ -11,7 +11,6 @@ import {
   AndroidGenericBuildProfile,
   AndroidManagedBuildProfile,
   CredentialsSource,
-  Workflow,
 } from '../../../../easJson';
 import { gitAddAsync, gitRootDirectory } from '../../../../git';
 import { Builder, BuilderContext } from '../../types';
@@ -169,7 +168,7 @@ class AndroidBuilder implements Builder<Platform.Android> {
     const projectRootDirectory = path.relative(await gitRootDirectory(), process.cwd()) || '.';
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
-      type: BuildType.Generic,
+      type: Workflow.Generic,
       gradleCommand: buildProfile.gradleCommand,
       artifactPath: buildProfile.artifactPath,
       releaseChannel: buildProfile.releaseChannel,
@@ -183,9 +182,7 @@ class AndroidBuilder implements Builder<Platform.Android> {
   ): Promise<Partial<Android.ManagedJob>> {
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
-      type: BuildType.Managed,
-      packageJson: { example: 'packageJson' },
-      manifest: { example: 'manifest' },
+      type: Workflow.Managed,
     };
   }
 

--- a/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/builders/iOSBuilder.ts
@@ -1,5 +1,5 @@
 import { IOSConfig } from '@expo/config';
-import { BuildType, iOS, Job, Platform, sanitizeJob } from '@expo/eas-build-job';
+import { iOS, Job, Platform, sanitizeJob, Workflow } from '@expo/eas-build-job';
 import sortBy from 'lodash/sortBy';
 import path from 'path';
 
@@ -12,7 +12,6 @@ import {
   CredentialsSource,
   iOSGenericBuildProfile,
   iOSManagedBuildProfile,
-  Workflow,
 } from '../../../../easJson';
 import { gitRootDirectory } from '../../../../git';
 import log from '../../../../log';
@@ -194,7 +193,7 @@ class iOSBuilder implements Builder<Platform.iOS> {
     const projectRootDirectory = path.relative(await gitRootDirectory(), process.cwd()) || '.';
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
-      type: BuildType.Generic,
+      type: Workflow.Generic,
       scheme: this.scheme,
       artifactPath: buildProfile.artifactPath,
       releaseChannel: buildProfile.releaseChannel,
@@ -208,9 +207,7 @@ class iOSBuilder implements Builder<Platform.iOS> {
   ): Promise<Partial<iOS.ManagedJob>> {
     return {
       ...(await this.prepareJobCommonAsync(archiveUrl)),
-      type: BuildType.Managed,
-      packageJson: { example: 'packageJson' },
-      manifest: { example: 'manifest' },
+      type: Workflow.Managed,
     };
   }
 

--- a/packages/expo-cli/src/commands/eas-build/build/credentials.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/credentials.ts
@@ -1,6 +1,8 @@
+import { Workflow } from '@expo/eas-build-job';
+
 import CommandError from '../../../CommandError';
 import { CredentialsProvider } from '../../../credentials/provider';
-import { CredentialsSource, Workflow } from '../../../easJson';
+import { CredentialsSource } from '../../../easJson';
 import log from '../../../log';
 import prompts from '../../../prompts';
 import { platformDisplayNames } from '../constants';

--- a/packages/expo-cli/src/commands/eas-build/build/metadata.ts
+++ b/packages/expo-cli/src/commands/eas-build/build/metadata.ts
@@ -1,4 +1,6 @@
-import { CredentialsSource, Workflow } from '../../../easJson';
+import { Workflow } from '@expo/eas-build-job';
+
+import { CredentialsSource } from '../../../easJson';
 import { BuilderContext, Platform, TrackingContext } from '../types';
 
 /**

--- a/packages/expo-cli/src/easJson.ts
+++ b/packages/expo-cli/src/easJson.ts
@@ -1,18 +1,9 @@
-import { Platform } from '@expo/eas-build-job';
+import { Platform, Workflow } from '@expo/eas-build-job';
 import Joi from '@hapi/joi';
 import fs from 'fs-extra';
 import path from 'path';
 
 // TODO(wkozyra95): move it to @expo/config or to separate package
-
-// Workflow is representing different value than BuildType from @expo/eas-build-job
-// Each workflow has a set of BuildTypes available
-// - Generic workflow allows to build 'generic' and 'generic-client'
-// - Managed workflow allows to build 'managed' and 'managed-client'
-export enum Workflow {
-  Generic = 'generic',
-  Managed = 'managed',
-}
 
 export enum CredentialsSource {
   LOCAL = 'local',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,10 +1423,10 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/eas-build-job@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.1.tgz#7b71f87ac57192ba03613e18fb0fd5f639d21b6d"
-  integrity sha512-V5zrRdz6qa45Aflh84CmsEyNcNHG95O7dyzQqpzEI73phB+Jr7ffM+AP0f3+POjy6mwNXIKHgbzH8VG3excPpA==
+"@expo/eas-build-job@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-0.1.2.tgz#104b9bcb1602a23aabf893506e8e55d0dc61cd79"
+  integrity sha512-hBYVWlEWi8Iu+jWmbzKy2bMsYoWvRwY7MZ+SdKpNvAl+sMpp8rwvxRyRs7cRTa6DuiQ2sdOxqemnw9MJ6S5cRA==
   dependencies:
     "@hapi/joi" "^17.1.1"
 


### PR DESCRIPTION
@sstur pointed out that he was experiencing a new error today when running a build with EAS Build preview:

<img width="880" alt="Screen Shot 2020-11-03 at 10 38 11 AM" src="https://user-images.githubusercontent.com/90494/98026900-b1de6300-1dc0-11eb-8f02-74655aa19d6b.png">

He noticed that `BuildType` was no longer exported from `@expo/eas-build-job`, I looked into this and it seems that the reason we didn't catch this locally is that we use the semver `^` matcher for the `@expo/eas-build-job` dep in expo-cli and so unless we manually update the lockfile every time we publish a new version of it, it's possible that we won't catch errors. Users installing via npm were getting `0.1.2` and in the expo-cli repo we were getting `0.1.1`.

So, I think for now it is reasonable for us to use a fixed version of `@expo/eas-build-job` for each version of expo-cli.

@wkozyra95 - I left some comments here for your consideration, but I'm going to move ahead with deploying this to unblock people previewing EAS Build