### PR TITLE
[config] fix: add files to 'copy bundle resources', not 'compile sour…

### DIFF
--- a/packages/config/src/ios/utils/Xcodeproj.ts
+++ b/packages/config/src/ios/utils/Xcodeproj.ts
@@ -42,7 +42,7 @@ export function addFileToGroup(
   file.fileRef = project.generateUuid();
   project.addToPbxFileReferenceSection(file);
   project.addToPbxBuildFileSection(file);
-  project.addToPbxSourcesBuildPhase(file);
+  project.addToPbxResourcesBuildPhase(file);
   const group = pbxGroupByPath(project, groupName);
   if (!group) {
     throw Error(`Group by name ${groupName} not found!`);


### PR DESCRIPTION
…ces' build phase

# why

the two instances where this function is used are:
- adding `GoogleService-Info.plist` to the project
- adding localization strings to the project

In both of those instances, when you follow the relevant guides for them, the respective files are added to the "Copy Bundle Resources" build phase, not the "Compile Sources" build phase ([google services guide](https://firebase.google.com/docs/ios/setup) and [localization guide](https://www.raywenderlich.com/250-internationalizing-your-ios-app-getting-started))

Placing them in the compile sources build phase causes errors like the one failing this build- https://expo.io/accounts/charliecruzan/builds/v2/9595f8bb-cd42-4208-8c30-c8e3b6f7d05d/logs

# test plan

ran eject locally, here's the result:

![image](https://user-images.githubusercontent.com/35579283/99994298-d0fc5f00-2d86-11eb-8d94-eb4d34de401d.png)
