### PR TITLE
[config] fill _internal object

### DIFF
--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -39,11 +39,6 @@ export interface ModProps<T = any> {
    */
   readonly projectName?: string;
 
-  /**
-   * true when the environment variable EXPO_DEBUG is enabled.
-   */
-  readonly isDebug: boolean;
-
   nextMod?: Mod<T>;
 }
 

--- a/packages/config-plugins/src/plugins/core-plugins.ts
+++ b/packages/config-plugins/src/plugins/core-plugins.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { boolish } from 'getenv';
 
 import {
   ConfigPlugin,
@@ -8,8 +7,6 @@ import {
   Mod,
   ModPlatform,
 } from '../Plugin.types';
-
-const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
 function ensureArray<T>(input: T | T[]): T[] {
   if (Array.isArray(input)) {
@@ -134,7 +131,7 @@ export function withInterceptedMod<T>(
 
   // Create a stack trace for debugging ahead of time
   let debugTrace: string = '';
-  if (EXPO_DEBUG) {
+  if (config._internal?.isDebug) {
     // Get a stack trace via the Error API
     const stack = new Error().stack;
     // Format the stack trace to create the debug log
@@ -142,7 +139,7 @@ export function withInterceptedMod<T>(
   }
 
   async function interceptingMod({ modRequest, ...config }: ExportedConfigWithProps<T>) {
-    if (modRequest.isDebug) {
+    if (config._internal?.isDebug) {
       // In debug mod, log the plugin stack in the order which they were invoked
       const modStack = chalk.bold(`${platform}.${mod}`);
       console.log(`${modStack}: ${debugTrace}`);

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -1,11 +1,8 @@
-import { boolish } from 'getenv';
 import path from 'path';
 
 import { ExportedConfig, Mod, ModConfig, ModPlatform } from '../Plugin.types';
 import { getHackyProjectName } from '../ios/utils/Xcodeproj';
 import { resolveModResults, withBaseMods } from './compiler-plugins';
-
-const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
 /**
  *
@@ -49,7 +46,6 @@ export async function evalModsAsync(
           platformProjectRoot,
           platform: platformName as ModPlatform,
           modName,
-          isDebug: EXPO_DEBUG,
         };
 
         const results = await (mod as Mod)({

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,6 +37,7 @@
     "@expo/config-types": "^40.0.0-beta.1",
     "@expo/json-file": "8.2.25",
     "fs-extra": "9.0.0",
+    "getenv": "0.7.0",
     "glob": "7.1.6",
     "require-from-string": "^2.0.2",
     "resolve-from": "^5.0.0",

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -134,6 +134,9 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
     }
 
     if (options.isPublicConfig) {
+      // Remove internal values with references to user's file paths from the public config.
+      delete configWithDefaultValues.exp._internal;
+
       if (configWithDefaultValues.exp.hooks) {
         delete configWithDefaultValues.exp.hooks;
       }

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -1,5 +1,6 @@
 import JsonFile, { JSONObject } from '@expo/json-file';
 import fs from 'fs-extra';
+import { boolish } from 'getenv';
 import { sync as globSync } from 'glob';
 import path from 'path';
 import semver from 'semver';
@@ -24,6 +25,8 @@ import { getExpoSDKVersion } from './Project';
 import { getDynamicConfig, getStaticConfig } from './getConfig';
 
 type SplitConfigs = { expo: ExpoConfig; mods: ModConfig };
+
+const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
 /**
  * If a config has an `expo` object then that will be used as the config.
@@ -104,18 +107,31 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
 
   function fillAndReturnConfig(config: SplitConfigs, dynamicConfigObjectType: string | null) {
     const configWithDefaultValues = {
-      ...ensureConfigHasDefaultValues(
+      ...ensureConfigHasDefaultValues({
         projectRoot,
-        config.expo,
-        packageJson,
-        options.skipSDKVersionRequirement
-      ),
+        exp: config.expo,
+        pkg: packageJson,
+        skipSDKVersionRequirement: options.skipSDKVersionRequirement,
+        paths,
+        packageJsonPath,
+      }),
       mods: config.mods,
       dynamicConfigObjectType,
       rootConfig,
       dynamicConfigPath: paths.dynamicConfigPath,
       staticConfigPath: paths.staticConfigPath,
     };
+
+    if (!configWithDefaultValues.exp._internal) {
+      configWithDefaultValues.exp._internal = {};
+    }
+
+    configWithDefaultValues.exp._internal.projectRoot = projectRoot;
+
+    if (options.isModdedConfig) {
+      // @ts-ignore: Add the mods back to the object.
+      configWithDefaultValues.exp.mods = config.mods ?? null;
+    }
 
     if (options.isPublicConfig) {
       if (configWithDefaultValues.exp.hooks) {
@@ -128,17 +144,20 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
         delete configWithDefaultValues.exp.android.config;
       }
     }
-    if (options.isModdedConfig) {
-      // @ts-ignore: Add the mods back to the object.
-      configWithDefaultValues.exp.mods = config.mods ?? null;
-    }
 
     return configWithDefaultValues;
   }
 
   // Fill in the static config
   function getContextConfig(config: SplitConfigs) {
-    return ensureConfigHasDefaultValues(projectRoot, config.expo, packageJson, true).exp;
+    return ensureConfigHasDefaultValues({
+      projectRoot,
+      exp: config.expo,
+      pkg: packageJson,
+      skipSDKVersionRequirement: true,
+      paths,
+      packageJsonPath,
+    }).exp;
   }
 
   if (paths.dynamicConfigPath) {
@@ -160,6 +179,29 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
 
   // No app.config.js but json or no config
   return fillAndReturnConfig(staticConfig || {}, null);
+}
+
+/**
+ * Adds the _internals object to an ExpoConfig.
+ *
+ * @param config
+ * @param projectRoot
+ */
+function ensureInternals(
+  config: Partial<ExpoConfig>,
+  internals: { projectRoot: string; packageJsonPath?: string } & Partial<ConfigFilePaths>
+): Partial<ExpoConfig> {
+  if (!config._internal) {
+    config._internal = {};
+  }
+
+  config._internal = {
+    isDebug: EXPO_DEBUG,
+    ...config._internal,
+    ...internals,
+  };
+
+  return config;
 }
 
 export function getPackageJson(
@@ -220,10 +262,17 @@ export function readConfigJson(
 
   exp = { ...exp };
 
-  const [pkg] = getPackageJsonAndPath(projectRoot, exp);
+  const [pkg, packageJsonPath] = getPackageJsonAndPath(projectRoot, exp);
 
   return {
-    ...ensureConfigHasDefaultValues(projectRoot, exp, pkg, skipNativeValidation),
+    ...ensureConfigHasDefaultValues({
+      projectRoot,
+      exp,
+      pkg,
+      skipSDKVersionRequirement: skipNativeValidation,
+      paths,
+      packageJsonPath,
+    }),
     mods: null,
     dynamicConfigPath: null,
     dynamicConfigObjectType: null,
@@ -418,15 +467,29 @@ const APP_JSON_EXAMPLE = JSON.stringify({
   },
 });
 
-function ensureConfigHasDefaultValues(
-  projectRoot: string,
-  exp: Partial<ExpoConfig> | null,
-  pkg: JSONObject,
-  skipSDKVersionRequirement: boolean = false
-): { exp: ExpoConfig; pkg: PackageJSONConfig } {
+function ensureConfigHasDefaultValues({
+  projectRoot,
+  exp,
+  pkg,
+  paths,
+  packageJsonPath,
+  skipSDKVersionRequirement = false,
+}: {
+  projectRoot: string;
+  exp: Partial<ExpoConfig> | null;
+  pkg: JSONObject;
+  skipSDKVersionRequirement?: boolean;
+  paths?: ConfigFilePaths;
+  packageJsonPath?: string;
+}): { exp: ExpoConfig; pkg: PackageJSONConfig } {
   if (!exp) {
     exp = {};
   }
+  exp = ensureInternals(exp, {
+    projectRoot,
+    ...(paths ?? {}),
+    packageJsonPath,
+  });
   // Defaults for package.json fields
   const pkgName = typeof pkg.name === 'string' ? pkg.name : path.basename(projectRoot);
   const pkgVersion = typeof pkg.version === 'string' ? pkg.version : '1.0.0';

--- a/packages/config/src/__tests__/Config-test.ts
+++ b/packages/config/src/__tests__/Config-test.ts
@@ -105,13 +105,7 @@ describe('getConfig public config', () => {
     expect(exp.android).toBeDefined();
     expect(exp.android.versionCode).toEqual(appJsonWithPrivateData.android.versionCode);
     expect(exp.android.config).toBeUndefined();
-    expect(exp._internal).toStrictEqual({
-      dynamicConfigPath: null,
-      isDebug: false,
-      packageJsonPath: '/private-data/package.json',
-      projectRoot: '/private-data',
-      staticConfigPath: '/private-data/app.json',
-    });
+    expect(exp._internal).toBeUndefined();
   });
 
   it('does not remove properties from a config with no private data', () => {

--- a/packages/config/src/__tests__/Config-test.ts
+++ b/packages/config/src/__tests__/Config-test.ts
@@ -105,6 +105,13 @@ describe('getConfig public config', () => {
     expect(exp.android).toBeDefined();
     expect(exp.android.versionCode).toEqual(appJsonWithPrivateData.android.versionCode);
     expect(exp.android.config).toBeUndefined();
+    expect(exp._internal).toStrictEqual({
+      dynamicConfigPath: null,
+      isDebug: false,
+      packageJsonPath: '/private-data/package.json',
+      projectRoot: '/private-data',
+      staticConfigPath: '/private-data/app.json',
+    });
   });
 
   it('does not remove properties from a config with no private data', () => {

--- a/packages/config/src/__tests__/ConfigParsing-test.ts
+++ b/packages/config/src/__tests__/ConfigParsing-test.ts
@@ -107,6 +107,13 @@ describe(getConfig, () => {
       // @ts-ignore: foo property is not defined
       expect(exp.foo).toBe('bar+value');
       expect(exp.name).toBe('rewrote+ts-config-test');
+      expect(exp._internal).toStrictEqual({
+        dynamicConfigPath: 'ts/app.config.ts',
+        isDebug: false,
+        packageJsonPath: 'ts/package.json',
+        projectRoot: 'ts',
+        staticConfigPath: null,
+      });
     });
     it('parses a js config', () => {
       // ensure config is composed (package.json values still exist)
@@ -123,6 +130,13 @@ describe(getConfig, () => {
       expect(exp.name).toBe('js-config-test+config');
       // Ensures that the app.json is read and passed to the method
       expect(exp.slug).toBe('someslug+config');
+      expect(exp._internal).toStrictEqual({
+        dynamicConfigPath: 'js/app.config.js',
+        isDebug: false,
+        packageJsonPath: 'js/package.json',
+        projectRoot: 'js',
+        staticConfigPath: 'js/app.json',
+      });
     });
     it('parses a js config with export default', () => {
       const projectRoot = 'js';
@@ -158,7 +172,7 @@ describe(getConfig, () => {
     // Test that setCustomConfigPath works to read custom json configs.
     it('uses a custom location', () => {
       const projectRoot = 'custom-location-json';
-      const customConfigPath = path.resolve(projectRoot, 'src/app.staging.json');
+      const customConfigPath = path.join(projectRoot, 'src/app.staging.json');
       setCustomConfigPath(projectRoot, customConfigPath);
 
       const { exp, staticConfigPath, dynamicConfigPath } = getConfig(projectRoot, {
@@ -192,6 +206,14 @@ describe(getConfig, () => {
       // A base app.json is parsed differently, ensure the app.json parsing doesn't accidentally reduce the "expo" object multiple times.
       // @ts-ignore: expo property is not defined
       expect(baseExp.expo).toStrictEqual({ name: 'app-expo-expo-name' });
+
+      expect(exp._internal).toStrictEqual({
+        dynamicConfigPath: null,
+        isDebug: false,
+        packageJsonPath: 'custom-location-json/package.json',
+        projectRoot: 'custom-location-json',
+        staticConfigPath: 'custom-location-json/src/app.staging.json',
+      });
     });
   });
 });


### PR DESCRIPTION
- Fill `config._internal` object with contents of `ConfigContext` -- this will make converting `app.config.js` function signature to `ConfigPlugin` easier.
- Added `config._internal.isDebug` and `config._internal.projectRoot` from `config.modRequest` -- this makes config mods more like regular plugins, and will make static plugins easier to resolve from root.
- Delete `_internal` in public configs to prevent exposing user computer file paths.