### PR TITLE
Always install eject pods in non interactive mode

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -357,7 +357,7 @@ Command.prototype.asyncAction = function (asyncFn: Action, skipUpdateCheck: bool
         log.error(chalk.red(err.message));
       } else if (err.isXDLError) {
         log.error(err.message);
-      } else if (err.isJsonFileError || err.isConfigError) {
+      } else if (err.isJsonFileError || err.isConfigError || err.isPackageManagerError) {
         if (err.code === 'EJSONEMPTY') {
           // Empty JSON is an easy bug to debug. Often this is thrown for package.json or app.json being empty.
           log.error(err.message);


### PR DESCRIPTION
- resolve https://github.com/expo/expo-cli/issues/2879 by skipping the sudo prompt. There is too much going on in the single process to attempt a prompt, so we'll just skip it and warn the user to install CocoaPods CLI and install the pods manually `npx pod-install`. 
- Improved the errors being thrown by `CocoaPodsPackageManager`, you can now see more input on why pod install failed:
```
⚠️  Unable to install the CocoaPods CLI. Continuing with project sync, you can install CocoaPods CLI afterwards.
Failed to install CocoaPods with Homebrew. Please install CocoaPods CLI manually and try again.
└─ Cause: CocoaPodsError: Homebrew installation appeared to succeed but CocoaPods CLI not found in PATH and unable to link.
└─ Cause: Error: brew exited with non-zero code: 1
```