### PR TITLE
Prevent passing a plugin that requires props without props

### DIFF
--- a/packages/config/src/plugins/core-plugins.ts
+++ b/packages/config/src/plugins/core-plugins.ts
@@ -13,11 +13,13 @@ function ensureArray<T>(input: T | T[]): T[] {
  * @param config exported config
  * @param plugins list of config config plugins to apply to the exported config
  */
-export const withPlugins: ConfigPlugin<(ConfigPlugin | [ConfigPlugin<any>, any])[]> = (
-  config,
-  // TODO: Type this somehow if possible.
-  plugins
-): ExportedConfig => {
+export const withPlugins: ConfigPlugin<
+  (
+    | ConfigPlugin
+    // TODO: Type this somehow if possible.
+    | [ConfigPlugin<any>, any]
+  )[]
+> = (config, plugins): ExportedConfig => {
   return plugins.reduce((prev, curr) => {
     const [plugins, args] = ensureArray(curr);
     return plugins(prev, args);

--- a/packages/config/src/plugins/core-plugins.ts
+++ b/packages/config/src/plugins/core-plugins.ts
@@ -7,15 +7,13 @@ function ensureArray<T>(input: T | T[]): T[] {
   return [input];
 }
 
-type AppliedConfigPlugin<T> = ConfigPlugin<T> | [ConfigPlugin<T>, T];
-
 /**
  * Plugin to chain a list of plugins together.
  *
  * @param config exported config
  * @param plugins list of config config plugins to apply to the exported config
  */
-export const withPlugins: ConfigPlugin<AppliedConfigPlugin<any>[]> = (
+export const withPlugins: ConfigPlugin<(ConfigPlugin | [ConfigPlugin<any>, any])[]> = (
   config,
   // TODO: Type this somehow if possible.
   plugins


### PR DESCRIPTION
```ts
const plugin = (config, props) => config

withPlugins(config, [
  [plugin, { /* props now required*/ }]
  // this will now throw a TS error as props are required.
  plugin
])
```