### PR TITLE
[prebuild] Only change react-native version when it's a fork

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -528,6 +528,13 @@ function updatePackageJSONDependencies({
   const requiredDependencies = ['react', 'react-native-unimodules', 'react-native', 'expo-updates'];
 
   for (const dependenciesKey of requiredDependencies) {
+    // Only overwrite the react-native version if it's an Expo fork.
+    if (dependenciesKey === 'react-native' && pkg.dependencies?.[dependenciesKey]) {
+      const dependencyVersion = pkg.dependencies[dependenciesKey];
+      if (!dependencyVersion.includes('github.com/expo/react-native')) {
+        continue;
+      }
+    }
     combinedDependencies[dependenciesKey] = defaultDependencies[dependenciesKey];
   }
   const combinedDevDependencies: DependenciesMap = createDependenciesMap({


### PR DESCRIPTION
- preserve when someone is using a fork or a custom version of react-native during eject or prebuild.