### PR TITLE
[config][xdl] migrate project/publish to getPublicExpoConfig

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -4,14 +4,12 @@ import {
   ExpoConfig,
   getConfig,
   getDefaultTarget,
-  getPublicExpoConfig,
   Hook,
   HookArguments,
   HookType,
   PackageJSONConfig,
   Platform,
   ProjectTarget,
-  PublicExpoConfig,
   readExpRcAsync,
   resolveModule,
 } from '@expo/config';
@@ -288,7 +286,7 @@ function prepareHooks(
   hooks: ExpoConfig['hooks'],
   hookType: HookType,
   projectRoot: string,
-  exp: PublicExpoConfig
+  exp: ExpoConfig
 ) {
   const validHooks: LoadedHook[] = [];
 
@@ -777,7 +775,7 @@ async function _uploadArtifactsAsync({
   options,
   pkg,
 }: {
-  exp: PublicExpoConfig;
+  exp: ExpoConfig;
   iosBundle: string;
   androidBundle: string;
   options: PublishOptions;
@@ -813,10 +811,9 @@ async function _getPublishExpConfigAsync(
   options.releaseChannel = options.releaseChannel || 'default';
 
   // Verify that exp/app.json and package.json exist
-  const { exp: privateExp, pkg } = getConfig(projectRoot);
+  const { exp: privateExp } = getConfig(projectRoot);
   const { hooks } = privateExp;
-
-  const exp = getPublicExpoConfig(projectRoot);
+  const { exp, pkg } = getConfig(projectRoot, { isPublicConfig: true });
 
   const { sdkVersion } = exp;
 

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -417,7 +417,6 @@ export async function exportForAppHosting(
     );
   }
 
-  // Delete keys that are normally deleted in the publish process
   const validPostExportHooks: LoadedHook[] = prepareHooks(hooks, 'postExport', projectRoot, exp);
 
   // Add assetUrl to manifest

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -11,6 +11,7 @@ import {
   PackageJSONConfig,
   Platform,
   ProjectTarget,
+  PublicExpoConfig,
   readExpRcAsync,
   resolveModule,
 } from '@expo/config';
@@ -287,7 +288,7 @@ function prepareHooks(
   hooks: ExpoConfig['hooks'],
   hookType: HookType,
   projectRoot: string,
-  exp: ExpoConfig
+  exp: PublicExpoConfig
 ) {
   const validHooks: LoadedHook[] = [];
 
@@ -777,7 +778,7 @@ async function _uploadArtifactsAsync({
   options,
   pkg,
 }: {
-  exp: ExpoConfig;
+  exp: PublicExpoConfig;
   iosBundle: string;
   androidBundle: string;
   options: PublishOptions;


### PR DESCRIPTION
Follow-up to https://github.com/expo/expo-cli/pull/2863 -- not necessary for `Constants.manifest` support but just to clean up the codebase a little bit.

Since we essentially use the public expo config during `expo publish` and `expo export`, this PR makes those commands use the actual `getPublicExpoConfig` method for this rather than duplicating its logic. Hopefully this will help catch issues and keep the public config in sync between publish/export and `Constants.manifest`.

Tested this by publishing NCL (which does have private config fields) with and without this change and then diffing the resulting manifests served by www. Ensured that no fields changed other than the ones we'd expect due to the time difference between publishes. (Definitely open to suggestions for how to test this more thoroughly, also.)