### PR TITLE
Added ability to skip platforms when ejecting

### DIFF
--- a/packages/config-plugins/src/plugins/__tests__/core-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/core-plugins-test.ts
@@ -97,7 +97,7 @@ describe(withExtendedMod, () => {
     });
 
     // Compile plugins generically
-    config = await evalModsAsync(config, '/');
+    config = await evalModsAsync(config, { projectRoot: '/' });
 
     // Plugins should all be functions
     expect(Object.values(config.mods.android).every(value => typeof value === 'function')).toBe(

--- a/packages/config-plugins/src/plugins/__tests__/expo-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/expo-plugins-test.ts
@@ -31,7 +31,7 @@ describe(evalModsAsync, () => {
       name: 'app',
       slug: '',
     };
-    config = await evalModsAsync(config, '/');
+    config = await evalModsAsync(config, { projectRoot: '/' });
     expect(config.ios).toBeUndefined();
   });
 });
@@ -72,9 +72,19 @@ describe('built-in plugins', () => {
       slug: '',
       ios: {},
     });
-    await expect(compileModsAsync(config, '/invalid')).rejects.toThrow(
+    await expect(compileModsAsync(config, { projectRoot: '/invalid' })).rejects.toThrow(
       'Failed to locate Info.plist files relative'
     );
+  });
+
+  it(`skips platforms`, async () => {
+    const config = withBranch({
+      name: 'app',
+      slug: '',
+      ios: {},
+    });
+    // should throw if the platform isn't skipped
+    await compileModsAsync(config, { projectRoot: '/invalid', platforms: ['android'] });
   });
 
   it('prefers named keys over info.plist overrides', async () => {
@@ -96,7 +106,7 @@ describe('built-in plugins', () => {
       expoUsername: 'bacon',
     });
     // Apply mod
-    config = await compileModsAsync(config, '/app');
+    config = await compileModsAsync(config, { projectRoot: '/app' });
     // This should be false because ios.config.usesNonExemptEncryption is used in favor of ios.infoPlist.ITSAppUsesNonExemptEncryption
     expect(config.ios?.infoPlist?.ITSAppUsesNonExemptEncryption).toBe(false);
   });
@@ -238,7 +248,7 @@ describe('built-in plugins', () => {
     });
 
     // Apply mod
-    config = await compileModsAsync(config, '/app');
+    config = await compileModsAsync(config, { projectRoot: '/app' });
 
     // App config should have been modified
     expect(config.name).toBe('my cool app');

