### PR TITLE
throw mod errors

### DIFF
--- a/packages/config-plugins/src/plugins/compiler-plugins.ts
+++ b/packages/config-plugins/src/plugins/compiler-plugins.ts
@@ -83,10 +83,10 @@ const withAndroidManifestBaseMod: ConfigPlugin = config => {
 
         await Manifest.writeAndroidManifestAsync(filePath, modResults);
       } catch (error) {
-        WarningAggregator.addWarningAndroid(
-          'android-manifest',
-          `AndroidManifest.xml configuration could not be applied. ${error.message}`
+        console.error(
+          `${modRequest.platform}.${modRequest.modName}: AndroidManifest.xml mod error:`
         );
+        throw error;
       }
       return results;
     },
@@ -119,10 +119,8 @@ const withAndroidStringsXMLBaseMod: ConfigPlugin = config => {
 
         await writeXMLAsync({ path: filePath, xml: modResults });
       } catch (error) {
-        WarningAggregator.addWarningAndroid(
-          `${modRequest.platform}-${modRequest.modName}`,
-          `strings.xml configuration could not be applied. ${error.message}`
-        );
+        console.error(`${modRequest.platform}.${modRequest.modName}: strings.xml mod error:`);
+        throw error;
       }
       return results;
     },
@@ -155,10 +153,10 @@ const withAndroidProjectBuildGradleBaseMod: ConfigPlugin = config => {
 
         await writeFile(filePath, modResults.contents);
       } catch (error) {
-        WarningAggregator.addWarningAndroid(
-          `${modRequest.platform}-${modRequest.modName}`,
-          `Project build.gradle could not be modified. ${error.message}`
+        console.error(
+          `${modRequest.platform}.${modRequest.modName}: android/build.gradle mod error:`
         );
+        throw error;
       }
       return results;
     },
@@ -191,10 +189,10 @@ const withAndroidSettingsGradleBaseMod: ConfigPlugin = config => {
 
         await writeFile(filePath, modResults.contents);
       } catch (error) {
-        WarningAggregator.addWarningAndroid(
-          `${modRequest.platform}-${modRequest.modName}`,
-          `Project settings.gradle could not be modified. ${error.message}`
+        console.error(
+          `${modRequest.platform}.${modRequest.modName}: android/settings.gradle mod error:`
         );
+        throw error;
       }
       return results;
     },
@@ -227,10 +225,10 @@ const withAndroidAppBuildGradleBaseMod: ConfigPlugin = config => {
 
         await writeFile(filePath, modResults.contents);
       } catch (error) {
-        WarningAggregator.addWarningAndroid(
-          `${modRequest.platform}-${modRequest.modName}`,
-          `App build.gradle could not be modified. ${error.message}`
+        console.error(
+          `${modRequest.platform}.${modRequest.modName}: android/app/build.gradle mod error:`
         );
+        throw error;
       }
       return results;
     },
@@ -263,10 +261,8 @@ const withAndroidMainActivityBaseMod: ConfigPlugin = config => {
 
         await writeFile(filePath, modResults.contents);
       } catch (error) {
-        WarningAggregator.addWarningAndroid(
-          `${modRequest.platform}-${modRequest.modName}`,
-          `MainActivity could not be modified. ${error.message}`
-        );
+        console.error(`${modRequest.platform}.${modRequest.modName}: MainActivity mod error:`);
+        throw error;
       }
       return results;
     },
@@ -451,10 +447,12 @@ const withEntitlementsBaseMod: ConfigPlugin = config => {
         resolveModResults(results, modRequest.platform, modRequest.modName);
         await writeFile(entitlementsPath, plist.build(results.modResults));
       } catch (error) {
-        WarningAggregator.addWarningIOS(
-          'entitlements',
-          `${entitlementsPath} configuration could not be applied.`
+        console.error(
+          `${modRequest.platform}.${modRequest.modName}: ${path.basename(
+            entitlementsPath
+          )} mod error:`
         );
+        throw error;
       }
       return results;
     },

