### PR TITLE
Move legacy build methods to expo-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🛠 Breaking changes
 
 - [json-file] Remove undocumented support for multi-part keys in `getAsync` and `setAsync` ([#3019](https://github.com/expo/expo-cli/pulls/3019))
+- [xdl] Remove Project methods `getLatestReleaseAsync`, `findReusableBuildAsync`, `getBuildStatusAsync`, `startBuildAsync` ([#3187](https://github.com/expo/expo-cli/pulls/3187))
+- [xdl] Remove Project types `BuildCreatedResult`, `TurtleMode`, `BuildJobFields`, `BuildStatusResult` ([#3187](https://github.com/expo/expo-cli/pulls/3187))
 
 ### 🎉 New features
 

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -12,9 +12,9 @@ import * as UrlUtils from '../utils/url';
 import { BuilderOptions } from './BaseBuilder.types';
 import BuildError from './BuildError';
 import { Platform, PLATFORMS } from './constants';
+import { findReusableBuildAsync } from './findReusableBuildAsync';
 
 const secondsToMilliseconds = (seconds: number): number => seconds * 1000;
-
 export default class BaseBuilder {
   protected projectConfig: ProjectConfig;
   manifest: ExpoConfig;
@@ -141,7 +141,7 @@ export default class BaseBuilder {
   async checkStatusBeforeBuild(): Promise<void> {
     log('Checking if this build already exists...\n');
 
-    const reuseStatus = await Project.findReusableBuildAsync(
+    const reuseStatus = await findReusableBuildAsync(
       this.options.releaseChannel!,
       this.platform(),
       this.manifest.sdkVersion!,

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -13,6 +13,7 @@ import { BuilderOptions } from './BaseBuilder.types';
 import BuildError from './BuildError';
 import { Platform, PLATFORMS } from './constants';
 import { findReusableBuildAsync } from './findReusableBuildAsync';
+import { getLatestReleaseAsync } from './getLatestReleaseAsync';
 
 const secondsToMilliseconds = (seconds: number): number => seconds * 1000;
 export default class BaseBuilder {
@@ -276,7 +277,7 @@ ${job.id}
       return ids;
     } else {
       log('Looking for releases...');
-      const release = await Project.getLatestReleaseAsync(this.projectDir, {
+      const release = await getLatestReleaseAsync(this.projectDir, {
         releaseChannel: this.options.releaseChannel!,
         platform: this.platform(),
         owner: this.manifest.owner,

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -13,7 +13,9 @@ import { BuilderOptions } from './BaseBuilder.types';
 import BuildError from './BuildError';
 import { Platform, PLATFORMS } from './constants';
 import { findReusableBuildAsync } from './findReusableBuildAsync';
+import { BuildJobFields, getBuildStatusAsync } from './getBuildStatusAsync';
 import { getLatestReleaseAsync } from './getLatestReleaseAsync';
+import { startBuildAsync } from './startBuildAsync';
 
 const secondsToMilliseconds = (seconds: number): number => seconds * 1000;
 export default class BaseBuilder {
@@ -100,7 +102,7 @@ export default class BaseBuilder {
 
   async checkForBuildInProgress() {
     log('Checking if there is a build in progress...\n');
-    const buildStatus = await Project.getBuildStatusAsync(this.projectDir, {
+    const buildStatus = await getBuildStatusAsync(this.projectDir, {
       platform: this.platform(),
       current: true,
       releaseChannel: this.options.releaseChannel,
@@ -116,7 +118,7 @@ export default class BaseBuilder {
   async checkStatus(platform: 'all' | 'ios' | 'android' = 'all'): Promise<void> {
     log('Fetching build history...\n');
 
-    const buildStatus = await Project.getBuildStatusAsync(this.projectDir, {
+    const buildStatus = await getBuildStatusAsync(this.projectDir, {
       platform,
       current: false,
       releaseChannel: this.options.releaseChannel,
@@ -165,7 +167,7 @@ Please see the docs (${chalk.underline(
   }
 
   async logBuildStatuses(buildStatus: {
-    jobs: Project.BuildJobFields[];
+    jobs: BuildJobFields[];
     canPurchasePriorityBuilds?: boolean;
     numberOfRemainingPriorityBuilds?: number;
     hasUnlimitedPriorityBuilds?: boolean;
@@ -304,12 +306,12 @@ ${job.id}
     let i = 0;
     while (true) {
       i++;
-      const result = await Project.getBuildStatusAsync(this.projectDir, {
+      const result = await getBuildStatusAsync(this.projectDir, {
         current: false,
         ...(publicUrl ? { publicUrl } : {}),
       });
 
-      const jobs = result.jobs?.filter((job: Project.BuildJobFields) => job.id === buildId);
+      const jobs = result.jobs?.filter((job: BuildJobFields) => job.id === buildId);
       const job = jobs ? jobs[0] : null;
       if (job) {
         switch (job.status) {
@@ -365,7 +367,7 @@ ${job.id}
     }
 
     // call out to build api here with url
-    const result = await Project.startBuildAsync(this.projectDir, opts);
+    const result = await startBuildAsync(this.projectDir, opts);
 
     const { id: buildId, priority, canPurchasePriorityBuilds } = result;
 

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig, getConfig, ProjectConfig } from '@expo/config';
-import { Project, RobotUser, User, UserManager, Versions } from '@expo/xdl';
+import { RobotUser, User, UserManager, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import ora from 'ora';
 import semver from 'semver';

--- a/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
+++ b/packages/expo-cli/src/commands/build/__tests__/build-ios-test.ts
@@ -44,6 +44,11 @@ jest.mock('commander', () => {
 jest.mock('../../../credentials/api/IosApiV2Wrapper', () => {
   return jest.fn(() => mockIosCredentialsApi);
 });
+jest.mock('../findReusableBuildAsync', () => {
+  return {
+    findReusableBuildAsync: jest.fn(() => ({})),
+  };
+});
 jest.mock('@expo/image-utils', () => ({
   generateImageAsync(input, { src }) {
     const fs = require('fs');
@@ -63,7 +68,6 @@ const mockedXDLModules = {
   Project: {
     getBuildStatusAsync: jest.fn(() => ({ jobs: [] })),
     getLatestReleaseAsync: jest.fn(() => ({ publicationId: 'test-publication-id' })),
-    findReusableBuildAsync: jest.fn(() => ({})),
     startBuildAsync: jest.fn(() => ({})),
   },
   IosCodeSigning: {

--- a/packages/expo-cli/src/commands/build/findReusableBuildAsync.ts
+++ b/packages/expo-cli/src/commands/build/findReusableBuildAsync.ts
@@ -1,5 +1,4 @@
-import ApiV2 from '../ApiV2';
-import UserManager from '../User';
+import { ApiV2, UserManager } from '@expo/xdl';
 
 export async function findReusableBuildAsync(
   releaseChannel: string,

--- a/packages/expo-cli/src/commands/build/getBuildStatusAsync.ts
+++ b/packages/expo-cli/src/commands/build/getBuildStatusAsync.ts
@@ -1,6 +1,6 @@
-import ApiV2 from '../ApiV2';
-import UserManager from '../User';
-import { assertValidProjectRoot } from './errors';
+import { ApiV2, UserManager } from '@expo/xdl';
+
+// import { assertValidProjectRoot } from './errors';
 import { getExpAsync, GetExpConfigOptions, validateOptions } from './startBuildAsync';
 
 type JobState = 'pending' | 'started' | 'in-progress' | 'finished' | 'errored' | 'sent-to-queue';
@@ -57,7 +57,7 @@ export async function getBuildStatusAsync(
 ): Promise<BuildStatusResult> {
   const user = await UserManager.ensureLoggedInAsync();
 
-  assertValidProjectRoot(projectRoot);
+  // assertValidProjectRoot(projectRoot);
   validateOptions(options);
   const { exp } = await getExpAsync(projectRoot, options);
 

--- a/packages/expo-cli/src/commands/build/getBuildStatusAsync.ts
+++ b/packages/expo-cli/src/commands/build/getBuildStatusAsync.ts
@@ -1,6 +1,5 @@
 import { ApiV2, UserManager } from '@expo/xdl';
 
-// import { assertValidProjectRoot } from './errors';
 import { getExpAsync, GetExpConfigOptions, validateOptions } from './startBuildAsync';
 
 type JobState = 'pending' | 'started' | 'in-progress' | 'finished' | 'errored' | 'sent-to-queue';
@@ -57,7 +56,6 @@ export async function getBuildStatusAsync(
 ): Promise<BuildStatusResult> {
   const user = await UserManager.ensureLoggedInAsync();
 
-  // assertValidProjectRoot(projectRoot);
   validateOptions(options);
   const { exp } = await getExpAsync(projectRoot, options);
 

--- a/packages/expo-cli/src/commands/build/getLatestReleaseAsync.ts
+++ b/packages/expo-cli/src/commands/build/getLatestReleaseAsync.ts
@@ -1,7 +1,5 @@
 import { getConfig } from '@expo/config';
-
-import ApiV2 from '../ApiV2';
-import UserManager from '../User';
+import { ApiV2, UserManager } from '@expo/xdl';
 
 type Release = {
   fullName: string;

--- a/packages/expo-cli/src/commands/build/startBuildAsync.ts
+++ b/packages/expo-cli/src/commands/build/startBuildAsync.ts
@@ -1,14 +1,15 @@
 import { configFilename, getConfig } from '@expo/config';
+import { Analytics, ApiV2, Config, ThirdParty, UserManager, XDLError } from '@expo/xdl';
 import joi from '@hapi/joi';
 import slug from 'slugify';
 
-import Analytics from '../Analytics';
-import ApiV2 from '../ApiV2';
-import Config from '../Config';
-import * as ThirdParty from '../ThirdParty';
-import UserManager from '../User';
-import XDLError from '../XDLError';
-import { assertValidProjectRoot } from './errors';
+// import Analytics from '../Analytics';
+// import ApiV2 from '../ApiV2';
+// import Config from '../Config';
+// import * as ThirdParty from '../ThirdParty';
+// import UserManager from '../User';
+// import XDLError from '../XDLError';
+// import { assertValidProjectRoot } from './errors';
 
 export type BuildCreatedResult = {
   id: string;
@@ -108,7 +109,7 @@ export async function startBuildAsync(
 ): Promise<BuildCreatedResult> {
   const user = await UserManager.ensureLoggedInAsync();
 
-  assertValidProjectRoot(projectRoot);
+  // assertValidProjectRoot(projectRoot);
   validateOptions(options);
   const { exp, configName, configPrefix } = await getExpAsync(projectRoot, options);
   validateManifest(options, exp, configName, configPrefix);

--- a/packages/expo-cli/src/commands/build/startBuildAsync.ts
+++ b/packages/expo-cli/src/commands/build/startBuildAsync.ts
@@ -3,14 +3,6 @@ import { Analytics, ApiV2, Config, ThirdParty, UserManager, XDLError } from '@ex
 import joi from '@hapi/joi';
 import slug from 'slugify';
 
-// import Analytics from '../Analytics';
-// import ApiV2 from '../ApiV2';
-// import Config from '../Config';
-// import * as ThirdParty from '../ThirdParty';
-// import UserManager from '../User';
-// import XDLError from '../XDLError';
-// import { assertValidProjectRoot } from './errors';
-
 export type BuildCreatedResult = {
   id: string;
   ids: string[];
@@ -109,7 +101,6 @@ export async function startBuildAsync(
 ): Promise<BuildCreatedResult> {
   const user = await UserManager.ensureLoggedInAsync();
 
-  // assertValidProjectRoot(projectRoot);
   validateOptions(options);
   const { exp, configName, configPrefix } = await getExpAsync(projectRoot, options);
   validateManifest(options, exp, configName, configPrefix);

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -10,6 +10,7 @@ import CommandError from '../CommandError';
 import log from '../log';
 import { getProjectOwner } from '../projects';
 import * as sendTo from '../sendTo';
+import { getBuildStatusAsync } from './build/getBuildStatusAsync';
 import * as TerminalLink from './utils/TerminalLink';
 import { formatNamedWarning } from './utils/logConfigWarnings';
 
@@ -216,7 +217,7 @@ async function logSDKMismatchWarningsAsync({
     return;
   }
 
-  const buildStatus = await Project.getBuildStatusAsync(projectRoot, {
+  const buildStatus = await getBuildStatusAsync(projectRoot, {
     platform: 'all',
     current: true,
     releaseChannel,

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -6,6 +6,7 @@ import CommandError from '../CommandError';
 import log from '../log';
 import printRunInstructionsAsync from '../printRunInstructionsAsync';
 import urlOpts, { URLOptions } from '../urlOpts';
+import { BuildJobFields, getBuildStatusAsync } from './build/getBuildStatusAsync';
 
 type ProjectUrlOptions = Command & {
   web?: boolean;
@@ -23,13 +24,13 @@ const logArtifactUrl = (platform: 'ios' | 'android') => async (
     throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
   }
 
-  const result = await Project.getBuildStatusAsync(projectDir, {
+  const result = await getBuildStatusAsync(projectDir, {
     current: false,
     ...(options.publicUrl ? { publicUrl: options.publicUrl } : {}),
   });
 
-  const url = result.jobs?.filter((job: Project.BuildJobFields) => job.platform === platform)[0]
-    ?.artifacts?.url;
+  const url = result.jobs?.filter((job: BuildJobFields) => job.platform === platform)[0]?.artifacts
+    ?.url;
   if (url) {
     log.nested(url);
   } else {

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -1,4 +1,4 @@
-import { Project, ProjectSettings, UrlUtils } from '@expo/xdl';
+import { ProjectSettings, UrlUtils } from '@expo/xdl';
 import chalk from 'chalk';
 import { Command } from 'commander';
 

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -150,15 +150,6 @@ export {
   stopReactNativeServerAsync,
 };
 export { PublishedProjectResult, publishAsync } from './project/publishAsync';
-export { BuildCreatedResult, startBuildAsync } from './project/startBuildAsync';
 export { exportAppAsync } from './project/exportAppAsync';
-
-export {
-  TurtleMode,
-  BuildJobFields,
-  BuildStatusResult,
-  getBuildStatusAsync,
-} from './project/getBuildStatusAsync';
-
 export { runHook } from './project/runHook';
 export { mergeAppDistributions } from './project/mergeAppDistributions';

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -161,6 +161,5 @@ export {
 } from './project/getBuildStatusAsync';
 
 export { runHook } from './project/runHook';
-export { findReusableBuildAsync } from './project/findReusableBuildAsync';
 export { getLatestReleaseAsync } from './project/getLatestReleaseAsync';
 export { mergeAppDistributions } from './project/mergeAppDistributions';

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -161,5 +161,4 @@ export {
 } from './project/getBuildStatusAsync';
 
 export { runHook } from './project/runHook';
-export { getLatestReleaseAsync } from './project/getLatestReleaseAsync';
 export { mergeAppDistributions } from './project/mergeAppDistributions';


### PR DESCRIPTION
# Why 

- Splitting up the monolith Project module and rearranging legacy code so it's easier to ensure people don't accidentally start using it. All of the `expo build` code will be in a legacy state as soon as managed EAS is working, moving it to expo-cli will ensure other packages don't pull it in and use it.
- Easier to optimize expo-cli when it uses xdl less since xdl is bundled with gulp and has a bunch of features that are harder to minimize.
- follow up #3164

# How

- Move `getLatestReleaseAsync`, `findReusableBuildAsync `, `getBuildStatusAsync`, `startBuildAsync` to expo-cli