### PR TITLE
[expo-cli] add option to assign created push key to current project

### DIFF
--- a/packages/expo-cli/src/credentials/views/Select.ts
+++ b/packages/expo-cli/src/credentials/views/Select.ts
@@ -90,7 +90,7 @@ export class SelectIosExperience implements IView {
   handleAction(ctx: Context, accountName: string, action: string): IView | null {
     switch (action) {
       case 'create-ios-push':
-        return new iosPushView.CreateIosPush(accountName);
+        return new iosPushView.CreateAndAssignIosPush(accountName);
       case 'update-ios-push':
         return new iosPushView.UpdateIosPush(accountName);
       case 'remove-ios-push':


### PR DESCRIPTION
fixes https://github.com/expo/expo/issues/11656

After generating a new push key, we should give the option to assign that key to the current project context, if there is one. Otherwise, it can be confusing that you need to create the key, _then_ assign it