### PR TITLE
[cli][upgrade] support projects without a config

### DIFF
--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -514,7 +514,9 @@ export async function upgradeAsync(
   }
 
   // Evaluate project config (app.config.js)
-  const { exp: currentExp, dynamicConfigPath } = ConfigUtils.getConfig(projectRoot);
+  const { exp: currentExp, dynamicConfigPath, staticConfigPath } = ConfigUtils.getConfig(
+    projectRoot
+  );
 
   const removingSdkVersionStep = logNewSection('Validating configuration.');
   if (dynamicConfigPath) {
@@ -529,7 +531,7 @@ export async function upgradeAsync(
     } else {
       removingSdkVersionStep.succeed('Validated configuration.');
     }
-  } else {
+  } else if (staticConfigPath) {
     try {
       const { rootConfig } = await ConfigUtils.readConfigJsonAsync(projectRoot);
       if (rootConfig.expo.sdkVersion && rootConfig.expo.sdkVersion !== 'UNVERSIONED') {
@@ -539,9 +541,12 @@ export async function upgradeAsync(
       } else {
         removingSdkVersionStep.succeed('Validated configuration.');
       }
-    } catch (_) {
+    } catch {
       removingSdkVersionStep.fail('Unable to validate configuration.');
     }
+  } else {
+    // No config present, nothing to change
+    removingSdkVersionStep.succeed('Validated configuration.');
   }
 
   await makeBreakingChangesToConfigAsync(projectRoot, targetSdkVersionString);

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -169,9 +169,12 @@ async function makeBreakingChangesToConfigAsync(
     'Updating your app.json to account for breaking changes (if applicable)...'
   );
 
-  const { exp: currentExp, dynamicConfigPath } = ConfigUtils.getConfig(projectRoot, {
-    skipSDKVersionRequirement: true,
-  });
+  const { exp: currentExp, dynamicConfigPath, staticConfigPath } = ConfigUtils.getConfig(
+    projectRoot,
+    {
+      skipSDKVersionRequirement: true,
+    }
+  );
 
   // Bail out early if we have a dynamic config!
   if (dynamicConfigPath) {
@@ -183,6 +186,11 @@ async function makeBreakingChangesToConfigAsync(
     } else {
       step.succeed('No additional changes necessary to app config.');
     }
+    return;
+  } else if (!staticConfigPath) {
+    // No config in the project, modifications don't need to be made.
+    // NOTICE: If we ever need to just simply add a value to the config for no reason, this check would break that.
+    step.succeed('No config present, skipping updates.');
     return;
   }
 


### PR DESCRIPTION
- fix https://github.com/expo/expo-cli/issues/2685 -- this will make upgrading expo/examples much easier.
- bit of an aha moment, projects without configs don't need any kind of upgrading, so certain steps can just be skipped.
- tested by running `expo upgrade` in `examples/with-facebook-auth`