### PR TITLE
use env variable for debug when _internal isn't defined

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -38,6 +38,7 @@
     "@expo/json-file": "8.2.25",
     "@expo/plist": "0.0.10",
     "fs-extra": "9.0.0",
+    "getenv": "0.7.0",
     "glob": "7.1.6",
     "invariant": "2.2.4",
     "slash": "^3.0.0",

--- a/packages/config-plugins/src/plugins/core-plugins.ts
+++ b/packages/config-plugins/src/plugins/core-plugins.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { boolish } from 'getenv';
 
 import {
   ConfigPlugin,
@@ -8,6 +9,8 @@ import {
   ModPlatform,
 } from '../Plugin.types';
 import { addHistoryItem, getHistoryItem, PluginHistoryItem } from '../utils/history';
+
+const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
 function ensureArray<T>(input: T | T[]): T[] {
   if (Array.isArray(input)) {
@@ -170,7 +173,10 @@ export function withInterceptedMod<T>(
 
   // Create a stack trace for debugging ahead of time
   let debugTrace: string = '';
-  if (config._internal?.isDebug) {
+  // Use the possibly user defined value. Otherwise fallback to the env variable.
+  // We support the env variable because user mods won't have _internal defined in time.
+  const isDebug = config._internal?.isDebug ?? EXPO_DEBUG;
+  if (isDebug) {
     // Get a stack trace via the Error API
     const stack = new Error().stack;
     // Format the stack trace to create the debug log
@@ -178,7 +184,7 @@ export function withInterceptedMod<T>(
   }
 
   async function interceptingMod({ modRequest, ...config }: ExportedConfigWithProps<T>) {
-    if (config._internal?.isDebug) {
+    if (isDebug) {
       // In debug mod, log the plugin stack in the order which they were invoked
       const modStack = chalk.bold(`${platform}.${mod}`);
       console.log(`${modStack}: ${debugTrace}`);


### PR DESCRIPTION
Fallback to the env variable when _internal isn't defined. We support the env variable because user mods won't have _internal defined in time.