### PR TITLE
[config-plugins] Support splash screen config on SDK 40

### DIFF
--- a/packages/config-plugins/src/android/SplashScreen.ts
+++ b/packages/config-plugins/src/android/SplashScreen.ts
@@ -44,7 +44,8 @@ export function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenCo
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
-  const splashScreenIsSupported = config.sdkVersion === '39.0.0' || !config.sdkVersion;
+  const splashScreenIsSupported =
+    config.sdkVersion === '39.0.0' || config.sdkVersion === '40.0.0' || !config.sdkVersion;
   if (!splashScreenIsSupported) {
     WarningAggregator.addWarningAndroid(
       'splash',

--- a/packages/config-plugins/src/ios/SplashScreen.ts
+++ b/packages/config-plugins/src/ios/SplashScreen.ts
@@ -38,7 +38,8 @@ export function getSplashScreen(config: ExpoConfig): IosSplashScreenConfig | und
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
-  const splashScreenIsSupported = config.sdkVersion === '39.0.0' || !config.sdkVersion;
+  const splashScreenIsSupported =
+    config.sdkVersion === '39.0.0' || config.sdkVersion === '40.0.0' || !config.sdkVersion;
   if (!splashScreenIsSupported) {
     WarningAggregator.addWarningIOS(
       'splash',


### PR DESCRIPTION
@expo/configure-splash-screen didn't change much between SDK 39 and 40 and should be compatible with both versions.