### PR TITLE
Update --dev-client for new requirements

### DIFF
--- a/packages/dev-tools/__mocks__/@expo/xdl.js
+++ b/packages/dev-tools/__mocks__/@expo/xdl.js
@@ -1,6 +1,9 @@
 const xdl = jest.genMockFromModule('@expo/xdl');
 
 xdl.UrlUtils = {
+  constructDeepLinkAsync(projectDir) {
+    return this.constructManifestUrlAsync(projectDir);
+  },
   constructManifestUrlAsync(projectDir) {
     return 'exp://mock-manifest-url';
   },

--- a/packages/dev-tools/server/graphql/GraphQLSchema.ts
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.ts
@@ -432,7 +432,7 @@ const resolvers = {
     },
     async manifestUrl(project) {
       if ((await Project.currentStatus(project.projectDir)) === 'running') {
-        return UrlUtils.constructManifestUrlAsync(project.projectDir);
+        return UrlUtils.constructDeepLinkAsync(project.projectDir);
       } else {
         return null;
       }

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -12,7 +12,7 @@ type Options = URLOptions & { sendTo?: string };
 async function action(projectRoot: string, options: Options) {
   await urlOpts.optsAsync(projectRoot, options);
 
-  const url = await UrlUtils.constructManifestUrlAsync(projectRoot);
+  const url = await UrlUtils.constructDeepLinkAsync(projectRoot);
 
   log.nested('Project manifest URL\n\n' + chalk.underline(url) + '\n');
 

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -113,6 +113,8 @@ async function normalizeOptionsAsync(
 
 async function cacheOptionsAsync(projectDir: string, options: NormalizedOptions): Promise<void> {
   await ProjectSettings.setAsync(projectDir, {
+    devClient: options.devClient,
+    scheme: options.scheme,
     dev: options.dev,
     minify: options.minify,
     https: options.https,
@@ -139,6 +141,9 @@ function parseStartOptions(options: NormalizedOptions): Project.StartOptions {
   }
 
   if (options.devClient) {
+    startOpts.devClient = true;
+
+    // TODO: is this redundant?
     startOpts.target = 'bare';
   } else {
     // For `expo start`, the default target is 'managed', for both managed *and* bare apps.
@@ -170,7 +175,7 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
 
   await Project.startAsync(rootPath, { ...startOpts, exp });
 
-  const url = await UrlUtils.constructManifestUrlAsync(projectDir);
+  const url = await UrlUtils.constructDeepLinkAsync(projectDir);
 
   const recipient = await sendTo.getRecipient(options.sendTo);
   if (recipient) {

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -97,7 +97,7 @@ export const printServerInfo = async (
     Webpack.printConnectionInstructions(projectDir);
     return;
   }
-  const url = await UrlUtils.constructManifestUrlAsync(projectDir);
+  const url = await UrlUtils.constructDeepLinkAsync(projectDir);
   log.newLine();
   log.nested(` ${u(url)}`);
   log.newLine();
@@ -107,8 +107,12 @@ export const printServerInfo = async (
   const item = (text: string): string => ` ${BLT} ` + wrapItem(text).trimStart();
   const iosInfo = process.platform === 'darwin' ? `, or ${b('i')} for iOS simulator` : '';
   const webInfo = `${b`w`} to run on ${u`w`}eb`;
-  log.nested(wrap(u('To run the app with live reloading, choose one of:')));
+  log.nested(wrap(u('To run the app, choose one of:')));
+
+  // TODO: if dev client, chanege this message!
   log.nested(item(`Scan the QR code above with the Expo app (Android) or the Camera app (iOS).`));
+
+  // TODO: if no react-native-web in package.json then don't show web info
   log.nested(item(`Press ${b`a`} for Android emulator${iosInfo}, or ${webInfo}.`));
   log.nested(item(`Press ${b`e`} to send a link to your phone with email.`));
 
@@ -230,7 +234,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         }
         case 'e': {
           stopWaitingForCommand();
-          const lanAddress = await UrlUtils.constructManifestUrlAsync(projectRoot, {
+          const lanAddress = await UrlUtils.constructDeepLinkAsync(projectRoot, {
             hostType: 'lan',
           });
           const defaultRecipient = await UserSettings.getAsync('sendTo', null);

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -61,7 +61,7 @@ async function action(projectDir: string, options: ProjectUrlOptions & URLOption
   }
   const url = options.web
     ? await getWebAppUrlAsync(projectDir)
-    : await UrlUtils.constructManifestUrlAsync(projectDir);
+    : await UrlUtils.constructDeepLinkAsync(projectDir);
 
   log.newLine();
   urlOpts.printQRCode(url);

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -8,6 +8,7 @@ import CommandError, { AbortCommandError } from './CommandError';
 import log from './log';
 import { getDevClientSchemeAsync } from './schemes';
 
+// NOTE: if you update this, you should also update assertValidOptions in UrlUtils.ts
 export type URLOptions = {
   devClient?: boolean;
   android?: boolean;

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -39,6 +39,16 @@ export function getDefaultConfig(
     resolveModule('react-native/package.json', projectRoot, exp)
   );
 
+  let hashAssetFilesPath;
+  try {
+    hashAssetFilesPath = resolveModule('expo-asset/tools/hashAssetFiles', projectRoot, exp);
+  } catch {
+    // TODO: we should warn/throw an error if the user has expo-updates installed but does not
+    // have hashAssetFiles available, or if the user is in managed workflow and does not have
+    // hashAssetFiles available. but in a bare app w/o expo-updates, just using dev-client,
+    // it is not needed
+  }
+
   const target = options.target ?? process.env.EXPO_TARGET ?? getDefaultTarget(projectRoot);
   if (!(target === 'managed' || target === 'bare')) {
     throw new Error(
@@ -85,7 +95,7 @@ export function getDefaultConfig(
       babelTransformerPath: require.resolve('metro-react-native-babel-transformer'),
       // TODO: Bacon: Add path for web platform
       assetRegistryPath: path.join(reactNativePath, 'Libraries/Image/AssetRegistry'),
-      assetPlugins: [resolveModule('expo-asset/tools/hashAssetFiles', projectRoot, exp)],
+      assetPlugins: hashAssetFilesPath ? [hashAssetFilesPath] : undefined,
     },
   });
 }

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -658,7 +658,7 @@ export async function openProjectAsync({
   try {
     await startAdbReverseAsync(projectRoot);
 
-    const projectUrl = await UrlUtils.constructManifestUrlAsync(projectRoot);
+    const projectUrl = await UrlUtils.constructDeepLinkAsync(projectRoot);
     const { exp } = getConfig(projectRoot, {
       skipSDKVersionRequirement: true,
     });

--- a/packages/xdl/src/DevSession.ts
+++ b/packages/xdl/src/DevSession.ts
@@ -34,7 +34,7 @@ export async function startSession(
     try {
       let url;
       if (platform === 'native') {
-        url = await UrlUtils.constructManifestUrlAsync(projectRoot);
+        url = await UrlUtils.constructDeepLinkAsync(projectRoot);
       } else if (platform === 'web') {
         url = await UrlUtils.constructWebAppUrlAsync(projectRoot);
       } else {

--- a/packages/xdl/src/ErrorCode.ts
+++ b/packages/xdl/src/ErrorCode.ts
@@ -32,5 +32,7 @@ export type ErrorCode =
   | 'WEBPACK_DEPRECATED'
   | 'WEBPACK_INVALID_OPTION'
   | 'NETWORK_REQUIRED'
-  //Shell Apps
-  | 'CREDENTIAL_ERROR';
+  // Shell Apps
+  | 'CREDENTIAL_ERROR'
+  // Dev Client
+  | 'NO_DEV_CLIENT_SCHEME';

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -84,6 +84,7 @@ type LoadedHook = Hook & {
 };
 
 export type StartOptions = {
+  devClient?: boolean;
   reset?: boolean;
   nonInteractive?: boolean;
   nonPersistent?: boolean;
@@ -1647,7 +1648,10 @@ export async function stopReactNativeServerAsync(projectRoot: string): Promise<v
   });
 }
 
-export async function startExpoServerAsync(projectRoot: string): Promise<void> {
+export async function startExpoServerAsync(
+  projectRoot: string,
+  options: StartOptions
+): Promise<void> {
   assertValidProjectRoot(projectRoot);
   await stopExpoServerAsync(projectRoot);
   const app = express();
@@ -1777,11 +1781,11 @@ export async function startAsync(
     await Webpack.restartAsync(projectRoot, options);
     DevSession.startSession(projectRoot, exp, 'web');
     return exp;
-  } else if (shouldUseDevServer(exp)) {
+  } else if (shouldUseDevServer(exp) || options.devClient) {
     await startDevServerAsync(projectRoot, options);
     DevSession.startSession(projectRoot, exp, 'native');
   } else {
-    await startExpoServerAsync(projectRoot);
+    await startExpoServerAsync(projectRoot, options);
     await startReactNativeServerAsync({ projectRoot, exp, options, verbose });
     DevSession.startSession(projectRoot, exp, 'native');
   }

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -8,6 +8,7 @@ export type ProjectSettings = {
   hostType: 'localhost' | 'lan' | 'tunnel';
   lanType: 'ip' | 'hostname';
   dev: boolean;
+  devClient: boolean;
   minify: boolean;
   urlRandomness: string | null;
   https: boolean;
@@ -19,6 +20,7 @@ const projectSettingsDefaults: ProjectSettings = {
   scheme: null,
   hostType: 'lan',
   lanType: 'ip',
+  devClient: false,
   dev: true,
   minify: false,
   urlRandomness: null,

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -659,7 +659,7 @@ export async function openProjectAsync({
   projectRoot: string;
   shouldPrompt?: boolean;
 }): Promise<{ success: true; url: string } | { success: false; error: string }> {
-  const projectUrl = await UrlUtils.constructManifestUrlAsync(projectRoot, {
+  const projectUrl = await UrlUtils.constructDeepLinkAsync(projectRoot, {
     hostType: 'localhost',
   });
   const { exp } = getConfig(projectRoot, {

--- a/packages/xdl/src/project/ExpSchema.ts
+++ b/packages/xdl/src/project/ExpSchema.ts
@@ -46,7 +46,8 @@ export async function getSchemaAsync(sdkVersion: string): Promise<Schema> {
  * @param sdkVersion
  */
 export async function getAssetSchemasAsync(sdkVersion: string): Promise<string[]> {
-  const schema = await getSchemaAsync(sdkVersion);
+  // If no SDK version is available then fall back to unversioned
+  const schema = await getSchemaAsync(sdkVersion ?? 'UNVERSIONED');
   const assetSchemas: string[] = [];
   const visit = (node: Schema, fieldPath: string) => {
     if (node.meta && node.meta.asset) {


### PR DESCRIPTION
- ~Should work without having the `expo` package installed.~ We will require that developers either set an SDK version or install the `expo` package (as a regular dependency or dev dependency) to use expo-dev-launcher.
- Should deep link into the app using the url format: `myscheme://expo-development-client/?url=url-encoded-path-to-app-manifest` ([described on Notion](https://www.notion.so/expo/Deep-Linking-URL-Format-for-Development-Clients-b721472abba0426ea1e747c3718aaf4a)).

### TODO

- [x] Write tests
- [x] Follow up on other TODOs included in the diff