### PR TITLE
[expo-cli] Fallback to jest-expo@sdkVersion-beta when using beta sdk 

### DIFF
--- a/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
@@ -83,6 +83,21 @@ describe('getDependenciesFromBundledNativeModules', () => {
       });
       expect(deps['jest-expo']).toBe('4.0.0');
     });
+
+    it('upgrades jest-expo to ^${sdkVersion}-beta when targetSdkVersion is beta and not included in relatedPackages', () => {
+      const deps = getDependenciesFromBundledNativeModules({
+        projectDependencies,
+        bundledNativeModules,
+        sdkVersion,
+        workflow: 'bare',
+        targetSdkVersion: {
+          ...targetSdkVersion,
+          relatedPackages: {},
+          beta: true,
+        },
+      });
+      expect(deps['jest-expo']).toBe('^3.0.0-beta');
+    });
   });
 
   describe('react-native', () => {

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -37,6 +37,7 @@ export type TargetSDKVersion = Pick<
   | 'iosClientUrl'
   | 'androidClientVersion'
   | 'androidClientUrl'
+  | 'beta'
 >;
 
 function logNewSection(title: string) {
@@ -128,7 +129,11 @@ export function getDependenciesFromBundledNativeModules({
   // If sdkVersion is known and jest-expo is used, then upgrade to the current sdk version
   // jest-expo is versioned with expo because jest-expo mocks out the native SDKs used it expo.
   if (sdkVersion && projectDependencies['jest-expo']) {
-    result['jest-expo'] = `^${sdkVersion}`;
+    let jestExpoVersion = `^${sdkVersion}`;
+    if (targetSdkVersion?.beta) {
+      jestExpoVersion = `${jestExpoVersion}-beta`;
+    }
+    result['jest-expo'] = jestExpoVersion;
   }
 
   if (!targetSdkVersion) {


### PR DESCRIPTION
Currently we always use the `jest-expo@sdkVersion` if not specified in bundledNaitveModules or relatedPackages. We should use the `-beta` version the SDK version is in beta.