### PR TITLE
[expo-cli] Improve handling of no answer for customize:web

### DIFF
--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -138,8 +138,8 @@ export async function action(projectDir: string = './', options: Options = { for
     instructions: '',
     choices: values,
   });
-  if (!answer) {
-    log('\n\u203A Exiting...\n');
+  if (!answer || answer.length === 0) {
+    log('\n\u203A Exiting with no change...\n');
     return;
   }
   await generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder });


### PR DESCRIPTION
I spent... too long not realizing I simply hadn't selected anything with space before hitting 'enter' in this menu.  The instructional copy was low enough contrast I didn't notice it until after I went debugging here in the code.

Briefly, the answer var will be an empty array if you didn't select anything but still hit "enter", and so this check will always be truthy in that case, firing the subsequent generate function without any copy noting that... nothing happened.  This PR clarifies the copy a bit, and makes sure it fires even when selection set is empty.