### PR TITLE
[expo cli] delete legacy upload:android code

### DIFF
--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -45,7 +45,6 @@ export default function (program: Command) {
     .option('--verbose', 'Always print logs from Submission Service')
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: AndroidSubmitCommandOptions) => {
-      // TODO: remove this once we verify `fastlane supply` works on linux / windows
       if (options.useSubmissionService) {
         log.warn(
           '\n`--use-submission-service is now the default and the flag will be deprecated in the future.`'
@@ -110,7 +109,7 @@ export default function (program: Command) {
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: IosPlatformOptions) => {
       try {
-        // TODO: remove this once we verify `fastlane supply` works on linux / windows
+        // TODO: remove this once we remove fastlane
         checkRuntimePlatform('ios');
 
         const args = pick(options, SOURCE_OPTIONS);

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -6,7 +6,6 @@ import log from '../log';
 import IOSUploader, { IosPlatformOptions, LANGUAGES } from './upload/IOSUploader';
 import AndroidSubmitCommand from './upload/submission-service/android/AndroidSubmitCommand';
 import { AndroidSubmitCommandOptions } from './upload/submission-service/android/types';
-import { SubmissionMode } from './upload/submission-service/types';
 import * as TerminalLink from './utils/TerminalLink';
 
 const SOURCE_OPTIONS = ['id', 'latest', 'path', 'url'];
@@ -52,7 +51,7 @@ export default function (program: Command) {
           '\n`--use-submission-service is now the default and the flag will be deprecated in the future.`'
         );
       }
-      const ctx = AndroidSubmitCommand.createContext(SubmissionMode.online, projectDir, options);
+      const ctx = AndroidSubmitCommand.createContext(projectDir, options);
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
     });

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -47,14 +47,12 @@ export default function (program: Command) {
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: AndroidSubmitCommandOptions) => {
       // TODO: remove this once we verify `fastlane supply` works on linux / windows
-      if (!options.useSubmissionService) {
-        checkRuntimePlatform('android');
+      if (options.useSubmissionService) {
+        log.warn(
+          '\n`--use-submission-service is now the default and the flag will be deprecated in the future.`'
+        );
       }
-
-      const submissionMode = options.useSubmissionService
-        ? SubmissionMode.online
-        : SubmissionMode.offline;
-      const ctx = AndroidSubmitCommand.createContext(submissionMode, projectDir, options);
+      const ctx = AndroidSubmitCommand.createContext(SubmissionMode.online, projectDir, options);
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
     });

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmissionConfig.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmissionConfig.ts
@@ -5,7 +5,6 @@ export interface AndroidSubmissionConfig {
   track: ReleaseTrack;
   serviceAccount: string;
   releaseStatus?: ReleaseStatus;
-  projectId: string;
 }
 
 enum ArchiveType {

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmissionConfig.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmissionConfig.ts
@@ -5,6 +5,7 @@ export interface AndroidSubmissionConfig {
   track: ReleaseTrack;
   serviceAccount: string;
   releaseStatus?: ReleaseStatus;
+  projectId: string;
 }
 
 enum ArchiveType {

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitCommand.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitCommand.ts
@@ -10,7 +10,6 @@ import {
   ArchiveTypeSource,
   ArchiveTypeSourceType,
 } from '../archive-source';
-import { SubmissionMode } from '../types';
 import { getExpoConfig } from '../utils/config';
 import { AndroidPackageSource, AndroidPackageSourceType } from './AndroidPackageSource';
 import { ArchiveType, ReleaseStatus, ReleaseTrack } from './AndroidSubmissionConfig';
@@ -20,12 +19,10 @@ import { AndroidSubmissionContext, AndroidSubmitCommandOptions } from './types';
 
 class AndroidSubmitCommand {
   static createContext(
-    mode: SubmissionMode,
     projectDir: string,
     commandOptions: AndroidSubmitCommandOptions
   ): AndroidSubmissionContext {
     return {
-      mode,
       projectDir,
       commandOptions,
     };
@@ -34,7 +31,7 @@ class AndroidSubmitCommand {
   constructor(private ctx: AndroidSubmissionContext) {}
 
   async runAsync(): Promise<void> {
-    if (this.ctx.mode === SubmissionMode.online && !(await UserManager.getCurrentUserAsync())) {
+    if (!(await UserManager.getCurrentUserAsync())) {
       await UserManager.ensureLoggedInAsync();
       log.addNewLineIfNone();
     }

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
@@ -29,7 +29,6 @@ export interface AndroidSubmissionOptions
   androidPackageSource: AndroidPackageSource;
   archiveSource: ArchiveSource;
   serviceAccountSource: ServiceAccountSource;
-  projectId: string;
 }
 
 interface ResolvedSourceOptions {
@@ -53,11 +52,11 @@ class AndroidSubmitter {
       { ...this.options, projectId },
       resolvedSourceOptions
     );
-    const submitter = new AndroidOnlineSubmitter(
+    const onlineSubmitter = new AndroidOnlineSubmitter(
       submissionConfig,
       this.ctx.commandOptions.verbose ?? false
     );
-    await submitter.submitAsync();
+    await onlineSubmitter.submitAsync();
   }
 
   private async resolveSourceOptions(): Promise<ResolvedSourceOptions> {
@@ -72,11 +71,16 @@ class AndroidSubmitter {
   }
 }
 
+export type AndroidOnlineSubmissionConfig = AndroidSubmissionConfig & { projectId: string };
+interface AndroidOnlineSubmissionOptions extends AndroidSubmissionOptions {
+  projectId: string;
+}
+
 class AndroidOnlineSubmitter {
   static async formatSubmissionConfigAndPrintSummary(
-    options: AndroidSubmissionOptions,
+    options: AndroidOnlineSubmissionOptions,
     { archive, androidPackage, serviceAccountPath }: ResolvedSourceOptions
-  ): Promise<AndroidSubmissionConfig> {
+  ): Promise<AndroidOnlineSubmissionConfig> {
     const serviceAccount = await fs.readFile(serviceAccountPath, 'utf-8');
     const submissionConfig = {
       androidPackage,
@@ -93,7 +97,7 @@ class AndroidOnlineSubmitter {
   }
 
   constructor(
-    private submissionConfig: AndroidSubmissionConfig,
+    private submissionConfig: AndroidOnlineSubmissionConfig,
     private verbose: boolean = false
   ) {}
 

--- a/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
@@ -7,9 +7,13 @@ import { jester } from '../../../../../__tests__/user-fixtures';
 import { ensureProjectExistsAsync } from '../../../../../projects';
 import SubmissionService from '../../SubmissionService';
 import { Platform, Submission, SubmissionStatus } from '../../SubmissionService.types';
-import { ArchiveType, ReleaseStatus, ReleaseTrack } from '../AndroidSubmissionConfig';
+import {
+  AndroidSubmissionConfig,
+  ArchiveType,
+  ReleaseStatus,
+  ReleaseTrack,
+} from '../AndroidSubmissionConfig';
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
-import { AndroidOnlineSubmissionConfig } from '../AndroidSubmitter';
 import { AndroidSubmitCommandOptions } from '../types';
 
 jest.mock('fs');
@@ -94,7 +98,7 @@ describe(AndroidSubmitCommand, () => {
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
 
-      const androidSubmissionConfig: AndroidOnlineSubmissionConfig = {
+      const androidSubmissionConfig: AndroidSubmissionConfig = {
         archiveUrl: 'http://expo.io/fake.apk',
         archiveType: ArchiveType.apk,
         androidPackage: testProject.appJSON.expo.android?.package,

--- a/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
@@ -7,8 +7,6 @@ import { jester } from '../../../../../__tests__/user-fixtures';
 import { ensureProjectExistsAsync } from '../../../../../projects';
 import SubmissionService from '../../SubmissionService';
 import { Platform, Submission, SubmissionStatus } from '../../SubmissionService.types';
-import { SubmissionMode } from '../../types';
-import { runTravelingFastlaneAsync } from '../../utils/travelingFastlane';
 import { ArchiveType, ReleaseStatus, ReleaseTrack } from '../AndroidSubmissionConfig';
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
 import { AndroidOnlineSubmissionConfig } from '../AndroidSubmitter';
@@ -16,7 +14,6 @@ import { AndroidSubmitCommandOptions } from '../types';
 
 jest.mock('fs');
 jest.mock('../../SubmissionService');
-jest.mock('../../utils/travelingFastlane');
 jest.mock('../../../../../projects');
 jest.mock('@expo/image-utils', () => ({
   generateImageAsync(input, { src }) {
@@ -93,11 +90,7 @@ describe(AndroidSubmitCommand, () => {
         track: 'internal',
         releaseStatus: 'draft',
       };
-      const ctx = AndroidSubmitCommand.createContext(
-        SubmissionMode.online,
-        testProject.projectRoot,
-        options
-      );
+      const ctx = AndroidSubmitCommand.createContext(testProject.projectRoot, options);
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
 
@@ -115,41 +108,6 @@ describe(AndroidSubmitCommand, () => {
         Platform.ANDROID,
         projectId,
         androidSubmissionConfig
-      );
-    });
-  });
-
-  describe('offline mode', () => {
-    afterEach(() => {
-      (runTravelingFastlaneAsync as jest.Mock).mockClear();
-    });
-
-    it('executes supply_android from traveling-fastlane', async () => {
-      const options: AndroidSubmitCommandOptions = {
-        path: '/apks/fake.apk',
-        type: 'apk',
-        key: '/google-service-account.json',
-        track: 'internal',
-        releaseStatus: 'draft',
-      };
-      const ctx = AndroidSubmitCommand.createContext(
-        SubmissionMode.offline,
-        testProject.projectRoot,
-        options
-      );
-      const command = new AndroidSubmitCommand(ctx);
-      await command.runAsync();
-
-      expect(runTravelingFastlaneAsync).toHaveBeenCalledWith(
-        expect.stringMatching(/supply_android$/),
-        [
-          '/apks/fake.apk',
-          testProject.appJSON.expo.android?.package,
-          '/google-service-account.json',
-          'internal',
-          'apk',
-          'draft',
-        ]
       );
     });
   });

--- a/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
@@ -7,13 +7,9 @@ import { jester } from '../../../../../__tests__/user-fixtures';
 import { ensureProjectExistsAsync } from '../../../../../projects';
 import SubmissionService from '../../SubmissionService';
 import { Platform, Submission, SubmissionStatus } from '../../SubmissionService.types';
-import {
-  AndroidSubmissionConfig,
-  ArchiveType,
-  ReleaseStatus,
-  ReleaseTrack,
-} from '../AndroidSubmissionConfig';
+import { ArchiveType, ReleaseStatus, ReleaseTrack } from '../AndroidSubmissionConfig';
 import AndroidSubmitCommand from '../AndroidSubmitCommand';
+import { AndroidOnlineSubmissionConfig } from '../AndroidSubmitter';
 import { AndroidSubmitCommandOptions } from '../types';
 
 jest.mock('fs');
@@ -98,7 +94,7 @@ describe(AndroidSubmitCommand, () => {
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
 
-      const androidSubmissionConfig: AndroidSubmissionConfig = {
+      const androidSubmissionConfig: AndroidOnlineSubmissionConfig = {
         archiveUrl: 'http://expo.io/fake.apk',
         archiveType: ArchiveType.apk,
         androidPackage: testProject.appJSON.expo.android?.package,

--- a/packages/expo-cli/src/commands/upload/submission-service/archive-source/index.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/archive-source/index.ts
@@ -1,5 +1,4 @@
 import { ArchiveType } from '../android/AndroidSubmissionConfig';
-import { SubmissionMode } from '../types';
 import {
   ArchiveFileSource,
   ArchiveFileSourceType,
@@ -17,8 +16,8 @@ export interface Archive {
   type: ArchiveType;
 }
 
-async function getArchiveAsync(mode: SubmissionMode, source: ArchiveSource): Promise<Archive> {
-  const location = await getArchiveFileLocationAsync(mode, source.archiveFile);
+async function getArchiveAsync(source: ArchiveSource): Promise<Archive> {
+  const location = await getArchiveFileLocationAsync(source.archiveFile);
   const type = await getArchiveTypeAsync(source.archiveType, location);
   return {
     location,

--- a/packages/expo-cli/src/commands/upload/submission-service/types.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/types.ts
@@ -1,7 +1,6 @@
 export interface SubmissionContext<T extends SubmitCommandOptions> {
   projectDir: string;
   commandOptions: T;
-  mode: SubmissionMode;
 }
 
 export interface SubmitCommandOptions {
@@ -12,10 +11,3 @@ export interface SubmitCommandOptions {
   verbose?: boolean;
   useSubmissionService?: boolean;
 }
-
-enum SubmissionMode {
-  online = 'online',
-  offline = 'offline',
-}
-
-export { SubmissionMode };


### PR DESCRIPTION
Follow up to https://github.com/expo/expo-cli/pull/2876

- Remove "offline" uploader. For future readers, this was not an "offline" method for uploading files to the internet as that would be impossible. 
- Removes the need for fastlane supply running locally on the users computer.