### PR TITLE
[eject] auto apply optional managed plugins

### DIFF
--- a/packages/config/src/plugins/withInternal.ts
+++ b/packages/config/src/plugins/withInternal.ts
@@ -2,7 +2,7 @@ import { boolish } from 'getenv';
 
 import { ConfigFilePaths, ConfigPlugin } from '../Config.types';
 
-const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
+export const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
 /**
  * Adds the _internal object.

--- a/packages/config/src/plugins/withStaticPlugin.ts
+++ b/packages/config/src/plugins/withStaticPlugin.ts
@@ -6,6 +6,7 @@ import {
   resolveConfigPluginFunction,
   StaticPlugin,
 } from './modulePluginResolver';
+import { EXPO_DEBUG } from './withInternal';
 
 /**
  * Resolves static module plugin and potentially falls back on a provided plugin if the module cannot be resolved
@@ -41,6 +42,10 @@ export const withStaticPlugin: ConfigPlugin<{
       // Resolve and evaluate plugins.
       withPlugin = resolveConfigPluginFunction(projectRoot, pluginResolve);
     } catch (error) {
+      if (EXPO_DEBUG) {
+        // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
+        console.log(`Error resolving plugin "${pluginResolve}"`, error);
+      }
       // If the static module failed to resolve, attempt to use a fallback.
       // This enables support for built-in plugins with versioned variations living in other packages.
       if (props.fallback) {

--- a/packages/expo-cli/src/commands/apply/configureManagedProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureManagedProjectAsync.ts
@@ -64,4 +64,5 @@ export default async function configureManagedProjectAsync({
     log.info(mods);
     log.debug();
   }
+  return config;
 }

--- a/packages/expo-cli/src/commands/apply/configureManagedProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureManagedProjectAsync.ts
@@ -8,14 +8,15 @@ import log from '../../log';
 // Expo managed packages that require extra update.
 // These get applied automatically to create parity with expo build in eas build.
 export const expoManagedPlugins = [
-  'expo-camera',
-  'expo-image-picker',
+  'expo-app-auth',
   'expo-av',
   'expo-background-fetch',
   'expo-barcode-scanner',
   'expo-brightness',
   'expo-calendar',
+  'expo-camera',
   'expo-contacts',
+  'expo-image-picker',
   'expo-file-system',
   'expo-location',
   'expo-media-library',

--- a/packages/expo-cli/src/commands/apply/configureManagedProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureManagedProjectAsync.ts
@@ -5,6 +5,8 @@ import { withStaticPlugin } from '@expo/config/build/plugins/withStaticPlugin';
 
 import log from '../../log';
 
+// Expo managed packages that require extra update.
+// These get applied automatically to create parity with expo build in eas build.
 export const expoManagedPlugins = [
   'expo-camera',
   'expo-image-picker',

--- a/packages/expo-cli/src/commands/apply/configureManagedProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureManagedProjectAsync.ts
@@ -1,0 +1,67 @@
+import { ConfigPlugin, ExpoConfig, getConfig } from '@expo/config';
+import { compileModsAsync, ModPlatform } from '@expo/config-plugins';
+import { StaticPlugin } from '@expo/config/build/plugins/modulePluginResolver';
+import { withStaticPlugin } from '@expo/config/build/plugins/withStaticPlugin';
+
+import log from '../../log';
+
+export const expoManagedPlugins = [
+  'expo-camera',
+  'expo-image-picker',
+  'expo-av',
+  'expo-background-fetch',
+  'expo-barcode-scanner',
+  'expo-brightness',
+  'expo-calendar',
+  'expo-contacts',
+  'expo-file-system',
+  'expo-location',
+  'expo-media-library',
+  'expo-notifications',
+  'expo-screen-orientation',
+  'expo-sensors',
+  'expo-task-manager',
+];
+
+const withOptionalPlugins: ConfigPlugin<(StaticPlugin | string)[]> = (config, plugins) => {
+  return plugins.reduce((prev, plugin) => {
+    return withStaticPlugin(prev, {
+      plugin,
+      // If a plugin doesn't exist, do nothing.
+      fallback: config => config,
+    });
+  }, config);
+};
+
+function withManagedPlugins(config: ExpoConfig) {
+  return withOptionalPlugins(config, expoManagedPlugins);
+}
+
+export default async function configureManagedProjectAsync({
+  projectRoot,
+  platforms,
+}: {
+  projectRoot: string;
+  platforms: ModPlatform[];
+}) {
+  let { exp: config } = getConfig(projectRoot, {
+    skipSDKVersionRequirement: true,
+    isModdedConfig: true,
+  });
+
+  // Add all built-in plugins
+  config = withManagedPlugins(config);
+
+  // compile all plugins and mods
+  config = await compileModsAsync(config, { projectRoot, platforms });
+
+  if (log.isDebug) {
+    log.debug();
+    log.debug('Evaluated Managed config:');
+    // @ts-ignore: mods not on config type
+    const { mods, ...rest } = config;
+    log.info(JSON.stringify(rest, null, 2));
+    log.info(mods);
+    log.debug();
+  }
+}

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -486,10 +486,12 @@ async function updatePackageJSONAsync({
     hashForDependencyMap(pkg.devDependencies) !== hashForDependencyMap(combinedDevDependencies);
   // Save the dependencies
   if (hasNewDependencies) {
-    pkg.dependencies = combinedDependencies;
+    // Use Object.assign to preserve the original order of dependencies, this makes it easier to see what changed in the git diff.
+    pkg.dependencies = Object.assign(pkg.dependencies, combinedDependencies);
   }
   if (hasNewDevDependencies) {
-    pkg.devDependencies = combinedDevDependencies;
+    // Same as with dependencies
+    pkg.devDependencies = Object.assign(pkg.devDependencies, combinedDevDependencies);
   }
 
   /**

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -17,6 +17,9 @@ import CommandError, { SilentError } from '../../CommandError';
 import log from '../../log';
 import configureAndroidProjectAsync from '../apply/configureAndroidProjectAsync';
 import configureIOSProjectAsync from '../apply/configureIOSProjectAsync';
+import configureManagedProjectAsync, {
+  expoManagedPlugins,
+} from '../apply/configureManagedProjectAsync';
 import * as CreateApp from '../utils/CreateApp';
 import * as GitIgnore from '../utils/GitIgnore';
 import { usesOldExpoUpdatesAsync } from '../utils/ProjectUtils';
@@ -101,6 +104,8 @@ export async function ejectAsync(
   if (platforms.includes('android')) {
     await configureAndroidStepAsync({ projectRoot, platforms });
   }
+
+  await configureManagedProjectAsync({ projectRoot, platforms });
 
   // Install CocoaPods
   let podsInstalled: boolean = false;
@@ -713,23 +718,7 @@ async function warnIfDependenciesRequireAdditionalSetupAsync(
   pkg: PackageJSONConfig,
   sdkVersion?: string
 ): Promise<void> {
-  const expoPackagesWithExtraSetup = [
-    'expo-camera',
-    'expo-image-picker',
-    'expo-av',
-    'expo-background-fetch',
-    'expo-barcode-scanner',
-    'expo-brightness',
-    'expo-calendar',
-    'expo-contacts',
-    'expo-file-system',
-    'expo-location',
-    'expo-media-library',
-    'expo-notifications',
-    'expo-screen-orientation',
-    'expo-sensors',
-    'expo-task-manager',
-  ].reduce(
+  const expoPackagesWithExtraSetup = expoManagedPlugins.reduce(
     (prev, curr) => ({
       ...prev,
       [curr]: `https://github.com/expo/expo/tree/master/packages/${curr}`,


### PR DESCRIPTION
When ejecting a project with expo SDK packages, we'll automatically apply a hardcoded list of package's plugins if they exist. This will create configuration parity with managed apps.

When a plugin can be auto-configured, it'll be removed from the list of plugins with additional setup.