### PR TITLE
[xdl] Stop building shell apps for 32-bit architecture

### DIFF
--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -102,7 +102,7 @@ async function _buildAsync(
   let buildCmd = `set -o pipefail && xcodebuild -workspace ${projectName}.xcworkspace -scheme ${projectName} -configuration ${configuration} -derivedDataPath ${buildDest} ${modernBuildSystemFragment}`,
     pathToArtifact;
   if (type === 'simulator') {
-    buildCmd += ` -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=NO | xcpretty`;
+    buildCmd += ` -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ARCHS="x86_64" ONLY_ACTIVE_ARCH=NO | xcpretty`;
     pathToArtifact = path.join(
       buildDest,
       'Build',


### PR DESCRIPTION
Since we dropped support for iOS 10.0 in https://github.com/expo/expo/pull/11344, we also have to remove `i386` from the architectures that we build shell apps against.

I could also add `arm64`, but I'm intentionally not doing it because some of our dependencies providing prebuilt binaries don't support this architecture yet.