### PR TITLE
[xdl][cli] Fix beta integration of init

### DIFF
--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -6,7 +6,6 @@ import { Exp, UserManager, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import program, { Command } from 'commander';
 import fs from 'fs-extra';
-import getenv from 'getenv';
 import padEnd from 'lodash/padEnd';
 import trimStart from 'lodash/trimStart';
 import npmPackageArg from 'npm-package-arg';

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -2,10 +2,11 @@ import { BareAppConfig, getConfig } from '@expo/config';
 import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
 import plist from '@expo/plist';
 import spawnAsync from '@expo/spawn-async';
-import { Exp, UserManager } from '@expo/xdl';
+import { Exp, UserManager, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import program, { Command } from 'commander';
 import fs from 'fs-extra';
+import getenv from 'getenv';
 import padEnd from 'lodash/padEnd';
 import trimStart from 'lodash/trimStart';
 import npmPackageArg from 'npm-package-arg';
@@ -180,6 +181,22 @@ async function action(projectDir: string, command: Command) {
     resolvedTemplate = 'blank';
   }
 
+  const { version, data: newestSdkReleaseData } = await Versions.newestReleasedSdkVersionAsync();
+
+  // If the user is opting into a beta then we need to append the template tag explicitly
+  // in order to not fall back to the latest tag for templates.
+  let versionParam = '';
+  if (newestSdkReleaseData?.beta) {
+    const majorVersion = parseInt(version, 10);
+    versionParam = `@sdk-${majorVersion}`;
+
+    // If the --template flag is provided without an explicit version, then opt-in to
+    // the beta version
+    if (resolvedTemplate && !resolvedTemplate.includes('@')) {
+      resolvedTemplate = `${resolvedTemplate}${versionParam}`;
+    }
+  }
+
   let templateSpec;
   if (resolvedTemplate) {
     templateSpec = npmPackageArg(resolvedTemplate);
@@ -228,7 +245,7 @@ async function action(projectDir: string, command: Command) {
           '--template: argument is required in non-interactive mode. Valid choices are: "blank", "tabs", "bare-minimum" or any custom template (name of npm package).',
       }
     );
-    templateSpec = npmPackageArg(template);
+    templateSpec = npmPackageArg(`${template}${versionParam}`);
   }
 
   const projectName = path.basename(projectRoot);

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -181,13 +181,16 @@ async function action(projectDir: string, command: Command) {
     resolvedTemplate = 'blank';
   }
 
-  const { version, data: newestSdkReleaseData } = await Versions.newestReleasedSdkVersionAsync();
+  const {
+    version: newestSdkVersion,
+    data: newestSdkReleaseData,
+  } = await Versions.newestReleasedSdkVersionAsync();
 
   // If the user is opting into a beta then we need to append the template tag explicitly
   // in order to not fall back to the latest tag for templates.
   let versionParam = '';
   if (newestSdkReleaseData?.beta) {
-    const majorVersion = parseInt(version, 10);
+    const majorVersion = parseInt(newestSdkVersion, 10);
     versionParam = `@sdk-${majorVersion}`;
 
     // If the --template flag is provided without an explicit version, then opt-in to

--- a/packages/xdl/src/Versions.ts
+++ b/packages/xdl/src/Versions.ts
@@ -55,6 +55,11 @@ export async function versionsAsync(): Promise<Versions> {
     0,
     path.join(__dirname, '../caches/versions.json')
   );
+
+  // Clear cache when opting in to beta because things can change quickly in beta
+  if (getenv.boolish('EXPO_BETA', false)) {
+    versionCache.clearAsync();
+  }
   return await versionCache.getAsync();
 }
 


### PR DESCRIPTION
We always use the latest template unless the user explicitly passes in a version. This PR changes that so if `EXPO_BETA=1` is enabled and the latest release is a beta, then it will append the `@sdk-x` tag to the selected template. When no beta is available or the `EXPO_BETA=1` flag is not set,  this will have no effect.