### PR TITLE
fix mod serialization

### DIFF
--- a/packages/config/src/Serialize.ts
+++ b/packages/config/src/Serialize.ts
@@ -64,7 +64,10 @@ export function serializeAfterStaticPlugins(val: any): any {
     const output: { [key: string]: any } = {};
     for (const property in val) {
       if (val.hasOwnProperty(property)) {
-        if (property === 'plugins' && Array.isArray(val[property])) {
+        if (property === 'mods') {
+          // Don't serialize mods
+          output[property] = val[property];
+        } else if (property === 'plugins' && Array.isArray(val[property])) {
           // Serialize the mods by removing any config plugins
           output[property] = val[property].map(serializeAndEvaluatePlugin);
         } else {

--- a/packages/config/src/__tests__/fixtures/plugins/my-plugin.js
+++ b/packages/config/src/__tests__/fixtures/plugins/my-plugin.js
@@ -1,4 +1,7 @@
+const { withAndroidManifest } = require('@expo/config-plugins');
+
 module.exports = config => {
   config.slug = 'from-custom-plugin';
-  return config;
+  // test that the mods don't get serialized
+  return withAndroidManifest(config, config => config);
 };


### PR DESCRIPTION
mods weren't being skipped in post-plugin serialization. I added a test that doesn't work due to the nature of our `requireString()` code.  Tests just run like this without the fix:

```
(node:16415) UnhandledPromiseRejectionWarning: TypeError: Cannot destructure property 'modRequest' of '_a' as it is undefined.
(node:16415) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled w
ith .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:16415) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS   @expo/config  src/__tests__/getConfig-e2e-test.ts
```