### PR TITLE
Remove es6-error in favor of Error

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -89,7 +89,6 @@
     "delay-async": "1.2.0",
     "env-editor": "^0.4.1",
     "envinfo": "7.5.0",
-    "es6-error": "3.2.0",
     "figures": "3.2.0",
     "fs-extra": "9.0.0",
     "getenv": "0.7.0",

--- a/packages/expo-cli/src/CommandError.ts
+++ b/packages/expo-cli/src/CommandError.ts
@@ -1,5 +1,3 @@
-import ExtendableError from 'es6-error';
-
 const ERROR_PREFIX = 'Error: ';
 
 export const ErrorCodes = {
@@ -18,7 +16,7 @@ export const ErrorCodes = {
 
 export type ErrorCode = keyof typeof ErrorCodes;
 
-export default class CommandError extends ExtendableError {
+export default class CommandError extends Error {
   code: string;
   isCommandError: true;
 

--- a/packages/expo-cli/src/CommandError.ts
+++ b/packages/expo-cli/src/CommandError.ts
@@ -34,6 +34,8 @@ export default class CommandError extends Error {
   }
 }
 
+CommandError.prototype.name = CommandError.name;
+
 export class AbortCommandError extends CommandError {
   constructor() {
     super('ABORTED', 'Interactive prompt was cancelled.');

--- a/packages/expo-cli/src/CommandError.ts
+++ b/packages/expo-cli/src/CommandError.ts
@@ -17,25 +17,22 @@ export const ErrorCodes = {
 export type ErrorCode = keyof typeof ErrorCodes;
 
 export default class CommandError extends Error {
+  readonly name = 'CommandError';
+  readonly isCommandError = true;
   code: string;
-  isCommandError: true;
 
   constructor(code: string, message: string = '') {
+    super('');
     // If e.toString() was called to get `message` we don't want it to look
     // like "Error: Error:".
     if (message.startsWith(ERROR_PREFIX)) {
       message = message.substring(ERROR_PREFIX.length);
     }
 
-    super(message || code);
-
+    this.message = message || code;
     this.code = code;
-    this.isCommandError = true;
   }
 }
-
-CommandError.prototype.name = CommandError.name;
-
 export class AbortCommandError extends CommandError {
   constructor() {
     super('ABORTED', 'Interactive prompt was cancelled.');

--- a/packages/expo-cli/src/commands/build/BuildError.ts
+++ b/packages/expo-cli/src/commands/build/BuildError.ts
@@ -1,6 +1,4 @@
-import ExtendableError from 'es6-error';
-
-export default class BuildError extends ExtendableError {
+export default class BuildError extends Error {
   name = 'BuildError';
 
   constructor(public message: string) {

--- a/packages/expo-cli/src/commands/build/BuildError.ts
+++ b/packages/expo-cli/src/commands/build/BuildError.ts
@@ -5,3 +5,4 @@ export default class BuildError extends Error {
     super();
   }
 }
+BuildError.prototype.name = BuildError.name;

--- a/packages/expo-cli/src/commands/build/BuildError.ts
+++ b/packages/expo-cli/src/commands/build/BuildError.ts
@@ -1,8 +1,7 @@
 export default class BuildError extends Error {
-  name = 'BuildError';
+  readonly name = 'BuildError';
 
   constructor(public message: string) {
     super();
   }
 }
-BuildError.prototype.name = BuildError.name;

--- a/packages/schemer/package.json
+++ b/packages/schemer/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "ajv": "^5.2.2",
-    "es6-error": "^4.0.2",
     "json-schema-traverse": "0.3.1",
     "lodash": "^4.17.15",
     "probe-image-size": "^3.1.0",

--- a/packages/schemer/src/Error.ts
+++ b/packages/schemer/src/Error.ts
@@ -6,6 +6,7 @@ export class SchemerError extends Error {
     this.errors = errors;
   }
 }
+SchemerError.prototype.name = SchemerError.name;
 
 export class ValidationError extends Error {
   errorCode: string;
@@ -34,6 +35,7 @@ export class ValidationError extends Error {
     this.meta = meta;
   }
 }
+ValidationError.prototype.name = ValidationError.name;
 
 export type ErrorCode = keyof typeof ErrorCodes;
 

--- a/packages/schemer/src/Error.ts
+++ b/packages/schemer/src/Error.ts
@@ -1,6 +1,4 @@
-import ExtendableError from 'es6-error';
-
-export class SchemerError extends ExtendableError {
+export class SchemerError extends Error {
   errors: ValidationError[];
   constructor(errors: ValidationError[]) {
     const message = errors.map(e => e.message).join('\n');
@@ -9,7 +7,7 @@ export class SchemerError extends ExtendableError {
   }
 }
 
-export class ValidationError extends ExtendableError {
+export class ValidationError extends Error {
   errorCode: string;
   fieldPath: string;
   message: string;

--- a/packages/schemer/src/Error.ts
+++ b/packages/schemer/src/Error.ts
@@ -1,14 +1,16 @@
 export class SchemerError extends Error {
+  readonly name = 'SchemerError';
   errors: ValidationError[];
+
   constructor(errors: ValidationError[]) {
-    const message = errors.map(e => e.message).join('\n');
-    super(message);
+    super('');
+    this.message = errors.map(e => e.message).join('\n');
     this.errors = errors;
   }
 }
-SchemerError.prototype.name = SchemerError.name;
 
 export class ValidationError extends Error {
+  readonly name = 'ValidationError';
   errorCode: string;
   fieldPath: string;
   message: string;
@@ -35,7 +37,6 @@ export class ValidationError extends Error {
     this.meta = meta;
   }
 }
-ValidationError.prototype.name = ValidationError.name;
 
 export type ErrorCode = keyof typeof ErrorCodes;
 

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -51,7 +51,6 @@
     "decache": "4.4.0",
     "delay-async": "1.2.0",
     "devcert": "^1.1.0",
-    "es6-error": "4.1.1",
     "express": "4.16.4",
     "form-data": "2.3.2",
     "freeport-async": "2.0.0",

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -22,6 +22,7 @@ type HttpMethod = 'get' | 'post' | 'put' | 'delete';
 type RequestOptions = AxiosRequestConfig & { formData?: FormData };
 
 class ApiError extends Error {
+  readonly name = 'ApiError';
   code: string;
   readonly _isApiError = true;
   serverError: any;
@@ -31,7 +32,6 @@ class ApiError extends Error {
     this.code = code;
   }
 }
-ApiError.prototype.name = ApiError.name;
 
 // These aren't constants because some commands switch between staging and prod
 function _rootBaseUrl() {

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosRequestConfig, Canceler } from 'axios';
 import concat from 'concat-stream';
-import ExtendableError from 'es6-error';
 import FormData from 'form-data';
 import fs from 'fs-extra';
 import path from 'path';
@@ -22,7 +21,7 @@ let exponentClient = 'xdl';
 type HttpMethod = 'get' | 'post' | 'put' | 'delete';
 type RequestOptions = AxiosRequestConfig & { formData?: FormData };
 
-class ApiError extends ExtendableError {
+class ApiError extends Error {
   code: string;
   readonly _isApiError = true;
   serverError: any;

--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -31,6 +31,7 @@ class ApiError extends Error {
     this.code = code;
   }
 }
+ApiError.prototype.name = ApiError.name;
 
 // These aren't constants because some commands switch between staging and prod
 function _rootBaseUrl() {

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -1,7 +1,6 @@
 import { JSONObject, JSONValue } from '@expo/json-file';
 import axios, { AxiosRequestConfig } from 'axios';
 import concat from 'concat-stream';
-import ExtendableError from 'es6-error';
 import FormData from 'form-data';
 import idx from 'idx';
 import merge from 'lodash/merge';
@@ -31,7 +30,7 @@ async function _convertFormDataToBuffer(formData: FormData): Promise<{ data: Buf
   });
 }
 
-export class ApiV2Error extends ExtendableError {
+export class ApiV2Error extends Error {
   code: string;
   details?: JSONValue;
   serverStack?: string;

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -31,6 +31,7 @@ async function _convertFormDataToBuffer(formData: FormData): Promise<{ data: Buf
 }
 
 export class ApiV2Error extends Error {
+  readonly name = 'ApiV2Error';
   code: string;
   details?: JSONValue;
   serverStack?: string;
@@ -42,7 +43,6 @@ export class ApiV2Error extends Error {
     this.code = code;
   }
 }
-ApiV2Error.prototype.name = ApiV2Error.name;
 
 type RequestOptions = {
   httpMethod: 'get' | 'post' | 'put' | 'patch' | 'delete';

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -42,6 +42,7 @@ export class ApiV2Error extends Error {
     this.code = code;
   }
 }
+ApiV2Error.prototype.name = ApiV2Error.name;
 
 type RequestOptions = {
   httpMethod: 'get' | 'post' | 'put' | 'patch' | 'delete';

--- a/packages/xdl/src/TurtleApi.ts
+++ b/packages/xdl/src/TurtleApi.ts
@@ -23,6 +23,7 @@ export class TurtleApiError extends Error {
     this.code = code;
   }
 }
+TurtleApiError.prototype.name = TurtleApiError.name;
 
 type RequestOptions = {
   httpMethod: 'get' | 'post' | 'put' | 'delete';

--- a/packages/xdl/src/TurtleApi.ts
+++ b/packages/xdl/src/TurtleApi.ts
@@ -13,6 +13,8 @@ import FormData from './tools/FormData';
 const apiBaseUrl = `${Config.turtleApi.scheme}://${Config.turtleApi.host}:${Config.turtleApi.port}`;
 
 export class TurtleApiError extends Error {
+  readonly name = 'TurtleApiError';
+
   code: string;
   details?: JSONValue;
   serverStack?: string;
@@ -23,7 +25,6 @@ export class TurtleApiError extends Error {
     this.code = code;
   }
 }
-TurtleApiError.prototype.name = TurtleApiError.name;
 
 type RequestOptions = {
   httpMethod: 'get' | 'post' | 'put' | 'delete';

--- a/packages/xdl/src/TurtleApi.ts
+++ b/packages/xdl/src/TurtleApi.ts
@@ -1,7 +1,6 @@
 import { JSONObject, JSONValue } from '@expo/json-file';
 import axios, { AxiosRequestConfig } from 'axios';
 import concat from 'concat-stream';
-import ExtendableError from 'es6-error';
 import fs from 'fs-extra';
 import idx from 'idx';
 import merge from 'lodash/merge';
@@ -13,7 +12,7 @@ import FormData from './tools/FormData';
 
 const apiBaseUrl = `${Config.turtleApi.scheme}://${Config.turtleApi.host}:${Config.turtleApi.port}`;
 
-export class TurtleApiError extends ExtendableError {
+export class TurtleApiError extends Error {
   code: string;
   details?: JSONValue;
   serverStack?: string;

--- a/packages/xdl/src/XDLError.ts
+++ b/packages/xdl/src/XDLError.ts
@@ -3,20 +3,22 @@ import { ErrorCode } from './ErrorCode';
 const ERROR_PREFIX = 'Error: ';
 
 export default class XDLError extends Error {
+  readonly name = 'XDLError';
+
   code: string;
   isXDLError: true;
 
   constructor(code: ErrorCode, message: string) {
+    super('');
+
     // If e.toString() was called to get `message` we don't want it to look
     // like "Error: Error:".
     if (message.startsWith(ERROR_PREFIX)) {
       message = message.substring(ERROR_PREFIX.length);
     }
 
-    super(message);
-
+    this.message = message;
     this.code = code;
     this.isXDLError = true;
   }
 }
-XDLError.prototype.name = XDLError.name;

--- a/packages/xdl/src/XDLError.ts
+++ b/packages/xdl/src/XDLError.ts
@@ -19,3 +19,4 @@ export default class XDLError extends Error {
     this.isXDLError = true;
   }
 }
+XDLError.prototype.name = XDLError.name;

--- a/packages/xdl/src/XDLError.ts
+++ b/packages/xdl/src/XDLError.ts
@@ -1,18 +1,12 @@
-import ExtendableError from 'es6-error';
-
 import { ErrorCode } from './ErrorCode';
 
 const ERROR_PREFIX = 'Error: ';
 
-export default class XDLError extends ExtendableError {
+export default class XDLError extends Error {
   code: string;
   isXDLError: true;
 
-  constructor(
-    code: ErrorCode,
-    message: string,
-    options: { noTrack: boolean } = { noTrack: false }
-  ) {
+  constructor(code: ErrorCode, message: string) {
     // If e.toString() was called to get `message` we don't want it to look
     // like "Error: Error:".
     if (message.startsWith(ERROR_PREFIX)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8805,16 +8805,6 @@ es5-ext@^0.10.35, es5-ext@^0.10.45, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@
     es6-symbol "~3.1.3"
     next-tick "~1.0.0"
 
-es6-error@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-3.2.0.tgz#e567cfdcb324d4e7ae5922a3700ada5de879a0ca"
-  integrity sha1-5WfP3LMk1OeuWSKjcAraXeh5oMo=
-
-es6-error@4.1.1, es6-error@^4.0.2:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
-  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
-
 es6-iterator@^2.0.1, es6-iterator@^2.0.3, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"


### PR DESCRIPTION
- Doesn't appear as though `es6-error` is adding any value. We have three copies of it in the repo.