### PR TITLE
[config] permissions plugins

### DIFF
--- a/packages/config/src/android/Permissions.ts
+++ b/packages/config/src/android/Permissions.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig } from '../Config.types';
+import { ConfigPlugin } from '../Plugin.types';
 import { createAndroidManifestPlugin } from '../plugins/android-plugins';
 import { AndroidManifest, ManifestUsesPermission } from './Manifest';
 
@@ -43,7 +44,17 @@ export const allPermissions = [
   'com.sonyericsson.home.permission.BROADCAST_BADGE',
 ];
 
-export const withPermissions = createAndroidManifestPlugin(setAndroidPermissions);
+export const withPermissions: ConfigPlugin<string[] | void> = (config, permissions) => {
+  if (Array.isArray(permissions)) {
+    if (!config.android) config.android = {};
+    if (!config.android.permissions) config.android.permissions = [];
+    config.android.permissions = [
+      // @ts-ignore
+      ...new Set(config.android.permissions.concat(permissions)),
+    ];
+  }
+  return createAndroidManifestPlugin(setAndroidPermissions);
+};
 
 function prefixAndroidPermissionsIfNecessary(permissions: string[]): string[] {
   return permissions.map(permission => {

--- a/packages/config/src/android/Permissions.ts
+++ b/packages/config/src/android/Permissions.ts
@@ -46,6 +46,7 @@ export const allPermissions = [
 
 export const withPermissions: ConfigPlugin<string[] | void> = (config, permissions) => {
   if (Array.isArray(permissions)) {
+    permissions = permissions.filter(Boolean);
     if (!config.android) config.android = {};
     if (!config.android.permissions) config.android.permissions = [];
     config.android.permissions = [

--- a/packages/config/src/android/Permissions.ts
+++ b/packages/config/src/android/Permissions.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '../Config.types';
 import { ConfigPlugin } from '../Plugin.types';
-import { createAndroidManifestPlugin } from '../plugins/android-plugins';
+import { withAndroidManifest } from '../plugins/android-plugins';
 import { AndroidManifest, ManifestUsesPermission } from './Manifest';
 
 const USES_PERMISSION = 'uses-permission';
@@ -54,7 +54,10 @@ export const withPermissions: ConfigPlugin<string[] | void> = (config, permissio
       ...new Set(config.android.permissions.concat(permissions)),
     ];
   }
-  return createAndroidManifestPlugin(setAndroidPermissions);
+  return withAndroidManifest(config, async config => {
+    config.modResults = await setAndroidPermissions(config, config.modResults);
+    return config;
+  });
 };
 
 function prefixAndroidPermissionsIfNecessary(permissions: string[]): string[] {

--- a/packages/config/src/ios/Permissions.ts
+++ b/packages/config/src/ios/Permissions.ts
@@ -1,0 +1,46 @@
+import { ConfigPlugin } from '../Plugin.types';
+import { withInfoPlist } from '../plugins/ios-plugins';
+import { InfoPlist } from './IosConfig.types';
+
+/**
+ * Apply permissions and their respective descriptions to the iOS Info.plist.
+ * Providing a null description will remove the permission from the Info.plist.
+ *
+ * @param config
+ * @param permissions record of strings where the key matches Info.plist permissions and the values are the permission descriptions.
+ */
+export const withPermissions: ConfigPlugin<Record<string, string | null>> = (
+  config,
+  permissions
+) => {
+  return withInfoPlist(config, async config => {
+    config.modResults = applyPermissions(permissions, config.modResults);
+    return config;
+  });
+};
+
+export function applyPermissions(
+  permissions: Record<string, string | null>,
+  infoPlist: Record<string, any>
+): InfoPlist {
+  const entries = Object.entries(permissions);
+  if (entries.length === 0) {
+    // TODO: Debug warn
+    // console.warn('[withPermissions] no permissions were provided');
+  }
+  for (const [permission, description] of entries) {
+    if (description == null) {
+      delete infoPlist[permission];
+    } else {
+      const existingPermission = infoPlist[permission];
+      if (existingPermission && existingPermission !== description) {
+        // TODO: Debug warn
+        //   console.warn(
+        //     `[withPermissionsIos][conflict] permission "${permission}" is already defined in the Info.plist with description "${existingPermission}"`
+        //   );
+      }
+      infoPlist[permission] = description;
+    }
+  }
+  return infoPlist;
+}

--- a/packages/config/src/ios/__tests__/Permissions-test.ts
+++ b/packages/config/src/ios/__tests__/Permissions-test.ts
@@ -1,0 +1,15 @@
+import { applyPermissions } from '../Permissions';
+
+describe(applyPermissions, () => {
+  it(`applies permissions`, () => {
+    expect(
+      applyPermissions(
+        { baz: 'new', foo: null, echo: 'delta' },
+        {
+          foo: 'bar',
+          baz: 'fox',
+        }
+      )
+    ).toStrictEqual({ baz: 'new', echo: 'delta' });
+  });
+});

--- a/packages/config/src/ios/index.ts
+++ b/packages/config/src/ios/index.ts
@@ -11,6 +11,7 @@ import * as Locales from './Locales';
 import * as Name from './Name';
 import * as Orientation from './Orientation';
 import * as Paths from './Paths';
+import * as Permissions from './Permissions';
 import * as ProvisioningProfile from './ProvisioningProfile';
 import * as RequiresFullScreen from './RequiresFullScreen';
 import * as Scheme from './Scheme';
@@ -41,6 +42,7 @@ export {
   Orientation,
   Paths,
   ProvisioningProfile,
+  Permissions,
   RequiresFullScreen,
   Scheme,
   Updates,


### PR DESCRIPTION
Most packages will need a generic method for adding permissions, this provides that.

Example:

```ts
const withImagePicker: ConfigPlugin<{
  photoLibraryPermission: string;
  cameraPermission: string;
  microphonePermission: string;
}> = (
  config,
  { photoLibraryPermission, cameraPermission, microphonePermission }
) => {
  return withPlugins(config, [
    (c) =>
      IOSConfig.Permissions.withPermissions(c, {
        NSPhotoLibraryUsageDescription: photoLibraryPermission,
        NSCameraUsageDescription: cameraPermission,
        NSMicrophoneUsageDescription: microphonePermission,
      }),
    (c) =>
      AndroidConfig.Permissions.withPermissions(
        c,
        [
          "android.permission.CAMERA",
          "android.permission.READ_EXTERNAL_STORAGE",
          "android.permission.WRITE_EXTERNAL_STORAGE",
          !!microphonePermission && "android.permission.RECORD_AUDIO",
        ].filter(Boolean) as string[]
      ),
  ]);
};

const withAV: ConfigPlugin<{
  microphonePermission?: string;
}> = (config, { microphonePermission }) => {
  return withPlugins(config, [
    (c) =>
      IOSConfig.Permissions.withPermissions(c, {
        NSMicrophoneUsageDescription: microphonePermission ?? null,
      }),
    (c) =>
      AndroidConfig.Permissions.withPermissions(
        c,
        [!!microphonePermission && "android.permission.RECORD_AUDIO"].filter(
          Boolean
        ) as string[]
      ),
  ]);
};
```