### PR TITLE
[config-plugins] feat: add android.applicationId

### DIFF
--- a/packages/config-plugins/src/android/ApplicationId.ts
+++ b/packages/config-plugins/src/android/ApplicationId.ts
@@ -1,0 +1,43 @@
+import { ExpoConfig } from '@expo/config-types';
+
+import { ConfigPlugin } from '../Plugin.types';
+import { withAppBuildGradle } from '../plugins/android-plugins';
+import * as WarningAggregator from '../utils/warnings';
+
+export const withApplicationIdGradle: ConfigPlugin = config => {
+  return withAppBuildGradle(config, config => {
+    if (config.modResults.language === 'groovy') {
+      config.modResults.contents = setApplicationIdInBuildGradle(
+        config,
+        config.modResults.contents
+      );
+    } else {
+      WarningAggregator.addWarningAndroid(
+        'android-application-id',
+        `Cannot automatically configure app build.gradle if it's not groovy`
+      );
+    }
+    return config;
+  });
+};
+
+/**
+ * Get `applicationId` from the android's configuration.
+ * If there's no `applicationId` it fallbacks and tries with `android.package`.
+ */
+export function getApplicationId(config: Pick<ExpoConfig, 'android'>) {
+  return config.android?.applicationId ?? config.android?.package ?? null;
+}
+
+export function setApplicationIdInBuildGradle(
+  config: Pick<ExpoConfig, 'android'>,
+  buildGradle: string
+) {
+  const applicationId = getApplicationId(config);
+  if (applicationId === null) {
+    return buildGradle;
+  }
+
+  const pattern = new RegExp(`applicationId ['"].*['"]`);
+  return buildGradle.replace(pattern, `applicationId '${applicationId}'`);
+}

--- a/packages/config-plugins/src/android/Package.ts
+++ b/packages/config-plugins/src/android/Package.ts
@@ -4,9 +4,8 @@ import { sync as globSync } from 'glob';
 import path from 'path';
 
 import { ConfigPlugin } from '../Plugin.types';
-import { createAndroidManifestPlugin, withAppBuildGradle } from '../plugins/android-plugins';
+import { createAndroidManifestPlugin } from '../plugins/android-plugins';
 import { withDangerousMod } from '../plugins/core-plugins';
-import * as WarningAggregator from '../utils/warnings';
 import { AndroidManifest } from './Manifest';
 import { getMainApplicationAsync } from './Paths';
 
@@ -14,20 +13,6 @@ export const withPackageManifest = createAndroidManifestPlugin(
   setPackageInAndroidManifest,
   'withPackageManifest'
 );
-
-export const withPackageGradle: ConfigPlugin = config => {
-  return withAppBuildGradle(config, config => {
-    if (config.modResults.language === 'groovy') {
-      config.modResults.contents = setPackageInBuildGradle(config, config.modResults.contents);
-    } else {
-      WarningAggregator.addWarningAndroid(
-        'android-package',
-        `Cannot automatically configure app build.gradle if it's not groovy`
-      );
-    }
-    return config;
-  });
-};
 
 export const withPackageRefactor: ConfigPlugin = config => {
   return withDangerousMod(config, [
@@ -120,16 +105,6 @@ export async function renamePackageOnDisk(
       }
     } catch {}
   });
