### PR TITLE
[image-utils] Fix blurry web favicon

### DIFF
--- a/packages/image-utils/src/jimp.ts
+++ b/packages/image-utils/src/jimp.ts
@@ -19,6 +19,7 @@ export async function resizeBufferAsync(buffer: Buffer, sizes: number[]): Promis
   return Promise.all(
     sizes.map(async size => {
       // Parse the buffer each time to prevent mutable copies.
+      // Parse the buffer each time to prevent mutable copies.
       const jimpImage = await Jimp.read(buffer);
       const mime = jimpImage.getMIME();
 

--- a/packages/image-utils/src/jimp.ts
+++ b/packages/image-utils/src/jimp.ts
@@ -16,9 +16,14 @@ type JimpGlobalOptions = Omit<SharpGlobalOptions, 'input'> & {
 };
 
 export async function resizeBufferAsync(buffer: Buffer, sizes: number[]): Promise<Buffer[]> {
-  const jimpImage = await Jimp.read(buffer);
-  const mime = jimpImage.getMIME();
-  return Promise.all(sizes.map(size => jimpImage.resize(size, size).getBufferAsync(mime)));
+  return Promise.all(
+    sizes.map(async size => {
+      const jimpImage = await Jimp.read(buffer);
+      const mime = jimpImage.getMIME();
+
+      return jimpImage.resize(size, size).getBufferAsync(mime);
+    })
+  );
 }
 
 export function convertFormat(format?: string): string | undefined {

--- a/packages/image-utils/src/jimp.ts
+++ b/packages/image-utils/src/jimp.ts
@@ -18,6 +18,7 @@ type JimpGlobalOptions = Omit<SharpGlobalOptions, 'input'> & {
 export async function resizeBufferAsync(buffer: Buffer, sizes: number[]): Promise<Buffer[]> {
   return Promise.all(
     sizes.map(async size => {
+      // Parse the buffer each time to prevent mutable copies.
       const jimpImage = await Jimp.read(buffer);
       const mime = jimpImage.getMIME();
 


### PR DESCRIPTION
Web favicon is blurry, it has been reported in https://github.com/expo/expo-cli/issues/2012, which is closed but problem is still here.

I checked code and notice an error when icons are resized.
Jimp [resize method](https://github.com/oliver-moran/jimp/tree/master/packages/plugin-resize#usage) is mutable, so images were all 16x16.