### PR TITLE
[config-plugins] Rename `IOSConfig.BundleIdenitifer` to `IOSConfig.BundleIdentifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- [config-plugins] Rename `IOSConfig.BundleIdenitifer` to `IOSConfig.BundleIdentifier`.
+
 ### 🎉 New features
 
 - [xdl] Automatically fall back to offline mode when manifest can't be signed. ([#3148](https://github.com/expo/expo-cli/pull/3148))

--- a/packages/config-plugins/src/ios/index.ts
+++ b/packages/config-plugins/src/ios/index.ts
@@ -1,6 +1,6 @@
 import * as AdMob from './AdMob';
 import * as Branch from './Branch';
-import * as BundleIdenitifer from './BundleIdentifier';
+import * as BundleIdentifier from './BundleIdentifier';
 import * as CustomInfoPlistEntries from './CustomInfoPlistEntries';
 import * as DeviceFamily from './DeviceFamily';
 import * as Entitlements from './Entitlements';
@@ -30,7 +30,7 @@ import * as XcodeUtils from './utils/Xcodeproj';
 export {
   AdMob,
   Branch,
-  BundleIdenitifer,
+  BundleIdentifier,
   CustomInfoPlistEntries,
   DeviceFamily,
   Entitlements,

--- a/packages/config-plugins/src/plugins/expo-plugins.ts
+++ b/packages/config-plugins/src/plugins/expo-plugins.ts
@@ -24,7 +24,7 @@ export const withExpoIOSPlugins: ConfigPlugin<{
   config.ios.bundleIdentifier = bundleIdentifier;
 
   return withPlugins(config, [
-    [IOSConfig.BundleIdenitifer.withBundleIdentifier, { bundleIdentifier }],
+    [IOSConfig.BundleIdentifier.withBundleIdentifier, { bundleIdentifier }],
     IOSConfig.Google.withGoogle,
     IOSConfig.Name.withDisplayName,
     // IOSConfig.Name.withName,


### PR DESCRIPTION
Fix a small typo in this identifier.