### PR TITLE
Remove last call to intercomHash endpoint

### DIFF
--- a/packages/xdl/src/__integration_tests__/UserSessions-test.ts
+++ b/packages/xdl/src/__integration_tests__/UserSessions-test.ts
@@ -94,7 +94,7 @@ describe.skip('User Sessions', () => {
     expect(auth?.sessionSecret).toBe(undefined);
   });
 
-  it('should use the token in apiv2', async () => {
+  it('should use the session token with API v2 requests', async () => {
     const UserManager = _newTestUserManager();
     await UserManager.loginAsync('user-pass', {
       username: userForTest.username,
@@ -103,7 +103,7 @@ describe.skip('User Sessions', () => {
 
     const user = await UserManager.getCurrentUserAsync();
     const api = ApiV2Client.clientForUser(user);
-    const response = await api.getAsync('auth/intercomUserHash', {}, {}, true);
+    const response = await api.getAsync('auth/userInfo', {}, {}, true);
     expect(response.status).toBe(200);
   });
 });


### PR DESCRIPTION
Why: This endpoint is otherwise unused; remove the last caller so we can remove it from www.

How: I replaced the endpoint with the `auth/userInfo` endpoint, which is still used and suffices for this test.

Test Plan: Ran `yarn integration-tests` in XDL after removing `.skip` from `UserSessions-test.ts`.