### PR TITLE
[travelling-fastlane] Update app_produce to return App ID

### DIFF
--- a/packages/traveling-fastlane/actions/app_produce.rb
+++ b/packages/traveling-fastlane/actions/app_produce.rb
@@ -18,7 +18,7 @@ captured_stderr = with_captured_stderr{
     }
     Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, config)
     apple_id = Produce::Manager.start_producing.to_s
-    $result = JSON.generate({ result: 'success', appleId: apple_id }
+    $result = JSON.generate({ result: 'success', appleId: apple_id })
   rescue Spaceship::Client::InvalidUserCredentialsError => invalid_cred
     $result = JSON.generate({
       result: 'failure',

--- a/packages/traveling-fastlane/actions/app_produce.rb
+++ b/packages/traveling-fastlane/actions/app_produce.rb
@@ -17,8 +17,8 @@ captured_stderr = with_captured_stderr{
       language: $language,
     }
     Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, config)
-    Produce::Manager.start_producing
-    $result = JSON.generate({ result: 'success' })
+    apple_id = Produce::Manager.start_producing.to_s
+    $result = JSON.generate({ result: 'success', appleId: apple_id }
   rescue Spaceship::Client::InvalidUserCredentialsError => invalid_cred
     $result = JSON.generate({
       result: 'failure',


### PR DESCRIPTION
By default, `fastlane produce` returns newly created App _"Apple ID"_ number, which is then required for `Transporter.app`/`fastlane pilot` to upload binary to TestFlight without 2FA login.

This PR modifies `app_produce.rb` script to return then number to the caller as JSON result.

Example (using built package):

```sh
/dev/test_proj/node_modules/@expo/traveling-fastlane-darwin/dist/app_produce my.BundleName "Some ApName" my-apple-id@icloud.com English
```

Result:
```
...
[11:27:10]: Creating new app 'Some ApName' on App Store Connect
[11:27:18]: Waiting for the newly created application to be available on App Store Connect...
[11:27:34]: Ensuring version number
[11:27:34]: Successfully created new app 'Some ApName' on App Store Connect with ID 1538xxxxxx
{"result":"success","appleId":"1538xxxxxx"}
```