### PR TITLE
[expo-cli][eject] Resolve main fields to determine if an index.js should be generated

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -514,7 +514,7 @@ async function updatePackageJSONAsync({
 }
 
 export function resolveBareEntryFile(projectRoot: string, main: any) {
-  // expo app entry is disallowed for bare projects.
+  // expo app entry is not needed for bare projects.
   if (isPkgMainExpoAppEntry(main)) return null;
   // Look at the `package.json`s `main` field for the main file.
   const resolvedMainField = main ?? './index';

--- a/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
+++ b/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
@@ -1,10 +1,15 @@
+import { vol } from 'memfs';
+
 import {
-  getTargetPaths,
   hashForDependencyMap,
   isPkgMainExpoAppEntry,
+  resolveBareEntryFile,
   shouldDeleteMainField,
   stripDashes,
 } from '../Eject';
+
+jest.mock('fs');
+jest.mock('resolve-from');
 
 describe('stripDashes', () => {
   it(`removes spaces and dashes from a string`, () => {
@@ -24,24 +29,91 @@ describe('hashForDependencyMap', () => {
   });
 });
 
-describe('getTargetPaths', () => {
-  it(`should include index.js when pkg.main should be deleted`, () => {
-    expect(getTargetPaths({ main: 'node_modules/expo/AppEntry.js' }, ['ios', 'android'])).toEqual([
-      'ios',
-      'android',
-      'index.js',
-    ]);
+describe(resolveBareEntryFile, () => {
+  const projectRoot = '/alpha';
+  const projectRootBeta = '/beta';
+
+  beforeAll(() => {
+    vol.fromJSON(
+      {
+        'index.js': '',
+        'src/index.js': '',
+      },
+      projectRoot
+    );
+    vol.fromJSON(
+      {
+        'App.js': '',
+      },
+      projectRootBeta
+    );
   });
 
-  it(`should not include index.js when pkg.main is left alone`, () => {
-    expect(getTargetPaths({ main: './src/index.js' }, ['ios', 'android'])).toEqual([
-      'ios',
-      'android',
-    ]);
+  afterAll(() => {
+    vol.reset();
   });
 
-  it(`should only include paths for given platforms`, () => {
-    expect(getTargetPaths({ main: './src/index.js' }, ['ios'])).toEqual(['ios']);
+  it(`resolves null when the app entry is managed`, () => {
+    // managed entry points shouldn't even be searched in bare.
+    expect(resolveBareEntryFile('/noop', 'node_modules/expo/AppEntry.js')).toEqual(null);
+    expect(resolveBareEntryFile('/noop', 'expo/AppEntry.js')).toEqual(null);
+  });
+  it(`resolves to the provided main field`, () => {
+    expect(resolveBareEntryFile(projectRoot, './src/index')).toEqual('/alpha/src/index.js');
+    expect(resolveBareEntryFile(projectRoot, './index')).toEqual('/alpha/index.js');
+    // Test that the "node_modules" aren't searched.
+    expect(resolveBareEntryFile(projectRootBeta, 'App')).toEqual('/beta/App.js');
+  });
+  // Uses the default file if it exists and isn't defined in the package.json.
+  it(`resolves to the existing default main file when no field is defined`, () => {
+    expect(resolveBareEntryFile(projectRoot, null)).toEqual('/alpha/index.js');
+  });
+  // support crna blank template -- https://github.com/expo/expo-cli/issues/2873
+  // no package.json main, but has a file that expo managed would resolve as the entry.
+  // This tests that a valid managed entry isn't resolved in bare.
+  it(`resolves to null when the default file doesn't exist`, () => {
+    expect(resolveBareEntryFile(projectRootBeta, null)).toEqual(null);
+  });
+});
+
+describe(resolveBareEntryFile, () => {
+  const projectRoot = '/alpha';
+  const projectRootBeta = '/beta';
+
+  beforeAll(() => {
+    vol.fromJSON(
+      {
+        'index.js': '',
+        'src/index.js': '',
+      },
+      projectRoot
+    );
+    vol.fromJSON(
+      {
+        'App.ios.js': '',
+      },
+      projectRootBeta
+    );
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it(`resolves null when the app entry is managed`, () => {
+    expect(resolveBareEntryFile('/noop', 'node_modules/expo/AppEntry.js')).toEqual(null);
+    expect(resolveBareEntryFile('/noop', 'expo/AppEntry.js')).toEqual(null);
+  });
+  it(`resolves to the provided main field`, () => {
+    expect(resolveBareEntryFile(projectRoot, './src/index')).toEqual('/alpha/src/index.js');
+    expect(resolveBareEntryFile(projectRoot, './index')).toEqual('/alpha/index.js');
+    expect(resolveBareEntryFile(projectRootBeta, 'App')).toEqual('/beta/App.ios.js');
+  });
+  it(`resolves to the existing default main file when no field is defined`, () => {
+    expect(resolveBareEntryFile(projectRoot, null)).toEqual('/alpha/index.js');
+  });
+  it(`resolves to null when the default file doesn't exist`, () => {
+    expect(resolveBareEntryFile(projectRootBeta, null)).toEqual(null);
   });
 });
 


### PR DESCRIPTION
- fix https://github.com/expo/expo-cli/issues/2873
- Ensure that an `index.js` is generated in projects that don't define a main field in their `package.json` if the `./index.js` (and platform extended variations) aren't present.
- Ensure that an `index.js` is not generated if the `package.json` defines a main field that resolves to an existing file, unless that file is the expo managed workflow default (`expo/AppEntry` + variations).