### PR TITLE
Don't expose Expo environment variables publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- [cli] Environment variables matching `EXPO_` or `REACT_NATIVE_` are no longer exposed publicly to the development-mode app or website ([#3063](https://github.com/expo/expo-cli/issues/3063))
 
 ### 🎉 New features
-
 
 ### 🐛 Bug fixes
 
@@ -62,7 +62,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 - [cli][xdl] Clear versions cache when running expo upgrade, to be safe
 - [config] fix mod serialization ([#3008](https://github.com/expo/expo-cli/issues/3008))
-- [config-plugins] use env variable for debug when _internal isn't defined ([#3011](https://github.com/expo/expo-cli/issues/3011))
+- [config-plugins] use env variable for debug when \_internal isn't defined ([#3011](https://github.com/expo/expo-cli/issues/3011))
 
 ### 📦 Packages updated
 
@@ -194,7 +194,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
-- [config] fill _internal object ([#2968](https://github.com/expo/expo-cli/issues/2968))
+- [config] fill \_internal object ([#2968](https://github.com/expo/expo-cli/issues/2968))
 
 ### 🐛 Bug fixes
 
@@ -215,7 +215,6 @@ This is the log of notable changes to Expo CLI and related packages.
 - uri-scheme@1.0.50
 - @expo/webpack-config@0.12.47
 - @expo/xdl@59.0.3
-
 
 ## [Fri, 27 Nov 2020 14:33:45 -0800](https://github.com/expo/expo-cli/commit/7bb61ba51da0eafce3faa8cbf59124f56ebe7e7d)
 

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -64,6 +64,7 @@
     "progress": "^2.0.3",
     "react-dev-utils": "~11.0.1",
     "react-refresh": "^0.8.2",
+    "semver": "~7.3.4",
     "style-loader": "~1.2.1",
     "terser-webpack-plugin": "^3.0.6",
     "url-loader": "~4.1.0",

--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { boolish } from 'getenv';
+import semver from 'semver';
 import { DefinePlugin as OriginalDefinePlugin } from 'webpack';
 
 import { getConfig, getMode, getPublicPaths } from '../env';
@@ -58,7 +59,10 @@ export function createClientEnvironment(
   const environment = getMode({ mode });
   const __DEV__ = environment !== 'production';
 
-  const ENV_VAR_REGEX = /^(CI$)/i;
+  // Adding the env variables to the Expo manifest is unsafe.
+  // This feature is deprecated in SDK 41 forward.
+  const isEnvBindingSupported = lteSdkVersion(nativeAppManifest, '40.0.0');
+  const ENV_VAR_REGEX = isEnvBindingSupported ? /^(EXPO_|REACT_NATIVE_|CI$)/i : /^(CI$)/i;
   const SECRET_REGEX = /(PASSWORD|SECRET|TOKEN)/i;
 
   const shouldDefineKeys = boolish('EXPO_WEBPACK_DEFINE_ENVIRONMENT_AS_KEYS', false);
@@ -134,5 +138,21 @@ export default class DefinePlugin extends OriginalDefinePlugin {
     const environmentVariables = createClientEnvironment(mode, publicUrl, publicAppManifest);
 
     super(environmentVariables);
+  }
+}
+
+function lteSdkVersion(exp: Pick<ExpoConfig, 'sdkVersion'>, sdkVersion: string): boolean {
+  if (!exp.sdkVersion) {
+    return false;
+  }
+
+  if (exp.sdkVersion === 'UNVERSIONED') {
+    return false;
+  }
+
+  try {
+    return semver.lte(exp.sdkVersion, sdkVersion);
+  } catch (e) {
+    return false;
   }
 }

--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -58,7 +58,7 @@ export function createClientEnvironment(
   const environment = getMode({ mode });
   const __DEV__ = environment !== 'production';
 
-  const ENV_VAR_REGEX = /^(EXPO_|REACT_NATIVE_|CI$)/i;
+  const ENV_VAR_REGEX = /^(CI$)/i;
   const SECRET_REGEX = /(PASSWORD|SECRET|TOKEN)/i;
 
   const shouldDefineKeys = boolish('EXPO_WEBPACK_DEFINE_ENVIRONMENT_AS_KEYS', false);

--- a/packages/xdl/src/project/ManifestHandler.ts
+++ b/packages/xdl/src/project/ManifestHandler.ts
@@ -14,6 +14,7 @@ import * as ProjectSettings from '../ProjectSettings';
 import * as UrlUtils from '../UrlUtils';
 import UserManager, { ANONYMOUS_USERNAME } from '../User';
 import UserSettings from '../UserSettings';
+import * as Versions from '../Versions';
 import * as Doctor from './Doctor';
 import * as ProjectUtils from './ProjectUtils';
 
@@ -201,7 +202,11 @@ export async function getManifestResponseAsync({
   };
   manifest.packagerOpts = packagerOpts;
   manifest.mainModuleName = mainModuleName;
-  manifest.env = getManifestEnvironment();
+  // Adding the env variables to the Expo manifest is unsafe.
+  // This feature is deprecated in SDK 41 forward.
+  if (manifest.sdkVersion && Versions.lteSdkVersion(manifest, '40.0.0')) {
+    manifest.env = getManifestEnvironment();
+  }
   // Add URLs to the manifest
   manifest.bundleUrl = await getBundleUrlAsync({
     projectRoot,


### PR DESCRIPTION
We currently expose the environment variables matching `EXPO_` and `REACT_NATIVE_` in development. This is a security risk and we have other more preferred methods for passing data to the client via the manifest `extras` field. 

- On web, this feature didn't quite work as expected, it only added to `process.env` and not `Constants.manifest.env`. It's now completely disabled as web presents a larger risk.
- On native, this feature will be disabled starting in SDK 41

# Test Plan

- Lower the minimum SDK requirement to a released version like `40.0.0`
- Add an environment variable starting with `EXPO_` like `expo EXPO_SOMN=true`
- Run a project with `console.log(process.env, Constants.manifest.env)` in it
- The logs should no longer show these env variables exposed
