### PR TITLE
[xdl] fix updates ON_ERROR_RECOVERY setting for SDK 39 Android apps.

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -467,7 +467,7 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
   const splashBackgroundColor = getSplashScreenBackgroundColor(manifest);
   const updatesDisabled = manifest.updates && manifest.updates.enabled === false;
   const updatesCheckAutomaticallyDisabled =
-    manifest.updates && manifest.checkAutomatically === 'ON_ERROR_RECOVERY';
+    manifest.updates && manifest.updates.checkAutomatically === 'ON_ERROR_RECOVERY';
   const fallbackToCacheTimeout = manifest.updates && manifest.updates.fallbackToCacheTimeout;
 
   // Clean build directories


### PR DESCRIPTION
This PR fixes the updates.checkAutomatically `ON_ERROR_RECOVERY` behavior for SDK 39 standalone Android apps. Currently this setting is not applied properly.

I just found this change in my local working directory -- I think I discovered this issue (and found the fix) during QA, but managed to forget to actually push and PR the change 😮 🤦 

TODO:
- release new xdl with this change
- update xdl in turtle and redeploy Android turtle to production