### PR TITLE
resolve empty hermes package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript": "^3.8.3"
   },
   "resolutions": {
-    "@types/webpack": "4.41.18"
+    "@types/webpack": "4.41.18",
+    "hermes-engine": "0.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11082,10 +11082,10 @@ he@1.2.x, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
-  integrity sha512-eNHUQHuadDMJARpaqvlCZoK/Nitpj6oywq3vQ3wCwEsww5morX34mW5PmKWQTO7aU0ck0hgulxR+EVDlXygGxQ==
+hermes-engine@0.0.0, hermes-engine@^0.2.1:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
+  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
 
 hex-color-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Resolve the empty hermes (required by `expo/metro-config`) package in development to cut down on CI time.

## Before

```
1.2G	.
921M	./node_modules
140M	./node_modules/@expo
138M	./node_modules/hermes-engine
116M	./node_modules/@expo/traveling-fastlane-darwin/dist/lib
116M	./node_modules/@expo/traveling-fastlane-darwin/dist
116M	./node_modules/@expo/traveling-fastlane-darwin
```

## After

```
1.0G	.
783M	./node_modules
140M	./node_modules/@expo
116M	./node_modules/@expo/traveling-fastlane-darwin/dist/lib
116M	./node_modules/@expo/traveling-fastlane-darwin/dist
116M	./node_modules/@expo/traveling-fastlane-darwin
106M	./packages
```