### PR TITLE
Auto configure TypeScript

### DIFF
--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -14,6 +14,7 @@ import log from '../log';
 import * as sendTo from '../sendTo';
 import urlOpts, { URLOptions } from '../urlOpts';
 import * as TerminalUI from './start/TerminalUI';
+import { ensureTypeScriptSetupAsync } from './utils/typescript/ensureTypeScriptSetup';
 
 type NormalizedOptions = URLOptions & {
   webOnly?: boolean;
@@ -155,6 +156,8 @@ function parseStartOptions(options: NormalizedOptions): Project.StartOptions {
 }
 
 async function startWebAction(projectDir: string, options: NormalizedOptions): Promise<void> {
+  await ensureTypeScriptSetupAsync(projectDir);
+
   const { exp, rootPath } = await configureProjectAsync(projectDir, options);
   const startOpts = parseStartOptions(options);
   await Project.startAsync(rootPath, { ...startOpts, exp });
@@ -166,6 +169,8 @@ async function startWebAction(projectDir: string, options: NormalizedOptions): P
 }
 
 async function action(projectDir: string, options: NormalizedOptions): Promise<void> {
+  await ensureTypeScriptSetupAsync(projectDir);
+
   const { exp, pkg, rootPath } = await configureProjectAsync(projectDir, options);
 
   // TODO: only validate dependencies if starting in managed workflow

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -156,9 +156,10 @@ function parseStartOptions(options: NormalizedOptions): Project.StartOptions {
 }
 
 async function startWebAction(projectDir: string, options: NormalizedOptions): Promise<void> {
-  await ensureTypeScriptSetupAsync(projectDir);
-
   const { exp, rootPath } = await configureProjectAsync(projectDir, options);
+  if (Versions.gteSdkVersion(exp, '34.0.0')) {
+    await ensureTypeScriptSetupAsync(projectDir);
+  }
   const startOpts = parseStartOptions(options);
   await Project.startAsync(rootPath, { ...startOpts, exp });
   await urlOpts.handleMobileOptsAsync(projectDir, options);
@@ -169,9 +170,11 @@ async function startWebAction(projectDir: string, options: NormalizedOptions): P
 }
 
 async function action(projectDir: string, options: NormalizedOptions): Promise<void> {
-  await ensureTypeScriptSetupAsync(projectDir);
-
   const { exp, pkg, rootPath } = await configureProjectAsync(projectDir, options);
+
+  if (Versions.gteSdkVersion(exp, '34.0.0')) {
+    await ensureTypeScriptSetupAsync(projectDir);
+  }
 
   // TODO: only validate dependencies if starting in managed workflow
   await validateDependenciesVersions(projectDir, exp, pkg);

--- a/packages/expo-cli/src/commands/utils/typescript/__tests__/ensureTypeScriptSetup-test.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/__tests__/ensureTypeScriptSetup-test.ts
@@ -1,0 +1,49 @@
+import { vol } from 'memfs';
+
+import { shouldSetupTypeScriptAsync } from '../ensureTypeScriptSetup';
+
+jest.mock('fs');
+jest.mock('resolve-from');
+
+describe(shouldSetupTypeScriptAsync, () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it(`returns null in a JS only project`, async () => {
+    vol.fromJSON({
+      '/app.js': 'noop',
+    });
+
+    expect(await shouldSetupTypeScriptAsync('/')).toBe(null);
+  });
+  it(`returns something in a project with TS files`, async () => {
+    vol.fromJSON({
+      '/somn.ts': '',
+    });
+
+    expect(await shouldSetupTypeScriptAsync('/')).toStrictEqual({ isBootstrapping: true });
+  });
+  it(`is bootstrapping a project with a blank tsconfig`, async () => {
+    vol.fromJSON({
+      '/tsconfig.json': '',
+    });
+
+    expect(await shouldSetupTypeScriptAsync('/')).toStrictEqual({ isBootstrapping: true });
+  });
+  it(`is bootstrapping a project with an empty object in the tsconfig`, async () => {
+    vol.fromJSON({
+      '/tsconfig.json': '{}',
+    });
+
+    expect(await shouldSetupTypeScriptAsync('/')).toStrictEqual({ isBootstrapping: true });
+  });
+
+  it(`is a TypeScript project`, async () => {
+    vol.fromJSON({
+      '/tsconfig.json': '{ foo: true }',
+    });
+
+    expect(await shouldSetupTypeScriptAsync('/')).toStrictEqual({ isBootstrapping: false });
+  });
+});

--- a/packages/expo-cli/src/commands/utils/typescript/__tests__/updateTSConfig-test.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/__tests__/updateTSConfig-test.ts
@@ -50,6 +50,34 @@ describe(updateTSConfigAsync, () => {
     });
   });
 
