### PR TITLE
[config-plugins] Fix app gradle versionName replacement after ejecting twice

### DIFF
--- a/packages/config-plugins/src/android/Version.ts
+++ b/packages/config-plugins/src/android/Version.ts
@@ -29,7 +29,7 @@ export function setVersionName(config: Pick<ExpoConfig, 'version'>, buildGradle:
     return buildGradle;
   }
 
-  const pattern = new RegExp(`versionName.*`);
+  const pattern = new RegExp(`versionName ".*"`);
   return buildGradle.replace(pattern, `versionName "${versionName}"`);
 }
 

--- a/packages/config-plugins/src/android/Version.ts
+++ b/packages/config-plugins/src/android/Version.ts
@@ -4,8 +4,6 @@ import { ConfigPlugin } from '../Plugin.types';
 import { withAppBuildGradle } from '../plugins/android-plugins';
 import * as WarningAggregator from '../utils/warnings';
 
-const DEFAULT_VERSION_NAME = '1.0';
-
 export const withVersion: ConfigPlugin = config => {
   return withAppBuildGradle(config, config => {
     if (config.modResults.language === 'groovy') {
@@ -25,17 +23,13 @@ export function getVersionName(config: Pick<ExpoConfig, 'version'>) {
   return config.version ?? null;
 }
 
-export function setVersionName(
-  config: Pick<ExpoConfig, 'version'>,
-  buildGradle: string,
-  versionToReplace = DEFAULT_VERSION_NAME
-) {
+export function setVersionName(config: Pick<ExpoConfig, 'version'>, buildGradle: string) {
   const versionName = getVersionName(config);
   if (versionName === null) {
     return buildGradle;
   }
 
-  const pattern = new RegExp(`versionName "${versionToReplace}"`);
+  const pattern = new RegExp(`versionName.*`);
   return buildGradle.replace(pattern, `versionName "${versionName}"`);
 }
 

--- a/packages/config-plugins/src/android/__tests__/Version-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Version-test.ts
@@ -47,8 +47,8 @@ describe('versionName', () => {
     );
   });
 
-  it(`replaces provided version name in build.gradle if version name is given`, () => {
-    expect(setVersionName({ version: '1.2.3' }, EXAMPLE_BUILD_GRADLE_2, '2.0')).toMatch(
+  it(`replaces provided version name in build.gradle if version name is not the default`, () => {
+    expect(setVersionName({ version: '1.2.3' }, EXAMPLE_BUILD_GRADLE_2)).toMatch(
       'versionName "1.2.3"'
     );
   });


### PR DESCRIPTION
Fixes #3081

The issue was that the `versionToReplace` parameter was never provided. There also didn't seem to be a good way of retrieving the value set in `android/app/build.gradle`.

Instead of doing that, I applied the same approach as [this `versionCode` fix](https://github.com/expo/expo-cli/commit/edd590b825db32b2db3dd8f0af324b7b3db24d6c#diff-791f73eecd02a99877dd27c2ea8f8eba5ee22d21ea2cda0c0622bf322b6d6b8fL47-L59)