### PR TITLE
[traveling-fastlane] manage_provisioning_profiles: add support for adhoc profiles

### DIFF
--- a/packages/traveling-fastlane/Rakefile
+++ b/packages/traveling-fastlane/Rakefile
@@ -19,6 +19,7 @@ SCRIPTS = [
   'manage_dist_certs',
   'manage_provisioning_profiles',
   'manage_push_keys',
+  'new_manage_provisioning_profiles',
   'pilot_upload',
   'preload',
   'resolve_itc_team_id',

--- a/packages/traveling-fastlane/actions/new_manage_provisioning_profiles.rb
+++ b/packages/traveling-fastlane/actions/new_manage_provisioning_profiles.rb
@@ -1,0 +1,212 @@
+# (@dsokal)
+# This is a slightly modified `manage_provisioning_profiles.rb` that's going to be used in eas-cli.
+# I didn't want to modify the original script because I didn't want to spend time on modifying expo-cli.
+# We're moving away from traveling-fastlane anyway.
+
+require 'spaceship'
+require 'json'
+require 'base64'
+require_relative 'funcs'
+
+$action, $appleId, $password, $teamId, $profileType, $bundleId, *$extraArgs = ARGV
+ENV['FASTLANE_TEAM_ID'] = $teamId
+ENV['SPACESHIP_AVOID_XCODE_API'] = '1'
+
+def get_certificate_provider()
+  if $profileType == 'in_house_dist'
+    Spaceship::Portal.certificate.in_house
+  elsif $profileType == 'in_house_adhoc'
+    Spaceship::Portal.certificate.in_house
+  elsif $profileType == 'app_store_dist'
+    Spaceship::Portal.certificate.production
+  elsif $profileType == 'app_store_adhoc'
+    Spaceship::Portal.certificate.production
+  else
+    raise ArgumentError, '$profileType must be one of: in_house_dist, in_house_adhoc, app_store_dist, app_store_adhoc'
+  end
+end
+
+def get_profile_provider()
+  if $profileType == 'in_house_dist'
+    Spaceship::Portal.provisioning_profile.in_house
+  elsif $profileType == 'in_house_adhoc'
+    Spaceship::Portal.provisioning_profile.ad_hoc
+  elsif $profileType == 'app_store_dist'
+    Spaceship::Portal.provisioning_profile.app_store
+  elsif $profileType == 'app_store_adhoc'
+    Spaceship::Portal.provisioning_profile.ad_hoc
+  else
+    raise ArgumentError, '$profileType must be one of: in_house_dist, in_house_adhoc, app_store_dist, app_store_adhoc'
+  end
+end
+
+def find_dist_cert(dist_cert_serial)
+  certs = get_certificate_provider().all
+  certs.find do |c|
+    c.raw_data['serialNum'] == dist_cert_serial
+  end
+end
+
+def create(cert, profile_name)
+  if cert == nil
+    {
+      result: 'failure',
+      reason: 'No cert available to make provision profile against',
+      rawDump: 'Make sure you were able to make a certificate prior to this step'
+    }
+  else
+    profile = get_profile_provider().create!(bundle_id: $bundleId, certificate: cert, name: profile_name)
+    profile_content = profile.download
+    {
+      provisioningProfileId: profile.id,
+      provisioningProfile: Base64.encode64(profile_content),
+      devices: profile.devices.map{|device| get_device_info(device)}
+
+    }
+  end
+end
+
+def revoke()
+  result = profile = get_profile_provider().find_by_bundle_id(bundle_id: $bundleId)
+  if result.length != 0
+    provisioning_profile = result[0]
+    provisioning_profile.delete!
+  end
+end
+
+def find_profile_by_id(profile_id, bundle_id)
+  profiles = get_profile_provider().find_by_bundle_id(bundle_id: bundle_id)
+  profiles.detect{|profile| profile.id == profile_id}
+end
+
+def assign_dist_cert(profile, dist_cert)
+  if dist_cert == nil
+    {
+      result: 'failure',
+      reason: 'No cert available to make provision profile against',
+      rawDump: 'Make sure you were able to make a certificate prior to this step'
+    }
+  end
+  # assign our dist cert to the existing profile
+  profile.certificates = [dist_cert]
+  profile =  profile.update!
+
+  {
+    provisioningProfileId: profile.id,
+    provisioningProfile: Base64.encode64(profile.download),
+    devices: profile.devices.map{|device| get_device_info(device)},
+  }
+end
+
+def list(bundle_id)
+  profiles = get_profile_provider().find_by_bundle_id(bundle_id: bundle_id)
+  profiles.map{|profile| get_profile_info(profile)}
+end
+
+def get_profile_info(profile)
+  {
+    name: profile.name,
+    status: profile.status,
+    expires: profile.expires.to_time.to_i,
+    distributionMethod: profile.distribution_method,
+    certificates: list_dist_certs(profile.certificates),
+    provisioningProfileId: profile.id,
+    provisioningProfile: Base64.encode64(profile.download),
+    devices: profile.devices.map{|device| get_device_info(device)},
+  }
+end
+
+def list_dist_certs(certs)
+  certs.map do |cert|
+    cert_info = {
+      id: cert.id,
+      name: cert.name,
+      status: cert.status,
+      ownerType: cert.owner_type,
+      ownerName: cert.owner_name,
+      ownerId: cert.owner_id,
+      serialNumber: cert.raw_data['serialNum'],
+    }
+    cert_info['created'] = cert.created.to_time.to_i if not cert.created.nil?
+    cert_info['expires'] = cert.expires.to_time.to_i if not cert.expires.nil?
+    cert_info
+  end
+end
+
+def get_device_info(device)
+  {
+    id: device.id,
+    name: device.name,
+    udid: device.udid,
+    platform: device.platform,
+    status: device.status,
+    deviceType: device.device_type,
+    model: device.model,
+  }
+end
+
+
+$result = nil
+
+with_captured_stderr{
+  begin
+    Spaceship::Portal.login($appleId, $password)
+    Spaceship::Portal.client.team_id = $teamId
+
+    if $action == 'create'
+      dist_cert_serial = $extraArgs[0]
+      profile_name = $extraArgs[1]
+      cert = find_dist_cert(dist_cert_serial)
+      provisioningProfile = create(cert, profile_name)
+      if provisioningProfile.key?('result')
+        $result = provisioningProfile
+      else
+        $result = { result: 'success', **provisioningProfile }
+      end
+    elsif $action == 'revoke'
+      revoke()
+      $result = { result: 'success' }
+    elsif $action == 'list'
+      $result = {
+        result: 'success',
+        profiles: list($bundleId),
+      }
+    elsif $action == 'use-existing'
+      profile_id = $extraArgs[0]
+      dist_cert_serial = $extraArgs[1]
+      cert = find_dist_cert(dist_cert_serial)
+      provisioningProfile = find_profile_by_id(profile_id, $bundleId)
+      provisioningProfile = assign_dist_cert(provisioningProfile, cert)
+      if provisioningProfile.key?('result')
+        $result = provisioningProfile
+      else
+        $result = { result: 'success', **provisioningProfile }
+      end
+    else
+      $result = {
+        result: 'failure',
+        reason: "Unknown action requested: #{$action}"
+      }
+    end
+  rescue Spaceship::Client::UnexpectedResponse => e
+    $result = {
+      result: 'failure',
+      reason: 'Unexpected response',
+      rawDump: e.error_info || dump_error(e)
+    }
+  rescue Spaceship::Client::InvalidUserCredentialsError => invalid_cred
+    $result = {
+      result: 'failure',
+      reason: 'Invalid credentials',
+      rawDump: invalid_cred.preferred_error_info
+    }
+  rescue Exception => e
+    $result = {
+      result: 'failure',
+      reason: 'Unknown reason',
+      rawDump: dump_error(e)
+    }
+  end
+}
+
+$stderr.puts JSON.generate($result)

--- a/packages/traveling-fastlane/publishing/darwin/index.js
+++ b/packages/traveling-fastlane/publishing/darwin/index.js
@@ -13,6 +13,7 @@ module.exports = () => {
     manageDistCerts: p('manage_dist_certs'),
     managePushKeys: p('manage_push_keys'),
     manageProvisioningProfiles: p('manage_provisioning_profiles'),
+    newManageProvisioningProfiles: p('new_manage_provisioning_profiles'),
     pilotUpload: p('pilot_upload'),
     resolveItcTeamId: p('resolve_itc_team_id'),
     supplyAndroid: p('supply_android'),

--- a/packages/traveling-fastlane/publishing/linux/index.js
+++ b/packages/traveling-fastlane/publishing/linux/index.js
@@ -13,6 +13,7 @@ module.exports = () => {
     manageDistCerts: p('manage_dist_certs'),
     managePushKeys: p('manage_push_keys'),
     manageProvisioningProfiles: p('manage_provisioning_profiles'),
+    newManageProvisioningProfiles: p('new_manage_provisioning_profiles'),
     pilotUpload: p('pilot_upload'),
     resolveItcTeamId: p('resolve_itc_team_id'),
     supplyAndroid: p('supply_android'),

--- a/packages/traveling-fastlane/wrappers/new_manage_provisioning_profiles_wrapper.sh
+++ b/packages/traveling-fastlane/wrappers/new_manage_provisioning_profiles_wrapper.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+# Figure out where this script is located.
+SELFDIR="`dirname \"$0\"`"
+SELFDIR="`cd \"$SELFDIR\" && pwd`"
+
+export BUNDLE_GEMFILE="$SELFDIR/lib/vendor/Gemfile"
+unset BUNDLE_IGNORE_CONFIG
+
+export FASTLANE_DISABLE_COLORS=1
+export FASTLANE_SKIP_UPDATE_CHECK=1
+export FASTLANE_DISABLE_ANIMATION=1
+
+script="$SELFDIR/lib/app/new_manage_provisioning_profiles.rb"
+
+lib_loc="$SELFDIR/lib/app"
+
+exec "$SELFDIR/lib/ruby/bin/ruby" -W0 -I"$lib_loc" -rpreload "$script" "$@"


### PR DESCRIPTION
This PR adds a slightly modified version of `manage_provisioning_profiles.rb` so I could use it for managing ad-hoc provisioning profiles in EAS CLI (the PR that takes advantage of the new script is here - https://github.com/expo/eas-cli/pull/59). 

Notable changes:
- replaced positional param `isEnterprise` with `profileType` (possible values: `in_house_dist`, `in_house_adhoc`, `app_store_dist`, `app_store_adhoc`)
- all commands which return the provisioning profile include the `devices` property (makes sense only for ad-hoc profiles)

#### For reviewers: diff between manage_provisioning_profiles and new_manage_provisioning_profiles
<details>
  <summary>Click to expand</summary>

```patch
0a1,5
> # (@dsokal)
> # This is a slightly modified `manage_provisioning_profiles.rb` that's going to be used in eas-cli.
> # I didn't want to modify the original script because I didn't want to spend time on modifying expo-cli.
> # We're moving away from traveling-fastlane anyway.
> 
6c11
< $action, $appleId, $password, $teamId, $isEnterprise, $bundleId, *$extraArgs = ARGV
---
> $action, $appleId, $password, $teamId, $profileType, $bundleId, *$extraArgs = ARGV
10,13c15,41
< def find_dist_cert(dist_cert_serial, is_enterprise)
<   certs = is_enterprise == 'true' \
<   ? Spaceship::Portal.certificate.in_house.all \
<   : Spaceship::Portal.certificate.production.all
---
> def get_certificate_provider()
>   if $profileType == 'in_house_dist'
>     Spaceship::Portal.certificate.in_house
>   elsif $profileType == 'in_house_adhoc'
>     Spaceship::Portal.certificate.in_house
>   elsif $profileType == 'app_store_dist'
>     Spaceship::Portal.certificate.production
>   elsif $profileType == 'app_store_adhoc'
>     Spaceship::Portal.certificate.production
>   else
>     raise ArgumentError, '$profileType must be one of: in_house_dist, in_house_adhoc, app_store_dist, app_store_adhoc'
>   end
> end
> 
> def get_profile_provider()
>   if $profileType == 'in_house_dist'
>     Spaceship::Portal.provisioning_profile.in_house
>   elsif $profileType == 'in_house_adhoc'
>     Spaceship::Portal.provisioning_profile.ad_hoc
>   elsif $profileType == 'app_store_dist'
>     Spaceship::Portal.provisioning_profile.app_store
>   elsif $profileType == 'app_store_adhoc'
>     Spaceship::Portal.provisioning_profile.ad_hoc
>   else
>     raise ArgumentError, '$profileType must be one of: in_house_dist, in_house_adhoc, app_store_dist, app_store_adhoc'
>   end
> end
14a43,44
> def find_dist_cert(dist_cert_serial)
>   certs = get_certificate_provider().all
28,30c58
<     profile = $isEnterprise == 'true' \
<       ? Spaceship::Portal.provisioning_profile.in_house.create!(bundle_id: $bundleId, certificate: cert, name: profile_name) \
<       : Spaceship::Portal.provisioning_profile.app_store.create!(bundle_id: $bundleId, certificate: cert, name: profile_name)
---
>     profile = get_profile_provider().create!(bundle_id: $bundleId, certificate: cert, name: profile_name)
34a63,64
>       devices: profile.devices.map{|device| get_device_info(device)}
> 
40,42c70
<   result = $isEnterprise == 'true' \
<     ? Spaceship::Portal.provisioning_profile.in_house.find_by_bundle_id(bundle_id: $bundleId) \
<     : Spaceship::Portal.provisioning_profile.app_store.find_by_bundle_id(bundle_id: $bundleId)
---
>   result = profile = get_profile_provider().find_by_bundle_id(bundle_id: $bundleId)
50,53c78
<   profiles = $isEnterprise == 'true' \
<     ? Spaceship::Portal.provisioning_profile.in_house.find_by_bundle_id(bundle_id: bundle_id) \
<     : Spaceship::Portal.provisioning_profile.app_store.find_by_bundle_id(bundle_id: bundle_id)
< 
---
>   profiles = get_profile_provider().find_by_bundle_id(bundle_id: bundle_id)
71a97
>     devices: profile.devices.map{|device| get_device_info(device)},
75,81c101,102
< def list(bundle_id, is_enterprise)
<   profiles = nil
<   if is_enterprise == 'true'
<     profiles = Spaceship::Portal.provisioning_profile.in_house.find_by_bundle_id(bundle_id: bundle_id)
<   else 
<     profiles = Spaceship::Portal.provisioning_profile.app_store.find_by_bundle_id(bundle_id: bundle_id)
<   end
---
> def list(bundle_id)
>   profiles = get_profile_provider().find_by_bundle_id(bundle_id: bundle_id)
93a115
>     devices: profile.devices.map{|device| get_device_info(device)},
113a136,147
> def get_device_info(device)
>   {
>     id: device.id,
>     name: device.name,
>     udid: device.udid,
>     platform: device.platform,
>     status: device.status,
>     deviceType: device.device_type,
>     model: device.model,
>   }
> end
> 
125c159
<       cert = find_dist_cert(dist_cert_serial, $isEnterprise)
---
>       cert = find_dist_cert(dist_cert_serial)
138c172
<         profiles: list($bundleId, $isEnterprise),
---
>         profiles: list($bundleId),
143c177
<       cert = find_dist_cert(dist_cert_serial, $isEnterprise)
---
>       cert = find_dist_cert(dist_cert_serial)

```

</details>