--- a/packages/config-plugins/src/plugins/compiler-plugins.ts
+++ b/packages/config-plugins/src/plugins/compiler-plugins.ts
@@ -83,9 +83,7 @@ const withAndroidManifestBaseMod: ConfigPlugin = config => {
 
         await Manifest.writeAndroidManifestAsync(filePath, modResults);
       } catch (error) {
-        console.error(
-          `${modRequest.platform}.${modRequest.modName}: AndroidManifest.xml mod error:`
-        );
+        console.error(`AndroidManifest.xml mod error:`);
         throw error;
       }
       return results;
@@ -119,7 +117,7 @@ const withAndroidStringsXMLBaseMod: ConfigPlugin = config => {
 
         await writeXMLAsync({ path: filePath, xml: modResults });
       } catch (error) {
-        console.error(`${modRequest.platform}.${modRequest.modName}: strings.xml mod error:`);
+        console.error(`strings.xml mod error:`);
         throw error;
       }
       return results;
@@ -153,9 +151,7 @@ const withAndroidProjectBuildGradleBaseMod: ConfigPlugin = config => {
 
         await writeFile(filePath, modResults.contents);
       } catch (error) {
-        console.error(
-          `${modRequest.platform}.${modRequest.modName}: android/build.gradle mod error:`
-        );
+        console.error(`android/build.gradle mod error:`);
         throw error;
       }
       return results;
@@ -189,9 +185,7 @@ const withAndroidSettingsGradleBaseMod: ConfigPlugin = config => {
 
         await writeFile(filePath, modResults.contents);
       } catch (error) {
-        console.error(
-          `${modRequest.platform}.${modRequest.modName}: android/settings.gradle mod error:`
-        );
+        console.error(`android/settings.gradle mod error:`);
         throw error;
       }
       return results;
@@ -225,9 +219,7 @@ const withAndroidAppBuildGradleBaseMod: ConfigPlugin = config => {
 
         await writeFile(filePath, modResults.contents);
       } catch (error) {
-        console.error(
-          `${modRequest.platform}.${modRequest.modName}: android/app/build.gradle mod error:`
-        );
+        console.error(`android/app/build.gradle mod error:`);
         throw error;
       }
       return results;
@@ -261,7 +253,7 @@ const withAndroidMainActivityBaseMod: ConfigPlugin = config => {
 
         await writeFile(filePath, modResults.contents);
       } catch (error) {
-        console.error(`${modRequest.platform}.${modRequest.modName}: MainActivity mod error:`);
+        console.error(`MainActivity mod error:`);
         throw error;
       }
       return results;
@@ -447,11 +439,7 @@ const withEntitlementsBaseMod: ConfigPlugin = config => {
         resolveModResults(results, modRequest.platform, modRequest.modName);
         await writeFile(entitlementsPath, plist.build(results.modResults));
       } catch (error) {
-        console.error(
-          `${modRequest.platform}.${modRequest.modName}: ${path.basename(
-            entitlementsPath
-          )} mod error:`
-        );
+        console.error(`${path.basename(entitlementsPath)} mod error:`);
         throw error;
       }
       return results;

--- a/packages/config-plugins/src/plugins/core-plugins.ts
+++ b/packages/config-plugins/src/plugins/core-plugins.ts
@@ -181,13 +181,15 @@ export function withInterceptedMod<T>(
     const stack = new Error().stack;
     // Format the stack trace to create the debug log
     debugTrace = getDebugPluginStackFromStackTrace(stack);
+    const modStack = chalk.bold(`${platform}.${mod}`);
+
+    debugTrace = `${modStack}: ${debugTrace}`;
   }
 
   async function interceptingMod({ modRequest, ...config }: ExportedConfigWithProps<T>) {
     if (isDebug) {
       // In debug mod, log the plugin stack in the order which they were invoked
-      const modStack = chalk.bold(`${platform}.${mod}`);
-      console.log(`${modStack}: ${debugTrace}`);
+      console.log(debugTrace);
     }
     return action({ ...config, modRequest: { ...modRequest, nextMod: interceptedMod } });
   }

