### PR TITLE
[xdl] Handle errors when trying to sign the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [xdl] Automatically fall back to offline mode when manifest can't be signed. ([#3148](https://github.com/expo/expo-cli/pull/3148))
+
 ### 🐛 Bug fixes
 
 ## [Tue, 26 Jan 2021 18:21:34 -0800](https://github.com/expo/expo-cli/commit/ee77eaa57684c3ac496eae24b5e10b8acb6b6e32)

--- a/packages/xdl/src/project/ManifestHandler.ts
+++ b/packages/xdl/src/project/ManifestHandler.ts
@@ -251,7 +251,12 @@ export async function getManifestResponseAsync({
       manifestString = await getManifestStringAsync(manifest, hostInfo.host, acceptSignature);
     } else if (error.code === 'ENOTFOUND') {
       // Got a DNS error, i.e. can't access exp.host, warn and enable offline mode.
-      addSigningDisabledWarning(projectRoot, 'Not connected to internet.');
+      addSigningDisabledWarning(
+        projectRoot,
+        `Could not reach Expo servers, please check if you can access ${
+          error.hostname || 'exp.host'
+        }.`
+      );
       Config.offline = true;
       manifestString = await getManifestStringAsync(manifest, hostInfo.host, acceptSignature);
     } else {

--- a/packages/xdl/src/project/ManifestHandler.ts
+++ b/packages/xdl/src/project/ManifestHandler.ts
@@ -244,7 +244,7 @@ export async function getManifestResponseAsync({
         `This project belongs to ${chalk.bold(
           `@${manifest.owner}`
         )} and you have not been granted the appropriate permissions.\n` +
-          `Please request access from an admin of @${manifest.owner} or change the \"owner\" field to an account you belong to.\n` +
+          `Please request access from an admin of @${manifest.owner} or change the "owner" field to an account you belong to.\n` +
           learnMore('https://docs.expo.io/versions/latest/config/app/#owner')
       );
       Config.offline = true;
@@ -274,7 +274,7 @@ const addSigningDisabledWarning = (() => {
       ProjectUtils.logWarning(
         projectRoot,
         'expo',
-        reason + '\n' + `Falling back to offline mode.`,
+        `${reason}\nFalling back to offline mode.`,
         'signing-disabled'
       );
     }


### PR DESCRIPTION
When the `ManifestHandler` tries to sign the manifest (requested by the client), automatically handle typical errors and fall back to offline mode:
- The project has an `owner` specified, but you lack permissions to that account -> fall back to offline mode! Fixes https://github.com/expo/expo-cli/issues/3062.
  <img width="934" alt="Screen Shot 2021-01-28 at 17 02 17" src="https://user-images.githubusercontent.com/497214/106159385-66540f00-618d-11eb-9ffe-48d25cb1b509.png">

- You don't have an internet connection, which results in `Error: getaddrinfo ENOTFOUND exp.host` -> fall back to offline mode! Fixes https://github.com/expo/expo-cli/issues/238.
  <img width="978" alt="Screen Shot 2021-01-28 at 16 59 05" src="https://user-images.githubusercontent.com/497214/106159407-6c49f000-618d-11eb-8ff1-a1f1e9b6e479.png">
