### PR TITLE
fix bug where android version code would append 1 every time eject was run

### DIFF
--- a/packages/config-plugins/src/android/Version.ts
+++ b/packages/config-plugins/src/android/Version.ts
@@ -44,16 +44,12 @@ export function getVersionCode(config: Pick<ExpoConfig, 'android'>) {
   return config.android?.versionCode ?? null;
 }
 
-export function setVersionCode(
-  config: Pick<ExpoConfig, 'android'>,
-  buildGradle: string,
-  versionCodeToReplace = DEFAULT_VERSION_CODE
-) {
+export function setVersionCode(config: Pick<ExpoConfig, 'android'>, buildGradle: string) {
   const versionCode = getVersionCode(config);
   if (versionCode === null) {
     return buildGradle;
   }
 
-  const pattern = new RegExp(`versionCode ${versionCodeToReplace}`);
+  const pattern = new RegExp(`versionCode.*`);
   return buildGradle.replace(pattern, `versionCode ${versionCode}`);
 }

--- a/packages/config-plugins/src/android/Version.ts
+++ b/packages/config-plugins/src/android/Version.ts
@@ -5,7 +5,6 @@ import { withAppBuildGradle } from '../plugins/android-plugins';
 import * as WarningAggregator from '../utils/warnings';
 
 const DEFAULT_VERSION_NAME = '1.0';
-const DEFAULT_VERSION_CODE = '1';
 
 export const withVersion: ConfigPlugin = config => {
   return withAppBuildGradle(config, config => {

--- a/packages/config-plugins/src/android/__tests__/Version-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Version-test.ts
@@ -70,7 +70,7 @@ describe('versionCode', () => {
   });
 
   it(`replaces provided version code in build.gradle if version code is given`, () => {
-    expect(setVersionCode({ android: { versionCode: 5 } }, EXAMPLE_BUILD_GRADLE_2, '4')).toMatch(
+    expect(setVersionCode({ android: { versionCode: 5 } }, EXAMPLE_BUILD_GRADLE_2)).toMatch(
       'versionCode 5'
     );
   });


### PR DESCRIPTION
running expo eject in a blank android project would add 1 to the versionCode every time it was run, this fixes that fwict.