### PR TITLE
[expo-cli][eject] warn iOS on windows

### DIFF
--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -23,7 +23,7 @@ export async function actionAsync(
   {
     platform,
     ...options
-  }: Eject.EjectAsyncOptions & {
+  }: Omit<Eject.EjectAsyncOptions, 'platforms'> & {
     npm?: boolean;
     platform?: string;
   }

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -79,7 +79,7 @@ export async function ejectAsync(
   logNextSteps(results);
 }
 
-function ensureValidPlatforms(platforms: ModPlatform[]): ModPlatform[] {
+export function ensureValidPlatforms(platforms: ModPlatform[]): ModPlatform[] {
   const isWindows = process.platform === 'win32';
   // Skip ejecting for iOS on Windows
   if (isWindows && platforms.includes('ios')) {

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -75,19 +75,23 @@ export async function ejectAsync(
   assertPlatforms(platforms);
   if (await maybeBailOnGitStatusAsync()) return;
 
+  const results = await prebuildAsync(projectRoot, { platforms, ...options });
+  logNextSteps(results);
+}
+
+function ensureValidPlatforms(platforms: ModPlatform[]): ModPlatform[] {
   const isWindows = process.platform === 'win32';
   // Skip ejecting for iOS on Windows
-  if (isWindows && !platforms.includes('ios')) {
+  if (isWindows && platforms.includes('ios')) {
     log.warn(
       `⚠️  Skipping generating the iOS native project files. Run ${chalk.bold(
         'expo eject'
       )} again from macOS or Linux to generate the iOS project.`
     );
     log.newLine();
+    return platforms.filter(platform => platform !== 'ios');
   }
-
-  const results = await prebuildAsync(projectRoot, { platforms, ...options });
-  logNextSteps(results);
+  return platforms;
 }
 
 /**
@@ -102,6 +106,7 @@ export async function prebuildAsync(
   projectRoot: string,
   { platforms, ...options }: EjectAsyncOptions
 ): Promise<PrebuildResults> {
+  platforms = ensureValidPlatforms(platforms);
   assertPlatforms(platforms);
 
   const { exp, pkg } = await ensureConfigAsync({ projectRoot, platforms });
@@ -224,7 +229,7 @@ export function logNextSteps({
     log.nested(
       `\u203A 📁 The property ${chalk.bold(
         `assetBundlePatterns`
-      )} does not have the same effect in the bare workflow. ${log.chalk.dim(
+      )} does not have the same effect in the bare workflow.\n  ${log.chalk.dim(
         learnMore('https://docs.expo.io/bare/updating-your-app/#embedding-assets')
       )}`
     );

--- a/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
+++ b/packages/expo-cli/src/commands/eject/__tests__/Eject-test.ts
@@ -1,6 +1,7 @@
 import { vol } from 'memfs';
 
 import {
+  ensureValidPlatforms,
   hashForDependencyMap,
   isPkgMainExpoAppEntry,
   resolveBareEntryFile,
@@ -26,6 +27,28 @@ describe('hashForDependencyMap', () => {
     expect(hashForDependencyMap({ a: '1.0.0', b: 2, c: '~3.0' })).toBe(
       hashForDependencyMap({ c: '~3.0', b: 2, a: '1.0.0' })
     );
+  });
+});
+
+describe(ensureValidPlatforms, () => {
+  const platform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {
+      value: platform,
+    });
+  });
+  it(`bails on windows if only ios is passed`, async () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+    });
+    expect(ensureValidPlatforms(['ios', 'android'])).toStrictEqual(['android']);
+  });
+  it(`allows ios on all platforms except windows`, async () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'other',
+    });
+    expect(ensureValidPlatforms(['ios', 'android'])).toStrictEqual(['ios', 'android']);
   });
 });
 


### PR DESCRIPTION
Fix a logic bug where ios warnings weren't being logged on windows.