### PR TITLE
[expo-cli] Use submission service by default

### DIFF
--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -47,14 +47,12 @@ export default function (program: Command) {
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: AndroidSubmitCommandOptions) => {
       // TODO: remove this once we verify `fastlane supply` works on linux / windows
-      if (!options.useSubmissionService) {
-        checkRuntimePlatform('android');
+      if (options.useSubmissionService) {
+        log.warn(
+          '\n`--use-submission-service is now the default and the flag will be deprecated in the future.`'
+        );
       }
-
-      const submissionMode = options.useSubmissionService
-        ? SubmissionMode.online
-        : SubmissionMode.offline;
-      const ctx = AndroidSubmitCommand.createContext(submissionMode, projectDir, options);
+      const ctx = AndroidSubmitCommand.createContext(SubmissionMode.online, projectDir, options);
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
     });


### PR DESCRIPTION
In order to drop Fastlane supply (Android upload) we need to switch to using the submission service by default.