### PR TITLE
[webpack] Fixed support for disabling automatic manifest.json tag injection

### DIFF
--- a/packages/webpack-config/src/plugins/PwaManifestWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/PwaManifestWebpackPlugin.ts
@@ -58,10 +58,14 @@ export default class PwaManifestWebpackPlugin extends JsonWebpackPlugin {
             ) => {
               // Skip if a custom injectFunction returns false or if
               // the htmlWebpackPlugin optuons includes a `favicons: false` flag
-              const isInjectionAllowed =
-                typeof this.pwaOptions.inject === 'function'
-                  ? this.pwaOptions.inject(data.plugin)
-                  : data.plugin.options.pwaManifest !== false;
+              let isInjectionAllowed: boolean;
+              if (typeof this.pwaOptions.inject === 'boolean') {
+                isInjectionAllowed = this.pwaOptions.inject;
+              } else if (typeof this.pwaOptions.inject === 'function') {
+                isInjectionAllowed = this.pwaOptions.inject(data.plugin);
+              } else {
+                isInjectionAllowed = data.plugin.options.pwaManifest !== false;
+              }
 
               if (isInjectionAllowed === false) {
                 return htmlCallback(null, data);


### PR DESCRIPTION
- fix https://github.com/expo/expo-cli/issues/3089


# Test Plan

- Following https://docs.expo.io/guides/progressive-web-apps/#manifestjson should work as expected:
  - only one manifest.json tag will be in the `web-build/index.html` (a duplicate will not be added).
  - Using `/manifest.json` won't break custom `manifest.json` file resolution. The file will now resolve relative to the user's static folder rather than to their computer.
- Standard behavior continues to work:
  - In a project without a `web/` folder, `expo build:web` will generate a `web-build/manifest.json` and inject a single manifest.json tag into the head of the generated index.html.