### PR TITLE
fix: Propogate private config from app.json to manifest in build process with the public URL flag

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -117,6 +117,15 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
       staticConfigPath: paths.staticConfigPath,
     };
 
+    if (options.isPrivateConfig) {
+      return {
+        exp: {
+          hooks: configWithDefaultValues.exp.hooks,
+          ios: configWithDefaultValues.exp.ios?.config,
+          android: configWithDefaultValues.exp.android?.config,
+        },
+      };
+    }
     if (options.isPublicConfig) {
       if (configWithDefaultValues.exp.hooks) {
         delete configWithDefaultValues.exp.hooks;

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -137,6 +137,7 @@ export type ConfigContext = {
 };
 
 export type GetConfigOptions = {
+  isPrivateConfig?: boolean;
   isPublicConfig?: boolean;
   /**
    * Should the config `mods` be preserved in the config? Used for compiling mods in the eject command.

--- a/packages/config/src/__tests__/Config-test.ts
+++ b/packages/config/src/__tests__/Config-test.ts
@@ -113,6 +113,87 @@ describe('getConfig public config', () => {
   });
 });
 
+describe('getConfig private config', () => {
+  const appJsonWithPrivateData = {
+    name: 'testing 123',
+    version: '0.1.0',
+    slug: 'testing-123',
+    sdkVersion: '100.0.0',
+    hooks: {
+      postPublish: [],
+    },
+    android: {
+      config: {
+        googleMaps: {
+          apiKey: 'test-key',
+        },
+      },
+      versionCode: 1,
+    },
+    ios: {
+      config: {
+        googleMapsApiKey: 'test-key',
+      },
+      buildNumber: '1.0',
+    },
+  };
+
+  const appJsonNoPrivateData = {
+    name: 'testing 123',
+    version: '0.1.0',
+    slug: 'testing-123',
+    sdkVersion: '100.0.0',
+    ios: {
+      buildNumber: '1.0',
+    },
+  };
+
+  beforeAll(() => {
+    const packageJson = JSON.stringify(
+      {
+        name: 'testing123',
+        version: '0.1.0',
+        description: 'fake description',
+        main: 'index.js',
+      },
+      null,
+      2
+    );
+
+    vol.fromJSON({
+      '/private-data/package.json': packageJson,
+      '/private-data/app.json': JSON.stringify({ expo: appJsonWithPrivateData }),
+      '/no-private-data/package.json': packageJson,
+      '/no-private-data/app.json': JSON.stringify({ expo: appJsonNoPrivateData }),
+    });
+  });
+
+  afterAll(() => vol.reset());
+
+  it('returns only private data from the config', () => {
+    const { exp } = getConfig('/private-data', { isPrivateConfig: true });
+
+    expect(exp).toEqual({
+      hooks: {
+        postPublish: [],
+      },
+      android: {
+        googleMaps: {
+          apiKey: 'test-key',
+        },
+      },
+      ios: {
+        googleMapsApiKey: 'test-key',
+      },
+    });
+  });
+
+  it('returns empty object from a config with no private data', () => {
+    const { exp } = getConfig('/no-private-data', { isPrivateConfig: true });
+    expect(exp).toEqual({});
+  });
+});
+
 describe('readConfigJson', () => {
   describe('sdkVersion', () => {
     beforeAll(() => {

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1057,8 +1057,12 @@ async function getConfigAsync(
     };
   } else {
     // get the externally hosted manifest
+    const { exp: privateExp } = getConfig(projectRoot, { isPrivateConfig: true });
     return {
-      exp: await ThirdParty.getManifest(options.publicUrl, options),
+      exp: {
+        ...(await ThirdParty.getManifest(options.publicUrl, options)),
+        ...privateExp,
+      },
       configName: options.publicUrl,
       configPrefix: '',
       pkg: {},


### PR DESCRIPTION
As described here: https://github.com/expo/expo/issues/10252
Private config values in app.json, such as Google Maps API Key, are not propagated properly through the build process when the --public-url flag is set.

@brentvatne 