### PR TITLE
Enable notifications by default

### DIFF
--- a/packages/config/src/ios/Entitlements.ts
+++ b/packages/config/src/ios/Entitlements.ts
@@ -190,6 +190,8 @@ const ENTITLEMENTS_TEMPLATE = `
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+<key>aps-environment</key>
+<string>development</string>
 </dict>
 </plist>
 `;

--- a/packages/config/src/ios/__tests__/Entitlements-test.ts
+++ b/packages/config/src/ios/__tests__/Entitlements-test.ts
@@ -54,7 +54,8 @@ describe(getEntitlementsPath, () => {
     // New file has the contents of the old entitlements file
     const data = plist.parse(await fs.readFile(entitlementsPath, 'utf8'));
     expect(data).toStrictEqual({
-      /* empty object by default */
+      // Push notifications enabled by default
+      'aps-environment': 'development',
     });
   });
 

--- a/packages/config/src/plugins/__tests__/__snapshots__/expo-plugins-test.ts.snap
+++ b/packages/config/src/plugins/__tests__/__snapshots__/expo-plugins-test.ts.snap
@@ -89,6 +89,7 @@ Object {
       "usesNonExemptEncryption": true,
     },
     "entitlements": Object {
+      "aps-environment": "development",
       "com.apple.developer.applesignin": Array [
         "Default",
       ],


### PR DESCRIPTION
- ejected projects have notifications by default so our template should come with notifications enabled by default too. Without this iTunes warns about a binary issue: `ITMS-90078: Missing Push Notification Entitlement`
- wasn't sure if we should do development or production by default but it seems we use development in the Expo client, and Xcode defaults to development.