### PR TITLE
Only use wasm on web platforms

### DIFF
--- a/packages/config/src/paths/__tests__/__snapshots__/extensions-test.ts.snap
+++ b/packages/config/src/paths/__tests__/__snapshots__/extensions-test.ts.snap
@@ -33,7 +33,6 @@ Array [
   "js",
   "jsx",
   "json",
-  "wasm",
 ]
 `;
 

--- a/packages/config/src/paths/extensions.ts
+++ b/packages/config/src/paths/extensions.ts
@@ -59,7 +59,7 @@ export function getManagedExtensions(
     'expo',
   ]);
   // Always add these last
-  _addMiscellaneousExtensions(fileExtensions);
+  _addMiscellaneousExtensions(platforms, fileExtensions);
   return fileExtensions;
 }
 
@@ -73,14 +73,17 @@ export function getBareExtensions(
     []
   );
   // Always add these last
-  _addMiscellaneousExtensions(fileExtensions);
+  _addMiscellaneousExtensions(platforms, fileExtensions);
   return fileExtensions;
 }
 
-function _addMiscellaneousExtensions(fileExtensions: string[]): string[] {
+function _addMiscellaneousExtensions(platforms: string[], fileExtensions: string[]): string[] {
   // Always add these with no platform extension
   // In the future we may want to add platform and workspace extensions to json.
   fileExtensions.push('json');
-  fileExtensions.push('wasm');
+  // Native doesn't currently support web assembly.
+  if (platforms.includes('web')) {
+    fileExtensions.push('wasm');
+  }
   return fileExtensions;
 }

--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -184,7 +184,6 @@ Object {
       ".js",
       ".jsx",
       ".json",
-      ".wasm",
     ],
     "plugins": Array [
       Object {
@@ -441,7 +440,6 @@ Object {
       ".js",
       ".jsx",
       ".json",
-      ".wasm",
     ],
     "plugins": Array [
       Object {


### PR DESCRIPTION
wasm isn't supported on native so skip module resolution for `.wasm` files. Removed `.android.wasm`, `.ios.wasm`, `.native.wasm`, and `.wasm` on iOS and Android.