### PR TITLE
[metro-config] Set server port in default config

### DIFF
--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -85,6 +85,9 @@ export function getDefaultConfig(
       ],
       getPolyfills: () => require(path.join(reactNativePath, 'rn-get-polyfills'))(),
     },
+    server: {
+      port: Number(process.env.RCT_METRO_PORT) || 8081,
+    },
     symbolicator: {
       customizeFrame: (frame: { file: string | null }) => {
         const collapse = Boolean(frame.file && INTERNAL_CALLSITES_REGEX.test(frame.file));


### PR DESCRIPTION
Set default port to 8081 to make sure it's used by default rather than 8080 from the Metro defaults,
as this is required by the build phase scripts in the Xcode project by default.