### PR TITLE
[xdl] Improve keytool errors

### DIFF
--- a/packages/xdl/src/credentials/AndroidCredentials.ts
+++ b/packages/xdl/src/credentials/AndroidCredentials.ts
@@ -51,6 +51,12 @@ export async function exportCertBinary(
       log.info('keytool is a part of OpenJDK: https://openjdk.java.net/');
       log.info('Also make sure that keytool is in your PATH after installation.');
     }
+    if (err.stdout) {
+      log.info(err.stdout);
+    }
+    if (err.stderr) {
+      log.error(err.stderr);
+    }
     throw err;
   }
 }
@@ -84,6 +90,12 @@ export async function exportCertBase64(
       log.warn('Are you sure you have keytool installed?');
       log.info('keytool is a part of OpenJDK: https://openjdk.java.net/');
       log.info('Also make sure that keytool is in your PATH after installation.');
+    }
+    if (err.stdout) {
+      log.info(err.stdout);
+    }
+    if (err.stderr) {
+      log.error(err.stderr);
     }
     throw err;
   }
@@ -174,13 +186,19 @@ export async function createKeystore(
       '-dname',
       `CN=${androidPackage},OU=,O=,L=,S=,C=US`,
     ]);
-  } catch (error) {
-    if (error.code === 'ENOENT') {
+  } catch (err) {
+    if (err.code === 'ENOENT') {
       log.warn('Are you sure you have keytool installed?');
       log.info('keytool is a part of OpenJDK: https://openjdk.java.net/');
       log.info('Also make sure that keytool is in your PATH after installation.');
     }
-    throw error;
+    if (err.stdout) {
+      log.info(err.stdout);
+    }
+    if (err.stderr) {
+      log.error(err.stderr);
+    }
+    throw err;
   }
 }
 


### PR DESCRIPTION
When Java is not installed, the legacy `keytool` error messages are cryptic and hard to understand. 
Resolves #3044 

Running `expo ba`

**before**

```
If you don't know what this means, let us generate it! :) › Generate new keystore
Failed to generate Android Keystore, it will be generated on Expo servers during the build
keytool exited with non-zero code: 1
```

**after**

```
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.

Failed to generate Android Keystore, it will be generated on Expo servers during the build
keytool exited with non-zero code: 1
```