### PR TITLE
clean up send command

### DIFF
--- a/packages/expo-cli/src/askUser.ts
+++ b/packages/expo-cli/src/askUser.ts
@@ -1,27 +1,18 @@
 import { UserSettings } from '@expo/xdl';
 
 import log from './log';
-import prompt from './prompts';
+import { promptEmailAsync } from './prompts';
 
-async function askForSendToAsync(): Promise<string> {
+export async function askForSendToAsync(): Promise<string> {
   const cachedValue = await UserSettings.getAsync('sendTo', null);
-  log("Enter an email address and we'll send a link to your phone.");
-  const answers = await prompt(
-    [
-      {
-        type: 'text',
-        name: 'sendTo',
-        message: `Your email address ${cachedValue ? ' (space to not send anything)' : ''}:`,
-        initial: cachedValue ?? undefined,
-      },
-    ],
+  log.nested("Enter an email address and we'll send a link");
+  const recipient = await promptEmailAsync(
+    {
+      message: `Email address`,
+      initial: cachedValue ?? undefined,
+    },
     { nonInteractiveHelp: 'Please specify email address with --send-to.' }
   );
-  const recipient = answers.sendTo.trim();
   await UserSettings.mergeAsync({ sendTo: recipient });
   return recipient;
 }
-
-export default {
-  askForSendToAsync,
-};

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -18,7 +18,7 @@ import { CreateOrReuseProvisioningProfileAdhoc } from '../../credentials/views/I
 import { SetupIosDist } from '../../credentials/views/SetupIosDist';
 import { SetupIosPush } from '../../credentials/views/SetupIosPush';
 import log from '../../log';
-import prompt, { confirmAsync, promptEmailAsync } from '../../prompts';
+import { confirmAsync, promptEmailAsync } from '../../prompts';
 import urlOpts from '../../urlOpts';
 import * as ClientUpgradeUtils from '../utils/ClientUpgradeUtils';
 import { createClientBuildRequest, getExperienceName, isAllowedToBuild } from './clientBuildApi';

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -18,7 +18,7 @@ import { CreateOrReuseProvisioningProfileAdhoc } from '../../credentials/views/I
 import { SetupIosDist } from '../../credentials/views/SetupIosDist';
 import { SetupIosPush } from '../../credentials/views/SetupIosPush';
 import log from '../../log';
-import prompt, { confirmAsync } from '../../prompts';
+import prompt, { confirmAsync, promptEmailAsync } from '../../prompts';
 import urlOpts from '../../urlOpts';
 import * as ClientUpgradeUtils from '../utils/ClientUpgradeUtils';
 import { createClientBuildRequest, getExperienceName, isAllowedToBuild } from './clientBuildApi';
@@ -209,15 +209,10 @@ export default function (program: Command) {
         if (user) {
           email = user.email;
         } else {
-          ({ email } = await prompt({
-            type: 'text',
-            name: 'email',
+          email = await promptEmailAsync({
             message: 'Please enter an email address to notify, when the build is completed:',
             initial: context?.user?.email,
-            format: value => value.trim(),
-            validate: (value: string) =>
-              /.+@.+/.test(value) ? true : "That doesn't look like a valid email.",
-          }));
+          });
         }
         log.newLine();
 

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -8,7 +8,7 @@ import path from 'path';
 
 import CommandError from '../CommandError';
 import log from '../log';
-import sendTo from '../sendTo';
+import * as sendTo from '../sendTo';
 import * as TerminalLink from './utils/TerminalLink';
 import { formatNamedWarning } from './utils/logConfigWarnings';
 

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -2,40 +2,34 @@ import { UrlUtils, UserSettings } from '@expo/xdl';
 import chalk from 'chalk';
 import { Command } from 'commander';
 
-import askUser from '../askUser';
+import { askForSendToAsync } from '../askUser';
 import log from '../log';
-import sendTo from '../sendTo';
+import * as sendTo from '../sendTo';
 import urlOpts, { URLOptions } from '../urlOpts';
 
 type Options = URLOptions & { sendTo?: string };
 
-async function action(projectDir: string, options: Options) {
-  await urlOpts.optsAsync(projectDir, options);
+async function action(projectRoot: string, options: Options) {
+  await urlOpts.optsAsync(projectRoot, options);
 
-  const url = await UrlUtils.constructManifestUrlAsync(projectDir);
+  const url = await UrlUtils.constructManifestUrlAsync(projectRoot);
 
-  log('Your project manifest URL is\n\n' + chalk.underline(url) + '\n');
+  log.nested('Project manifest URL\n\n' + chalk.underline(url) + '\n');
 
-  if (await urlOpts.handleMobileOptsAsync(projectDir, options)) {
+  if (await urlOpts.handleMobileOptsAsync(projectRoot, options)) {
     return;
   }
 
-  let recipient;
-  if (typeof options.sendTo !== 'boolean') {
-    recipient = options.sendTo;
-  } else {
-    recipient = await UserSettings.getAsync('sendTo', null);
-  }
+  let recipient =
+    typeof options.sendTo !== 'boolean'
+      ? options.sendTo
+      : await UserSettings.getAsync('sendTo', null);
 
   if (!recipient) {
-    recipient = await askUser.askForSendToAsync();
+    recipient = await askForSendToAsync();
   }
 
-  if (recipient) {
-    await sendTo.sendUrlAsync(url, recipient);
-  } else {
-    log.gray("(Not sending anything because you didn't specify a recipient.)");
-  }
+  await sendTo.sendUrlAsync(url, recipient);
 }
 
 export default function (program: Command) {

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -11,7 +11,7 @@ import semver from 'semver';
 
 import { installExitHooks } from '../exit';
 import log from '../log';
-import sendTo from '../sendTo';
+import * as sendTo from '../sendTo';
 import urlOpts, { URLOptions } from '../urlOpts';
 import * as TerminalUI from './start/TerminalUI';
 

--- a/packages/expo-cli/src/prompts.ts
+++ b/packages/expo-cli/src/prompts.ts
@@ -209,3 +209,27 @@ export async function toggleConfirmAsync(
   );
   return value ?? null;
 }
+
+/**
+ * Prompt the user for an email address.
+ *
+ * @param questions
+ * @param options
+ */
+export async function promptEmailAsync(
+  questions: NamelessQuestion,
+  options?: PromptOptions
+): Promise<string> {
+  const { value } = await prompt(
+    {
+      type: 'text',
+      format: value => value.trim(),
+      validate: (value: string) =>
+        /.+@.+/.test(value) ? true : "That doesn't look like a valid email.",
+      ...questions,
+      name: 'value',
+    },
+    options
+  );
+  return value.trim();
+}

--- a/packages/expo-cli/src/sendTo.ts
+++ b/packages/expo-cli/src/sendTo.ts
@@ -1,10 +1,10 @@
-import simpleSpinner from '@expo/simple-spinner';
 import { Exp, UserSettings } from '@expo/xdl';
+import ora from 'ora';
 
-import askUser from './askUser';
+import { askForSendToAsync } from './askUser';
 import log from './log';
 
-async function getRecipient(sendTo?: string | boolean): Promise<string> {
+export async function getRecipient(sendTo?: string | boolean): Promise<string> {
   let recipient: string | null = '';
   if (sendTo) {
     if (typeof sendTo !== 'boolean') {
@@ -14,26 +14,20 @@ async function getRecipient(sendTo?: string | boolean): Promise<string> {
     }
 
     if (!recipient) {
-      return await askUser.askForSendToAsync();
+      return await askForSendToAsync();
     }
   }
 
   return recipient;
 }
-
-async function sendUrlAsync(url: string, recipient: string) {
-  log('Sending URL to', recipient);
-  simpleSpinner.start();
+export async function sendUrlAsync(url: string, recipient: string) {
+  const email = log.chalk.bold(recipient);
+  const spinner = ora(`Sending URL to ${email}`).start();
   try {
     var result = await Exp.sendAsync(recipient, url);
-  } finally {
-    simpleSpinner.stop();
+    spinner.succeed(`Sent URL to ${email}`);
+  } catch (e) {
+    spinner.fail(`Failed to email ${email}: ${e.message}`);
   }
-  log('Sent.');
   return result;
 }
-
-export default {
-  getRecipient,
-  sendUrlAsync,
-};


### PR DESCRIPTION
- use ora instead of simple spinner (this matches the prompts logs closer)
- surface error API message
- unify email prompt validation
- unify exports