### PR TITLE
[xdl] Support Expo Go name in shellapp template

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -774,8 +774,13 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
 
   // App name
   await regexFileAsync(
-    '"app_name">Expo',
-    `"app_name">${xmlWeirdAndroidEscape(name)}`,
+    '"app_name">Expo<',
+    `"app_name">${xmlWeirdAndroidEscape(name)}<`,
+    path.join(shellPath, 'app', 'src', 'main', 'res', 'values', 'strings.xml')
+  );
+  await regexFileAsync(
+    '"app_name">Expo Go<',
+    `"app_name">${xmlWeirdAndroidEscape(name)}<`,
     path.join(shellPath, 'app', 'src', 'main', 'res', 'values', 'strings.xml')
   );
 


### PR DESCRIPTION
Support name `Expo Go` in shellapp template