### PR TITLE
Support updating the project settings.gradle name on sync

### DIFF
--- a/packages/config/src/Plugin.types.ts
+++ b/packages/config/src/Plugin.types.ts
@@ -88,6 +88,10 @@ export interface ModConfig {
      * Modify the `android/build.gradle` as a string.
      */
     projectBuildGradle?: Mod<AndroidPaths.GradleProjectFile>;
+    /**
+     * Modify the `android/settings.gradle` as a string.
+     */
+    settingsGradle?: Mod<AndroidPaths.GradleProjectFile>;
   };
   ios?: {
     /**

--- a/packages/config/src/android/Name.ts
+++ b/packages/config/src/android/Name.ts
@@ -1,11 +1,39 @@
 import { ExpoConfig } from '../Config.types';
 import { assert } from '../Errors';
-import { createStringsXmlPlugin } from '../plugins/android-plugins';
+import { ConfigPlugin } from '../Plugin.types';
+import { addWarningAndroid } from '../WarningAggregator';
+import { createStringsXmlPlugin, withSettingsGradle } from '../plugins/android-plugins';
 import { buildResourceItem, readResourcesXMLAsync, ResourceXML } from './Resources';
 import { getProjectStringsXMLPathAsync, removeStringItem, setStringItem } from './Strings';
 import { writeXMLAsync } from './XML';
 
+/**
+ * Sanitize a name, this should be used for files and gradle names.
+ * - `[/, \, :, <, >, ", ?, *, |]` are not allowed https://bit.ly/3l6xqKL
+ *
+ * @param name
+ */
+export function sanitizeNameForGradle(name: string): string {
+  // Gradle disallows these:
+  // The project name 'My-Special 😃 Co/ol_Project' must not contain any of the following characters: [/, \, :, <, >, ", ?, *, |]. Set the 'rootProject.name' or adjust the 'include' statement (see https://docs.gradle.org/6.2/dsl/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[]) for more details).
+  return name.replace(/(\/|\\|:|<|>|"|\?|\*|\|)/g, '');
+}
+
 export const withName = createStringsXmlPlugin(applyNameFromConfig, 'withName');
+
+export const withNameSettingsGradle: ConfigPlugin = config => {
+  return withSettingsGradle(config, config => {
+    if (config.modResults.language === 'groovy') {
+      config.modResults.contents = applyNameSettingsGradle(config, config.modResults.contents);
+    } else {
+      addWarningAndroid(
+        'android-name-settings-gradle',
+        `Cannot automatically configure settings.gradle if it's not groovy`
+      );
+    }
+    return config;
+  });
+};
 
 export function getName(config: Pick<ExpoConfig, 'name'>) {
   return typeof config.name === 'string' ? config.name : null;
@@ -42,4 +70,20 @@ function applyNameFromConfig(
     return setStringItem([buildResourceItem({ name: 'app_name', value: name })], stringsJSON);
   }
   return removeStringItem('app_name', stringsJSON);
+}
+
+/**
+ * Regex a name change -- fragile.
+ *
+ * @param config
+ * @param settingsGradle
+ */
+export function applyNameSettingsGradle(config: Pick<ExpoConfig, 'name'>, settingsGradle: string) {
+  const name = sanitizeNameForGradle(getName(config) ?? '');
+
+  // Select rootProject.name = '***' and replace the contents between the quotes.
+  return settingsGradle.replace(
+    /rootProject.name\s?=\s?(["'])(?:(?=(\\?))\2.)*?\1/g,
+    `rootProject.name = '${name}'`
+  );
 }

--- a/packages/config/src/android/Paths.ts
+++ b/packages/config/src/android/Paths.ts
@@ -55,15 +55,18 @@ export async function getMainActivityAsync(projectRoot: string): Promise<Applica
   return getProjectFileAsync(projectRoot, 'MainActivity');
 }
 
-async function getBuildGradleAsync(projectRoot: string): Promise<GradleProjectFile> {
-  const groovyPath = path.resolve(projectRoot, 'build.gradle');
-  const ktPath = path.resolve(projectRoot, 'build.gradle.kts');
+async function getGradleFileAsync(
+  projectRoot: string,
+  gradleName: string
+): Promise<GradleProjectFile> {
+  const groovyPath = path.resolve(projectRoot, `${gradleName}.gradle`);
+  const ktPath = path.resolve(projectRoot, `${gradleName}.gradle.kts`);
 
   const isGroovy = await fs.pathExists(groovyPath);
   const isKotlin = !isGroovy && (await fs.pathExists(ktPath));
 
   if (!isGroovy && !isKotlin) {
-    throw new Error(`Failed to find 'build.gradle' file for project: ${projectRoot}.`);
+    throw new Error(`Failed to find '${gradleName}.gradle' file for project: ${projectRoot}.`);
   }
   const filePath = isGroovy ? groovyPath : ktPath;
   return {
@@ -74,15 +77,15 @@ async function getBuildGradleAsync(projectRoot: string): Promise<GradleProjectFi
 }
 
 export async function getProjectBuildGradleAsync(projectRoot: string): Promise<GradleProjectFile> {
-  return getBuildGradleAsync(path.join(projectRoot, 'android'));
+  return getGradleFileAsync(path.join(projectRoot, 'android'), 'build');
+}
+
+export async function getSettingsGradleAsync(projectRoot: string): Promise<GradleProjectFile> {
+  return getGradleFileAsync(path.join(projectRoot, 'android'), 'settings');
 }
 
 export async function getAppBuildGradleAsync(projectRoot: string): Promise<GradleProjectFile> {
-  return getBuildGradleAsync(path.join(projectRoot, 'android', 'app'));
-}
-
-export function getAndroidBuildGradle(projectRoot: string): string {
-  return path.join(projectRoot, 'android', 'build.gradle');
+  return getGradleFileAsync(path.join(projectRoot, 'android', 'app'), 'build');
 }
 
 export function getAppBuildGradle(projectRoot: string): string {

--- a/packages/config/src/plugins/android-plugins.ts
+++ b/packages/config/src/plugins/android-plugins.ts
@@ -92,7 +92,7 @@ export const withMainActivity: ConfigPlugin<Mod<ApplicationProjectFile>> = (conf
 };
 
 /**
- * Provides the project build.gradle for modification.
+ * Provides the project /build.gradle for modification.
  *
  * @param config
  * @param action
@@ -115,6 +115,20 @@ export const withAppBuildGradle: ConfigPlugin<Mod<GradleProjectFile>> = (config,
   return withExtendedMod(config, {
     platform: 'android',
     mod: 'appBuildGradle',
+    action,
+  });
+};
+
+/**
+ * Provides the /settings.gradle for modification.
+ *
+ * @param config
+ * @param action
+ */
+export const withSettingsGradle: ConfigPlugin<Mod<GradleProjectFile>> = (config, action) => {
+  return withExtendedMod(config, {
+    platform: 'android',
+    mod: 'settingsGradle',
     action,
   });
 };

--- a/packages/config/src/plugins/compiler-plugins.ts
+++ b/packages/config/src/plugins/compiler-plugins.ts
@@ -51,6 +51,7 @@ function applyAndroidBaseMods(config: ExportedConfig): ExportedConfig {
   config = withAndroidStringsXMLBaseMod(config);
   config = withAndroidManifestBaseMod(config);
   config = withAndroidMainActivityBaseMod(config);
+  config = withAndroidSettingsGradleBaseMod(config);
   config = withAndroidProjectBuildGradleBaseMod(config);
   config = withAndroidAppBuildGradleBaseMod(config);
   return config;
@@ -157,6 +158,42 @@ const withAndroidProjectBuildGradleBaseMod: ConfigPlugin = config => {
         addWarningAndroid(
           `${modRequest.platform}-${modRequest.modName}`,
           `Project build.gradle could not be modified. ${error.message}`
+        );
+      }
+      return results;
+    },
+  });
+};
+
+const withAndroidSettingsGradleBaseMod: ConfigPlugin = config => {
+  return withInterceptedMod<AndroidPaths.GradleProjectFile>(config, {
+    platform: 'android',
+    mod: 'settingsGradle',
+    skipEmptyMod: true,
+    async action({ modRequest: { nextMod, ...modRequest }, ...config }) {
+      let results: ExportedConfigWithProps<AndroidPaths.GradleProjectFile> = {
+        ...config,
+        modRequest,
+      };
+
+      try {
+        let modResults = await AndroidPaths.getSettingsGradleAsync(modRequest.projectRoot);
+        // Currently don't support changing the path or language
+        const filePath = modResults.path;
+
+        results = await nextMod!({
+          ...config,
+          modResults,
+          modRequest,
+        });
+        resolveModResults(results, modRequest.platform, modRequest.modName);
+        modResults = results.modResults;
+
+        await writeFile(filePath, modResults.contents);
+      } catch (error) {
+        addWarningAndroid(
+          `${modRequest.platform}-${modRequest.modName}`,
+          `Project settings.gradle could not be modified. ${error.message}`
         );
       }
       return results;

--- a/packages/config/src/plugins/expo-plugins.ts
+++ b/packages/config/src/plugins/expo-plugins.ts
@@ -59,6 +59,9 @@ export const withExpoAndroidPlugins: ConfigPlugin<{
   config.android.package = props.package;
 
   return withPlugins(config, [
+    // settings.gradle
+    AndroidConfig.Name.withNameSettingsGradle,
+
     // project build.gradle
     AndroidConfig.GoogleServices.withClassPath,
 


### PR DESCRIPTION
- resolve https://github.com/expo/expo-cli/issues/2696
- added mod for settings.gradle `android.settingsGradle`
- added mod to update the name property using regex
- tested the name using naming convention I discovered by using a bunch of invalid characters in Android studio then syncing the gradle files. Eventually I got a useful error message regarding which characters couldn't be used (but no docs pages).
- tested building a project using a complex name, added unit tests for core functionality.