### PR TITLE
[cli] Fix build/status return types

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -2,7 +2,6 @@ import { ExpoConfig, getConfig, ProjectConfig } from '@expo/config';
 import { Project, User, UserManager, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import delayAsync from 'delay-async';
-import invariant from 'invariant';
 import ora from 'ora';
 import semver from 'semver';
 

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -125,16 +125,10 @@ export default class BaseBuilder {
       return;
     }
 
-    const { canPurchasePriorityBuilds, numberOfRemainingPriorityBuilds } = buildStatus;
-    invariant(
-      canPurchasePriorityBuilds !== undefined && numberOfRemainingPriorityBuilds !== undefined,
-      'canPurchasePriorityBuilds and numberOfRemainingPriorityBuilds should be defined when there are build jobs'
-    );
-
     await this.logBuildStatuses({
       jobs: buildStatus.jobs,
-      canPurchasePriorityBuilds,
-      numberOfRemainingPriorityBuilds,
+      canPurchasePriorityBuilds: buildStatus.canPurchasePriorityBuilds,
+      numberOfRemainingPriorityBuilds: buildStatus.numberOfRemainingPriorityBuilds,
       hasUnlimitedPriorityBuilds: buildStatus.hasUnlimitedPriorityBuilds,
     });
   }
@@ -165,9 +159,9 @@ Please see the docs (${chalk.underline(
   }
 
   async logBuildStatuses(buildStatus: {
-    jobs: Record<string, any>[];
-    canPurchasePriorityBuilds: boolean;
-    numberOfRemainingPriorityBuilds: number;
+    jobs: Project.BuildJobFields[];
+    canPurchasePriorityBuilds?: boolean;
+    numberOfRemainingPriorityBuilds?: number;
     hasUnlimitedPriorityBuilds?: boolean;
   }) {
     log('=================');
@@ -196,7 +190,8 @@ Please see the docs (${chalk.underline(
       );
 
       const hasPriorityBuilds =
-        buildStatus.numberOfRemainingPriorityBuilds > 0 || buildStatus.hasUnlimitedPriorityBuilds;
+        (buildStatus.numberOfRemainingPriorityBuilds || 0) > 0 ||
+        buildStatus.hasUnlimitedPriorityBuilds;
       const shouldShowUpgradeInfo =
         !hasPriorityBuilds &&
         i === 0 &&

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -190,7 +190,7 @@ Please see the docs (${chalk.underline(
       );
 
       const hasPriorityBuilds =
-        (buildStatus.numberOfRemainingPriorityBuilds || 0) > 0 ||
+        (buildStatus.numberOfRemainingPriorityBuilds ?? 0) > 0 ||
         buildStatus.hasUnlimitedPriorityBuilds;
       const shouldShowUpgradeInfo =
         !hasPriorityBuilds &&

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1105,13 +1105,13 @@ export interface BuildJobFields {
 }
 
 export type BuildStatusResult = {
-  jobs: BuildJobFields[];
-  err: null;
+  jobs?: BuildJobFields[];
+  err?: null;
   userHasBuiltAppBefore: boolean;
   userHasBuiltExperienceBefore: boolean;
-  canPurchasePriorityBuilds: boolean;
-  numberOfRemainingPriorityBuilds: number;
-  hasUnlimitedPriorityBuilds: boolean;
+  canPurchasePriorityBuilds?: boolean;
+  numberOfRemainingPriorityBuilds?: number;
+  hasUnlimitedPriorityBuilds?: boolean;
 };
 
 export type BuildCreatedResult = {


### PR DESCRIPTION
# Why

While investigating https://github.com/expo/expo-cli/issues/2909, noticed that the types here were incorrect. The issue looks like it was fixed in https://github.com/expo/expo-cli/pull/2912 (invalid property access on a possibly undefined variable), but the correct types help verify that it was fixed.

I don't think this is a server issue unless this is widespread, but I'm not sure how to check since we don't seem to have sentry for expo-cli. @EvanBacon, @fson - any suggestions on how to see the rate of this error since it's client-side?

# How

Copy types from www, the source of truth in the matter.

# Test Plan

`yarn tsc`