### PR TITLE
Prevent adding duplicate Xcode references for files

### DIFF
--- a/packages/config-plugins/src/ios/Google.ts
+++ b/packages/config-plugins/src/ios/Google.ts
@@ -8,7 +8,7 @@ import { createInfoPlistPlugin, withXcodeProject } from '../plugins/ios-plugins'
 import { InfoPlist } from './IosConfig.types';
 import { getSourceRoot } from './Paths';
 import { appendScheme } from './Scheme';
-import { addFileToGroup, getProjectName } from './utils/Xcodeproj';
+import { addResourceFileToGroup, getProjectName } from './utils/Xcodeproj';
 
 export const withGoogle = createInfoPlistPlugin(setGoogleConfig, 'withGoogle');
 
@@ -85,6 +85,6 @@ export function setGoogleServicesFile(
   );
 
   const projectName = getProjectName(projectRoot);
-  project = addFileToGroup(`${projectName}/GoogleService-Info.plist`, projectName, project);
+  project = addResourceFileToGroup(`${projectName}/GoogleService-Info.plist`, projectName, project);
   return project;
 }

--- a/packages/config-plugins/src/ios/Locales.ts
+++ b/packages/config-plugins/src/ios/Locales.ts
@@ -7,7 +7,7 @@ import { XcodeProject } from 'xcode';
 import { ConfigPlugin } from '../Plugin.types';
 import { withXcodeProject } from '../plugins/ios-plugins';
 import * as WarningAggregator from '../utils/warnings';
-import { addFileToGroup, ensureGroupRecursively, getProjectName } from './utils/Xcodeproj';
+import { addResourceFileToGroup, ensureGroupRecursively, getProjectName } from './utils/Xcodeproj';
 
 type LocaleJson = Record<string, string>;
 type ResolvedLocalesJson = Record<string, LocaleJson>;
@@ -63,7 +63,7 @@ export async function setLocalesAsync(
     // Ensure the file doesn't already exist
     if (!group?.children.some(({ comment }) => comment === stringName)) {
       // Only write the file if it doesn't already exist.
-      project = addFileToGroup(strings, `${projectName}/Supporting/${lang}.lproj`, project);
+      project = addResourceFileToGroup(strings, `${projectName}/Supporting/${lang}.lproj`, project);
     }
   }
 

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -59,7 +59,7 @@ export function getHackyProjectName(projectRoot: string, config: ExpoConfig): st
 // TODO(brentvatne): I couldn't figure out how to do this with an existing
 // higher level function exposed by the xcode library, but we should find out how to do
 // that and replace this with it
-export function addFileToGroup(
+export function addResourceFileToGroup(
   filepath: string,
   groupName: string,
   project: XcodeProject


### PR DESCRIPTION
# Why

- resolve https://github.com/expo/expo-cli/issues/3085

# How

Not much we can do here to make the plugin idempotent. This problem doesn't occur in prebuild where the feature is considered "stable". 
We'll now warn if a duplicate file reference is skipped because an existing file reference is conflicting. The contents of the file will still be copied over though.
