### PR TITLE
[xdl] Switch to in-process Metro JS bundling starting from SDK 40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [xdl] Switch to in-process Metro JS bundling through `@expo/dev-server` starting from SDK 40 ([#2921](https://github.com/expo/expo-cli/pull/2921))
+
 ### 🐛 Bug fixes
 
 ## [Mon, 9 Nov 2020 13:44:59 -0800](https://github.com/expo/expo-cli/commit/d5b8759b32d5a7747067a969728d9ba732926824)


### PR DESCRIPTION
Always use in-process Metro (`@expo/dev-server`) for SDK 40 and newer. Metro is used to bundle JS in `expo start` , `expo publish` and `expo export` commands. `@expo/dev-server` is a rewrite of the interface between Expo CLI and Metro bundler that uses the JS APIs of Metro (instead of running React Native CLI as a subprocess) to make bundling faster and handling Metro configurations more predictable.

For older SDK versions, keep the old behavior (in-process Metro can be enabled by setting `EXPO_USE_DEV_SERVER=true` in the environment).

This is not a breaking change because the behavior for already released SDKs stays the same and all SDK 40 testing is done using in-process Metro.

Fixes #2322.