--- a/packages/config-plugins/src/plugins/__tests__/plugin-compiler-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/plugin-compiler-test.ts
@@ -28,7 +28,7 @@ describe(compileModsAsync, () => {
       slug: '',
       mods: null,
     };
-    const config = await compileModsAsync(exportedConfig, projectRoot);
+    const config = await compileModsAsync(exportedConfig, { projectRoot });
 
     expect(config.name).toBe('app');
     // Base mods are skipped when no mods are applied, these shouldn't be defined.
@@ -59,7 +59,7 @@ describe(compileModsAsync, () => {
     };
 
     // Apply mod plugin
-    const config = await compileModsAsync(exportedConfig, projectRoot);
+    const config = await compileModsAsync(exportedConfig, { projectRoot });
 
     expect(internalValue).toBe('en');
 
@@ -94,7 +94,7 @@ describe(compileModsAsync, () => {
       };
 
       // Apply mod plugin
-      await expect(compileModsAsync(exportedConfig, projectRoot)).rejects.toThrow(
+      await expect(compileModsAsync(exportedConfig, { projectRoot })).rejects.toThrow(
         /Mod `mods.ios.infoPlist` evaluated to an object that is not a valid project config/
       );
     });

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -11,10 +11,10 @@ import { resolveModResults, withBaseMods } from './compiler-plugins';
  */
 export async function compileModsAsync(
   config: ExportedConfig,
-  projectRoot: string
+  props: { projectRoot: string; platforms?: ModPlatform[] }
 ): Promise<ExportedConfig> {
   config = withBaseMods(config);
-  return await evalModsAsync(config, projectRoot);
+  return await evalModsAsync(config, props);
 }
 
 /**
@@ -24,9 +24,12 @@ export async function compileModsAsync(
  */
 export async function evalModsAsync(
   config: ExportedConfig,
-  projectRoot: string
+  { projectRoot, platforms }: { projectRoot: string; platforms?: ModPlatform[] }
 ): Promise<ExportedConfig> {
   for (const [platformName, platform] of Object.entries(config.mods ?? ({} as ModConfig))) {
+    if (platforms && !platforms.includes(platformName as any)) {
+      continue;
+    }
     const entries = Object.entries(platform);
     if (entries.length) {
       const dangerousIndex = entries.findIndex(([modName]) => modName === 'dangerous');

--- a/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts
@@ -1,11 +1,17 @@
 import { getConfig } from '@expo/config';
-import { compileModsAsync, withExpoAndroidPlugins } from '@expo/config-plugins';
+import { compileModsAsync, ModPlatform, withExpoAndroidPlugins } from '@expo/config-plugins';
 import { UserManager } from '@expo/xdl';
 
 import log from '../../log';
 import { getOrPromptForPackage } from '../eject/ConfigValidation';
 
-export default async function configureAndroidProjectAsync(projectRoot: string) {
+export default async function configureAndroidProjectAsync({
+  projectRoot,
+  platforms,
+}: {
+  projectRoot: string;
+  platforms: ModPlatform[];
+}) {
   // Check package before reading the config because it may mutate the config if the user is prompted to define it.
   const packageName = await getOrPromptForPackage(projectRoot);
   const expoUsername =
@@ -23,7 +29,7 @@ export default async function configureAndroidProjectAsync(projectRoot: string) 
   });
 
   // compile all plugins and mods
-  config = await compileModsAsync(config, projectRoot);
+  config = await compileModsAsync(config, { projectRoot, platforms });
 
   if (log.isDebug) {
     log.debug();

--- a/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureIOSProjectAsync.ts
@@ -1,11 +1,17 @@
 import { getConfig } from '@expo/config';
-import { compileModsAsync, withExpoIOSPlugins } from '@expo/config-plugins';
+import { compileModsAsync, ModPlatform, withExpoIOSPlugins } from '@expo/config-plugins';
 import { UserManager } from '@expo/xdl';
 
 import log from '../../log';
 import { getOrPromptForBundleIdentifier } from '../eject/ConfigValidation';
 
-export default async function configureIOSProjectAsync(projectRoot: string) {
+export default async function configureIOSProjectAsync({
+  projectRoot,
+  platforms,
+}: {
+  projectRoot: string;
+  platforms: ModPlatform[];
+}) {
   // Check bundle ID before reading the config because it may mutate the config if the user is prompted to define it.
   const bundleIdentifier = await getOrPromptForBundleIdentifier(projectRoot);
   const expoUsername =
@@ -23,7 +29,7 @@ export default async function configureIOSProjectAsync(projectRoot: string) {
   });
 
   // compile all plugins and mods
-  config = await compileModsAsync(config, projectRoot);
+  config = await compileModsAsync(config, { projectRoot, platforms });
 
   if (log.isDebug) {
     log.debug();

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -55,5 +55,7 @@ export default function (program: Command) {
     .option('--force', 'Skip legacy eject warnings.') // TODO: remove the force flag when SDK 36 is no longer supported: after SDK 40 is released.
     .option('--no-install', 'Skip installing npm packages and CocoaPods.')
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
+    .option('--no-ios', 'Skip iOS syncing')
+    .option('--no-android', 'Skip Android syncing')
     .asyncActionProjectDir(actionAsync);
 }

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -1,8 +1,10 @@
 import { getConfig } from '@expo/config';
+import { ModPlatform } from '@expo/config-plugins';
 import { Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import { Command } from 'commander';
 
+import CommandError from '../CommandError';
 import log from '../log';
 import { confirmAsync } from '../prompts';
 import * as Eject from './eject/Eject';
@@ -17,9 +19,43 @@ async function userWantsToEjectWithoutUpgradingAsync() {
   return answer;
 }
 
+function getDefaultPlatforms(): ModPlatform[] {
+  const platforms: ModPlatform[] = ['android'];
+  if (process.platform !== 'win32') {
+    platforms.push('ios');
+  }
+  return platforms;
+}
+
+function platformsFromPlatform(platform?: string): ModPlatform[] {
+  if (!platform) {
+    return getDefaultPlatforms();
+  }
+  switch (platform) {
+    case 'ios':
+      if (process.platform === 'win32') {
+        log.warn('Ejecting on windows is unsupported');
+        // continue anyways :shrug:
+      }
+      return ['ios'];
+    case 'android':
+      return ['android'];
+    case 'all':
+      return getDefaultPlatforms();
+    default:
+      throw new CommandError(`Unsupported platform "${platform}". Options are: ios, android, all`);
+  }
+}
+
 export async function actionAsync(
   projectDir: string,
-  options: (LegacyEject.EjectAsyncOptions | Eject.EjectAsyncOptions) & { npm?: boolean }
+  {
+    platform,
+    ...options
+  }: (LegacyEject.EjectAsyncOptions | Eject.EjectAsyncOptions) & {
+    npm?: boolean;
+    platform?: string;
+  }
 ) {
   const { exp } = getConfig(projectDir);
 
@@ -36,7 +72,10 @@ export async function actionAsync(
     }
   } else {
     log.debug('Eject Mode: Latest');
-    await Eject.ejectAsync(projectDir, options as Eject.EjectAsyncOptions);
+    await Eject.ejectAsync(projectDir, {
+      ...options,
+      platforms: platformsFromPlatform(platform),
+    } as Eject.EjectAsyncOptions);
   }
 }
 
@@ -55,7 +94,6 @@ export default function (program: Command) {
     .option('--force', 'Skip legacy eject warnings.') // TODO: remove the force flag when SDK 36 is no longer supported: after SDK 40 is released.
     .option('--no-install', 'Skip installing npm packages and CocoaPods.')
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
-    .option('--no-ios', 'Skip iOS syncing')
-    .option('--no-android', 'Skip Android syncing')
+    .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
     .asyncActionProjectDir(actionAsync);
 }


### PR DESCRIPTION
- support managed projects in `eas build` by disabling certain platforms when ejecting
  - skips the bundle id or package name prompt
- added `--platform` to `expo eject` to choose platforms (ios, android, all (like eas)).
  - tested that a project without a corresponding native folder can sync successfully
- added `platforms` to mod compiler, this is used for skipping any mod on a particular platform.
  - third-party plugins that use a particular mod will automatically be compliant
  - missing native files won't be written or read