### PR TITLE
[xdl] Define max content and body lengths in Axios 0.21

### DIFF
--- a/packages/xdl/src/Api.ts
+++ b/packages/xdl/src/Api.ts
@@ -4,7 +4,7 @@ import FormData from 'form-data';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { MAX_CONTENT_LENGTH } from './ApiV2';
+import { MAX_BODY_LENGTH, MAX_CONTENT_LENGTH } from './ApiV2';
 import Config from './Config';
 import * as ConnectionStatus from './ConnectionStatus';
 import * as Extract from './Extract';
@@ -78,6 +78,7 @@ async function _callMethodAsync(
     method,
     headers,
     maxContentLength: MAX_CONTENT_LENGTH,
+    maxBodyLength: MAX_BODY_LENGTH,
   };
 
   if (requestBody) {

--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -10,6 +10,7 @@ import Config from './Config';
 import * as ConnectionStatus from './ConnectionStatus';
 
 export const MAX_CONTENT_LENGTH = 100 /* MB */ * 1024 * 1024;
+export const MAX_BODY_LENGTH = 100 /* MB */ * 1024 * 1024;
 
 // These aren't constants because some commands switch between staging and prod
 function _rootBaseUrl() {
@@ -224,6 +225,7 @@ export default class ApiV2Client {
 
     reqOptions = merge({}, reqOptions, extraRequestOptions, uploadOptions, {
       maxContentLength: MAX_CONTENT_LENGTH,
+      maxBodyLength: MAX_BODY_LENGTH,
     });
 
     let response;

--- a/packages/xdl/src/project/__tests__/ManifestHandler-test.ts
+++ b/packages/xdl/src/project/__tests__/ManifestHandler-test.ts
@@ -86,6 +86,7 @@ describe('getSignedManifestStringAsync', () => {
           "Expo-Session": "SECRET",
           "Exponent-Client": "xdl",
         },
+        "maxBodyLength": 104857600,
         "maxContentLength": 104857600,
         "method": "post",
         "url": "https://exp.host/--/api/v2/manifest/sign",


### PR DESCRIPTION
Fixes #3158 

## What changed?

Axios split `maxContentLength` and `maxBodyLength`. As @fson pointed out, [the first used to imply the latter](https://github.com/axios/axios/blob/8d0b92b2678d96770304dd767cd05a59d37f12cf/lib/adapters/http.js#L175-L177). Now they [split it up into two different config properties](https://github.com/axios/axios/pull/2781). So, we need to define `maxBodyLength` too.

## Test plan

- Create a new project
- [Import an image (20mb+)](https://effigis.com/en/solutions/satellite-images/satellite-image-samples/) in `App.js`, `const Img = require('./assets/my-img.jpg');`
- `npx expo-cli@4.1.4 publish --release-channel=test`, will fail with `Request body larger than maxBodyLength limit`
- CLI with this PR succeeds without errors.