### PR TITLE
Added support for a custom scheme property

### DIFF
--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -10,6 +10,7 @@ export type URLOptions = {
   android?: boolean;
   ios?: boolean;
   web?: boolean;
+  scheme?: string;
   host?: 'lan' | 'tunnel' | 'localhost';
   tunnel?: boolean;
   lan?: boolean;
@@ -18,6 +19,7 @@ export type URLOptions = {
 
 function addOptions(program: Command) {
   program
+    .option('--scheme <scheme>', 'Custom URI protocol to use with a dev client')
     .option('-a, --android', 'Opens your app in Expo client on a connected Android device')
     .option(
       '-i, --ios',
@@ -59,6 +61,13 @@ async function optsAsync(projectDir: string, options: any) {
     opts.hostType = 'lan';
   } else if (options.localhost) {
     opts.hostType = 'localhost';
+  }
+
+  if (typeof options.scheme === 'string') {
+    opts.scheme = options.scheme ?? null;
+  } else {
+    // Ensure this is reset when users don't use `--scheme`
+    opts.scheme = null;
   }
 
   await ProjectSettings.setAsync(projectDir, opts);

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 export type ProjectSettings = {
+  scheme: string | null;
   hostType: 'localhost' | 'lan' | 'tunnel';
   lanType: 'ip' | 'hostname';
   dev: boolean;
@@ -15,6 +16,7 @@ export type Settings = ProjectSettings;
 
 const projectSettingsFile = 'settings.json';
 const projectSettingsDefaults: ProjectSettings = {
+  scheme: null,
   hostType: 'lan',
   lanType: 'ip',
   dev: true,

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -203,6 +203,8 @@ export async function constructWebAppUrlAsync(
 
 function assertValidOptions(opts: Partial<URLOptions>): URLOptions {
   const schema = joi.object().keys({
+    scheme: joi.string().optional().allow(null),
+    // Replaced by `scheme`
     urlType: joi.any().valid('exp', 'http', 'redirect', 'no-protocol'),
     lanType: joi.any().valid('ip', 'hostname'),
     hostType: joi.any().valid('localhost', 'lan', 'tunnel'),
@@ -238,8 +240,11 @@ async function ensureOptionsAsync(
 
 function resolveProtocol(
   projectRoot: string,
-  { urlType }: Pick<URLOptions, 'urlType'>
+  { urlType, ...options }: Pick<URLOptions, 'urlType' | 'scheme'>
 ): string | null {
+  if (options.scheme) {
+    return options.scheme;
+  }
   if (urlType === 'http') {
     return 'http';
   } else if (urlType === 'no-protocol') {


### PR DESCRIPTION
- Running `expo start --scheme custom` presents a QR with the `custom://` protocol. Running without the `--scheme` property resets the protocol to `exp://`.

<img width="980" alt="Screen Shot 2020-11-06 at 3 37 53 PM" src="https://user-images.githubusercontent.com/9664363/98378257-11997000-2046-11eb-9597-2733c85d9e6c.png">

