### PR TITLE
Do not override pageExtensions but extend it

### DIFF
--- a/packages/next-adapter/src/withExpo.ts
+++ b/packages/next-adapter/src/withExpo.ts
@@ -6,7 +6,7 @@ import { NextConfig } from 'next';
 export default function withExpo(nextConfig: NextConfig = {}): NextConfig {
   return {
     ...nextConfig,
-    pageExtensions: getBareExtensions(['web']),
+    pageExtensions: [...getBareExtensions(['web']), ...nextConfig.pageExtensions],
     webpack(config: AnyConfiguration, options: any): AnyConfiguration {
       // Prevent define plugin from overwriting Next.js environment.
       process.env.EXPO_WEBPACK_DEFINE_ENVIRONMENT_AS_KEYS = 'true';


### PR DESCRIPTION
This causes a problem when other page extensions need to be configured