--- a/packages/config-plugins/src/utils/errors.ts
+++ b/packages/config-plugins/src/utils/errors.ts
@@ -6,6 +6,22 @@ export class UnexpectedError extends Error {
   }
 }
 
+export class ModError extends Error {
+  constructor(messageOrError?: string | Error) {
+    const message =
+      (typeof messageOrError === 'string' ? messageOrError : messageOrError?.message) ??
+      'This error should fail silently in the CLI';
+    super(message);
+    if (typeof messageOrError !== 'string') {
+      // forward the props of the incoming error for tests or processes outside of expo-cli that use expo cli internals.
+      this.stack = messageOrError?.stack ?? this.stack;
+      this.name = messageOrError?.name ?? this.name;
+    } else {
+      this.name = 'ModError';
+    }
+  }
+}
+
 export function assert(value: any, message?: string | Error): asserts value {
   // TODO: Upgrade node? TypeScript isn't properly asserting values without this wrapper.
   return nodeAssert(value, message);

--- a/packages/config-plugins/src/utils/errors.ts
+++ b/packages/config-plugins/src/utils/errors.ts
@@ -6,22 +6,6 @@ export class UnexpectedError extends Error {
   }
 }
 
-export class ModError extends Error {
-  constructor(messageOrError?: string | Error) {
-    const message =
-      (typeof messageOrError === 'string' ? messageOrError : messageOrError?.message) ??
-      'This error should fail silently in the CLI';
-    super(message);
-    if (typeof messageOrError !== 'string') {
-      // forward the props of the incoming error for tests or processes outside of expo-cli that use expo cli internals.
-      this.stack = messageOrError?.stack ?? this.stack;
-      this.name = messageOrError?.name ?? this.name;
-    } else {
-      this.name = 'ModError';
-    }
-  }
-}
-
 export function assert(value: any, message?: string | Error): asserts value {
   // TODO: Upgrade node? TypeScript isn't properly asserting values without this wrapper.
   return nodeAssert(value, message);


### PR DESCRIPTION
passing them as warnings was pretty useless 

## Before

completes without any problems and logs the following warnings
```
⚠️  Android config synced with warnings that should be fixed:
- android-manifest: AndroidManifest.xml configuration could not be applied. Assignment to constant variable.
```

### After

Fails immediately with the following error:

```
android.manifest: AndroidManifest.xml mod error:
Assignment to constant variable.
TypeError: Assignment to constant variable.
    at /Users/evanbacon/Documents/GitHub/crypto-wallet/withStripe.js:94:21
    at action (/Users/evanbacon/Documents/GitHub/crypto-wallet/node_modules/@expo/config-plugins/src/plugins/core-plugins.ts:119:29)
    at interceptingMod (/Users/evanbacon/Documents/GitHub/crypto-wallet/node_modules/@expo/config-plugins/src/plugins/core-plugins.ts:186:12)
    at action (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/core-plugins.ts:120:14)
    at action (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/compiler-plugins.ts:76:19)
    at evalModsAsync (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/mod-compiler.ts:54:25)
    at compileModsAsync (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/mod-compiler.ts:17:10)
    at configureAndroidProjectAsync (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/src/commands/apply/configureAndroidProjectAsync.ts:32:12)
    at configureAndroidStepAsync (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/src/commands/eject/Eject.ts:244:3)
    at Object.ejectAsync (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/src/commands/eject/Eject.ts:102:5)
    at actionAsync (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/src/commands/eject.ts:75:5)
    at Command.<anonymous> (/Users/evanbacon/.nvm/versions/node/v12.18.1/lib/node_modules/expo-cli/src/exp.ts:346:7)
```