### PR TITLE
[xdl]<fix>: Remove default splash screen image on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [xdl] On Android remove default template splash image when no splash image is specified in the app manifest ([#2883](https://github.com/expo/expo-cli/pull/2883))
+
 ## [Mon, 9 Nov 2020 13:44:59 -0800](https://github.com/expo/expo-cli/commit/d5b8759b32d5a7747067a969728d9ba732926824)
 
 ### 🛠 Breaking changes

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1065,18 +1065,18 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
     path.join(shellPath, 'app', 'src', 'main', 'res', 'values', 'colors.xml')
   );
 
-  // Splash Background
-  if (backgroundImages && backgroundImages.length > 0) {
-    // Delete the placeholder images
-    const splashImageFilename =
-      majorSdkVersion >= 39 ? 'splashscreen_image.png' : 'shell_launch_background_image.png';
-    globSync(`**/${splashImageFilename}'`, {
-      cwd: path.join(shellPath, 'app', 'src', 'main', 'res'),
-      absolute: true,
-    }).forEach(filePath => {
-      fs.removeSync(filePath);
-    });
+  // Delete the placeholder splash images
+  const splashImageFilename =
+    majorSdkVersion >= 39 ? 'splashscreen_image.png' : 'shell_launch_background_image.png';
+  globSync(`**/${splashImageFilename}`, {
+    cwd: path.join(shellPath, 'app', 'src', 'main', 'res'),
+    absolute: true,
+  }).forEach(filePath => {
+    fs.removeSync(filePath);
+  });
 
+  // Use the splash images provided by the user
+  if (backgroundImages && backgroundImages.length > 0) {
     await Promise.all(
       backgroundImages.map(async image => {
         if (isRunningInUserContext) {


### PR DESCRIPTION
When a user does not provide a splash image we shouldn't show any image.
Ensured the splash screen image from Expo Client is not propagated to standalones.

Resolves https://forums.expo.io/t/how-to-remove-default-expo-splash-screen/44789/2

# Test plan

I've jumped back to `sdk-39` branch, build local standalone simulator app for Android.

# TODOs

- [x] test it on staging (publish `xdl` `-rc` version on npm & update in `turtle` on staging)
- [ ] publish `xdl` with this change
- [x] ~(back-porting to SDK 39) rebuild `sdk-39` Android shell tarball using this newer xdl version~ _edit: this is not needed as `turtle` is running this piece of code_
- [ ] update `@expo/xdl` version in `turtle` and ship to production