### PR TITLE
[config-types] replace Developer Services with EAS Priority Plan

### DIFF
--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -17,7 +17,7 @@ export interface ExpoConfig {
    */
   slug: string;
   /**
-   * The Expo account name of the team owner, only applicable if you are enrolled in Expo Developer Services. If not provided, defaults to the username of the current user.
+   * The Expo account name of the team owner. If not provided, defaults to the username of the current user.
    */
   owner?: string;
   /**

--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -17,7 +17,7 @@ export interface ExpoConfig {
    */
   slug: string;
   /**
-   * The Expo account name of the team owner. If not provided, defaults to the username of the current user.
+   * The name of the Expo organization that owns this project. If not provided, defaults to the username of the current user.
    */
   owner?: string;
   /**


### PR DESCRIPTION
**do not land until orgs release**

Developer Services is getting renamed, and once organizations are announced the `owner` field won't apply to only Developer Services users anyways. 