### PR TITLE
[dev-client][cli] Created scheme resolver

### DIFF
--- a/packages/expo-cli/src/schemes.ts
+++ b/packages/expo-cli/src/schemes.ts
@@ -1,0 +1,64 @@
+import { AndroidConfig, IOSConfig } from '@expo/config';
+import plist from '@expo/plist';
+import * as fs from 'fs-extra';
+
+import { AbortCommandError } from './CommandError';
+import log from './log';
+
+async function getSchemesForIosAsync(projectRoot: string) {
+  try {
+    const configPath = IOSConfig.Paths.getInfoPlistPath(projectRoot);
+    const rawPlist = fs.readFileSync(configPath, 'utf8');
+    const plistObject = plist.parse(rawPlist);
+    return IOSConfig.Scheme.getSchemesFromPlist(plistObject);
+  } catch {
+    // No ios folder or some other error
+    return [];
+  }
+}
+
+async function getSchemesForAndroidAsync(projectRoot: string) {
+  try {
+    const configPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectRoot);
+    const manifest = await AndroidConfig.Manifest.readAndroidManifestAsync(configPath);
+    return await AndroidConfig.Scheme.getSchemesFromManifest(manifest);
+  } catch {
+    // No android folder or some other error
+    return [];
+  }
+}
+
+function intersecting<T>(a: T[], b: T[]): T[] {
+  const [c, d] = a.length > b.length ? [a, b] : [b, a];
+  return c.filter(value => d.includes(value));
+}
+
+export async function getDevClientSchemeAsync(projectRoot: string): Promise<string> {
+  const [ios, android] = await Promise.all([
+    getSchemesForIosAsync(projectRoot),
+    getSchemesForAndroidAsync(projectRoot),
+  ]);
+
+  const [matching] = intersecting(ios, android);
+  if (!matching) {
+    log.warn(
+      '\nDev Client: No common URI schemes could be found for the native ios and android projects, this is required for opening the project\n'
+    );
+    log(
+      `Ensure your project is ejected, then either add a common scheme with ${log.chalk.cyan(
+        'npx uri-scheme add my-scheme'
+      )} or provide a scheme with the ${log.chalk.cyan('--scheme')} flag\n`
+    );
+    log(
+      log.chalk.dim(
+        `You can see all of the existing schemes for your native projects by running ${log.chalk.cyan(
+          'npx uri-scheme list'
+        )}\n`
+      )
+    );
+
+    // No log error
+    throw new AbortCommandError();
+  }
+  return matching;
+}

--- a/packages/expo-cli/src/schemes.ts
+++ b/packages/expo-cli/src/schemes.ts
@@ -45,7 +45,7 @@ export async function getDevClientSchemeAsync(projectRoot: string): Promise<stri
       '\nDev Client: No common URI schemes could be found for the native ios and android projects, this is required for opening the project\n'
     );
     log(
-      `Ensure your project is ejected, then either add a common scheme with ${log.chalk.cyan(
+      `Add a common scheme with ${log.chalk.cyan(
         'npx uri-scheme add my-scheme'
       )} or provide a scheme with the ${log.chalk.cyan('--scheme')} flag\n`
     );

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -5,8 +5,10 @@ import qrcodeTerminal from 'qrcode-terminal';
 
 import CommandError from './CommandError';
 import log from './log';
+import { getDevClientSchemeAsync } from './schemes';
 
 export type URLOptions = {
+  devClient?: boolean;
   android?: boolean;
   ios?: boolean;
   web?: boolean;
@@ -18,6 +20,7 @@ export type URLOptions = {
 
 function addOptions(program: Command) {
   program
+    .option('--dev-client', 'Starts the bundler for use with the Expo dev client')
     .option('-a, --android', 'Opens your app in Expo client on a connected Android device')
     .option(
       '-i, --ios',
@@ -59,6 +62,11 @@ async function optsAsync(projectDir: string, options: any) {
     opts.hostType = 'lan';
   } else if (options.localhost) {
     opts.hostType = 'localhost';
+  }
+
+  if (options.devClient) {
+    const scheme = await getDevClientSchemeAsync(projectDir);
+    // TODO: Use scheme, pending https://github.com/expo/expo-cli/pull/2860
   }
 
   await ProjectSettings.setAsync(projectDir, opts);

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -67,23 +67,26 @@ async function optsAsync(projectDir: string, options: any) {
     opts.hostType = 'localhost';
   }
 
-  if (opts.devClient) {
+  // Prevent using --dev-client in a managed app.
+  if (options.devClient) {
     const target = process.env.EXPO_TARGET ?? getDefaultTarget(projectDir);
     if (target !== 'bare') {
       log.warn(
-        `${log.chalk.cyan(
+        `\nOption ${log.chalk.cyan(
           '--dev-client'
         )} can only be used in bare workflow apps. Run ${log.chalk.cyan(
           'expo eject'
-        )} and try again`
+        )} and try again\n`
       );
       throw new AbortCommandError();
     }
   }
 
   if (typeof options.scheme === 'string') {
+    // Use the custom scheme
     opts.scheme = options.scheme ?? null;
   } else if (options.devClient) {
+    // Attempt to find the scheme or warn the user how to setup a custom scheme
     opts.scheme = await getDevClientSchemeAsync(projectDir);
   } else {
     // Ensure this is reset when users don't use `--scheme` or `--dev-client`


### PR DESCRIPTION
Created `--dev-client` flag for resolving the uri-scheme automatically or warning the user how to set one up. Pending scheme PR https://github.com/expo/expo-cli/pull/2860. Kinda pending https://github.com/expo/expo-cli/pull/2859 for improved Info.plist resolving.

# States

Custom scheme

<img width="781" alt="Screen Shot 2020-11-06 at 7 13 56 PM" src="https://user-images.githubusercontent.com/9664363/98400542-79f74a00-2064-11eb-8b6e-e4d415e33838.png">

`--dev-client` in an ejected project

<img width="781" alt="Screen Shot 2020-11-06 at 7 14 35 PM" src="https://user-images.githubusercontent.com/9664363/98400563-8380b200-2064-11eb-8201-db955ef2d622.png">

`--dev-client` in a mismatched URI scheme project

<img width="781" alt="Screen Shot 2020-11-06 at 7 15 14 PM" src="https://user-images.githubusercontent.com/9664363/98400591-909da100-2064-11eb-8451-25c23e577373.png">

`--dev-client` in a managed project

<img width="781" alt="Screen Shot 2020-11-06 at 7 13 42 PM" src="https://user-images.githubusercontent.com/9664363/98400657-b62aaa80-2064-11eb-912f-7920315e68af.png">



