### PR TITLE
[cli][build] Use unified website route for all builds (no more /v2)

### DIFF
--- a/packages/expo-cli/src/commands/utils/url.ts
+++ b/packages/expo-cli/src/commands/utils/url.ts
@@ -19,9 +19,7 @@ export function constructBuildLogsUrl({
   username?: string;
   v2?: boolean;
 }): string {
-  if (v2) {
-    return `${getExpoDomainUrl()}/accounts/${username}/builds/v2/${buildId}`;
-  } else if (username) {
+  if (username) {
     return `${getExpoDomainUrl()}/accounts/${username}/builds/${buildId}`;
   } else {
     return `${getExpoDomainUrl()}/builds/${buildId}`;


### PR DESCRIPTION
As a follow-up to https://github.com/expo/universe/pull/6547, which unifies the URL structure of builds pages for Turtle v2, we should stop serving those URLs in our CLIs.