### PR TITLE
[expo-cli] pass username to apple auth check

### DIFF
--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -151,6 +151,7 @@ export async function authenticateAsync(options: Options = {}): Promise<AppleCtx
   try {
     const authState = await loginAsync(
       {
+        username: options.appleId,
         cookies: options.cookies,
         teamId: options.teamId,
       },


### PR DESCRIPTION
- fix https://github.com/expo/expo-cli/issues/3138