### PR TITLE
clean up fetch commands

### DIFF
--- a/packages/expo-cli/src/commands/fetch/android.ts
+++ b/packages/expo-cli/src/commands/fetch/android.ts
@@ -1,7 +1,8 @@
 import { AndroidCredentials } from '@expo/xdl';
-import fs from 'fs-extra';
+import chalk from 'chalk';
+import * as fs from 'fs-extra';
 import invariant from 'invariant';
-import path from 'path';
+import * as path from 'path';
 
 import { Context } from '../../credentials';
 import { runCredentialsManager } from '../../credentials/route';
@@ -14,36 +15,40 @@ type Options = {
   };
 };
 
-async function maybeRenameExistingFile(projectDir: string, filename: string) {
-  const desiredFilePath = path.resolve(projectDir, filename);
+function assertSlug(slug: any): asserts slug {
+  invariant(slug, `${chalk.bold(slug)} field must be set in your app.json or app.config.js`);
+}
+
+async function maybeRenameExistingFileAsync(projectRoot: string, filename: string) {
+  const desiredFilePath = path.resolve(projectRoot, filename);
 
   if (await fs.pathExists(desiredFilePath)) {
     let num = 1;
-    while (await fs.pathExists(path.resolve(projectDir, `OLD_${num}_${filename}`))) {
+    while (await fs.pathExists(path.resolve(projectRoot, `OLD_${num}_${filename}`))) {
       num++;
     }
     log(
       `\nA file already exists at "${desiredFilePath}"\n  Renaming the existing file to OLD_${num}_${filename}\n`
     );
-    await fs.rename(desiredFilePath, path.resolve(projectDir, `OLD_${num}_${filename}`));
+    await fs.rename(desiredFilePath, path.resolve(projectRoot, `OLD_${num}_${filename}`));
   }
 }
 
 export async function fetchAndroidKeystoreAsync(
-  projectDir: string,
+  projectRoot: string,
   options: Options
 ): Promise<void> {
   const ctx = new Context();
-  await ctx.init(projectDir, {
+  await ctx.init(projectRoot, {
     nonInteractive: options.parent?.nonInteractive,
   });
 
   const keystoreFilename = `${ctx.manifest.slug}.jks`;
-  await maybeRenameExistingFile(projectDir, keystoreFilename);
-  const backupKeystoreOutputPath = path.resolve(projectDir, keystoreFilename);
+  await maybeRenameExistingFileAsync(projectRoot, keystoreFilename);
+  const backupKeystoreOutputPath = path.resolve(projectRoot, keystoreFilename);
   const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
 
-  invariant(ctx.manifest.slug, 'app.json slug field must be set');
+  assertSlug(ctx.manifest.slug);
   await runCredentialsManager(
     ctx,
     new DownloadKeystore(experienceName, {
@@ -53,14 +58,17 @@ export async function fetchAndroidKeystoreAsync(
   );
 }
 
-export async function fetchAndroidHashesAsync(projectDir: string, options: Options): Promise<void> {
+export async function fetchAndroidHashesAsync(
+  projectRoot: string,
+  options: Options
+): Promise<void> {
   const ctx = new Context();
-  await ctx.init(projectDir, {
+  await ctx.init(projectRoot, {
     nonInteractive: options.parent?.nonInteractive,
   });
-  const outputPath = path.resolve(projectDir, `${ctx.manifest.slug}.tmp.jks`);
+  const outputPath = path.resolve(projectRoot, `${ctx.manifest.slug}.tmp.jks`);
   try {
-    invariant(ctx.manifest.slug, 'app.json slug field must be set');
+    assertSlug(ctx.manifest.slug);
     const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
     const view = new DownloadKeystore(experienceName, {
       outputPath,
@@ -88,22 +96,22 @@ export async function fetchAndroidHashesAsync(projectDir: string, options: Optio
 }
 
 export async function fetchAndroidUploadCertAsync(
-  projectDir: string,
+  projectRoot: string,
   options: Options
 ): Promise<void> {
   const ctx = new Context();
-  await ctx.init(projectDir, {
+  await ctx.init(projectRoot, {
     nonInteractive: options.parent?.nonInteractive,
   });
 
-  const keystorePath = path.resolve(projectDir, `${ctx.manifest.slug}.tmp.jks`);
+  const keystorePath = path.resolve(projectRoot, `${ctx.manifest.slug}.tmp.jks`);
 
   const uploadKeyFilename = `${ctx.manifest.slug}_upload_cert.pem`;
-  await maybeRenameExistingFile(projectDir, uploadKeyFilename);
-  const uploadKeyPath = path.resolve(projectDir, uploadKeyFilename);
+  await maybeRenameExistingFileAsync(projectRoot, uploadKeyFilename);
+  const uploadKeyPath = path.resolve(projectRoot, uploadKeyFilename);
 
   try {
-    invariant(ctx.manifest.slug, 'app.json slug field must be set');
+    assertSlug(ctx.manifest.slug);
     const experienceName = `@${ctx.manifest.owner || ctx.user.username}/${ctx.manifest.slug}`;
     const view = new DownloadKeystore(experienceName, {
       outputPath: keystorePath,

--- a/packages/expo-cli/src/commands/fetch/index.ts
+++ b/packages/expo-cli/src/commands/fetch/index.ts
@@ -5,7 +5,7 @@ import {
   fetchAndroidKeystoreAsync,
   fetchAndroidUploadCertAsync,
 } from './android';
-import fetchIosCerts from './ios';
+import fetchIosCertsAsync from './ios';
 
 export default function (program: Command) {
   program
@@ -15,7 +15,7 @@ export default function (program: Command) {
       `Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.`
     )
     .helpGroup('credentials')
-    .asyncActionProjectDir(fetchIosCerts);
+    .asyncActionProjectDir(fetchIosCertsAsync);
 
   program
     .command('fetch:android:keystore [path]')

--- a/packages/expo-cli/src/commands/fetch/ios.ts
+++ b/packages/expo-cli/src/commands/fetch/ios.ts
@@ -1,22 +1,19 @@
 import chalk from 'chalk';
-import fs from 'fs-extra';
-import path from 'path';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 
 import { Context } from '../../credentials/context';
 import log from '../../log';
+import { getOrPromptForBundleIdentifier } from '../eject/ConfigValidation';
 
-async function fetchIosCerts(projectDir: string): Promise<void> {
-  const inProjectDir = (filename: string): string => path.resolve(projectDir, filename);
+async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
+  const inProjectDir = (filename: string): string => path.resolve(projectRoot, filename);
+
+  const bundleIdentifier = await getOrPromptForBundleIdentifier(projectRoot);
+
   try {
     const ctx = new Context();
-    await ctx.init(projectDir);
-
-    const bundleIdentifier = ctx.manifest?.ios?.bundleIdentifier;
-    if (!bundleIdentifier) {
-      throw new Error(
-        `Your project must have a \`bundleIdentifier\` set in the Expo config (app.json or app.config.js).\nSee https://expo.fyi/bundle-identifier`
-      );
-    }
+    await ctx.init(projectRoot);
 
     const app = {
       accountName: ctx.manifest.owner ?? ctx.user.username,
@@ -63,7 +60,7 @@ async function fetchIosCerts(projectDir: string): Promise<void> {
     }
     if (provisioningProfile) {
       const provisioningProfilePath = path.resolve(
-        projectDir,
+        projectRoot,
         `${app.projectName}.mobileprovision`
       );
       await fs.writeFile(provisioningProfilePath, Buffer.from(provisioningProfile, 'base64'));
@@ -86,4 +83,4 @@ Push P12 password:         ${
   log('All done!');
 }
 
-export default fetchIosCerts;
+export default fetchIosCertsAsync;

--- a/packages/expo-cli/src/commands/fetch/ios.ts
+++ b/packages/expo-cli/src/commands/fetch/ios.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
+import CommandError from '../../CommandError';
 import { Context } from '../../credentials/context';
 import log from '../../log';
 import { getOrPromptForBundleIdentifier } from '../eject/ConfigValidation';
@@ -77,7 +78,9 @@ Push P12 password:         ${
     }
 `);
   } catch (e) {
-    throw new Error('Unable to fetch credentials for this project. Are you sure they exist?');
+    throw new CommandError(
+      'Unable to fetch credentials for this project. Are you sure they exist?'
+    );
   }
 
   log('All done!');


### PR DESCRIPTION
- improve bundle id resolution with `getOrPromptForBundleIdentifier`
- improve errors
  - unify slug assertions
  - show config syntax errors correctly
  - use single line error format on iOS (switch to CommandError)
- projectDir -> projectRoot
- add async suffix
