### PR TITLE
Use 'managed' as the default target for the dev server

### DIFF
--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -140,6 +140,10 @@ function parseStartOptions(options: NormalizedOptions): Project.StartOptions {
 
   if (options.devClient) {
     startOpts.target = 'bare';
+  } else {
+    // For `expo start`, the default target is 'managed', for both managed *and* bare apps.
+    // See: https://docs.expo.io/bare/using-expo-client
+    startOpts.target = 'managed';
   }
 
   return startOpts;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1740,7 +1740,7 @@ async function startDevServerAsync(projectRoot: string, startOptions: StartOptio
   }
   if (startOptions.target) {
     // EXPO_TARGET is used by @expo/metro-config to determine the target when getDefaultConfig is
-    // called from metro.config.js and the --target option is used to override the default target.
+    // called from metro.config.js.
     process.env.EXPO_TARGET = startOptions.target;
   }
 


### PR DESCRIPTION
It's possible to develop bare apps with Expo Go as documented in https://docs.expo.io/bare/using-expo-client/

For this use case, we need to use 'managed' as the default target for the dev server, because otherwise bare apps would default to 'bare':
https://github.com/expo/expo-cli/blob/cc4613dc4d9aeedcfb3ea69d9293fb66142c7148/packages/metro-config/src/ExpoMetroConfig.ts#L42