### PR TITLE
remove invariant in favor of assert

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -39,7 +39,6 @@
     "@expo/plist": "0.0.10",
     "fs-extra": "9.0.0",
     "glob": "7.1.6",
-    "invariant": "2.2.4",
     "slash": "^3.0.0",
     "slugify": "^1.3.4",
     "xcode": "^2.1.0",

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -95,7 +95,6 @@
     "glob": "7.1.6",
     "got": "^11.1.4",
     "indent-string": "4.0.0",
-    "invariant": "2.2.4",
     "js-yaml": "^3.13.1",
     "keychain": "1.3.0",
     "leven": "^3.1.0",

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -1,8 +1,8 @@
 import { ApiV2, RegistrationData, User, UserManager } from '@expo/xdl';
 import { ApiV2Error } from '@expo/xdl/build/ApiV2';
+import assert from 'assert';
 import chalk from 'chalk';
 import program from 'commander';
-import invariant from 'invariant';
 
 import CommandError from './CommandError';
 import log from './log';
@@ -223,7 +223,7 @@ export async function _retryUsernamePasswordAuthWithOTPAsync(
   }
 ): Promise<User> {
   const { secondFactorDevices, smsAutomaticallySent } = metadata;
-  invariant(
+  assert(
     secondFactorDevices !== undefined && smsAutomaticallySent !== undefined,
     `Malformed OTP error metadata: ${metadata}`
   );
@@ -232,10 +232,7 @@ export async function _retryUsernamePasswordAuthWithOTPAsync(
   let otp: string | null = null;
 
   if (smsAutomaticallySent) {
-    invariant(
-      primaryDevice,
-      'OTP should only automatically be sent when there is a primary device'
-    );
+    assert(primaryDevice, 'OTP should only automatically be sent when there is a primary device');
     log.nested(
       `One-time password was sent to the phone number ending in ${primaryDevice.sms_phone_number}.`
     );

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -1,10 +1,10 @@
 import { ApiV2, RegistrationData, User, UserManager } from '@expo/xdl';
 import { ApiV2Error } from '@expo/xdl/build/ApiV2';
-import assert from 'assert';
 import chalk from 'chalk';
 import program from 'commander';
 
 import CommandError from './CommandError';
+import { assert } from './assert';
 import log from './log';
 import promptNew, { confirmAsync, Question as NewQuestion, selectAsync } from './prompts';
 import { nonEmptyInput } from './validators';

--- a/packages/expo-cli/src/assert.ts
+++ b/packages/expo-cli/src/assert.ts
@@ -1,0 +1,6 @@
+import nodeAssert from 'assert';
+
+export function assert(value: any, message?: string | Error): asserts value {
+  // TODO: Remove after upgrading to `@types/node@^14`
+  return nodeAssert(value, message);
+}

--- a/packages/expo-cli/src/commands/fetch/android.ts
+++ b/packages/expo-cli/src/commands/fetch/android.ts
@@ -1,7 +1,7 @@
 import { AndroidCredentials } from '@expo/xdl';
+import assert from 'assert';
 import chalk from 'chalk';
 import * as fs from 'fs-extra';
-import invariant from 'invariant';
 import * as path from 'path';
 
 import { Context } from '../../credentials';
@@ -16,7 +16,7 @@ type Options = {
 };
 
 function assertSlug(slug: any): asserts slug {
-  invariant(slug, `${chalk.bold(slug)} field must be set in your app.json or app.config.js`);
+  assert(slug, `${chalk.bold(slug)} field must be set in your app.json or app.config.js`);
 }
 
 async function maybeRenameExistingFileAsync(projectRoot: string, filename: string) {

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -1,10 +1,10 @@
 import { findConfigFile, getConfig } from '@expo/config';
 import { ApiV2, UserManager } from '@expo/xdl';
+import assert from 'assert';
 import chalk from 'chalk';
 import CliTable from 'cli-table3';
 import { Command } from 'commander';
 import crypto from 'crypto';
-import invariant from 'invariant';
 import ora from 'ora';
 
 import CommandError, { ErrorCodes } from '../CommandError';
@@ -76,8 +76,8 @@ async function addAsync(
   projectRoot: string,
   { url, event, ...options }: { url?: string; event?: WebhookEvent; secret?: string }
 ) {
-  invariant(typeof url === 'string' && /^https?/.test(url), '--url: a HTTP URL is required');
-  invariant(typeof event === 'string', '--event: string is required');
+  assert(typeof url === 'string' && /^https?/.test(url), '--url: a HTTP URL is required');
+  assert(typeof event === 'string', '--event: string is required');
   const secret = validateSecret(options) || generateSecret();
 
   const { experienceName, project, client } = await setupAsync(projectRoot);
@@ -96,8 +96,8 @@ export async function updateAsync(
     ...options
   }: { id?: string; url?: string; event?: WebhookEvent; secret?: string }
 ) {
-  invariant(typeof id === 'string', '--id must be a webhook ID');
-  invariant(event == null || typeof event === 'string', '--event: string is required');
+  assert(typeof id === 'string', '--id must be a webhook ID');
+  assert(event == null || typeof event === 'string', '--event: string is required');
   let secret = validateSecret(options);
 
   const { project, client } = await setupAsync(projectRoot);
@@ -112,7 +112,7 @@ export async function updateAsync(
 }
 
 async function removeAsync(projectRoot: string, { id }: { id?: string }) {
-  invariant(typeof id === 'string', '--id must be a webhook ID');
+  assert(typeof id === 'string', '--id must be a webhook ID');
   const { project, client } = await setupAsync(projectRoot);
 
   await client.deleteAsync(`projects/${project.id}/webhooks/${id}`);
@@ -120,7 +120,7 @@ async function removeAsync(projectRoot: string, { id }: { id?: string }) {
 
 function validateSecret({ secret }: { secret?: string }): string | null {
   if (secret) {
-    invariant(
+    assert(
       secret.length >= SECRET_MIN_LENGTH && secret.length < SECRET_MAX_LENGTH,
       `--secret: should be ${SECRET_MIN_LENGTH}-${SECRET_MAX_LENGTH} characters long`
     );

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -1,6 +1,5 @@
 import { findConfigFile, getConfig } from '@expo/config';
 import { ApiV2, UserManager } from '@expo/xdl';
-import assert from 'assert';
 import chalk from 'chalk';
 import CliTable from 'cli-table3';
 import { Command } from 'commander';
@@ -8,6 +7,7 @@ import crypto from 'crypto';
 import ora from 'ora';
 
 import CommandError, { ErrorCodes } from '../CommandError';
+import { assert } from '../assert';
 import log from '../log';
 
 const SECRET_MIN_LENGTH = 16;

--- a/packages/expo-cli/src/credentials/api/IosApi.ts
+++ b/packages/expo-cli/src/credentials/api/IosApi.ts
@@ -1,11 +1,11 @@
 import { ApiV2 } from '@expo/xdl';
-import assert from 'assert';
 import forEach from 'lodash/forEach';
 import keyBy from 'lodash/keyBy';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
 import * as appleApi from '../../appleApi';
+import { assert } from '../../assert';
 import {
   IosAppCredentials,
   IosCredentials,

--- a/packages/expo-cli/src/credentials/api/IosApi.ts
+++ b/packages/expo-cli/src/credentials/api/IosApi.ts
@@ -1,5 +1,5 @@
 import { ApiV2 } from '@expo/xdl';
-import invariant from 'invariant';
+import assert from 'assert';
 import forEach from 'lodash/forEach';
 import keyBy from 'lodash/keyBy';
 import omit from 'lodash/omit';
@@ -26,7 +26,7 @@ export interface AppLookupParams {
 
 export function getAppLookupParams(experienceName: string, bundleIdentifier: string) {
   const matchedExperienceName = experienceName.match(/@(.+)\/(.+)/);
-  invariant(matchedExperienceName && matchedExperienceName.length >= 3, 'invalid experience name');
+  assert(matchedExperienceName && matchedExperienceName.length >= 3, 'invalid experience name');
   return {
     accountName: matchedExperienceName[1],
     projectName: matchedExperienceName[2],
@@ -113,8 +113,8 @@ export default class IosApi {
     await this.refetchUserCredentials(id, accountName);
 
     const distCert = this.credentials[accountName]?.userCredentials?.[String(id)];
-    invariant(id && distCert, 'distribution certificate does not exists');
-    invariant(distCert.type === 'dist-cert', 'wrong type of user credential');
+    assert(id && distCert, 'distribution certificate does not exists');
+    assert(distCert.type === 'dist-cert', 'wrong type of user credential');
     return distCert as IosDistCredentials;
   }
 
@@ -129,8 +129,8 @@ export default class IosApi {
     await this.refetchUserCredentials(id, accountName);
 
     const distCert = this.credentials[accountName]?.userCredentials[String(id)];
-    invariant(distCert, 'distribution certificate does not exists');
-    invariant(distCert.type === 'dist-cert', 'wrong type of user credential');
+    assert(distCert, 'distribution certificate does not exists');
+    assert(distCert.type === 'dist-cert', 'wrong type of user credential');
     return distCert as IosDistCredentials;
   }
 
@@ -156,8 +156,8 @@ export default class IosApi {
     await this.refetchUserCredentials(id, accountName);
 
     const pushKey = this.credentials[accountName]?.userCredentials?.[String(id)];
-    invariant(id && pushKey, 'push key does not exists');
-    invariant(pushKey.type === 'push-key', 'wrong type of user credentials');
+    assert(id && pushKey, 'push key does not exists');
+    assert(pushKey.type === 'push-key', 'wrong type of user credentials');
     return pushKey;
   }
 
@@ -171,8 +171,8 @@ export default class IosApi {
     await this.refetchUserCredentials(id, accountName);
 
     const pushKey = this.credentials[accountName]?.userCredentials?.[String(id)];
-    invariant(id && pushKey, 'push key does not exists');
-    invariant(pushKey.type === 'push-key', 'wrong type of user credentials');
+    assert(id && pushKey, 'push key does not exists');
+    assert(pushKey.type === 'push-key', 'wrong type of user credentials');
     return pushKey;
   }
 

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -1,8 +1,8 @@
 import plist, { PlistObject } from '@expo/plist';
 import { IosCodeSigning, PKCS12Utils } from '@expo/xdl';
+import assert from 'assert';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import invariant from 'invariant';
 import ora from 'ora';
 
 import CommandError from '../../CommandError';
@@ -96,7 +96,7 @@ export class CreateProvisioningProfile implements IView {
       }
     }
     const distCert = await ctx.ios.getDistCert(this.app);
-    invariant(distCert, 'missing distribution certificate');
+    assert(distCert, 'missing distribution certificate');
     return await generateProvisioningProfile(ctx, this.app.bundleIdentifier, distCert);
   }
 }
@@ -117,7 +117,7 @@ export class UseExistingProvisioningProfile implements IView {
     const selected = await selectProfileFromApple(ctx.appleCtx, this.app.bundleIdentifier);
     if (selected) {
       const distCert = await ctx.ios.getDistCert(this.app);
-      invariant(distCert, 'missing distribution certificate');
+      assert(distCert, 'missing distribution certificate');
 
       await configureAndUpdateProvisioningProfile(ctx, this.app, distCert, selected);
     }
@@ -158,7 +158,7 @@ export class CreateOrReuseProvisioningProfile implements IView {
     }
 
     const distCert = await ctx.ios.getDistCert(this.app);
-    invariant(distCert, 'missing distribution certificate');
+    assert(distCert, 'missing distribution certificate');
 
     const autoselectedProfile = this.choosePreferred(existingProfiles, distCert);
     // autoselect creds if we find valid certs
@@ -413,7 +413,7 @@ export async function useProvisioningProfileFromParams(
   provisioningProfile: ProvisioningProfile
 ): Promise<ProvisioningProfile> {
   const distCert = await ctx.ios.getDistCert(app);
-  invariant(distCert, 'missing distribution certificate');
+  assert(distCert, 'missing distribution certificate');
 
   const isValid = await validateProfileWithoutApple(
     provisioningProfile,

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -1,6 +1,5 @@
 import plist, { PlistObject } from '@expo/plist';
 import { IosCodeSigning, PKCS12Utils } from '@expo/xdl';
-import assert from 'assert';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import ora from 'ora';
@@ -13,6 +12,7 @@ import {
   ProvisioningProfileInfo,
   ProvisioningProfileManager,
 } from '../../appleApi';
+import { assert } from '../../assert';
 import log from '../../log';
 import prompt, { confirmAsync, Question } from '../../prompts';
 import { displayIosAppCredentials } from '../actions/list';

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -1,5 +1,4 @@
-import assert from 'assert';
-
+import { assert } from '../../assert';
 import prompts, { confirmAsync } from '../../prompts';
 import { displayAndroidCredentials, displayIosCredentials } from '../actions/list';
 import { AppLookupParams } from '../api/IosApi';

--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -1,4 +1,4 @@
-import invariant from 'invariant';
+import assert from 'assert';
 
 import prompts, { confirmAsync } from '../../prompts';
 import { displayAndroidCredentials, displayIosCredentials } from '../actions/list';
@@ -130,7 +130,7 @@ export class SelectAndroidExperience implements IView {
       });
 
       if (runProjectContext) {
-        invariant(ctx.manifest.slug, 'app.json slug field must be set');
+        assert(ctx.manifest.slug, 'app.json slug field must be set');
         const view = new androidView.ExperienceView(experienceName);
         CredentialsManager.get().changeMainView(view);
         return view;

--- a/packages/plist/src/parse.ts
+++ b/packages/plist/src/parse.ts
@@ -24,7 +24,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE. */
 
-import invariant from 'invariant';
+import assert from 'assert';
 import { DOMParser } from 'xmldom';
 
 const TEXT_NODE = 3;
@@ -71,7 +71,7 @@ function isEmptyNode(node: { [key: string]: any }): boolean {
 export function parse(xml: string): any {
   // prevent the parser from logging non-fatel errors
   const doc = new DOMParser({ errorHandler() {} }).parseFromString(xml);
-  invariant(
+  assert(
     doc.documentElement.nodeName === 'plist',
     'malformed document. First element should be <plist>'
   );
@@ -118,10 +118,10 @@ function parsePlistXML(node: { [key: string]: any }): any {
     for (i = 0; i < node.childNodes.length; i++) {
       if (shouldIgnoreNode(node.childNodes[i])) continue;
       if (counter % 2 === 0) {
-        invariant(node.childNodes[i].nodeName === 'key', 'Missing key while parsing <dict/>.');
+        assert(node.childNodes[i].nodeName === 'key', 'Missing key while parsing <dict/>.');
         key = parsePlistXML(node.childNodes[i]);
       } else {
-        invariant(
+        assert(
           node.childNodes[i].nodeName !== 'key',
           'Unexpected key "' + parsePlistXML(node.childNodes[i]) + '" while parsing <dict/>.'
         );
@@ -165,10 +165,10 @@ function parsePlistXML(node: { [key: string]: any }): any {
     }
     return res;
   } else if (node.nodeName === 'integer') {
-    invariant(!isEmptyNode(node), 'Cannot parse "" as integer.');
+    assert(!isEmptyNode(node), 'Cannot parse "" as integer.');
     return parseInt(node.childNodes[0].nodeValue, 10);
   } else if (node.nodeName === 'real') {
-    invariant(!isEmptyNode(node), 'Cannot parse "" as real.');
+    assert(!isEmptyNode(node), 'Cannot parse "" as real.');
     res = '';
     for (i = 0; i < node.childNodes.length; i++) {
       if (node.childNodes[i].nodeType === TEXT_NODE) {
@@ -188,7 +188,7 @@ function parsePlistXML(node: { [key: string]: any }): any {
     }
     return Buffer.from(res, 'base64');
   } else if (node.nodeName === 'date') {
-    invariant(!isEmptyNode(node), 'Cannot parse "" as Date.');
+    assert(!isEmptyNode(node), 'Cannot parse "" as Date.');
     return new Date(node.childNodes[0].nodeValue);
   } else if (node.nodeName === 'true') {
     return true;

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -62,7 +62,6 @@
     "idx": "2.4.0",
     "indent-string": "3.2.0",
     "internal-ip": "4.3.0",
-    "invariant": "2.2.4",
     "is-reachable": "^4.0.0",
     "json-schema-deref-sync": "^0.13.0",
     "latest-version": "5.1.0",

--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -1,5 +1,5 @@
+import assert from 'assert';
 import fs from 'fs-extra';
-import invariant from 'invariant';
 import path from 'path';
 import rimraf from 'rimraf';
 
@@ -54,7 +54,7 @@ async function _getOrCreateTemplateDirectoryAsync(context, iosExpoViewUrl) {
       if (!isDirectory(expoRootTemplateDirectory)) {
         fs.mkdirpSync(expoRootTemplateDirectory);
         logger.info('Downloading iOS code...');
-        invariant(iosExpoViewUrl, `The URL for ExpoKit iOS must be set`);
+        assert(iosExpoViewUrl, `The URL for ExpoKit iOS must be set`);
         await Api.downloadAsync(iosExpoViewUrl, expoRootTemplateDirectory, {
           extract: true,
         });
@@ -167,7 +167,7 @@ async function _renderPodfileFromTemplateAsync(
     context.data.shellAppSdkVersion || sdkVersion
   );
   if (context.type === 'user') {
-    invariant(iosClientVersion, `The iOS client version must be specified`);
+    assert(iosClientVersion, `The iOS client version must be specified`);
     reactNativeDependencyPath = path.join(context.data.projectPath, 'node_modules', 'react-native');
     modulesPath = path.join(context.data.projectPath, 'node_modules');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11420,7 +11420,7 @@ interpret@1.2.0, interpret@^1.0.0, interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@2.2.4, invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==


### PR DESCRIPTION
Remove invariant in favor of built in package assert.

invariant is still thoroughly used in the repo though, this just reduces the amount of top-level dependencies:
```
   - "_project_#@babel#preset-env" depends on it
   - Hoisted from "_project_#@babel#preset-env#invariant"
   - Hoisted from "_project_#metro#invariant"
   - Hoisted from "_project_#metro-source-map#invariant"
   - Hoisted from "_project_#metro-symbolicate#invariant"
   - Hoisted from "_project_#@expo#dev-tools#react-dnd#invariant"
   - Hoisted from "_project_#@expo#metro-config#expo#invariant"
   - Hoisted from "_project_#@babel#preset-env#@babel#compat-data#invariant"
   - Hoisted from "_project_#@babel#preset-env#@babel#helper-compilation-targets#invariant"
   - Hoisted from "_project_#metro#jest-haste-map#invariant"
   - Hoisted from "_project_#metro-core#jest-haste-map#invariant"
   - Hoisted from "_project_#@expo#metro-config#metro#invariant"
   - Hoisted from "_project_#@expo#metro-config#react-native#invariant"
   - Hoisted from "_project_#@expo#dev-tools#react-redux#invariant"
   - Hoisted from "_project_#@expo#dev-tools#react-dnd#dnd-core#invariant"
   - Hoisted from "_project_#@expo#dev-tools#next#@babel#preset-env#invariant"
   - Hoisted from "_project_#@expo#metro-config#expo#@unimodules#react-native-adapter#invariant"
   - Hoisted from "_project_#@expo#metro-config#expo#expo-asset#invariant"
   - Hoisted from "_project_#@expo#metro-config#expo#expo-location#invariant"
   - Hoisted from "_project_#@expo#metro-config#metro#jest-haste-map#invariant"
   - Hoisted from "_project_#@expo#metro-config#metro-react-native-babel-transformer#metro-source-map#invariant"
   - Hoisted from "_project_#@expo#metro-config#metro#metro-source-map#invariant"
   - Hoisted from "_project_#@expo#metro-config#metro#metro-symbolicate#invariant"
   - Hoisted from "_project_#@expo#metro-config#metro#metro-symbolicate#metro-source-map#invariant"
   - Hoisted from "_project_#@expo#metro-config#metro-react-native-babel-transformer#metro-source-map#metro-symbolicate#invariant"
   ```