### PR TITLE
[expo-cli] Auto-login when envvars are defined

### DIFF
--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -37,6 +37,14 @@ export type SecondFactorDevice = {
 export async function loginOrRegisterAsync(): Promise<User> {
   log.warn('An Expo user account is required to proceed.');
 
+  // Always try to auto-login when these variables are set, even in non-interactive mode
+  if (process.env.EXPO_CLI_USERNAME && process.env.EXPO_CLI_PASSWORD) {
+    return login({
+      username: process.env.EXPO_CLI_USERNAME,
+      password: process.env.EXPO_CLI_PASSWORD,
+    });
+  }
+
   if (program.nonInteractive) {
     throw new CommandError(
       'NOT_LOGGED_IN',


### PR DESCRIPTION
Fixes #3119

When users define both `EXPO_CLI_USERNAME` and `EXPO_CLI_PASSWORD`, authenticate them. Even when using an interactive prompt.

<img width="394" alt="Screenshot 2021-01-26 at 16 09 56" src="https://user-images.githubusercontent.com/1203991/105863260-ff99ee80-5ff0-11eb-810f-c835d869d0d7.png">
