### PR TITLE
[xdl] Default to Metro port 8081 with --dev-client

### DIFF
--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1796,7 +1796,9 @@ async function stopExpoServerAsync(projectRoot: string): Promise<void> {
 async function startDevServerAsync(projectRoot: string, startOptions: StartOptions) {
   assertValidProjectRoot(projectRoot);
 
-  const port = await _getFreePortAsync(19000); // Create packager options
+  const port = startOptions.devClient
+    ? Number(process.env.RCT_METRO_PORT) || 8081
+    : await _getFreePortAsync(19000);
   await ProjectSettings.setPackagerInfoAsync(projectRoot, {
     expoServerPort: port,
     packagerPort: port,


### PR DESCRIPTION
## Why

The Gradle/Xcode projects for bare apps [expect the Metro bundler to run on port 8081, unless a different port is specified using the `RCT_METRO_PORT` environment variable.](https://github.com/facebook/react-native/blob/f2c6279ca497b34d5a2bfbb6f2d33dc7a7bea02a/template/ios/HelloWorld.xcodeproj/project.pbxproj#L253)

When running a bare project with `expo start --dev-client`, Expo CLI starts Metro on the first available port from `19000` and up. This is how Expo CLI has always worked, but this means the Gradle/Xcode projects won't find the Metro instance and will always start their own, even if you've already started Expo CLI.

## How

This PR changes the default port used with `--dev-client` to `8081`, or the value of `RCT_METRO_PORT` if set, [matching the behavior of RN CLI](https://github.com/react-native-community/cli/blob/bbb21e3ee1bf56d1cb1eedbd8d1876f80c001d99/packages/cli/src/tools/loadMetroConfig.ts#L97-L99).

However, the behavior for managed apps (free port `>=19000`) remains unchanged, because:
- changing it would be a breaking change, since people might have firewall rules or other configuration expecting port 19000 or higher, or other software using the port `8081` (Technically it is breaking for `--dev-client` too, but this flag is still experimental.)
- using a fixed port prevents running many projects at once, which has always been possible for managed projects.

## Test plan

Ran `expo start --dev-server`, ran Xcode build in my bare project and made sure that a new Metro terminal window didn't pop up.