### PR TITLE
[configure-splash-screen] guard .pbxproj for bare workflow

### DIFF
--- a/unlinked-packages/configure-splash-screen/package.json
+++ b/unlinked-packages/configure-splash-screen/package.json
@@ -26,14 +26,14 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo-cli.git",
-    "directory": "packages/configure-splash-screen"
+    "directory": "unlinked-packages/configure-splash-screen"
   },
   "bugs": {
     "url": "https://github.com/expo/expo-cli/issues"
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo-cli/tree/master/packages/configure-splash-screen",
+  "homepage": "https://github.com/expo/expo-cli/tree/master/unlinked-packages/configure-splash-screen",
   "engines": {
     "node": ">=10"
   },

--- a/unlinked-packages/configure-splash-screen/src/ios/pbxproj.ts
+++ b/unlinked-packages/configure-splash-screen/src/ios/pbxproj.ts
@@ -59,6 +59,11 @@ export default async function readPbxProject(projectRootPath: string): Promise<I
     );
   }
 
+  // PBXVariantGroup may not exist in bare project, but is required by xcode package
+  if (!pbxProject.hash.project.objects.PBXVariantGroup) {
+    pbxProject.hash.project.objects.PBXVariantGroup = {};
+  }
+
   return {
     projectName,
     projectPath,


### PR DESCRIPTION
a workaround for #2801 