### PR TITLE
[config] use config option instead of custom config method

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -62,13 +62,6 @@ function getSupportedPlatforms(
   return platforms;
 }
 
-export function getConfigWithMods(projectRoot: string, options?: GetConfigOptions): ProjectConfig {
-  const config = getConfig(projectRoot, options);
-  // @ts-ignore: Add the mods back to the object.
-  config.exp.mods = config.mods ?? null;
-  return config;
-}
-
 /**
  * Evaluate the config for an Expo project.
  * If a function is exported from the `app.config.js` then a partial config will be passed as an argument.
@@ -134,6 +127,10 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
       if (configWithDefaultValues.exp.android?.config) {
         delete configWithDefaultValues.exp.android.config;
       }
+    }
+    if (options.isModdedConfig) {
+      // @ts-ignore: Add the mods back to the object.
+      configWithDefaultValues.exp.mods = config.mods ?? null;
     }
 
     return configWithDefaultValues;

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -138,6 +138,12 @@ export type ConfigContext = {
 
 export type GetConfigOptions = {
   isPublicConfig?: boolean;
+  /**
+   * Should the config `mods` be preserved in the config? Used for compiling mods in the eject command.
+   *
+   * @default false
+   */
+  isModdedConfig?: boolean;
   skipSDKVersionRequirement?: boolean;
   strict?: boolean;
 };

--- a/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
@@ -1,4 +1,4 @@
-import { getConfigWithMods } from '@expo/config';
+import { getConfig } from '@expo/config';
 import { withExpoAndroidPlugins } from '@expo/config/build/plugins/expo-plugins';
 import { compileModsAsync } from '@expo/config/build/plugins/mod-compiler';
 import { UserManager } from '@expo/xdl';
@@ -11,7 +11,10 @@ export default async function configureAndroidProjectAsync(projectRoot: string) 
   const expoUsername =
     process.env.EAS_BUILD_USERNAME || (await UserManager.getCurrentUsernameAsync());
 
-  let { exp: config } = getConfigWithMods(projectRoot, { skipSDKVersionRequirement: true });
+  let { exp: config } = getConfig(projectRoot, {
+    skipSDKVersionRequirement: true,
+    isModdedConfig: true,
+  });
 
   // Add all built-in plugins
   config = withExpoAndroidPlugins(config, {

--- a/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
@@ -1,4 +1,4 @@
-import { getConfigWithMods } from '@expo/config';
+import { getConfig } from '@expo/config';
 import { withExpoIOSPlugins } from '@expo/config/build/plugins/expo-plugins';
 import { compileModsAsync } from '@expo/config/build/plugins/mod-compiler';
 import { UserManager } from '@expo/xdl';
@@ -11,7 +11,10 @@ export default async function configureIOSProjectAsync(projectRoot: string) {
   const expoUsername =
     process.env.EAS_BUILD_USERNAME || (await UserManager.getCurrentUsernameAsync());
 
-  let { exp: config } = getConfigWithMods(projectRoot, { skipSDKVersionRequirement: true });
+  let { exp: config } = getConfig(projectRoot, {
+    skipSDKVersionRequirement: true,
+    isModdedConfig: true,
+  });
 
   // Add all built-in plugins
   config = withExpoIOSPlugins(config, {


### PR DESCRIPTION
Delete `getConfigWithMods` in favor of a `GetConfigOptions` property. Similar to what we do with `isPublicConfig`.