### PR TITLE
Check for optional `devDependencies`

### DIFF
--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -516,8 +516,8 @@ function updatePackageJSONDependencies({
   tempDir: string;
   pkg: PackageJSONConfig;
 }): DependenciesModificationResults {
-  if(!pkg.devDependencies) {
-    pkg.devDependencies = {}
+  if (!pkg.devDependencies) {
+    pkg.devDependencies = {};
   }
   const { dependencies, devDependencies } = getPackageJson(tempDir);
   const defaultDependencies = createDependenciesMap(dependencies);

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -516,6 +516,9 @@ function updatePackageJSONDependencies({
   tempDir: string;
   pkg: PackageJSONConfig;
 }): DependenciesModificationResults {
+  if(!pkg.devDependencies) {
+    pkg.devDependencies = {}
+  }
   const { dependencies, devDependencies } = getPackageJson(tempDir);
   const defaultDependencies = createDependenciesMap(dependencies);
   const defaultDevDependencies = createDependenciesMap(devDependencies);
@@ -539,7 +542,7 @@ function updatePackageJSONDependencies({
   }
   const combinedDevDependencies: DependenciesMap = createDependenciesMap({
     ...defaultDevDependencies,
-    ...pkg?.devDependencies,
+    ...pkg.devDependencies,
   });
 
   // Only change the dependencies if the normalized hash changes, this helps to reduce meaningless changes.

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -539,7 +539,7 @@ function updatePackageJSONDependencies({
   }
   const combinedDevDependencies: DependenciesMap = createDependenciesMap({
     ...defaultDevDependencies,
-    ...pkg.devDependencies,
+    ...pkg?.devDependencies,
   });
 
   // Only change the dependencies if the normalized hash changes, this helps to reduce meaningless changes.


### PR DESCRIPTION
Noticed this bug when trying to eject without `devDependencies` defined in package.json.