### PR TITLE
[expo cli] mostly remove inquirer

### DIFF
--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -4,7 +4,7 @@ import wordwrap from 'wordwrap';
 
 import { learnMore } from '../commands/utils/TerminalLink';
 import log from '../log';
-import prompt from '../prompt';
+import prompt from '../prompts';
 import { nonEmptyInput } from '../validators';
 import { runAction, travelingFastlane } from './fastlane';
 import * as Keychain from './keychain';
@@ -133,12 +133,12 @@ async function _promptForAppleId({
 
   const { appleId: promptAppleId } = await prompt(
     {
-      type: 'input',
+      type: 'text',
       name: 'appleId',
       message: `Apple ID:`,
       validate: nonEmptyInput,
-      default: lastAppleId ?? undefined,
-      ...(previousAppleId && { default: previousAppleId }),
+      initial: lastAppleId ?? undefined,
+      ...(previousAppleId && { initial: previousAppleId }),
     },
     {
       nonInteractiveHelp: 'Pass your Apple ID using the --apple-id flag.',
@@ -205,7 +205,7 @@ async function _chooseTeam(teams: FastlaneTeam[], userProvidedTeamId?: string): 
   } else {
     log(`You have ${teams.length} teams associated with your account`);
     const choices = teams.map((team, i) => ({
-      name: `${i + 1}) ${team.teamId} "${team.name}" (${team.type})`,
+      title: `${i + 1}) ${team.teamId} "${team.name}" (${team.type})`,
       value: team,
     }));
     const { team } = await prompt(

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -210,7 +210,7 @@ async function _chooseTeam(teams: FastlaneTeam[], userProvidedTeamId?: string): 
     }));
     const { team } = await prompt(
       {
-        type: 'list',
+        type: 'select',
         name: 'team',
         message: 'Which team would you like to use?',
         choices,

--- a/packages/expo-cli/src/askUser.ts
+++ b/packages/expo-cli/src/askUser.ts
@@ -1,7 +1,7 @@
 import { UserSettings } from '@expo/xdl';
 
 import log from './log';
-import prompt from './prompt';
+import prompt from './prompts';
 
 async function askForSendToAsync(): Promise<string> {
   const cachedValue = await UserSettings.getAsync('sendTo', null);
@@ -9,10 +9,10 @@ async function askForSendToAsync(): Promise<string> {
   const answers = await prompt(
     [
       {
-        type: 'input',
+        type: 'text',
         name: 'sendTo',
         message: `Your email address ${cachedValue ? ' (space to not send anything)' : ''}:`,
-        default: cachedValue ?? undefined,
+        initial: cachedValue ?? undefined,
       },
     ],
     { nonInteractiveHelp: 'Please specify email address with --send-to.' }

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -18,8 +18,7 @@ import { CreateOrReuseProvisioningProfileAdhoc } from '../../credentials/views/I
 import { SetupIosDist } from '../../credentials/views/SetupIosDist';
 import { SetupIosPush } from '../../credentials/views/SetupIosPush';
 import log from '../../log';
-import prompt from '../../prompt';
-import { confirmAsync } from '../../prompts';
+import prompt, { confirmAsync } from '../../prompts';
 import urlOpts from '../../urlOpts';
 import * as ClientUpgradeUtils from '../utils/ClientUpgradeUtils';
 import { createClientBuildRequest, getExperienceName, isAllowedToBuild } from './clientBuildApi';
@@ -211,10 +210,11 @@ export default function (program: Command) {
           email = user.email;
         } else {
           ({ email } = await prompt({
+            type: 'text',
             name: 'email',
             message: 'Please enter an email address to notify, when the build is completed:',
-            default: context?.user?.email,
-            filter: value => value.trim(),
+            initial: context?.user?.email,
+            format: value => value.trim(),
             validate: (value: string) =>
               /.+@.+/.test(value) ? true : "That doesn't look like a valid email.",
           }));

--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -3,8 +3,7 @@ import { UserManager } from '@expo/xdl';
 import got from 'got';
 
 import log from '../../log';
-import prompt from '../../prompt';
-import { confirmAsync } from '../../prompts';
+import prompt, { confirmAsync } from '../../prompts';
 import { learnMore } from '../utils/TerminalLink';
 import { isUrlAvailableAsync } from '../utils/url';
 
@@ -133,15 +132,14 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
   // prompt a better error message, recommend a default value, and help the user
   // validate their custom bundle ID upfront.
   const { bundleIdentifier } = await prompt(
-    [
-      {
-        name: 'bundleIdentifier',
-        default: recommendedBundleId,
-        // The Apple helps people know this isn't an EAS feature.
-        message: `What would you like your iOS bundle identifier to be?`,
-        validate: validateBundleId,
-      },
-    ],
+    {
+      type: 'text',
+      name: 'bundleIdentifier',
+      initial: recommendedBundleId,
+      // The Apple helps people know this isn't an EAS feature.
+      message: `What would you like your iOS bundle identifier to be?`,
+      validate: validateBundleId,
+    },
     {
       nonInteractiveHelp: noBundleIdMessage,
     }
@@ -220,14 +218,13 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
   // prompt a better error message, recommend a default value, and help the user
   // validate their custom android package upfront.
   const { packageName } = await prompt(
-    [
-      {
-        name: 'packageName',
-        default: recommendedPackage,
-        message: `What would you like your Android package name to be?`,
-        validate: validatePackage,
-      },
-    ],
+    {
+      type: 'text',
+      name: 'packageName',
+      initial: recommendedPackage,
+      message: `What would you like your Android package name to be?`,
+      validate: validatePackage,
+    },
     {
       nonInteractiveHelp: noPackageMessage,
     }

--- a/packages/expo-cli/src/commands/upload/IOSUploader.ts
+++ b/packages/expo-cli/src/commands/upload/IOSUploader.ts
@@ -7,7 +7,7 @@ import CommandError from '../../CommandError';
 import { authenticate, requestAppleIdCreds } from '../../appleApi';
 import { Context } from '../../credentials/context';
 import log from '../../log';
-import prompt, { Question } from '../../prompt';
+import prompt, { Question } from '../../prompts';
 import BaseUploader, { PlatformOptions } from './BaseUploader';
 import { runFastlaneAsync } from './utils';
 
@@ -15,7 +15,7 @@ const PLATFORM = 'ios';
 
 const APP_NAME_TOO_LONG_MSG = `An app name can't be longer than 30 characters.`;
 const APP_NAME_QUESTION: Question = {
-  type: 'input',
+  type: 'text',
   name: 'appName',
   message: 'How would you like to name your app?',
   validate(appName: string): string | true {

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidPackageSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidPackageSource.ts
@@ -1,4 +1,5 @@
-import prompt from '../../../../prompt';
+import prompt from '../../../../prompts';
+import { nonEmptyInput } from '../../../../validators';
 
 enum AndroidPackageSourceType {
   userDefined,
@@ -27,8 +28,8 @@ async function getAndroidPackageAsync(source: AndroidPackageSource) {
     const { androidPackage } = await prompt({
       name: 'androidPackage',
       message: 'Android package name:',
-      type: 'input',
-      validate: (val: string): boolean => val !== '',
+      type: 'text',
+      validate: nonEmptyInput,
     });
     return androidPackage;
   } else {

--- a/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
@@ -1,5 +1,5 @@
 import log from '../../../../log';
-import prompt from '../../../../prompt';
+import prompt from '../../../../prompts';
 import { existingFile } from '../../../../validators';
 import { learnMore } from '../../../utils/TerminalLink';
 
@@ -62,8 +62,8 @@ async function askForServiceAccountPathAsync(): Promise<string> {
   const { filePath } = await prompt({
     name: 'filePath',
     message: 'Path to Google Service Account file:',
-    default: 'api-0000000000000000000-111111-aaaaaabbbbbb.json',
-    type: 'input',
+    initial: 'api-0000000000000000000-111111-aaaaaabbbbbb.json',
+    type: 'text',
     validate: async (path: string): Promise<boolean | string> => {
       if (!(await existingFile(path, false))) {
         return `File ${path} doesn't exist.`;

--- a/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/ServiceAccountSource-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/ServiceAccountSource-test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 
-import prompt from '../../../../../prompt';
+import prompt from '../../../../../prompts';
 import {
   getServiceAccountAsync,
   ServiceAccountSource,
@@ -8,7 +8,7 @@ import {
 } from '../ServiceAccountSource';
 
 jest.mock('fs');
-jest.mock('../../../../../prompt');
+jest.mock('../../../../../prompts');
 
 describe(getServiceAccountAsync, () => {
   beforeAll(() => {

--- a/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveFileSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveFileSource.ts
@@ -3,7 +3,7 @@ import { StandaloneBuild } from '@expo/xdl';
 import validator from 'validator';
 
 import log from '../../../../log';
-import prompt from '../../../../prompt';
+import prompt from '../../../../prompts';
 import { existingFile } from '../../../../validators';
 import { getAppConfig } from '../utils/config';
 import {
@@ -170,20 +170,20 @@ async function handleBuildIdSourceAsync(source: ArchiveFileBuildIdSource): Promi
 async function handlePromptSourceAsync(source: ArchiveFilePromptSource): Promise<string> {
   const { sourceType: sourceTypeRaw } = await prompt({
     name: 'sourceType',
-    type: 'list',
+    type: 'select',
     message: 'What would you like to submit?',
     choices: [
-      { name: 'I have a url to the app archive', value: ArchiveFileSourceType.url },
+      { title: 'I have a url to the app archive', value: ArchiveFileSourceType.url },
       {
-        name: "I'd like to upload the app archive from my computer",
+        title: "I'd like to upload the app archive from my computer",
         value: ArchiveFileSourceType.path,
       },
       {
-        name: 'The latest build from Expo servers',
+        title: 'The latest build from Expo servers',
         value: ArchiveFileSourceType.latest,
       },
       {
-        name: 'A build identified by a build id',
+        title: 'A build identified by a build id',
         value: ArchiveFileSourceType.buildId,
       },
     ],
@@ -234,8 +234,8 @@ async function askForArchiveUrlAsync(): Promise<string> {
   const { url } = await prompt({
     name: 'url',
     message: 'URL:',
-    default: defaultArchiveUrl,
-    type: 'input',
+    initial: defaultArchiveUrl,
+    type: 'text',
     validate: (url: string): string | boolean => {
       if (url === defaultArchiveUrl) {
         return 'That was just an example URL, meant to show you the format that we expect for the response.';
@@ -254,8 +254,8 @@ async function askForArchivePathAsync(): Promise<string> {
   const { path } = await prompt({
     name: 'path',
     message: 'Path to the app archive file (aab or apk):',
-    default: defaultArchivePath,
-    type: 'input',
+    initial: defaultArchivePath,
+    type: 'text',
     validate: async (path: string): Promise<boolean | string> => {
       if (path === defaultArchivePath) {
         return 'That was just an example path, meant to show you the format that we expect for the response.';
@@ -273,7 +273,7 @@ async function askForBuildIdAsync(): Promise<string> {
   const { id } = await prompt({
     name: 'id',
     message: 'Build ID:',
-    type: 'input',
+    type: 'text',
     validate: (val: string): string | boolean => {
       if (!validator.isUUID(val)) {
         return `${val} is not a valid id`;

--- a/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveTypeSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveTypeSource.ts
@@ -1,5 +1,5 @@
 import log from '../../../../log';
-import prompt from '../../../../prompt';
+import prompt from '../../../../prompts';
 import { ArchiveType } from '../android/AndroidSubmissionConfig';
 
 enum ArchiveTypeSourceType {
@@ -83,11 +83,11 @@ async function handlePromptSourceAsync(
   const inferredArchiveType = inferArchiveTypeFromLocation(location);
   const { archiveType: archiveTypeRaw } = await prompt({
     name: 'archiveType',
-    type: 'list',
+    type: 'select',
     message: "What's the archive type?",
     choices: [
-      { name: 'APK', value: ArchiveType.apk },
-      { name: 'AAB', value: ArchiveType.aab },
+      { title: 'APK', value: ArchiveType.apk },
+      { title: 'AAB', value: ArchiveType.aab },
     ],
     ...(inferredArchiveType && { default: inferredArchiveType }),
   });

--- a/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
+++ b/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
@@ -2,7 +2,7 @@ import * as ConfigUtils from '@expo/config';
 import { Versions } from '@expo/xdl';
 import chalk from 'chalk';
 
-import prompt from '../../prompt';
+import prompt from '../../prompts';
 import { findProjectRootAsync } from './ProjectUtils';
 
 export async function getExpoSdkConfig(path: string) {
@@ -89,10 +89,9 @@ interface InstallClientOptions {
 
 export async function askClientToInstall(options: InstallClientOptions): Promise<AvailableClient> {
   const answer = await prompt({
-    type: 'list',
+    type: 'select',
     name: 'targetClient',
     message: 'Choose an SDK version to install the client for:',
-    pageSize: 20,
     choices: options.clients.map(client => {
       const clientVersion = `- client ${client.clientVersion || 'version unknown'}`;
       const clientLabels = [
@@ -106,7 +105,7 @@ export async function askClientToInstall(options: InstallClientOptions): Promise
 
       return {
         value: client,
-        name: `${chalk.bold(client.sdkVersionString)} ${chalk.gray(clientMessage)}`,
+        title: `${chalk.bold(client.sdkVersionString)} ${chalk.gray(clientMessage)}`,
       };
     }),
   });

--- a/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
+++ b/packages/expo-cli/src/commands/utils/ClientUpgradeUtils.ts
@@ -92,6 +92,7 @@ export async function askClientToInstall(options: InstallClientOptions): Promise
     type: 'select',
     name: 'targetClient',
     message: 'Choose an SDK version to install the client for:',
+    optionsPerPage: 20,
     choices: options.clients.map(client => {
       const clientVersion = `- client ${client.clientVersion || 'version unknown'}`;
       const clientLabels = [

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -1,7 +1,7 @@
 import isEmpty from 'lodash/isEmpty';
 
 import log from '../../log';
-import prompt from '../../prompt';
+import prompt from '../../prompts';
 import { displayAndroidAppCredentials } from '../actions/list';
 import { Context, IView } from '../context';
 import { DownloadKeystore, RemoveKeystore, UpdateKeystore } from './AndroidKeystore';
@@ -21,25 +21,23 @@ class ExperienceView implements IView {
       log.newLine();
     }
 
-    const { action } = await prompt([
-      {
-        type: 'list',
-        name: 'action',
-        message: 'What do you want to do?',
-        choices: [
-          { value: 'update-keystore', name: 'Update upload Keystore' },
-          { value: 'remove-keystore', name: 'Remove keystore' },
-          { value: 'update-fcm-key', name: 'Update FCM Api Key' },
-          { value: 'fetch-keystore', name: 'Download Keystore from the Expo servers' },
-          // { value: 'fetch-public-cert', name: 'Extract public cert from Keystore' },
-          // {
-          //   value: 'fetch-private-signing-key',
-          //   name:
-          //     'Extract private signing key (required when migration to App Signing by Google Play)',
-          // },
-        ],
-      },
-    ]);
+    const { action } = await prompt({
+      type: 'select',
+      name: 'action',
+      message: 'What do you want to do?',
+      choices: [
+        { value: 'update-keystore', title: 'Update upload Keystore' },
+        { value: 'remove-keystore', title: 'Remove keystore' },
+        { value: 'update-fcm-key', title: 'Update FCM Api Key' },
+        { value: 'fetch-keystore', title: 'Download Keystore from the Expo servers' },
+        // { value: 'fetch-public-cert', title: 'Extract public cert from Keystore' },
+        // {
+        //   value: 'fetch-private-signing-key',
+        //   title:
+        //     'Extract private signing key (required when migration to App Signing by Google Play)',
+        // },
+      ],
+    });
 
     return this.handleAction(ctx, action);
   }

--- a/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
@@ -20,7 +20,7 @@ export class UpdateFcmKey implements IView {
       type: 'text',
       name: 'fcmApiKey',
       message: 'FCM Api Key',
-      validate: value => value.length > 0 || "FCM Api Key can't be empty",
+      validate: (value: string) => value.length > 0 || "FCM Api Key can't be empty",
     });
 
     await ctx.android.updateFcmKey(this.experienceName, fcmApiKey);

--- a/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import CommandError from '../../CommandError';
 import log from '../../log';
-import prompt from '../../prompt';
+import prompt from '../../prompts';
 import { Context, IView } from '../context';
 
 export class UpdateFcmKey implements IView {
@@ -16,14 +16,12 @@ export class UpdateFcmKey implements IView {
       );
     }
 
-    const { fcmApiKey } = await prompt([
-      {
-        type: 'input',
-        name: 'fcmApiKey',
-        message: 'FCM Api Key',
-        validate: value => value.length > 0 || "FCM Api Key can't be empty",
-      },
-    ]);
+    const { fcmApiKey } = await prompt({
+      type: 'text',
+      name: 'fcmApiKey',
+      message: 'FCM Api Key',
+      validate: value => value.length > 0 || "FCM Api Key can't be empty",
+    });
 
     await ctx.android.updateFcmKey(this.experienceName, fcmApiKey);
     log(chalk.green('Updated successfully'));

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -269,6 +269,7 @@ export class CreateOrReuseDistributionCert implements IView {
       name: 'action',
       message: 'Select an iOS distribution certificate to use for code signing:',
       choices,
+      optionsPerPage: 20,
     };
 
     const { action } = await prompt(question);
@@ -461,6 +462,7 @@ async function generateDistCert(ctx: Context, accountName: string): Promise<Dist
           type: 'multiselect',
           name: 'revoke',
           message: 'Select certificates to revoke.',
+          optionsPerPage: 20,
           choices: certs.map((cert, index) => ({
             value: index,
             title: formatDistCertFromApple(cert, credentials),

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -8,8 +8,7 @@ import terminalLink from 'terminal-link';
 import CommandError from '../../CommandError';
 import { DistCert, DistCertInfo, DistCertManager, isDistCert } from '../../appleApi';
 import log from '../../log';
-import prompt, { Question } from '../../prompt';
-import { confirmAsync } from '../../prompts';
+import prompt, { confirmAsync, Question } from '../../prompts';
 import { displayIosUserCredentials } from '../actions/list';
 import { askForUserProvided, CredentialSchema } from '../actions/promptForCredentials';
 import { AppLookupParams, getAppLookupParams } from '../api/IosApi';
@@ -259,18 +258,17 @@ export class CreateOrReuseDistributionCert implements IView {
   async _createOrReuse(ctx: Context): Promise<IView | null> {
     const choices = [
       {
-        name: '[Choose existing certificate] (Recommended)',
+        title: '[Choose existing certificate] (Recommended)',
         value: 'CHOOSE_EXISTING',
       },
-      { name: '[Add a new certificate]', value: 'GENERATE' },
+      { title: '[Add a new certificate]', value: 'GENERATE' },
     ];
 
     const question: Question = {
-      type: 'list',
+      type: 'select',
       name: 'action',
       message: 'Select an iOS distribution certificate to use for code signing:',
       choices,
-      pageSize: Infinity,
     };
 
     const { action } = await prompt(question);
@@ -344,11 +342,11 @@ async function selectDistCertFromList(
   }
 
   const question: Question = {
-    type: 'list',
+    type: 'select',
     name: 'credentialsIndex',
     message: 'Select certificate from the list.',
     choices: distCerts.map((entry, index) => ({
-      name: formatDistCert(entry, iosCredentials, getValidityStatus(entry, validDistCerts)),
+      title: formatDistCert(entry, iosCredentials, getValidityStatus(entry, validDistCerts)),
       value: index,
     })),
   };
@@ -460,14 +458,13 @@ async function generateDistCert(ctx: Context, accountName: string): Promise<Dist
 
       const { revoke } = await prompt([
         {
-          type: 'checkbox',
+          type: 'multiselect',
           name: 'revoke',
           message: 'Select certificates to revoke.',
           choices: certs.map((cert, index) => ({
             value: index,
-            name: formatDistCertFromApple(cert, credentials),
+            title: formatDistCertFromApple(cert, credentials),
           })),
-          pageSize: Infinity,
         },
       ]);
 

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -14,8 +14,7 @@ import {
   ProvisioningProfileManager,
 } from '../../appleApi';
 import log from '../../log';
-import prompt, { Question } from '../../prompt';
-import { confirmAsync } from '../../prompts';
+import prompt, { confirmAsync, Question } from '../../prompts';
 import { displayIosAppCredentials } from '../actions/list';
 import { askForUserProvided } from '../actions/promptForCredentials';
 import { AppLookupParams, getAppLookupParams } from '../api/IosApi';
@@ -184,18 +183,17 @@ export class CreateOrReuseProvisioningProfile implements IView {
   async _createOrReuse(ctx: Context): Promise<IView | null> {
     const choices = [
       {
-        name: '[Choose existing provisioning profile] (Recommended)',
+        title: '[Choose existing provisioning profile] (Recommended)',
         value: 'CHOOSE_EXISTING',
       },
-      { name: '[Add a new provisioning profile]', value: 'GENERATE' },
+      { title: '[Add a new provisioning profile]', value: 'GENERATE' },
     ];
 
     const question: Question = {
-      type: 'list',
+      type: 'select',
       name: 'action',
       message: 'Select a Provisioning Profile:',
       choices,
-      pageSize: Infinity,
     };
 
     const { action } = await prompt(question);
@@ -224,11 +222,11 @@ async function selectProfileFromApple(
   }
 
   const question: Question = {
-    type: 'list',
+    type: 'select',
     name: 'credentialsIndex',
     message: 'Select Provisioning Profile from the list.',
     choices: profiles.map((entry, index) => ({
-      name: formatProvisioningProfileFromApple(entry),
+      title: formatProvisioningProfileFromApple(entry),
       value: index,
     })),
   };
@@ -254,11 +252,11 @@ async function selectProfileFromExpo(
   };
 
   const question: Question = {
-    type: 'list',
+    type: 'select',
     name: 'credentialsIndex',
     message: 'Select Provisioning Profile from the list.',
     choices: profiles.map((entry, index) => ({
-      name: getName(entry),
+      title: getName(entry),
       value: index,
     })),
   };

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -194,6 +194,7 @@ export class CreateOrReuseProvisioningProfile implements IView {
       name: 'action',
       message: 'Select a Provisioning Profile:',
       choices,
+      optionsPerPage: 20,
     };
 
     const { action } = await prompt(question);

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -508,6 +508,7 @@ async function generatePushKey(ctx: Context, accountName: string): Promise<PushK
             value: index,
             title: formatPushKeyFromApple(key, credentials),
           })),
+          optionsPerPage: 20,
         },
       ]);
 

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -6,8 +6,7 @@ import terminalLink from 'terminal-link';
 import CommandError from '../../CommandError';
 import { isPushKey, PushKey, PushKeyInfo, PushKeyManager } from '../../appleApi';
 import log from '../../log';
-import prompt, { Question } from '../../prompt';
-import { confirmAsync } from '../../prompts';
+import prompt, { confirmAsync, Question } from '../../prompts';
 import { displayIosUserCredentials } from '../actions/list';
 import { askForUserProvided, CredentialSchema } from '../actions/promptForCredentials';
 import { AppLookupParams, getAppLookupParams } from '../api/IosApi';
@@ -283,18 +282,17 @@ export class CreateOrReusePushKey implements IView {
   async _createOrReuse(ctx: Context): Promise<IView | null> {
     const choices = [
       {
-        name: '[Choose existing push key] (Recommended)',
+        title: '[Choose existing push key] (Recommended)',
         value: 'CHOOSE_EXISTING',
       },
-      { name: '[Add a new push key]', value: 'GENERATE' },
+      { title: '[Add a new push key]', value: 'GENERATE' },
     ];
 
     const question: Question = {
-      type: 'list',
+      type: 'select',
       name: 'action',
       message: 'Select an iOS push key to use for push notifications:',
       choices,
-      pageSize: Infinity,
     };
 
     const { action } = await prompt(question);
@@ -388,11 +386,11 @@ async function selectPushCredFromList(
   };
 
   const question: Question = {
-    type: 'list',
+    type: 'select',
     name: 'credentialsIndex',
     message: 'Select credentials from list',
     choices: pushCredentials.map((entry, index) => ({
-      name: getName(entry),
+      title: getName(entry),
       value: index,
     })),
   };
@@ -503,14 +501,13 @@ async function generatePushKey(ctx: Context, accountName: string): Promise<PushK
 
       const { revoke } = await prompt([
         {
-          type: 'checkbox',
+          type: 'multiselect',
           name: 'revoke',
           message: 'Select Push Notifications Key to revoke.',
           choices: keys.map((key, index) => ({
             value: index,
-            name: formatPushKeyFromApple(key, credentials),
+            title: formatPushKeyFromApple(key, credentials),
           })),
-          pageSize: Infinity,
         },
       ]);
 

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -18,6 +18,7 @@ export class SelectPlatform implements IView {
       name: 'platform',
       message: 'Select platform',
       choices: ['ios', 'android'].map(value => ({ value, title: value })),
+      optionsPerPage: 20,
     });
     const view = platform === 'ios' ? new SelectIosExperience() : new SelectAndroidExperience();
     CredentialsManager.get().changeMainView(view);
@@ -153,6 +154,7 @@ export class SelectAndroidExperience implements IView {
         title: cred.experienceName,
         value: cred.experienceName,
       })),
+      optionsPerPage: 20,
     };
     const { experienceName } = await prompts(question);
 

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -1,7 +1,7 @@
 import invariant from 'invariant';
 
 import prompt, { ChoiceType, Question } from '../../prompt';
-import { confirmAsync } from '../../prompts';
+import prompts, { confirmAsync, Question as QuestionNew } from '../../prompts';
 import { displayAndroidCredentials, displayIosCredentials } from '../actions/list';
 import { AppLookupParams } from '../api/IosApi';
 import { Context, IView } from '../context';
@@ -13,15 +13,12 @@ import * as iosPushView from './IosPushCredentials';
 
 export class SelectPlatform implements IView {
   async open(ctx: Context): Promise<IView | null> {
-    const { platform } = await prompt([
-      {
-        type: 'list',
-        name: 'platform',
-        message: 'Select platform',
-        pageSize: Infinity,
-        choices: ['ios', 'android'],
-      },
-    ]);
+    const { platform } = await prompts({
+      type: 'select',
+      name: 'platform',
+      message: 'Select platform',
+      choices: ['ios', 'android'].map(value => ({ value, title: value })),
+    });
     const view = platform === 'ios' ? new SelectIosExperience() : new SelectAndroidExperience();
     CredentialsManager.get().changeMainView(view);
     return view;
@@ -148,17 +145,16 @@ export class SelectAndroidExperience implements IView {
     const credentials = await ctx.android.fetchAll();
     await displayAndroidCredentials(Object.values(credentials));
 
-    const question: Question = {
-      type: 'list',
+    const question: QuestionNew = {
+      type: 'select',
       name: 'experienceName',
       message: 'Select application',
       choices: Object.values(credentials).map(cred => ({
-        name: cred.experienceName,
+        title: cred.experienceName,
         value: cred.experienceName,
       })),
-      pageSize: Infinity,
     };
-    const { experienceName } = await prompt(question);
+    const { experienceName } = await prompts(question);
 
     return new androidView.ExperienceView(experienceName);
   }
@@ -186,17 +182,15 @@ export class DoQuit implements IQuit {
 
 export class AskQuit implements IQuit {
   async runAsync(mainpage: IView): Promise<IView> {
-    const { selected } = await prompt([
-      {
-        type: 'list',
-        name: 'selected',
-        message: 'Do you want to quit Credential Manager',
-        choices: [
-          { value: 'exit', name: 'Quit Credential Manager' },
-          { value: 'mainpage', name: 'Go back to experience overview.' },
-        ],
-      },
-    ]);
+    const { selected } = await prompts({
+      type: 'select',
+      name: 'selected',
+      message: 'Do you want to quit Credential Manager',
+      choices: [
+        { value: 'exit', title: 'Quit Credential Manager' },
+        { value: 'mainpage', title: 'Go back to experience overview.' },
+      ],
+    });
     if (selected === 'exit') {
       process.exit(0);
     }

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -1,9 +1,13 @@
 import program from 'commander';
-import prompts, { Choice, Options, PromptType, PromptObject as Question } from 'prompts';
+import prompts, { Choice, Options, PromptObject, PromptType } from 'prompts';
 
 import CommandError, { AbortCommandError } from './CommandError';
 
-export { PromptType, Question };
+export type Question<V extends string = string> = PromptObject<V> & {
+  optionsPerPage?: number;
+};
+
+export { PromptType };
 
 type PromptOptions = { nonInteractiveHelp?: string } & Options;
 


### PR DESCRIPTION
# Why

- It's a big messy package that increases our CLI install time by including packages like rxjs
- part of https://github.com/expo/expo-cli/issues/1983
- still three complex cases to remove later. One of which is in `react-dev-utils` https://github.com/facebook/create-react-app/pull/10083

# How

- copy the changes made in eas-cli.
- changed `type`s
  - list -> select
  - input or undefined -> text
- changed options
  - `pageSize` -> `optionsPerPage` (also added the missing type in our abstraction).
  - default -> initial
  - filter -> format
  - choices.name -> choices.title
