### PR TITLE
[xdl] fix expo export --dump-sourcemap for sdk 40+ and bare projects

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -490,11 +490,10 @@ export async function exportForAppHosting(
     const androidMapPath = path.join(outputDir, 'bundles', androidMapName);
     await writeArtifactSafelyAsync(projectRoot, null, androidMapPath, androidSourceMap);
 
-    if (!(target === 'bare' && semver.lte('40.0.0', exp.sdkVersion))) {
+    if (target === 'managed' && semver.lt(exp.sdkVersion, '40.0.0')) {
       // Remove original mapping to incorrect sourcemap paths
-      // In SDK 40+ bare projects, we no longer need to do this. It's also possible we should no
-      // longer do this in managed projects and/or older SDK versions, but this is safest for now
-      logger.global.info('Configuring sourcemaps');
+      // In SDK 40+ and bare projects, we no longer need to do this.
+      logger.global.info('Configuring source maps');
       await truncateLastNLines(iosJsPath, 1);
       await truncateLastNLines(androidJsPath, 1);
     }

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -490,10 +490,14 @@ export async function exportForAppHosting(
     const androidMapPath = path.join(outputDir, 'bundles', androidMapName);
     await writeArtifactSafelyAsync(projectRoot, null, androidMapPath, androidSourceMap);
 
-    // Remove original mapping to incorrect sourcemap paths
-    logger.global.info('Configuring sourcemaps');
-    await truncateLastNLines(iosJsPath, 1);
-    await truncateLastNLines(androidJsPath, 1);
+    if (!(target === 'bare' && semver.lte('40.0.0', exp.sdkVersion))) {
+      // Remove original mapping to incorrect sourcemap paths
+      // In SDK 40+ bare projects, we no longer need to do this. It's also possible we should no
+      // longer do this in managed projects and/or older SDK versions, but this is safest for now
+      logger.global.info('Configuring sourcemaps');
+      await truncateLastNLines(iosJsPath, 1);
+      await truncateLastNLines(androidJsPath, 1);
+    }
 
     // Add correct mapping to sourcemap paths
     await fs.appendFile(iosJsPath, `\n//# sourceMappingURL=${iosMapName}`);


### PR DESCRIPTION
Fixes https://github.com/expo/expo/issues/11652

Currently, JS bundles created from `expo export --dump-sourcemap` do not run in an SDK 40 bare project -- they fail with the familiar `Module AppRegistry is not a registered callable module` error. The cause seems to be the following lines:

https://github.com/expo/expo-cli/blob/62339b5fb7300569ca6cbb034251070bf8a63999/packages/xdl/src/Project.ts#L495-L496

The line that's being truncated is:

```
eric@Erics-iMac SelfHostTest % cat bundles/android-bcbcf3a727c6c6465382b49ddcf806e8.js
...
__r(0);
```

The bundles run fine without this line truncated. Since I'm not sure of the context/reasoning around truncating this line in the first place, I've simply added a gate that doesn't truncate for SDK 40+ bare projects.

# Test plan

- self-hosted update created with `expo export --dump-sourcemap` loads and runs
- also verified there is only one `sourceMappingURL` present in the bundle (the one added right below the relevant code in expo-cli):
```
eric@Erics-iMac SelfHostTest % cat dist/bundles/android-ed94ad221ad84051ddc6d46b5aef6ada.js | grep "sourceMappingURL"
//# sourceMappingURL=android-ed94ad221ad84051ddc6d46b5aef6ada.map
```

@quinlanj , adding you as a reviewer just in case you remember any context around this from 2 years ago 😅 