### PR TITLE
use less lodash and ignore tests in xdl publish

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -97,7 +97,7 @@
     "js-yaml": "^3.13.1",
     "keychain": "1.3.0",
     "leven": "^3.1.0",
-    "lodash": "4.17.19",
+    "lodash": "^4.17.19",
     "md5-file": "^5.0.0",
     "npm-package-arg": "6.1.0",
     "ora": "3.4.0",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -5,6 +5,7 @@
   "main": "build/xdl.js",
   "files": [
     "build",
+    "!**/__integration_tests__/**",
     "binaries",
     "caches",
     "scripts"
@@ -64,7 +65,7 @@
     "is-reachable": "^4.0.0",
     "json-schema-deref-sync": "^0.13.0",
     "latest-version": "5.1.0",
-    "lodash": "4.17.19",
+    "lodash": "^4.17.19",
     "md5hex": "1.0.0",
     "minimatch": "3.0.4",
     "minipass": "2.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13591,11 +13591,6 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
 "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"


### PR DESCRIPTION
- remove more lodash copies by allowing flexible versions. In the repo the versions are `4.17.19` but in product there are two `4.17.20` and `4.17.19`. Adding version flexibility cuts down on one more copy of lodash (4mb).
- ignore `**/__integration_tests__/**` tests when bundling expo/xdl. 