### PR TITLE
[config] add getPublicExpoConfig method and tests

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -15,7 +15,6 @@ import {
   Platform,
   ProjectConfig,
   ProjectTarget,
-  PublicExpoConfig,
   WriteConfigOptions,
 } from './Config.types';
 import { ConfigError } from './Errors';
@@ -75,6 +74,8 @@ export function getConfigWithMods(projectRoot: string, options?: GetConfigOption
  * If a function is exported from the `app.config.js` then a partial config will be passed as an argument.
  * The partial config is composed from any existing app.json, and certain fields from the `package.json` like name and description.
  *
+ * If options.omitPrivateExpoConfig is true, the Expo config will include only public-facing portions.
+ * The resulting config should be suitable for hosting or embedding in a publicly readable location.
  *
  * **Example**
  * ```js
@@ -109,7 +110,7 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
   );
 
   function fillAndReturnConfig(config: SplitConfigs, dynamicConfigObjectType: string | null) {
-    return {
+    const configWithDefaultValues = {
       ...ensureConfigHasDefaultValues(
         projectRoot,
         config.expo,
@@ -122,6 +123,20 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
       dynamicConfigPath: paths.dynamicConfigPath,
       staticConfigPath: paths.staticConfigPath,
     };
+
+    if (options.omitPrivateExpoConfig) {
+      if (configWithDefaultValues.exp.hooks) {
+        delete configWithDefaultValues.exp.hooks;
+      }
+      if (configWithDefaultValues.exp.ios?.config) {
+        delete configWithDefaultValues.exp.ios.config;
+      }
+      if (configWithDefaultValues.exp.android?.config) {
+        delete configWithDefaultValues.exp.android.config;
+      }
+    }
+
+    return configWithDefaultValues;
   }
 
   // Fill in the static config
@@ -148,28 +163,6 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
 
   // No app.config.js but json or no config
   return fillAndReturnConfig(staticConfig || {}, null);
-}
-
-/**
- * Evaluate and return the public-facing portions of the Expo config for a project.
- * The resulting config should be suitable for hosting or embedding in a publicly readable location.
- *
- * @param projectRoot the root folder containing all of your application code
- * @param options enforce criteria for a project config
- */
-export function getPublicExpoConfig(
-  projectRoot: string,
-  options: GetConfigOptions = {}
-): PublicExpoConfig {
-  const { exp } = getConfig(projectRoot, options);
-  delete exp.hooks;
-  if (exp.ios?.config) {
-    delete exp.ios.config;
-  }
-  if (exp.android?.config) {
-    delete exp.android.config;
-  }
-  return exp;
 }
 
 export function getPackageJson(

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -74,7 +74,7 @@ export function getConfigWithMods(projectRoot: string, options?: GetConfigOption
  * If a function is exported from the `app.config.js` then a partial config will be passed as an argument.
  * The partial config is composed from any existing app.json, and certain fields from the `package.json` like name and description.
  *
- * If options.omitPrivateExpoConfig is true, the Expo config will include only public-facing portions.
+ * If options.isPublicConfig is true, the Expo config will include only public-facing options (omitting private keys).
  * The resulting config should be suitable for hosting or embedding in a publicly readable location.
  *
  * **Example**
@@ -124,7 +124,7 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
       staticConfigPath: paths.staticConfigPath,
     };
 
-    if (options.omitPrivateExpoConfig) {
+    if (options.isPublicConfig) {
       if (configWithDefaultValues.exp.hooks) {
         delete configWithDefaultValues.exp.hooks;
       }

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -15,6 +15,7 @@ import {
   Platform,
   ProjectConfig,
   ProjectTarget,
+  PublicExpoConfig,
   WriteConfigOptions,
 } from './Config.types';
 import { ConfigError } from './Errors';
@@ -147,6 +148,28 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
 
   // No app.config.js but json or no config
   return fillAndReturnConfig(staticConfig || {}, null);
+}
+
+/**
+ * Evaluate and return the public-facing portions of the Expo config for a project.
+ * The resulting config should be suitable for hosting or embedding in a publicly readable location.
+ *
+ * @param projectRoot the root folder containing all of your application code
+ * @param options enforce criteria for a project config
+ */
+export function getPublicExpoConfig(
+  projectRoot: string,
+  options: GetConfigOptions = {}
+): PublicExpoConfig {
+  const { exp } = getConfig(projectRoot, options);
+  delete exp.hooks;
+  if (exp.ios?.config) {
+    delete exp.ios.config;
+  }
+  if (exp.android?.config) {
+    delete exp.android.config;
+  }
+  return exp;
 }
 
 export function getPackageJson(

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -137,7 +137,7 @@ export type ConfigContext = {
 };
 
 export type GetConfigOptions = {
-  omitPrivateExpoConfig?: boolean;
+  isPublicConfig?: boolean;
   skipSDKVersionRequirement?: boolean;
   strict?: boolean;
 };

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -60,6 +60,11 @@ export type HookArguments = {
   log: (msg: any) => void;
 };
 
+export type PublicExpoConfig = Omit<ExpoConfig, 'hooks' | 'ios' | 'android'> & {
+  ios?: Omit<ExpoConfig['ios'], 'config'>;
+  android?: Omit<ExpoConfig['android'], 'config'>;
+};
+
 export type ExpoAppManifest = ExpoConfig & {
   sdkVersion: string;
   bundledAssets?: string[];

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -60,11 +60,6 @@ export type HookArguments = {
   log: (msg: any) => void;
 };
 
-export type PublicExpoConfig = Omit<ExpoConfig, 'hooks' | 'ios' | 'android'> & {
-  ios?: Omit<ExpoConfig['ios'], 'config'>;
-  android?: Omit<ExpoConfig['android'], 'config'>;
-};
-
 export type ExpoAppManifest = ExpoConfig & {
   sdkVersion: string;
   bundledAssets?: string[];
@@ -142,6 +137,7 @@ export type ConfigContext = {
 };
 
 export type GetConfigOptions = {
+  omitPrivateExpoConfig?: boolean;
   skipSDKVersionRequirement?: boolean;
   strict?: boolean;
 };

--- a/packages/config/src/__tests__/Config-test.js
+++ b/packages/config/src/__tests__/Config-test.js
@@ -1,11 +1,6 @@
 import { vol } from 'memfs';
 
-import {
-  getConfig,
-  getProjectConfigDescription,
-  getPublicExpoConfig,
-  readConfigJson,
-} from '../Config';
+import { getConfig, getProjectConfigDescription, readConfigJson } from '../Config';
 
 jest.mock('fs');
 jest.mock('resolve-from');
@@ -42,7 +37,7 @@ describe(`getProjectConfigDescription`, () => {
   });
 });
 
-describe('getPublicExpoConfig', () => {
+describe('getConfig with omitPrivateExpoConfig', () => {
   const appJsonWithPrivateData = {
     name: 'testing 123',
     version: '0.1.0',
@@ -100,7 +95,7 @@ describe('getPublicExpoConfig', () => {
   afterAll(() => vol.reset());
 
   it('removes only private data from the config', () => {
-    const exp = getPublicExpoConfig('/private-data');
+    const { exp } = getConfig('/private-data', { omitPrivateExpoConfig: true });
 
     expect(exp.hooks).toBeUndefined();
 
@@ -114,7 +109,7 @@ describe('getPublicExpoConfig', () => {
   });
 
   it('does not remove properties from a config with no private data', () => {
-    const exp = getPublicExpoConfig('/no-private-data');
+    const { exp } = getConfig('/no-private-data', { omitPrivateExpoConfig: true });
     expect(exp).toMatchObject(appJsonNoPrivateData);
   });
 });

--- a/packages/config/src/__tests__/Config-test.js
+++ b/packages/config/src/__tests__/Config-test.js
@@ -37,7 +37,7 @@ describe(`getProjectConfigDescription`, () => {
   });
 });
 
-describe('getConfig with omitPrivateExpoConfig', () => {
+describe('getConfig public config', () => {
   const appJsonWithPrivateData = {
     name: 'testing 123',
     version: '0.1.0',
@@ -95,7 +95,7 @@ describe('getConfig with omitPrivateExpoConfig', () => {
   afterAll(() => vol.reset());
 
   it('removes only private data from the config', () => {
-    const { exp } = getConfig('/private-data', { omitPrivateExpoConfig: true });
+    const { exp } = getConfig('/private-data', { isPublicConfig: true });
 
     expect(exp.hooks).toBeUndefined();
 
@@ -109,7 +109,7 @@ describe('getConfig with omitPrivateExpoConfig', () => {
   });
 
   it('does not remove properties from a config with no private data', () => {
-    const { exp } = getConfig('/no-private-data', { omitPrivateExpoConfig: true });
+    const { exp } = getConfig('/no-private-data', { isPublicConfig: true });
     expect(exp).toMatchObject(appJsonNoPrivateData);
   });
 });


### PR DESCRIPTION
First piece of `Constants.manifest` support in bare workflow. Later we'll be adding a script to `expo-constants` that evaluates and generates and app config to include in bare apps for `Constants.manifest`.

This PR adds a method to `@expo/config` which that script can use to get the subset of the app config intended for public consumption (e.g. the data that would be served with the manifest from expo-cli or www).

From reading the publish code in XDL, it looks like the pieces of the app config that are deleted *for the purpose of not being visible in the public manifest* are the `hooks`, `ios.config`, and `android.config` fields. (Many other fields are changed, of course, but these seem to be the sensitive ones.) Therefore, the current implementation of this method simply deletes those fields.

Added some unit tests to ensure there are no accidental regressions here, and that other fields aren't touched.