+  it(`uses an unversioned config when the versioned config isn't available`, async () => {
+    vol.fromJSON({
+      '/tsconfig.json': '{ "compilerOptions": {} }',
+    });
+    resolveBaseTSConfig.mockImplementationOnce(() => null);
+
+    await updateTSConfigAsync({
+      projectRoot: '/',
+      tsConfigPath: '/tsconfig.json',
+      isBootstrapping: true,
+    });
+
+    expect(JSON.parse(await fs.readFile('/tsconfig.json', 'utf8'))).toStrictEqual({
+      compilerOptions: {
+        allowJs: true,
+        allowSyntheticDefaultImports: true,
+        esModuleInterop: true,
+        jsx: 'react-native',
+        lib: ['esnext'],
+        moduleResolution: 'node',
+        noEmit: true,
+        resolveJsonModule: true,
+        skipLibCheck: true,
+        target: 'esnext',
+      },
+    });
+  });
+
   it(`forces the base config to be Expo`, async () => {
     vol.fromJSON({
       '/tsconfig.json': '{ "extends": "foobar", "compilerOptions": { "strict": true } }',

--- a/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
@@ -9,7 +9,11 @@ import CommandError from '../../../CommandError';
 import log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { logNewSection } from '../CreateApp';
-import { collectMissingPackages, hasTSConfig, queryProjectTypeScriptFiles } from './resolveModules';
+import {
+  collectMissingPackages,
+  hasTSConfig,
+  queryFirstProjectTypeScriptFileAsync,
+} from './resolveModules';
 import { isTypeScriptSetupDisabled, updateTSConfigAsync } from './updateTSConfig';
 
 export async function ensureTypeScriptSetupAsync(projectRoot: string): Promise<void> {
@@ -53,8 +57,8 @@ export async function shouldSetupTypeScriptAsync(
   }
   // This is a somewhat heavy check in larger projects.
   // Test that this is reasonably paced by running expo start in `expo/apps/native-component-list`
-  const typescriptFiles = queryProjectTypeScriptFiles(projectRoot);
-  if (typescriptFiles.length) {
+  const typescriptFile = await queryFirstProjectTypeScriptFileAsync(projectRoot);
+  if (typescriptFile) {
     return { isBootstrapping: true };
   }
 

--- a/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
@@ -1,6 +1,4 @@
 import * as PackageManager from '@expo/package-manager';
-import { isUsingYarn } from '@expo/package-manager/build';
-import { confirmAsync } from '@expo/xdl/build/Prompts';
 import chalk from 'chalk';
 import program from 'commander';
 import * as fs from 'fs-extra';
@@ -9,6 +7,7 @@ import wrapAnsi from 'wrap-ansi';
 
 import CommandError from '../../../CommandError';
 import log from '../../../log';
+import { confirmAsync } from '../../../prompts';
 import { logNewSection } from '../CreateApp';
 import { collectMissingPackages, hasTSConfig, queryProjectTypeScriptFiles } from './resolveModules';
 import { isTypeScriptSetupDisabled, updateTSConfigAsync } from './updateTSConfig';
@@ -74,7 +73,7 @@ async function ensureRequiredDependenciesAsync(
 
   const readableMissingPackages = missing.map(p => p.pkg).join(', ');
 
-  const isYarn = isUsingYarn(projectRoot);
+  const isYarn = PackageManager.isUsingYarn(projectRoot);
 
   let title = `It looks like you're trying to use TypeScript but don't have the required dependencies installed.`;
 

--- a/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
@@ -38,7 +38,7 @@ export async function ensureTypeScriptSetupAsync(projectRoot: string): Promise<v
   await updateTSConfigAsync({ projectRoot, tsConfigPath, isBootstrapping: intent.isBootstrapping });
 }
 
-async function shouldSetupTypeScriptAsync(
+export async function shouldSetupTypeScriptAsync(
   projectRoot: string
 ): Promise<{ isBootstrapping: boolean } | null> {
   const tsConfigPath = await hasTSConfig(projectRoot);

--- a/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
@@ -1,0 +1,146 @@
+import * as PackageManager from '@expo/package-manager';
+import { isUsingYarn } from '@expo/package-manager/build';
+import { confirmAsync } from '@expo/xdl/build/Prompts';
+import chalk from 'chalk';
+import program from 'commander';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import wrapAnsi from 'wrap-ansi';
+
+import CommandError from '../../../CommandError';
+import log from '../../../log';
+import { logNewSection } from '../CreateApp';
+import { collectMissingPackages, hasTSConfig, queryProjectTypeScriptFiles } from './resolveModules';
+import { isTypeScriptSetupDisabled, updateTSConfigAsync } from './updateTSConfig';
+
+export async function ensureTypeScriptSetupAsync(projectRoot: string): Promise<void> {
+  if (isTypeScriptSetupDisabled) {
+    log(chalk.dim('\u203A Skipping TypeScript verification'));
+    return;
+  }
+
+  const tsConfigPath = path.join(projectRoot, 'tsconfig.json');
+
+  // Ensure the project is TypeScript before continuing.
+  const intent = await shouldSetupTypeScriptAsync(projectRoot);
+  if (!intent) {
+    return;
+  }
+
+  // Ensure TypeScript packages are installed
+  await ensureRequiredDependenciesAsync(
+    projectRoot,
+    // Don't prompt in CI
+    program.nonInteractive
+  );
+
+  // Update the config
+  await updateTSConfigAsync({ projectRoot, tsConfigPath, isBootstrapping: intent.isBootstrapping });
+}
+
+async function shouldSetupTypeScriptAsync(
+  projectRoot: string
+): Promise<{ isBootstrapping: boolean } | null> {
+  const tsConfigPath = await hasTSConfig(projectRoot);
+
+  // Enable TS setup if the project has a `tsconfig.json`
+  if (tsConfigPath) {
+    const content = await fs.readFile(tsConfigPath, { encoding: 'utf8' }).then(
+      txt => txt.trim(),
+      () => null
+    );
+    const isBlankConfig = content === '' || content === '{}';
+    return { isBootstrapping: isBlankConfig };
+  }
+  // This is a somewhat heavy check in larger projects.
+  // Test that this is reasonably paced by running expo start in `expo/apps/native-component-list`
+  const typescriptFiles = queryProjectTypeScriptFiles(projectRoot);
+  if (typescriptFiles.length) {
+    return { isBootstrapping: true };
+  }
+
+  return null;
+}
+
+async function ensureRequiredDependenciesAsync(
+  projectRoot: string,
+  skipPrompt: boolean = false
+): Promise<string> {
+  const { resolutions, missing } = collectMissingPackages(projectRoot);
+  if (!missing.length) {
+    return resolutions.typescript!;
+  }
+  // Prompt to install or bail out...
+
+  const readableMissingPackages = missing.map(p => p.pkg).join(', ');
+
+  const isYarn = isUsingYarn(projectRoot);
+
+  let title = `It looks like you're trying to use TypeScript but don't have the required dependencies installed.`;
+
+  if (!skipPrompt) {
+    if (
+      await confirmAsync({
+        message: title + ` Would you like to install ${chalk.cyan(readableMissingPackages)}?`,
+        initial: true,
+      })
+    ) {
+      await installPackagesAsync(projectRoot, {
+        isYarn,
+        devPackages: missing.map(({ pkg }) => pkg),
+      });
+      // Try again but skip prompting twice.
+      return await ensureRequiredDependenciesAsync(projectRoot, true);
+    }
+
+    // Reset the title so it doesn't print twice in interactive mode.
+    title = '';
+  } else {
+    title += '\n\n';
+  }
+
+  const col = process.stdout.columns || 80;
+
+  const installCommand =
+    (isYarn ? 'yarn add --dev' : 'npm install --save-dev') +
+    ' ' +
+    missing.map(p => p.pkg).join(' ');
+
+  let disableMessage =
+    "If you're not using TypeScript, please remove the TypeScript files from your project";
+
+  if (await hasTSConfig(projectRoot)) {
+    disableMessage += ` and delete the tsconfig.json.`;
+  } else {
+    disableMessage += '.';
+  }
+
+  const solution = `Please install ${chalk.bold(
+    readableMissingPackages
+  )} by running:\n\n  ${chalk.reset.bold(installCommand)}\n\n`;
+
+  // This prevents users from starting a misconfigured JS or TS project by default.
+  throw new CommandError(wrapAnsi(title + solution + disableMessage + '\n', col));
+}
+
+async function installPackagesAsync(
+  projectRoot: string,
+  { isYarn, devPackages }: { isYarn: boolean; devPackages: string[] }
+) {
+  const packageManager = PackageManager.createForProject(projectRoot, {
+    yarn: isYarn,
+    log,
+    silent: !log.isDebug,
+  });
+
+  const packagesStr = chalk.bold(devPackages.join(', '));
+  log.newLine();
+  const installingPackageStep = logNewSection(`Installing ${packagesStr}`);
+  try {
+    await packageManager.addDevAsync(...devPackages);
+  } catch (e) {
+    installingPackageStep.fail(`Failed to install ${packagesStr} with error: ${e.message}`);
+    throw e;
+  }
+  installingPackageStep.succeed(`Installed ${packagesStr}`);
+}

--- a/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
@@ -21,11 +21,7 @@ export function queryProjectTypeScriptFiles(projectRoot: string): string[] {
 }
 
 export function resolveBaseTSConfig(projectRoot: string): string | null {
-  try {
-    return require.resolve('expo/tsconfig.base.json', { paths: [projectRoot] });
-  } catch {
-    return null;
-  }
+  return resolveFrom.silent(projectRoot, 'expo/tsconfig.base.json') ?? null;
 }
 
 export async function hasTSConfig(projectRoot: string): Promise<string | null> {

--- a/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
@@ -25,7 +25,6 @@ export function resolveBaseTSConfig(projectRoot: string): string | null {
 }
 
 export async function hasTSConfig(projectRoot: string): Promise<string | null> {
-  // TODO: Does this work in a monorepo?
   const tsConfigPath = path.join(projectRoot, 'tsconfig.json');
   if (await fileExistsAsync(tsConfigPath)) {
     return tsConfigPath;

--- a/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
@@ -1,0 +1,61 @@
+import { fileExistsAsync } from '@expo/config';
+import { sync as globSync } from 'glob';
+import * as path from 'path';
+import resolveFrom from 'resolve-from';
+
+const requiredPackages = [
+  // use typescript/package.json to skip node module cache issues when the user installs
+  // the package and attempts to resolve the module in the same process.
+  { file: 'typescript/package.json', pkg: 'typescript' },
+  { file: '@types/react/index.d.ts', pkg: '@types/react' },
+  { file: '@types/react-native/index.d.ts', pkg: '@types/react-native' },
+];
+
+export const baseTSConfigName = 'expo/tsconfig.base';
+
+export function queryProjectTypeScriptFiles(projectRoot: string): string[] {
+  return globSync('**/*.{ts,tsx}', {
+    cwd: projectRoot,
+    ignore: ['**/@(Carthage|Pods|node_modules)/**', '**/*.d.ts', '/{ios,android}/**'],
+  });
+}
+
+export function resolveBaseTSConfig(projectRoot: string): string | null {
+  try {
+    return require.resolve('expo/tsconfig.base.json', { paths: [projectRoot] });
+  } catch {
+    return null;
+  }
+}
+
+export async function hasTSConfig(projectRoot: string): Promise<string | null> {
+  // TODO: Does this work in a monorepo?
+  const tsConfigPath = path.join(projectRoot, 'tsconfig.json');
+  if (await fileExistsAsync(tsConfigPath)) {
+    return tsConfigPath;
+  }
+  return null;
+}
+
+export function collectMissingPackages(
+  projectRoot: string
+): {
+  missing: {
+    file: string;
+    pkg: string;
+  }[];
+  resolutions: Record<string, string>;
+} {
+  const resolutions: Record<string, string> = {};
+
+  const missingPackages = requiredPackages.filter(p => {
+    try {
+      resolutions[p.pkg] = resolveFrom(projectRoot, p.file);
+      return false;
+    } catch {
+      return true;
+    }
+  });
+
+  return { missing: missingPackages, resolutions };
+}

--- a/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
@@ -1,0 +1,109 @@
+import JsonFile from '@expo/json-file';
+import chalk from 'chalk';
+import { boolish } from 'getenv';
+
+import log from '../../../log';
+import { baseTSConfigName, resolveBaseTSConfig } from './resolveModules';
+
+const TS_FEATURE_FLAG = 'EXPO_NO_TYPESCRIPT_SETUP';
+
+export const isTypeScriptSetupDisabled = boolish(TS_FEATURE_FLAG, false);
+
+export async function updateTSConfigAsync({
+  projectRoot,
+  tsConfigPath,
+  isBootstrapping,
+}: {
+  projectRoot: string;
+  tsConfigPath: string;
+  isBootstrapping: boolean;
+}): Promise<void> {
+  if (isBootstrapping) {
+    await JsonFile.writeAsync(tsConfigPath, {});
+  }
+
+  const projectTSConfig = JsonFile.read(tsConfigPath, {
+    // Some tsconfig.json files have a generated comment in the file.
+    json5: true,
+  });
+  if (projectTSConfig.compilerOptions == null) {
+    projectTSConfig.compilerOptions = {};
+    isBootstrapping = true;
+  }
+
+  const modifications: [string, string][] = [];
+
+  // If the default TSConfig template exists (SDK +41), then use it in the project
+  const hasTemplateTsconfig = resolveBaseTSConfig(projectRoot);
+  if (hasTemplateTsconfig) {
+    if (projectTSConfig.extends !== baseTSConfigName) {
+      projectTSConfig.extends = baseTSConfigName;
+      modifications.push(['extends', baseTSConfigName]);
+    }
+  } else if (isBootstrapping) {
+    // TODO: Maybe don't do this
+    // SDK -40 or expo isn't installed.
+    projectTSConfig.compilerOptions = {
+      allowSyntheticDefaultImports: true,
+      jsx: 'react-native',
+      lib: ['dom', 'esnext'],
+      moduleResolution: 'node',
+      noEmit: true,
+      skipLibCheck: true,
+      resolveJsonModule: true,
+      // @ts-ignore
+      ...(projectTSConfig.compilerOptions || {}),
+    };
+  }
+
+  // Ensure the project is excluding node modules.
+  if (!Array.isArray(projectTSConfig.exclude)) {
+    projectTSConfig.exclude = [];
+  }
+
+  if (!projectTSConfig.exclude.find(v => String(v).includes('node_modules'))) {
+    projectTSConfig.exclude.push('node_modules');
+    const formatArray = (array: string[]) => array.join(', ');
+    modifications.push(['exclude', formatArray(projectTSConfig.exclude as string[])]);
+  }
+
+  // If no changes, then quietly bail out
+  if (!modifications.length) {
+    return;
+  }
+
+  // Write changes and log out a summary of what changed
+  await JsonFile.writeAsync(tsConfigPath, projectTSConfig);
+
+  log.addNewLineIfNone();
+
+  if (isBootstrapping) {
+    log(`${chalk.bold`TypeScript`}: A ${chalk.cyan('tsconfig.json')} has been auto generated`);
+    log.newLine();
+    return;
+  }
+
+  log(
+    `${chalk.bold`TypeScript`}: The ${chalk.cyan(
+      'tsconfig.json'
+    )} has been updated ${chalk.dim`(Use ${TS_FEATURE_FLAG} to skip)`}`
+  );
+  log.newLine();
+
+  log(`\u203A ${chalk.bold('Required')} modifications made to the ${chalk.cyan('tsconfig.json')}:`);
+
+  log.newLine();
+
+  // Sort the items based on key name length
+  printTable(modifications.sort((a, b) => a[0].length - b[0].length));
+
+  log.newLine();
+}
+
+function printTable(items: string[][]) {
+  const tableFormat = (name: string, msg: string) =>
+    `  ${chalk.bold`${name}`} is now ${chalk.cyan(msg)}`;
+  for (const [key, value] of items) {
+    log(tableFormat(key, value));
+  }
+}

--- a/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
@@ -40,6 +40,21 @@ export async function updateTSConfigAsync({
       projectTSConfig.extends = baseTSConfigName;
       modifications.push(['extends', baseTSConfigName]);
     }
+  } else if (isBootstrapping) {
+    // use an unversioned config when the versioned config cannot be resolved
+    projectTSConfig.compilerOptions = {
+      jsx: 'react-native',
+      target: 'esnext',
+      lib: ['esnext'],
+      allowJs: true,
+      skipLibCheck: true,
+      noEmit: true,
+      allowSyntheticDefaultImports: true,
+      resolveJsonModule: true,
+      esModuleInterop: true,
+      moduleResolution: 'node',
+    };
+    modifications.push(['compilerOptions', 'configured']);
   }
 
   // If no changes, then quietly bail out

--- a/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
@@ -56,17 +56,6 @@ export async function updateTSConfigAsync({
     };
   }
 
-  // Ensure the project is excluding node modules.
-  if (!Array.isArray(projectTSConfig.exclude)) {
-    projectTSConfig.exclude = [];
-  }
-
-  if (!projectTSConfig.exclude.find(v => String(v).includes('node_modules'))) {
-    projectTSConfig.exclude.push('node_modules');
-    const formatArray = (array: string[]) => array.join(', ');
-    modifications.push(['exclude', formatArray(projectTSConfig.exclude as string[])]);
-  }
-
   // If no changes, then quietly bail out
   if (!modifications.length) {
     return;

--- a/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
@@ -40,20 +40,6 @@ export async function updateTSConfigAsync({
       projectTSConfig.extends = baseTSConfigName;
       modifications.push(['extends', baseTSConfigName]);
     }
-  } else if (isBootstrapping) {
-    // TODO: Maybe don't do this
-    // SDK -40 or expo isn't installed.
-    projectTSConfig.compilerOptions = {
-      allowSyntheticDefaultImports: true,
-      jsx: 'react-native',
-      lib: ['dom', 'esnext'],
-      moduleResolution: 'node',
-      noEmit: true,
-      skipLibCheck: true,
-      resolveJsonModule: true,
-      // @ts-ignore
-      ...(projectTSConfig.compilerOptions || {}),
-    };
   }
 
   // If no changes, then quietly bail out
@@ -68,15 +54,18 @@ export async function updateTSConfigAsync({
 
   if (isBootstrapping) {
     log(`${chalk.bold`TypeScript`}: A ${chalk.cyan('tsconfig.json')} has been auto generated`);
-    log.newLine();
-    return;
+  } else {
+    log(
+      `${chalk.bold`TypeScript`}: The ${chalk.cyan(
+        'tsconfig.json'
+      )} has been updated ${chalk.dim`(Use ${TS_FEATURE_FLAG} to skip)`}`
+    );
+    logModifications(modifications);
   }
+  log.newLine();
+}
 
-  log(
-    `${chalk.bold`TypeScript`}: The ${chalk.cyan(
-      'tsconfig.json'
-    )} has been updated ${chalk.dim`(Use ${TS_FEATURE_FLAG} to skip)`}`
-  );
+function logModifications(modifications: string[][]) {
   log.newLine();
 
   log(`\u203A ${chalk.bold('Required')} modifications made to the ${chalk.cyan('tsconfig.json')}:`);


### PR DESCRIPTION
- When running `expo start`, auto detect if TypeScript is in use, then do the following:
  - Verify that the required packages are installed. If not, prompt to install them then try again (disabled in CI).
  - Ensure the `tsconfig.json` is properly configured.
  - Tell users how to remove TypeScript if they added it by accident (tsconfig.json, TypeScript project files).
- Feature can be disabled using `EXPO_NO_TYPESCRIPT_SETUP=1`
- Detect and use `expo/tsconfig.base` as the default `extends` value when it's present (https://github.com/expo/expo/pull/11680).

# Test Plan

- [x] Unit tests
- [x] Ran in NCL to test that the preset is used
- [x] Ran in a few complex projects to see if the changes would be annoying.