-}
-
-export function setPackageInBuildGradle(config: Pick<ExpoConfig, 'android'>, buildGradle: string) {
-  const packageName = getPackage(config);
-  if (packageName === null) {
-    return buildGradle;
-  }
-
-  const pattern = new RegExp(`applicationId ['"].*['"]`);
-  return buildGradle.replace(pattern, `applicationId '${packageName}'`);
 }
 
 export function setPackageInAndroidManifest(

--- a/packages/config-plugins/src/android/__tests__/ApplicationId-test.ts
+++ b/packages/config-plugins/src/android/__tests__/ApplicationId-test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { getApplicationId, setApplicationIdInBuildGradle } from '../ApplicationId';
+
+const fixturesPath = resolve(__dirname, 'fixtures');
+const buildGradlePath = resolve(fixturesPath, 'build.gradle');
+const buildGradleContent = readFileSync(buildGradlePath, 'utf-8');
+
+describe('applicationId', () => {
+  it(`returns null if no applicationId nor package is provided`, () => {
+    expect(getApplicationId({})).toBe(null);
+  });
+
+  it(`returns the applicationId if provided`, () => {
+    expect(getApplicationId({ android: { applicationId: 'com.example.xyz' } })).toBe(
+      'com.example.xyz'
+    );
+  });
+
+  it(`returns the applicationId if package is provided and applicationId is not provided`, () => {
+    expect(getApplicationId({ android: { package: 'com.example.xyz' } })).toBe('com.example.xyz');
+  });
+
+  it(`sets the applicationId in build.gradle if applicationId is given`, () => {
+    expect(
+      setApplicationIdInBuildGradle(
+        { android: { applicationId: 'my.new.app' } },
+        buildGradleContent
+      )
+    ).toMatch("applicationId 'my.new.app'");
+  });
+
+  it(`sets the applicationId in build.gradle if there's no applicationId, but package is given`, () => {
+    expect(
+      setApplicationIdInBuildGradle({ android: { package: 'my.new.app' } }, buildGradleContent)
+    ).toMatch("applicationId 'my.new.app'");
+  });
+});

--- a/packages/config-plugins/src/android/__tests__/Package-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Package-test.ts
@@ -1,25 +1,10 @@
 import { resolve } from 'path';
 
 import { readAndroidManifestAsync } from '../Manifest';
-import { getPackage, setPackageInAndroidManifest, setPackageInBuildGradle } from '../Package';
+import { getPackage, setPackageInAndroidManifest } from '../Package';
 
 const fixturesPath = resolve(__dirname, 'fixtures');
 const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
-
-const EXAMPLE_BUILD_GRADLE = `
-  android {
-      compileSdkVersion rootProject.ext.compileSdkVersion
-      buildToolsVersion rootProject.ext.buildToolsVersion
-  
-      defaultConfig {
-          applicationId "com.helloworld"
-          minSdkVersion rootProject.ext.minSdkVersion
-          targetSdkVersion rootProject.ext.targetSdkVersion
-          versionCode 1
-          versionName "1.0"
-      }
-  }
-  `;
 
 describe('package', () => {
   it(`returns null if no package is provided`, () => {
@@ -28,12 +13,6 @@ describe('package', () => {
 
   it(`returns the package if provided`, () => {
     expect(getPackage({ android: { package: 'com.example.xyz' } })).toBe('com.example.xyz');
-  });
-
-  it(`sets the applicationId in build.gradle if package is given`, () => {
-    expect(
-      setPackageInBuildGradle({ android: { package: 'my.new.app' } }, EXAMPLE_BUILD_GRADLE)
-    ).toMatch("applicationId 'my.new.app'");
   });
 
   it('adds package to android manifest', async () => {

--- a/packages/config-plugins/src/android/__tests__/fixtures/build.gradle
+++ b/packages/config-plugins/src/android/__tests__/fixtures/build.gradle
@@ -1,0 +1,12 @@
+android {
+  compileSdkVersion rootProject.ext.compileSdkVersion
+  buildToolsVersion rootProject.ext.buildToolsVersion
+
+  defaultConfig {
+    applicationId "com.helloworld"
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+    versionCode 1
+    versionName "1.0"
+  }
+}

--- a/packages/config-plugins/src/android/index.ts
+++ b/packages/config-plugins/src/android/index.ts
@@ -1,4 +1,5 @@
 import * as AllowBackup from './AllowBackup';
+import * as ApplicationId from './ApplicationId';
 import * as Branch from './Branch';
 import * as Colors from './Colors';
 import * as EasBuild from './EasBuild';
@@ -27,6 +28,7 @@ import * as Version from './Version';
 
 export {
   AllowBackup,
+  ApplicationId,
   EasBuild,
   Manifest,
   Branch,

--- a/packages/config-plugins/src/plugins/expo-plugins.ts
+++ b/packages/config-plugins/src/plugins/expo-plugins.ts
@@ -70,7 +70,7 @@ export const withExpoAndroidPlugins: ConfigPlugin<{
 
     // app/build.gradle
     AndroidConfig.GoogleServices.withApplyPlugin,
-    AndroidConfig.Package.withPackageGradle,
+    AndroidConfig.ApplicationId.withApplicationIdGradle,
     AndroidConfig.Version.withVersion,
 
     // AndroidManifest.xml

--- a/packages/config-types/scripts/generate.ts
+++ b/packages/config-types/scripts/generate.ts
@@ -74,6 +74,9 @@ async function fetchSchemaAsync(version: string): Promise<Record<string, any>> {
   const ts = await compile(schema as any, 'ExpoConfig', {
     bannerComment: `/* tslint:disable */\n/**\n* The standard Expo config object defined in \`app.config.js\` files.\n*/`,
     unknownAny: false,
+    style: {
+      singleQuote: true,
+    },
   });
   const filepath = `src/ExpoConfig.ts`;
   fs.ensureDirSync(path.dirname(filepath));

--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -469,9 +469,13 @@ export interface Android {
    */
   publishBundlePath?: string;
   /**
-   * The package name for your Android standalone app. You make it up, but it needs to be unique on the Play Store. See [this StackOverflow question](http://stackoverflow.com/questions/6273892/android-package-name-convention).
+   * The package name for your Android standalone app. By default it is also used as the `applicationId` in your application. You can provide `applicationId` separately.
    */
   package?: string;
+  /**
+   * Unique application ID that identifies your app on the device and in Google Play Store. Providing this is optional as the value provided in the `package` parameter is being used as as default value for this parameter as well. Once the application is published to the store with the specific `applicationId`, this value cannot be changed. [Learn more](https://developer.android.com/studio/build/application-id)
+   */
+  applicationId?: string;
   /**
    * Version number required by Google Play. Increment by one for each release. Must be an integer. [Learn more](https://developer.android.com/studio/publish/versioning.html)
    */


### PR DESCRIPTION
Followup of https://github.com/expo/expo-cli/pull/2962

Adjust `config-plugins` to accommodate new `android.applicationId` property.