### PR TITLE
[expo-cli] Validate project owner when publishing

### DIFF
--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -309,7 +309,7 @@ export function logBareWorkflowWarnings(pkg: PackageJSONConfig) {
   );
 }
 
-export default function(program: Command) {
+export default function (program: Command) {
   program
     .command('publish [path]')
     .alias('p')

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -1,6 +1,12 @@
-import { getConfig, getDefaultTarget, PackageJSONConfig, ProjectTarget } from '@expo/config';
+import {
+  ExpoConfig,
+  getConfig,
+  getDefaultTarget,
+  PackageJSONConfig,
+  ProjectTarget,
+} from '@expo/config';
 import simpleSpinner from '@expo/simple-spinner';
-import { Project } from '@expo/xdl';
+import { Project, UserManager } from '@expo/xdl';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import fs from 'fs';
@@ -8,6 +14,7 @@ import path from 'path';
 
 import CommandError from '../CommandError';
 import log from '../log';
+import { getProjectOwner } from '../projects';
 import * as sendTo from '../sendTo';
 import * as TerminalLink from './utils/TerminalLink';
 import { formatNamedWarning } from './utils/logConfigWarnings';
@@ -36,6 +43,10 @@ export async function action(
 
   const target = options.target ?? getDefaultTarget(projectDir);
 
+  // note: this validates the exp.owner when the user is a robot
+  const user = await UserManager.ensureLoggedInAsync();
+  const owner = getProjectOwner(user, exp);
+
   log.addNewLineIfNone();
 
   // Log building info before building.
@@ -46,6 +57,9 @@ export async function action(
   }
   log(`- Release channel: ${log.chalk.bold(options.releaseChannel)}`);
   log(`- Workflow: ${log.chalk.bold(target.replace(/\b\w/g, l => l.toUpperCase()))}`);
+  if (user.kind === 'robot') {
+    log(`- Owner: ${log.chalk.bold(owner)}`);
+  }
 
   log.newLine();
 
@@ -301,7 +315,7 @@ export function logBareWorkflowWarnings(pkg: PackageJSONConfig) {
   );
 }
 
-export default function (program: Command) {
+export default function(program: Command) {
   program
     .command('publish [path]')
     .alias('p')

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -1,10 +1,4 @@
-import {
-  ExpoConfig,
-  getConfig,
-  getDefaultTarget,
-  PackageJSONConfig,
-  ProjectTarget,
-} from '@expo/config';
+import { getConfig, getDefaultTarget, PackageJSONConfig, ProjectTarget } from '@expo/config';
 import simpleSpinner from '@expo/simple-spinner';
 import { Project, UserManager } from '@expo/xdl';
 import chalk from 'chalk';

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -3,6 +3,7 @@ import { ApiV2, UserManager } from '@expo/xdl';
 import ora from 'ora';
 
 import log from '../../log';
+import { getProjectOwner } from '../../projects';
 import { confirmAsync } from '../../prompts';
 import * as table from './cli-table';
 
@@ -79,7 +80,7 @@ export async function getPublishHistoryAsync(
 
   const api = ApiV2.clientForUser(user);
   return await api.postAsync('publish/history', {
-    owner: exp.owner,
+    owner: getProjectOwner(user, exp),
     slug: exp.slug,
     version: VERSION,
     releaseChannel: options.releaseChannel,
@@ -224,7 +225,7 @@ export async function getPublicationDetailAsync(
 
   const api = ApiV2.clientForUser(user);
   const result = await api.postAsync('publish/details', {
-    owner: exp.owner,
+    owner: getProjectOwner(user, exp),
     publishId: options.publishId,
     slug: exp.slug,
   });


### PR DESCRIPTION
Right now, people who are using robots without the `owner` field see the "Robots are not supported for this API call" error. Which isn't descriptive about the missing `owner` field. This adds validation with descriptive error messages for all the 3 `expo publish:*` commands we have.

I also added the `Owner: ...` field when publishing as robot, but maybe we should include it whenever the owner isn't the same as the user's username?

publish with robot | publish with user
--- | ---
![screenshot_2021-01-07_at_16 20 23](https://user-images.githubusercontent.com/1203991/103910261-ecd47e00-5104-11eb-907d-f81a17bc3a81.png) |  ![screenshot_2021-01-07_at_16 20 55](https://user-images.githubusercontent.com/1203991/103910277-f0680500-5104-11eb-8be3-2cb5eeb4bbbd.png)
