### PR TITLE
Refactor log module for better mocking capabilities

### DIFF
--- a/packages/expo-cli/src/__tests__/accounts-test.ts
+++ b/packages/expo-cli/src/__tests__/accounts-test.ts
@@ -2,7 +2,7 @@ import { ApiV2 } from '@expo/xdl';
 
 import { _retryUsernamePasswordAuthWithOTPAsync, UserSecondFactorDeviceMethod } from '../accounts';
 import { jester } from '../credentials/__tests__/fixtures/mocks-constants';
-import log from '../log';
+import Log from '../log';
 import prompt, { selectAsync } from '../prompts';
 import { mockExpoXDL } from './mock-utils';
 
@@ -37,7 +37,7 @@ beforeEach(() => {
 
 describe(_retryUsernamePasswordAuthWithOTPAsync, () => {
   it('shows SMS OTP prompt when SMS is primary and code was automatically sent', async () => {
-    const logSpy = jest.spyOn(log, 'nested').mockImplementation(() => {});
+    const logSpy = jest.spyOn(Log, 'nested').mockImplementation(() => {});
 
     (prompt as any)
       .mockImplementationOnce(() => ({ otp: 'hello' }))
@@ -66,7 +66,7 @@ describe(_retryUsernamePasswordAuthWithOTPAsync, () => {
   });
 
   it('shows authenticator OTP prompt when authenticator is primary', async () => {
-    const logSpy = jest.spyOn(log, 'nested').mockImplementation(() => {});
+    const logSpy = jest.spyOn(Log, 'nested').mockImplementation(() => {});
 
     (prompt as any)
       .mockImplementationOnce(() => ({ otp: 'hello' }))

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -7,7 +7,7 @@ import openBrowser from 'react-dev-utils/openBrowser';
 
 import CommandError, { SilentError } from './CommandError';
 import { assert } from './assert';
-import log from './log';
+import Log from './log';
 import promptNew, { confirmAsync, Question as NewQuestion, selectAsync } from './prompts';
 import { nonEmptyInput } from './validators';
 
@@ -35,7 +35,7 @@ export type SecondFactorDevice = {
 };
 
 export async function loginOrRegisterAsync(): Promise<User> {
-  log.warn('An Expo user account is required to proceed.');
+  Log.warn('An Expo user account is required to proceed.');
 
   // Always try to auto-login when these variables are set, even in non-interactive mode
   if (process.env.EXPO_CLI_USERNAME && process.env.EXPO_CLI_PASSWORD) {
@@ -76,8 +76,8 @@ export async function loginOrRegisterAsync(): Promise<User> {
 
   if (action === 'register') {
     openRegistrationInBrowser();
-    log.newLine();
-    log.log(
+    Log.newLine();
+    Log.log(
       `Log in with ${chalk.bold(
         'expo login'
       )} after you have created your account through the website.`
@@ -137,8 +137,8 @@ export async function login(options: CommandOptions): Promise<User> {
 async function _promptForOTPAsync(cancelBehavior: 'cancel' | 'menu'): Promise<string | null> {
   const enterMessage =
     cancelBehavior === 'cancel'
-      ? `press ${log.chalk.bold('Enter')} to cancel`
-      : `press ${log.chalk.bold('Enter')} for more options`;
+      ? `press ${Log.chalk.bold('Enter')} to cancel`
+      : `press ${Log.chalk.bold('Enter')} for more options`;
   const otpQuestion: NewQuestion = {
     type: 'text',
     name: 'otp',
@@ -257,14 +257,14 @@ export async function _retryUsernamePasswordAuthWithOTPAsync(
 
   if (smsAutomaticallySent) {
     assert(primaryDevice, 'OTP should only automatically be sent when there is a primary device');
-    log.nested(
+    Log.nested(
       `One-time password was sent to the phone number ending in ${primaryDevice.sms_phone_number}.`
     );
     otp = await _promptForOTPAsync('menu');
   }
 
   if (primaryDevice?.method === UserSecondFactorDeviceMethod.AUTHENTICATOR) {
-    log.nested('One-time password from authenticator required.');
+    Log.nested('One-time password from authenticator required.');
     otp = await _promptForOTPAsync('menu');
   }
 
@@ -334,7 +334,7 @@ async function _usernamePasswordAuth(
   }
 
   if (user) {
-    log.log(`\nSuccess. You are now logged in as ${chalk.green(user.username)}.`);
+    Log.log(`\nSuccess. You are now logged in as ${chalk.green(user.username)}.`);
     return user;
   } else {
     throw new Error('Unexpected Error: No user returned from the API');

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -77,7 +77,7 @@ export async function loginOrRegisterAsync(): Promise<User> {
   if (action === 'register') {
     openRegistrationInBrowser();
     log.newLine();
-    log(
+    log.log(
       `Log in with ${chalk.bold(
         'expo login'
       )} after you have created your account through the website.`
@@ -334,7 +334,7 @@ async function _usernamePasswordAuth(
   }
 
   if (user) {
-    log(`\nSuccess. You are now logged in as ${chalk.green(user.username)}.`);
+    log.log(`\nSuccess. You are now logged in as ${chalk.green(user.username)}.`);
     return user;
   } else {
     throw new Error('Unexpected Error: No user returned from the API');

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -184,7 +184,7 @@ export async function authenticateAsync(options: Options = {}): Promise<AppleCtx
     if (error.message === 'ABORTED') {
       process.exit(1);
     }
-    log(chalk.red('Authentication with Apple Developer Portal failed!'));
+    log.log(chalk.red('Authentication with Apple Developer Portal failed!'));
     throw error;
   }
 }

--- a/packages/expo-cli/src/appleApi/authenticate.ts
+++ b/packages/expo-cli/src/appleApi/authenticate.ts
@@ -9,7 +9,7 @@ import chalk from 'chalk';
 
 import { AbortCommandError } from '../CommandError';
 import { assert } from '../assert';
-import log from '../log';
+import Log from '../log';
 import { toggleConfirmAsync } from '../prompts';
 import {
   deletePasswordAsync,
@@ -97,7 +97,7 @@ async function loginAsync(
     });
   } catch (error) {
     if (error instanceof InvalidUserCredentialsError) {
-      log.error(error.message);
+      Log.error(error.message);
       // Remove the invalid password so it isn't automatically used...
       await deletePasswordAsync({ username });
 
@@ -146,7 +146,7 @@ async function loginWithUserCredentialsAsync({
 
 export async function authenticateAsync(options: Options = {}): Promise<AppleCtx> {
   // help keep apple login visually apart from the other operations.
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 
   try {
     const authState = await loginAsync(
@@ -184,7 +184,7 @@ export async function authenticateAsync(options: Options = {}): Promise<AppleCtx
     if (error.message === 'ABORTED') {
       process.exit(1);
     }
-    log.log(chalk.red('Authentication with Apple Developer Portal failed!'));
+    Log.log(chalk.red('Authentication with Apple Developer Portal failed!'));
     throw error;
   }
 }

--- a/packages/expo-cli/src/appleApi/contractMessages.ts
+++ b/packages/expo-cli/src/appleApi/contractMessages.ts
@@ -84,15 +84,15 @@ export async function assertContractMessagesAsync(context: RequestContext, spinn
       spinner.stop();
     }
     log.newLine();
-    log(chalk.yellow.bold('Messages from App Store Connect:'));
+    log.log(chalk.yellow.bold('Messages from App Store Connect:'));
     log.newLine();
     for (const message of messages) {
       if (log.isDebug) {
-        log(JSON.stringify(message, null, 2));
+        log.log(JSON.stringify(message, null, 2));
         log.newLine();
       }
       log.addNewLineIfNone();
-      log(formatContractMessage(message));
+      log.log(formatContractMessage(message));
     }
     log.addNewLineIfNone();
     // Only throw an error if we know that the status is fatal, otherwise attempt to finish the process.

--- a/packages/expo-cli/src/appleApi/contractMessages.ts
+++ b/packages/expo-cli/src/appleApi/contractMessages.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { Ora } from 'ora';
 
 import CommandError from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import { convertHTMLToASCII } from '../utils/convertHTMLToASCII';
 
 async function getContractStatusAsync(
@@ -13,7 +13,7 @@ async function getContractStatusAsync(
     const capabilities = await ITCAgreements.getCapabilitiesAsync(context);
     return capabilities?.contractStatus ?? null;
   } catch (error) {
-    log.warn(`Failed to get iTunes contract status: ${error.message}`);
+    Log.warn(`Failed to get iTunes contract status: ${error.message}`);
     return null;
   }
 }
@@ -22,7 +22,7 @@ async function getContractMessagesAsync(context: RequestContext) {
   try {
     return await ITCAgreements.getContractMessagesAsync(context);
   } catch (error) {
-    log.warn(`Failed to get iTunes contract messages: ${error.message}`);
+    Log.warn(`Failed to get iTunes contract messages: ${error.message}`);
     return null;
   }
 }
@@ -56,10 +56,10 @@ async function getRequiredContractMessagesAsync(
   // There is a small chance that this could result in a false positive if the messages are extraneous, so we'll also
   // prompt the user to open an issue so we can address the new contract state if it ever appears.
   // TODO: Maybe a silent analytic would be better
-  log.error(
+  Log.error(
     `\nUnexpected Apple developer contract status "${status}". Please open an issue on https://github.com/expo/eas-cli`
   );
-  log.newLine();
+  Log.newLine();
   return { messages: (await getContractMessagesAsync(context)) ?? [], isFatal: false };
 }
 
@@ -83,18 +83,18 @@ export async function assertContractMessagesAsync(context: RequestContext, spinn
     if (spinner) {
       spinner.stop();
     }
-    log.newLine();
-    log.log(chalk.yellow.bold('Messages from App Store Connect:'));
-    log.newLine();
+    Log.newLine();
+    Log.log(chalk.yellow.bold('Messages from App Store Connect:'));
+    Log.newLine();
     for (const message of messages) {
-      if (log.isDebug) {
-        log.log(JSON.stringify(message, null, 2));
-        log.newLine();
+      if (Log.isDebug) {
+        Log.log(JSON.stringify(message, null, 2));
+        Log.newLine();
       }
-      log.addNewLineIfNone();
-      log.log(formatContractMessage(message));
+      Log.addNewLineIfNone();
+      Log.log(formatContractMessage(message));
     }
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     // Only throw an error if we know that the status is fatal, otherwise attempt to finish the process.
     if (isFatal) {
       throw new CommandError('App Store Connect has agreement updates that must be resolved');

--- a/packages/expo-cli/src/appleApi/pushKey.ts
+++ b/packages/expo-cli/src/appleApi/pushKey.ts
@@ -4,7 +4,7 @@ import dateformat from 'dateformat';
 import ora from 'ora';
 
 import CommandError from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import { AppleCtx, getRequestContext } from './authenticate';
 
 export type PushKeyInfo = {
@@ -90,7 +90,7 @@ async function revokePushKeyAsync(authCtx: AppleCtx, ids: string[]): Promise<voi
 
     spinner.succeed(`Revoked ${name}`);
   } catch (error) {
-    log.error(error);
+    Log.error(error);
     spinner.fail(`Failed to revoke ${name}`);
     throw error;
   }

--- a/packages/expo-cli/src/appleApi/resolveCredentials.ts
+++ b/packages/expo-cli/src/appleApi/resolveCredentials.ts
@@ -55,7 +55,7 @@ function getAppleIdFromEnvironmentOrOptions({
 }
 
 async function promptUsernameAsync(): Promise<string> {
-  log('\u203A Log in to your Apple Developer account to continue');
+  log.log('\u203A Log in to your Apple Developer account to continue');
 
   // Get the email address that was last used and set it as
   // the default value for quicker authentication.
@@ -91,13 +91,13 @@ export async function promptPasswordAsync({
   const cachedPassword = await getCachedPasswordAsync({ username });
 
   if (cachedPassword) {
-    log(`\u203A Using password for ${username} from your local Keychain`);
-    log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
+    log.log(`\u203A Using password for ${username} from your local Keychain`);
+    log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
     return cachedPassword;
   }
 
   // https://docs.expo.io/distribution/security/#apple-developer-account-credentials
-  log(
+  log.log(
     wrapAnsi(
       chalk.bold(
         `\u203A The password is only used to authenticate with Apple and never stored on EAS servers`
@@ -105,7 +105,7 @@ export async function promptPasswordAsync({
       process.stdout.columns || 80
     )
   );
-  log(`  ${learnMore('https://bit.ly/2VtGWhU')}`);
+  log.log(`  ${learnMore('https://bit.ly/2VtGWhU')}`);
 
   const { password } = await promptAsync({
     type: 'password',
@@ -146,7 +146,7 @@ export async function deletePasswordAsync({
   const serviceName = getKeychainServiceName(username);
   const success = await Keychain.deletePasswordAsync({ username, serviceName });
   if (success) {
-    log('\u203A Removed Apple ID password from the native Keychain');
+    log.log('\u203A Removed Apple ID password from the native Keychain');
   }
   return success;
 }
@@ -166,12 +166,12 @@ async function getCachedPasswordAsync({
 
 async function cachePasswordAsync({ username, password }: Auth.UserCredentials): Promise<boolean> {
   if (Keychain.EXPO_NO_KEYCHAIN) {
-    log('\u203A Skip storing Apple ID password in the local Keychain.');
+    log.log('\u203A Skip storing Apple ID password in the local Keychain.');
     return false;
   }
 
-  log(`\u203A Saving Apple ID password to the local Keychain`);
-  log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
+  log.log(`\u203A Saving Apple ID password to the local Keychain`);
+  log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
   const serviceName = getKeychainServiceName(username);
   return Keychain.setPasswordAsync({ username, password, serviceName });
 }

--- a/packages/expo-cli/src/appleApi/resolveCredentials.ts
+++ b/packages/expo-cli/src/appleApi/resolveCredentials.ts
@@ -5,7 +5,7 @@ import wrapAnsi from 'wrap-ansi';
 
 import CommandError from '../CommandError';
 import { learnMore } from '../commands/utils/TerminalLink';
-import log from '../log';
+import Log from '../log';
 import promptAsync from '../prompts';
 import * as Keychain from './keychain';
 
@@ -38,7 +38,7 @@ function getAppleIdFromEnvironmentOrOptions({
     : undefined;
 
   if (process.env.EXPO_APPLE_ID_PASSWORD) {
-    log.error('EXPO_APPLE_ID_PASSWORD is deprecated, please use EXPO_APPLE_PASSWORD instead!');
+    Log.error('EXPO_APPLE_ID_PASSWORD is deprecated, please use EXPO_APPLE_PASSWORD instead!');
   }
 
   // partial apple id params were set, assume user has intention of passing it in
@@ -55,7 +55,7 @@ function getAppleIdFromEnvironmentOrOptions({
 }
 
 async function promptUsernameAsync(): Promise<string> {
-  log.log('\u203A Log in to your Apple Developer account to continue');
+  Log.log('\u203A Log in to your Apple Developer account to continue');
 
   // Get the email address that was last used and set it as
   // the default value for quicker authentication.
@@ -91,13 +91,13 @@ export async function promptPasswordAsync({
   const cachedPassword = await getCachedPasswordAsync({ username });
 
   if (cachedPassword) {
-    log.log(`\u203A Using password for ${username} from your local Keychain`);
-    log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
+    Log.log(`\u203A Using password for ${username} from your local Keychain`);
+    Log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
     return cachedPassword;
   }
 
   // https://docs.expo.io/distribution/security/#apple-developer-account-credentials
-  log.log(
+  Log.log(
     wrapAnsi(
       chalk.bold(
         `\u203A The password is only used to authenticate with Apple and never stored on EAS servers`
@@ -105,7 +105,7 @@ export async function promptPasswordAsync({
       process.stdout.columns || 80
     )
   );
-  log.log(`  ${learnMore('https://bit.ly/2VtGWhU')}`);
+  Log.log(`  ${learnMore('https://bit.ly/2VtGWhU')}`);
 
   const { password } = await promptAsync({
     type: 'password',
@@ -146,7 +146,7 @@ export async function deletePasswordAsync({
   const serviceName = getKeychainServiceName(username);
   const success = await Keychain.deletePasswordAsync({ username, serviceName });
   if (success) {
-    log.log('\u203A Removed Apple ID password from the native Keychain');
+    Log.log('\u203A Removed Apple ID password from the native Keychain');
   }
   return success;
 }
@@ -166,12 +166,12 @@ async function getCachedPasswordAsync({
 
 async function cachePasswordAsync({ username, password }: Auth.UserCredentials): Promise<boolean> {
   if (Keychain.EXPO_NO_KEYCHAIN) {
-    log.log('\u203A Skip storing Apple ID password in the local Keychain.');
+    Log.log('\u203A Skip storing Apple ID password in the local Keychain.');
     return false;
   }
 
-  log.log(`\u203A Saving Apple ID password to the local Keychain`);
-  log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
+  Log.log(`\u203A Saving Apple ID password to the local Keychain`);
+  Log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
   const serviceName = getKeychainServiceName(username);
   return Keychain.setPasswordAsync({ username, password, serviceName });
 }

--- a/packages/expo-cli/src/askUser.ts
+++ b/packages/expo-cli/src/askUser.ts
@@ -1,11 +1,11 @@
 import { UserSettings } from '@expo/xdl';
 
-import log from './log';
+import Log from './log';
 import { promptEmailAsync } from './prompts';
 
 export async function askForSendToAsync(): Promise<string> {
   const cachedValue = await UserSettings.getAsync('sendTo', null);
-  log.nested("Enter an email address and we'll send a link");
+  Log.nested("Enter an email address and we'll send a link");
   const recipient = await promptEmailAsync(
     {
       message: `Email address`,

--- a/packages/expo-cli/src/commands/__tests__/export-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/export-test.ts
@@ -3,7 +3,7 @@ import { vol } from 'memfs';
 
 import { mockExpoXDL } from '../../__tests__/mock-utils';
 import { jester } from '../../credentials/__tests__/fixtures/mocks-constants';
-import log from '../../log';
+import Log from '../../log';
 import { collectMergeSourceUrlsAsync, ensurePublicUrlAsync, promptPublicUrlAsync } from '../export';
 
 jest.mock('fs');
@@ -43,7 +43,7 @@ describe('ensurePublicUrlAsync', () => {
     );
   });
   it(`does not throw when an invalid URL is used in dev mode`, async () => {
-    const logWarnSpy = jest.spyOn(log, 'nestedWarn').mockImplementation(() => {});
+    const logWarnSpy = jest.spyOn(Log, 'nestedWarn').mockImplementation(() => {});
 
     await expect(ensurePublicUrlAsync('bacon', true)).resolves.toBe('bacon');
     await expect(ensurePublicUrlAsync('ssh://bacon.io', true)).resolves.toBe('ssh://bacon.io');
@@ -54,7 +54,7 @@ describe('ensurePublicUrlAsync', () => {
   });
 
   it(`validates a URL`, async () => {
-    const logWarnSpy = jest.spyOn(log, 'nestedWarn').mockImplementation(() => {});
+    const logWarnSpy = jest.spyOn(Log, 'nestedWarn').mockImplementation(() => {});
 
     await expect(ensurePublicUrlAsync('https://expo.io', true)).resolves.toBe('https://expo.io');
     // No warnings thrown

--- a/packages/expo-cli/src/commands/__tests__/publish-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/publish-test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 
-import log from '../../log';
+import Log from '../../log';
 import {
   isInvalidReleaseChannel,
   logBareWorkflowWarnings,
@@ -39,36 +39,36 @@ describe('warnings', () => {
     vol.reset();
   });
   it(`skips expo-updates warnings if expo-kit is not installed`, () => {
-    (log.nestedWarn as jest.Mock).mockReset();
+    (Log.nestedWarn as jest.Mock).mockReset();
     logExpoUpdatesWarnings({ dependencies: { 'expo-updates': '1.0.0' } });
-    expect(log.nestedWarn).toBeCalledTimes(0);
+    expect(Log.nestedWarn).toBeCalledTimes(0);
   });
   it(`warns about expo-updates not working in ExpoKit`, () => {
-    (log.nestedWarn as jest.Mock).mockReset();
+    (Log.nestedWarn as jest.Mock).mockReset();
     logExpoUpdatesWarnings({ dependencies: { 'expo-updates': '1.0.0', expokit: '1.0.0' } });
-    expect(log.nestedWarn).toBeCalledTimes(1);
+    expect(Log.nestedWarn).toBeCalledTimes(1);
   });
 
   it(`skips bare workflow warnings if expo is not installed in a bare project`, () => {
-    (log.nestedWarn as jest.Mock).mockReset();
+    (Log.nestedWarn as jest.Mock).mockReset();
     logBareWorkflowWarnings({});
-    expect(log.nestedWarn).toBeCalledTimes(0);
+    expect(Log.nestedWarn).toBeCalledTimes(0);
   });
 
   it(`warns about publishing in a bare workflow project when expo is installed`, () => {
-    (log.nestedWarn as jest.Mock).mockReset();
+    (Log.nestedWarn as jest.Mock).mockReset();
     logBareWorkflowWarnings({ dependencies: { expo: '1.0.0' } });
-    expect(log.nestedWarn).toBeCalledTimes(1);
+    expect(Log.nestedWarn).toBeCalledTimes(1);
   });
 
   it(`skips warning about assets if shared file exists`, () => {
-    (log.nestedWarn as jest.Mock).mockReset();
+    (Log.nestedWarn as jest.Mock).mockReset();
     logOptimizeWarnings({ projectRoot: 'optimized' });
-    expect(log.nestedWarn).toBeCalledTimes(0);
+    expect(Log.nestedWarn).toBeCalledTimes(0);
   });
   it(`warns about unoptimized assets when shared folder is missing`, () => {
-    (log.nestedWarn as jest.Mock).mockReset();
+    (Log.nestedWarn as jest.Mock).mockReset();
     logOptimizeWarnings({ projectRoot: '/' });
-    expect(log.nestedWarn).toBeCalledTimes(1);
+    expect(Log.nestedWarn).toBeCalledTimes(1);
   });
 });

--- a/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
@@ -1,7 +1,7 @@
 import { vol } from 'memfs';
 
 import { mockExpoXDL } from '../../__tests__/mock-utils';
-import log from '../../log';
+import Log from '../../log';
 import {
   getDependenciesFromBundledNativeModules,
   maybeFormatSdkVersion,
@@ -36,7 +36,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
       targetSdkVersion: null,
     });
 
-    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(Log.warn).toHaveBeenCalledTimes(1);
   });
 
   describe('priority', () => {

--- a/packages/expo-cli/src/commands/apply/configureProjectAsync.ts
+++ b/packages/expo-cli/src/commands/apply/configureProjectAsync.ts
@@ -11,7 +11,7 @@ import {
 } from '@expo/config-plugins';
 import { UserManager } from '@expo/xdl';
 
-import log from '../../log';
+import Log from '../../log';
 import { getOrPromptForBundleIdentifier, getOrPromptForPackage } from '../eject/ConfigValidation';
 
 // Expo managed packages that require extra update.
@@ -114,14 +114,14 @@ export default async function configureManagedProjectAsync({
   // compile all plugins and mods
   config = await compileModsAsync(config, { projectRoot, platforms });
 
-  if (log.isDebug) {
-    log.debug();
-    log.debug('Evaluated config:');
+  if (Log.isDebug) {
+    Log.debug();
+    Log.debug('Evaluated config:');
     // @ts-ignore: mods not on config type
     const { mods, ...rest } = config;
-    log.info(JSON.stringify(rest, null, 2));
-    log.info(mods);
-    log.debug();
+    Log.info(JSON.stringify(rest, null, 2));
+    Log.info(mods);
+    Log.debug();
   }
 
   return config;

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import semver from 'semver';
 
-import log from '../../log';
+import Log from '../../log';
 import { getProjectOwner } from '../../projects';
 import { action as publishAction } from '../publish';
 import { sleep } from '../utils/promise';
@@ -45,7 +45,7 @@ export default class BaseBuilder {
       if (!(e instanceof BuildError)) {
         throw e;
       } else {
-        log.error(e.message);
+        Log.error(e.message);
         process.exit(1);
       }
     }
@@ -63,7 +63,7 @@ export default class BaseBuilder {
       if (!(e instanceof BuildError)) {
         throw e;
       } else {
-        log.error(e.message);
+        Log.error(e.message);
         process.exit(1);
       }
     }
@@ -82,7 +82,7 @@ export default class BaseBuilder {
 
   async checkProjectConfig(): Promise<void> {
     if (this.manifest.isDetached) {
-      log.error(`'expo build:${this.platform()}' is not supported for detached projects.`);
+      Log.error(`'expo build:${this.platform()}' is not supported for detached projects.`);
       process.exit(1);
     }
 
@@ -90,7 +90,7 @@ export default class BaseBuilder {
     const oldestSupportedMajorVersion = await Versions.oldestSupportedMajorVersionAsync();
     if (semver.major(this.manifest.sdkVersion!) === oldestSupportedMajorVersion) {
       const { version } = await Versions.newestReleasedSdkVersionAsync();
-      log.warn(
+      Log.warn(
         `\nSDK${oldestSupportedMajorVersion} will be ${chalk.bold(
           'deprecated'
         )} next! We recommend upgrading versions, ideally to the latest (SDK${semver.major(
@@ -101,7 +101,7 @@ export default class BaseBuilder {
   }
 
   async checkForBuildInProgress() {
-    log('Checking if there is a build in progress...\n');
+    Log('Checking if there is a build in progress...\n');
     const buildStatus = await getBuildStatusAsync(this.projectDir, {
       platform: this.platform(),
       current: true,
@@ -116,7 +116,7 @@ export default class BaseBuilder {
   }
 
   async checkStatus(platform: 'all' | 'ios' | 'android' = 'all'): Promise<void> {
-    log('Fetching build history...\n');
+    Log('Fetching build history...\n');
 
     const buildStatus = await getBuildStatusAsync(this.projectDir, {
       platform,
@@ -129,7 +129,7 @@ export default class BaseBuilder {
     }
 
     if (!(buildStatus.jobs && buildStatus.jobs.length)) {
-      log('No currently active or previous builds for this project.');
+      Log('No currently active or previous builds for this project.');
       return;
     }
 
@@ -142,7 +142,7 @@ export default class BaseBuilder {
   }
 
   async checkStatusBeforeBuild(): Promise<void> {
-    log('Checking if this build already exists...\n');
+    Log('Checking if this build already exists...\n');
 
     const reuseStatus = await findReusableBuildAsync(
       this.options.releaseChannel!,
@@ -152,17 +152,17 @@ export default class BaseBuilder {
       this.manifest.owner
     );
     if (reuseStatus.canReuse) {
-      log.warn(`Did you know that Expo provides over-the-air updates?
+      Log.warn(`Did you know that Expo provides over-the-air updates?
 Please see the docs (${chalk.underline(
         'https://docs.expo.io/guides/configuring-ota-updates/'
       )}) and check if you can use them instead of building your app binaries again.`);
 
-      log.warn(
+      Log.warn(
         `There were no new changes from the last build, you can download that build from here: ${chalk.underline(
           reuseStatus.downloadUrl!
         )}`
       );
-      log.newLine();
+      Log.newLine();
     }
   }
 
@@ -172,9 +172,9 @@ Please see the docs (${chalk.underline(
     numberOfRemainingPriorityBuilds?: number;
     hasUnlimitedPriorityBuilds?: boolean;
   }) {
-    log('=================');
-    log(' Builds Statuses ');
-    log('=================\n');
+    Log('=================');
+    Log(' Builds Statuses ');
+    Log('=================\n');
 
     const username = this.manifest.owner
       ? this.manifest.owner
@@ -190,7 +190,7 @@ Please see the docs (${chalk.underline(
         packageExtension = 'APK';
       }
 
-      log(
+      Log(
         `### ${i} | ${platform} | ${UrlUtils.constructBuildLogsUrl({
           buildId: job.id,
           username: username ?? undefined,
@@ -253,15 +253,15 @@ ${job.id}
           break;
       }
 
-      log(status);
+      Log(status);
       if (job.status === 'finished') {
         if (job.artifacts) {
-          log(`${packageExtension}: ${job.artifacts.url}`);
+          Log(`${packageExtension}: ${job.artifacts.url}`);
         } else {
-          log(`Problem getting ${packageExtension} URL. Please try to build again.`);
+          Log(`Problem getting ${packageExtension} URL. Please try to build again.`);
         }
       }
-      log();
+      Log();
     });
   }
 
@@ -278,7 +278,7 @@ ${job.id}
       }
       return ids;
     } else {
-      log('Looking for releases...');
+      Log('Looking for releases...');
       const release = await getLatestReleaseAsync(this.projectDir, {
         releaseChannel: this.options.releaseChannel!,
         platform: this.platform(),
@@ -287,7 +287,7 @@ ${job.id}
       if (!release) {
         throw new BuildError('No releases found. Please create one using `expo publish` first.');
       }
-      log(
+      Log(
         `Using existing release on channel "${release.channel}":\n` +
           `publicationId: ${release.publicationId}\n  publishedTime: ${release.publishedTime}`
       );
@@ -299,7 +299,7 @@ ${job.id}
     buildId: string,
     { interval = 30, publicUrl }: { interval?: number; publicUrl?: string } = {}
   ): Promise<any> {
-    log(
+    Log(
       `Waiting for build to complete.\nYou can press Ctrl+C to exit. It won't cancel the build, you'll be able to monitor it at the printed URL.`
     );
     const spinner = ora().start();
@@ -371,12 +371,12 @@ ${job.id}
 
     const { id: buildId, priority, canPurchasePriorityBuilds } = result;
 
-    log('Build started, it may take a few minutes to complete.');
-    log(
+    Log('Build started, it may take a few minutes to complete.');
+    Log(
       `You can check the queue length at ${chalk.underline(UrlUtils.constructTurtleStatusUrl())}\n`
     );
     if (priority === 'normal' && canPurchasePriorityBuilds) {
-      log(
+      Log(
         'You can make this faster. 🐢\nGet priority builds at: https://expo.io/settings/billing\n'
       );
     }
@@ -389,7 +389,7 @@ ${job.id}
         username: this.manifest.owner || (user?.kind === 'user' ? user.username : undefined),
       });
 
-      log(`You can monitor the build at\n\n ${chalk.underline(url)}\n`);
+      Log(`You can monitor the build at\n\n ${chalk.underline(url)}\n`);
     }
 
     if (this.options.wait) {
@@ -398,10 +398,10 @@ ${job.id}
       const artifactUrl = completedJob.artifactId
         ? UrlUtils.constructArtifactUrl(completedJob.artifactId)
         : completedJob.artifacts.url;
-      log.addNewLineIfNone();
-      log(`${chalk.green('Successfully built standalone app:')} ${chalk.underline(artifactUrl)}`);
+      Log.addNewLineIfNone();
+      Log(`${chalk.green('Successfully built standalone app:')} ${chalk.underline(artifactUrl)}`);
     } else {
-      log('Alternatively, run `expo build:status` to monitor it from the command line.');
+      Log('Alternatively, run `expo build:status` to monitor it from the command line.');
     }
   }
 

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -101,7 +101,7 @@ export default class BaseBuilder {
   }
 
   async checkForBuildInProgress() {
-    Log('Checking if there is a build in progress...\n');
+    Log.log('Checking if there is a build in progress...\n');
     const buildStatus = await getBuildStatusAsync(this.projectDir, {
       platform: this.platform(),
       current: true,
@@ -116,7 +116,7 @@ export default class BaseBuilder {
   }
 
   async checkStatus(platform: 'all' | 'ios' | 'android' = 'all'): Promise<void> {
-    Log('Fetching build history...\n');
+    Log.log('Fetching build history...\n');
 
     const buildStatus = await getBuildStatusAsync(this.projectDir, {
       platform,
@@ -129,7 +129,7 @@ export default class BaseBuilder {
     }
 
     if (!(buildStatus.jobs && buildStatus.jobs.length)) {
-      Log('No currently active or previous builds for this project.');
+      Log.log('No currently active or previous builds for this project.');
       return;
     }
 
@@ -142,7 +142,7 @@ export default class BaseBuilder {
   }
 
   async checkStatusBeforeBuild(): Promise<void> {
-    Log('Checking if this build already exists...\n');
+    Log.log('Checking if this build already exists...\n');
 
     const reuseStatus = await findReusableBuildAsync(
       this.options.releaseChannel!,
@@ -172,9 +172,9 @@ Please see the docs (${chalk.underline(
     numberOfRemainingPriorityBuilds?: number;
     hasUnlimitedPriorityBuilds?: boolean;
   }) {
-    Log('=================');
-    Log(' Builds Statuses ');
-    Log('=================\n');
+    Log.log('=================');
+    Log.log(' Builds Statuses ');
+    Log.log('=================\n');
 
     const username = this.manifest.owner
       ? this.manifest.owner
@@ -190,7 +190,7 @@ Please see the docs (${chalk.underline(
         packageExtension = 'APK';
       }
 
-      Log(
+      Log.log(
         `### ${i} | ${platform} | ${UrlUtils.constructBuildLogsUrl({
           buildId: job.id,
           username: username ?? undefined,
@@ -253,15 +253,15 @@ ${job.id}
           break;
       }
 
-      Log(status);
+      Log.log(status);
       if (job.status === 'finished') {
         if (job.artifacts) {
-          Log(`${packageExtension}: ${job.artifacts.url}`);
+          Log.log(`${packageExtension}: ${job.artifacts.url}`);
         } else {
-          Log(`Problem getting ${packageExtension} URL. Please try to build again.`);
+          Log.log(`Problem getting ${packageExtension} URL. Please try to build again.`);
         }
       }
-      Log();
+      Log.log();
     });
   }
 
@@ -278,7 +278,7 @@ ${job.id}
       }
       return ids;
     } else {
-      Log('Looking for releases...');
+      Log.log('Looking for releases...');
       const release = await getLatestReleaseAsync(this.projectDir, {
         releaseChannel: this.options.releaseChannel!,
         platform: this.platform(),
@@ -287,7 +287,7 @@ ${job.id}
       if (!release) {
         throw new BuildError('No releases found. Please create one using `expo publish` first.');
       }
-      Log(
+      Log.log(
         `Using existing release on channel "${release.channel}":\n` +
           `publicationId: ${release.publicationId}\n  publishedTime: ${release.publishedTime}`
       );
@@ -299,7 +299,7 @@ ${job.id}
     buildId: string,
     { interval = 30, publicUrl }: { interval?: number; publicUrl?: string } = {}
   ): Promise<any> {
-    Log(
+    Log.log(
       `Waiting for build to complete.\nYou can press Ctrl+C to exit. It won't cancel the build, you'll be able to monitor it at the printed URL.`
     );
     const spinner = ora().start();
@@ -371,12 +371,12 @@ ${job.id}
 
     const { id: buildId, priority, canPurchasePriorityBuilds } = result;
 
-    Log('Build started, it may take a few minutes to complete.');
-    Log(
+    Log.log('Build started, it may take a few minutes to complete.');
+    Log.log(
       `You can check the queue length at ${chalk.underline(UrlUtils.constructTurtleStatusUrl())}\n`
     );
     if (priority === 'normal' && canPurchasePriorityBuilds) {
-      Log(
+      Log.log(
         'You can make this faster. 🐢\nGet priority builds at: https://expo.io/settings/billing\n'
       );
     }
@@ -389,7 +389,7 @@ ${job.id}
         username: this.manifest.owner || (user?.kind === 'user' ? user.username : undefined),
       });
 
-      Log(`You can monitor the build at\n\n ${chalk.underline(url)}\n`);
+      Log.log(`You can monitor the build at\n\n ${chalk.underline(url)}\n`);
     }
 
     if (this.options.wait) {
@@ -399,9 +399,11 @@ ${job.id}
         ? UrlUtils.constructArtifactUrl(completedJob.artifactId)
         : completedJob.artifacts.url;
       Log.addNewLineIfNone();
-      Log(`${chalk.green('Successfully built standalone app:')} ${chalk.underline(artifactUrl)}`);
+      Log.log(
+        `${chalk.green('Successfully built standalone app:')} ${chalk.underline(artifactUrl)}`
+      );
     } else {
-      Log('Alternatively, run `expo build:status` to monitor it from the command line.');
+      Log.log('Alternatively, run `expo build:status` to monitor it from the command line.');
     }
   }
 

--- a/packages/expo-cli/src/commands/build/index.ts
+++ b/packages/expo-cli/src/commands/build/index.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 
 import CommandError from '../../CommandError';
-import log from '../../log';
+import Log from '../../log';
 import { confirmAsync } from '../../prompts';
 import * as ProjectUtils from '../utils/ProjectUtils';
 import AndroidBuilder from './AndroidBuilder';
@@ -26,18 +26,18 @@ async function maybeBailOnWorkflowWarning({
   }
 
   const command = `expo build:${platform}`;
-  log.warn(chalk.bold(`⚠️  ${command} currently only supports managed workflow apps.`));
-  log.warn(
+  Log.warn(chalk.bold(`⚠️  ${command} currently only supports managed workflow apps.`));
+  Log.warn(
     `If you proceed with this command, we can run the build for you but it will not include any custom native modules or changes that you have made to your local native projects.`
   );
-  log.warn(
+  Log.warn(
     `Unless you are sure that you know what you are doing, we recommend aborting the build and doing a native release build through ${
       platform === 'ios' ? 'Xcode' : 'Android Studio'
     }.`
   );
 
   if (nonInteractive) {
-    log.warn(`Skipping confirmation prompt because non-interactive mode is enabled.`);
+    Log.warn(`Skipping confirmation prompt because non-interactive mode is enabled.`);
     return false;
   }
 
@@ -148,7 +148,7 @@ export default function (program: Command) {
     .asyncActionProjectDir(
       async (projectRoot: string, options: AndroidOptions) => {
         if (options.generateKeystore) {
-          log.warn(
+          Log.warn(
             `The --generate-keystore flag is deprecated and does not do anything. A Keystore will always be generated on the Expo servers if it's missing.`
           );
         }

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -94,7 +94,7 @@ class IOSBuilder extends BaseBuilder {
     if (confirm) {
       return await ctx.ensureAppleCtx();
     } else {
-      Log(
+      Log.log(
         chalk.green(
           'No problem! 👌 \nWe can’t auto-generate credentials if you don’t have access to the main Apple account. \nBut we can still set it up if you upload your credentials.'
         )
@@ -145,7 +145,7 @@ class IOSBuilder extends BaseBuilder {
     });
 
     if (this.options.skipCredentialsCheck) {
-      Log('Skipping credentials check...');
+      Log.log('Skipping credentials check...');
       return;
     }
     await this.bestEffortAppleCtx(context);
@@ -160,12 +160,12 @@ class IOSBuilder extends BaseBuilder {
           'expo.fyi/credentials-non-interactive',
           'https://expo.fyi/credentials-non-interactive'
         );
-        Log(
+        Log.log(
           chalk.bold.red(
             `Additional information needed to setup credentials in non-interactive mode.`
           )
         );
-        Log(chalk.bold.red(`Learn more about how to resolve this: ${link}.`));
+        Log.log(chalk.bold.red(`Learn more about how to resolve this: ${link}.`));
         Log.newLine();
 
         // We don't want to display project credentials when we bail out due to
@@ -177,7 +177,7 @@ class IOSBuilder extends BaseBuilder {
         );
       }
 
-      Log(
+      Log.log(
         chalk.bold.red(
           'Failed to prepare all credentials. \nThe next time you build, we will automatically use the following configuration:'
         )
@@ -355,7 +355,7 @@ class IOSBuilder extends BaseBuilder {
     }
 
     Log.newLine();
-    Log(
+    Log.log(
       `You can now publish to the App Store with ${TerminalLink.transporterAppLink()} or ${chalk.bold(
         'expo upload:ios'
       )}. ${TerminalLink.learnMore('https://docs.expo.io/distribution/uploading-apps/')}`
@@ -371,14 +371,14 @@ class IOSBuilder extends BaseBuilder {
 
     if (isMacOsCatalinaOrLater && this.options.type === 'simulator') {
       Log.newLine();
-      Log(
+      Log.log(
         chalk.bold(
           `🚨 If the build is not installable on your simulator because of "${chalk.underline(
             `... is damaged and can't be opened.`
           )}", please run:`
         )
       );
-      Log(chalk.grey.bold('xattr -rd com.apple.quarantine /path/to/your.app'));
+      Log.log(chalk.grey.bold('xattr -rd com.apple.quarantine /path/to/your.app'));
     }
   }
 }

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -27,7 +27,7 @@ import {
 import { SetupIosDist } from '../../../credentials/views/SetupIosDist';
 import { SetupIosProvisioningProfile } from '../../../credentials/views/SetupIosProvisioningProfile';
 import { SetupIosPush } from '../../../credentials/views/SetupIosPush';
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { getOrPromptForBundleIdentifier } from '../../eject/ConfigValidation';
 import * as TerminalLink from '../../utils/TerminalLink';
@@ -56,7 +56,7 @@ class IOSBuilder extends BaseBuilder {
       simulator: 'Run the build on a simulator',
     });
     this.maybeWarnDamagedSimulator();
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     await this.checkForBuildInProgress();
     if (this.options.type === 'archive') {
       await this.prepareCredentials();
@@ -94,7 +94,7 @@ class IOSBuilder extends BaseBuilder {
     if (confirm) {
       return await ctx.ensureAppleCtx();
     } else {
-      log(
+      Log(
         chalk.green(
           'No problem! 👌 \nWe can’t auto-generate credentials if you don’t have access to the main Apple account. \nBut we can still set it up if you upload your credentials.'
         )
@@ -145,7 +145,7 @@ class IOSBuilder extends BaseBuilder {
     });
 
     if (this.options.skipCredentialsCheck) {
-      log('Skipping credentials check...');
+      Log('Skipping credentials check...');
       return;
     }
     await this.bestEffortAppleCtx(context);
@@ -155,18 +155,18 @@ class IOSBuilder extends BaseBuilder {
       await this.produceCredentials(context, appLookupParams);
     } catch (e) {
       if (e.code === ErrorCodes.NON_INTERACTIVE) {
-        log.newLine();
+        Log.newLine();
         const link = TerminalLink.fallbackToTextAndUrl(
           'expo.fyi/credentials-non-interactive',
           'https://expo.fyi/credentials-non-interactive'
         );
-        log(
+        Log(
           chalk.bold.red(
             `Additional information needed to setup credentials in non-interactive mode.`
           )
         );
-        log(chalk.bold.red(`Learn more about how to resolve this: ${link}.`));
-        log.newLine();
+        Log(chalk.bold.red(`Learn more about how to resolve this: ${link}.`));
+        Log.newLine();
 
         // We don't want to display project credentials when we bail out due to
         // non-interactive mode error, because we are unable to recover without
@@ -177,7 +177,7 @@ class IOSBuilder extends BaseBuilder {
         );
       }
 
-      log(
+      Log(
         chalk.bold.red(
           'Failed to prepare all credentials. \nThe next time you build, we will automatically use the following configuration:'
         )
@@ -200,7 +200,7 @@ class IOSBuilder extends BaseBuilder {
         await runCredentialsManager(ctx, new SetupIosDist(appLookupParams));
       }
     } catch (e) {
-      log.error('Failed to set up Distribution Certificate');
+      Log.error('Failed to set up Distribution Certificate');
       throw e;
     }
   }
@@ -214,7 +214,7 @@ class IOSBuilder extends BaseBuilder {
         await runCredentialsManager(ctx, new SetupIosPush(appLookupParams));
       }
     } catch (e) {
-      log.error('Failed to set up Push Key');
+      Log.error('Failed to set up Push Key');
       throw e;
     }
   }
@@ -230,7 +230,7 @@ class IOSBuilder extends BaseBuilder {
         await runCredentialsManager(ctx, new SetupIosProvisioningProfile(appLookupParams));
       }
     } catch (e) {
-      log.error('Failed to set up Provisioning Profile');
+      Log.error('Failed to set up Provisioning Profile');
       throw e;
     }
   }
@@ -354,8 +354,8 @@ class IOSBuilder extends BaseBuilder {
       return;
     }
 
-    log.newLine();
-    log(
+    Log.newLine();
+    Log(
       `You can now publish to the App Store with ${TerminalLink.transporterAppLink()} or ${chalk.bold(
         'expo upload:ios'
       )}. ${TerminalLink.learnMore('https://docs.expo.io/distribution/uploading-apps/')}`
@@ -370,15 +370,15 @@ class IOSBuilder extends BaseBuilder {
       os.platform() === 'darwin' && semver.satisfies(os.release(), '>=19.0.0');
 
     if (isMacOsCatalinaOrLater && this.options.type === 'simulator') {
-      log.newLine();
-      log(
+      Log.newLine();
+      Log(
         chalk.bold(
           `🚨 If the build is not installable on your simulator because of "${chalk.underline(
             `... is damaged and can't be opened.`
           )}", please run:`
         )
       );
-      log(chalk.grey.bold('xattr -rd com.apple.quarantine /path/to/your.app'));
+      Log(chalk.grey.bold('xattr -rd com.apple.quarantine /path/to/your.app'));
     }
   }
 }

--- a/packages/expo-cli/src/commands/build/utils.ts
+++ b/packages/expo-cli/src/commands/build/utils.ts
@@ -2,7 +2,7 @@ import { Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import program from 'commander';
 
-import log from '../../log';
+import Log from '../../log';
 import prompts from '../../prompts';
 
 export async function checkIfSdkIsSupported(
@@ -15,7 +15,7 @@ export async function checkIfSdkIsSupported(
   const { version: latestSDKVersion } = await Versions.newestReleasedSdkVersionAsync();
 
   if (!isSupported) {
-    log.error(
+    Log.error(
       chalk.red(
         'Unsupported SDK version: our app builders ' +
           (majorSdkVersion < minimumSdkVersionSupported
@@ -39,7 +39,7 @@ export async function askBuildType<T extends string>(
   }
 
   if (typeIsInvalid) {
-    log.error(`Build type must be one of (${allowedTypes.join(', ')})`);
+    Log.error(`Build type must be one of (${allowedTypes.join(', ')})`);
 
     if (program.nonInteractive) {
       process.exit(1);

--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import terminalLink from 'terminal-link';
 
 import { SilentError } from '../CommandError';
-import log from '../log';
+import Log from '../log';
 
 type Options = {
   dest?: string;
@@ -15,8 +15,8 @@ async function action(projectDir: string, options: Options) {
   try {
     await Detach.bundleAssetsAsync(projectDir, options);
   } catch (e) {
-    log.error(e);
-    log.error(
+    Log.error(e);
+    Log.error(
       `Before making a release build, make sure you have run '${chalk.bold(
         'expo publish'
       )}' at least once. ${terminalLink(

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -18,7 +18,7 @@ import { CreateIosDist } from '../../credentials/views/IosDistCert';
 import { CreateOrReuseProvisioningProfileAdhoc } from '../../credentials/views/IosProvisioningProfileAdhoc';
 import { SetupIosDist } from '../../credentials/views/SetupIosDist';
 import { SetupIosPush } from '../../credentials/views/SetupIosPush';
-import log from '../../log';
+import Log from '../../log';
 import { confirmAsync, promptEmailAsync } from '../../prompts';
 import urlOpts from '../../urlOpts';
 import * as ClientUpgradeUtils from '../utils/ClientUpgradeUtils';
@@ -187,8 +187,8 @@ export default function (program: Command) {
         }
 
         if (Object.keys(disabledServices).length > 0) {
-          log.newLine();
-          log.warn('These services will be disabled in your custom Expo client:');
+          Log.newLine();
+          Log.warn('These services will be disabled in your custom Expo client:');
           const table = new CliTable({ head: ['Service', 'Reason'], style: { head: ['cyan'] } });
           table.push(
             ...Object.keys(disabledServices).map(serviceKey => {
@@ -196,8 +196,8 @@ export default function (program: Command) {
               return [service.name, service.reason];
             })
           );
-          log.log(table.toString());
-          log.log(
+          Log.log(table.toString());
+          Log.log(
             'See https://docs.expo.io/guides/adhoc-builds/#optional-additional-configuration-steps for more details.'
           );
         }
@@ -211,22 +211,22 @@ export default function (program: Command) {
             initial: (context?.user as User)?.email,
           });
         }
-        log.newLine();
+        Log.newLine();
 
         let addUdid;
         if (udids.length === 0) {
-          log.log(
+          Log.log(
             'There are no devices registered to your Apple Developer account. Please follow the instructions below to register an iOS device.'
           );
           addUdid = true;
         } else {
-          log.log(
+          Log.log(
             'Custom builds of Expo Go can only be installed on devices which have been registered with Apple at build-time.'
           );
-          log.log('These devices are currently registered on your Apple Developer account:');
+          Log.log('These devices are currently registered on your Apple Developer account:');
           const table = new CliTable({ head: ['Name', 'Identifier'], style: { head: ['cyan'] } });
           table.push(...devices.map(device => [device.attributes.name, device.attributes.udid]));
-          log.log(table.toString());
+          Log.log(table.toString());
 
           const udidPrompt = await confirmAsync({
             message: 'Would you like to register a new device to use Expo Go with?',
@@ -247,29 +247,29 @@ export default function (program: Command) {
           customAppConfig: exp,
         });
 
-        log.newLine();
+        Log.newLine();
         if (addUdid) {
           urlOpts.printQRCode(result.registrationUrl);
-          log.log(
+          Log.log(
             'Open the following link on your iOS device (or scan the QR code) and follow the instructions to install the development profile:'
           );
-          log.newLine();
-          log.log(chalk.green(`${result.registrationUrl}`));
-          log.newLine();
-          log.log('Please note that you can only register one iOS device per request.');
-          log.log(
+          Log.newLine();
+          Log.log(chalk.green(`${result.registrationUrl}`));
+          Log.newLine();
+          Log.log('Please note that you can only register one iOS device per request.');
+          Log.log(
             "After you register your device, we'll start building your client, and you'll receive an email when it's ready to install."
           );
         } else {
           urlOpts.printQRCode(result.statusUrl);
-          log.log('Your custom Expo client is being built! 🛠');
-          log.log(
+          Log.log('Your custom Expo client is being built! 🛠');
+          Log.log(
             'Open this link on your iOS device (or scan the QR code) to view build logs and install the client:'
           );
-          log.newLine();
-          log.log(chalk.green(`${result.statusUrl}`));
+          Log.newLine();
+          Log.log(chalk.green(`${result.statusUrl}`));
         }
-        log.newLine();
+        Log.newLine();
       }
     );
 
@@ -293,7 +293,7 @@ export default function (program: Command) {
 
       if (forceLatest) {
         if (!latestClient?.url) {
-          log.error(
+          Log.error(
             `Unable to find latest client version. Check your internet connection or run this command again without the ${chalk.bold(
               '--latest'
             )} flag.`
@@ -304,21 +304,21 @@ export default function (program: Command) {
         if (
           await Simulator.upgradeExpoAsync({ url: latestClient.url, version: latestClient.version })
         ) {
-          log.log('Done!');
+          Log.log('Done!');
         } else {
-          log.error(`Unable to install Expo client ${latestClient.version} for iOS.`);
+          Log.error(`Unable to install Expo client ${latestClient.version} for iOS.`);
         }
         return;
       }
 
       if (!currentSdkVersion) {
-        log.log(
+        Log.log(
           'Could not find your Expo project. If you run this from a project, we can help pick the right Expo client version!'
         );
       }
 
       if (currentSdk && !recommendedClient) {
-        log.log(
+        Log.log(
           `You are currently using SDK ${currentSdkVersion}. Unfortunately, we couldn't detect the proper client version for this SDK.`
         );
       }
@@ -333,7 +333,7 @@ export default function (program: Command) {
             url: recommendedClient.url,
             version: recommendedClient.version,
           });
-          log.log('Done!');
+          Log.log('Done!');
           return;
         }
       } else {
@@ -347,7 +347,7 @@ export default function (program: Command) {
             url: latestClient?.url,
             version: latestClient?.version,
           });
-          log.log('Done!');
+          Log.log('Done!');
           return;
         }
       }
@@ -369,9 +369,9 @@ export default function (program: Command) {
             url: latestClient?.url,
             version: latestClient?.version,
           });
-          log.log('Done!');
+          Log.log('Done!');
         } else {
-          log.log('No client to install');
+          Log.log('No client to install');
         }
         return;
       }
@@ -383,7 +383,7 @@ export default function (program: Command) {
       });
 
       if (await Simulator.upgradeExpoAsync({ url: targetClient.clientUrl })) {
-        log.log('Done!');
+        Log.log('Done!');
       }
     });
 
@@ -407,7 +407,7 @@ export default function (program: Command) {
 
       if (forceLatest) {
         if (!latestClient?.url) {
-          log.error(
+          Log.error(
             `Unable to find latest client version. Check your internet connection or run this command again without the ${chalk.bold(
               '--latest'
             )} flag.`
@@ -418,22 +418,22 @@ export default function (program: Command) {
         if (
           await Android.upgradeExpoAsync({ url: latestClient.url, version: latestClient.version })
         ) {
-          log.log('Done!');
+          Log.log('Done!');
         } else {
-          log.error(`Unable to install Expo client ${latestClient.version} for Android.`);
+          Log.error(`Unable to install Expo client ${latestClient.version} for Android.`);
         }
 
         return;
       }
 
       if (!currentSdkVersion) {
-        log.log(
+        Log.log(
           'Could not find your Expo project. If you run this from a project, we can help pick the right Expo client version!'
         );
       }
 
       if (currentSdk && !recommendedClient) {
-        log.log(
+        Log.log(
           `You are currently using SDK ${currentSdkVersion}. Unfortunately, we couldn't detect the proper client version for this SDK.`
         );
       }
@@ -448,7 +448,7 @@ export default function (program: Command) {
             url: recommendedClient.url,
             version: recommendedClient.version,
           });
-          log.log('Done!');
+          Log.log('Done!');
           return;
         }
       } else {
@@ -462,7 +462,7 @@ export default function (program: Command) {
             url: latestClient?.url,
             version: latestClient?.version,
           });
-          log.log('Done!');
+          Log.log('Done!');
           return;
         }
       }
@@ -484,9 +484,9 @@ export default function (program: Command) {
             url: latestClient?.url,
             version: latestClient?.version,
           });
-          log.log('Done!');
+          Log.log('Done!');
         } else {
-          log.log('No client to install');
+          Log.log('No client to install');
         }
         return;
       }
@@ -498,7 +498,7 @@ export default function (program: Command) {
       });
 
       if (await Android.upgradeExpoAsync({ url: targetClient.clientUrl })) {
-        log.log('Done!');
+        Log.log('Done!');
       }
     });
 }

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -196,8 +196,8 @@ export default function (program: Command) {
               return [service.name, service.reason];
             })
           );
-          log(table.toString());
-          log(
+          log.log(table.toString());
+          log.log(
             'See https://docs.expo.io/guides/adhoc-builds/#optional-additional-configuration-steps for more details.'
           );
         }
@@ -215,18 +215,18 @@ export default function (program: Command) {
 
         let addUdid;
         if (udids.length === 0) {
-          log(
+          log.log(
             'There are no devices registered to your Apple Developer account. Please follow the instructions below to register an iOS device.'
           );
           addUdid = true;
         } else {
-          log(
+          log.log(
             'Custom builds of Expo Go can only be installed on devices which have been registered with Apple at build-time.'
           );
-          log('These devices are currently registered on your Apple Developer account:');
+          log.log('These devices are currently registered on your Apple Developer account:');
           const table = new CliTable({ head: ['Name', 'Identifier'], style: { head: ['cyan'] } });
           table.push(...devices.map(device => [device.attributes.name, device.attributes.udid]));
-          log(table.toString());
+          log.log(table.toString());
 
           const udidPrompt = await confirmAsync({
             message: 'Would you like to register a new device to use Expo Go with?',
@@ -250,24 +250,24 @@ export default function (program: Command) {
         log.newLine();
         if (addUdid) {
           urlOpts.printQRCode(result.registrationUrl);
-          log(
+          log.log(
             'Open the following link on your iOS device (or scan the QR code) and follow the instructions to install the development profile:'
           );
           log.newLine();
-          log(chalk.green(`${result.registrationUrl}`));
+          log.log(chalk.green(`${result.registrationUrl}`));
           log.newLine();
-          log('Please note that you can only register one iOS device per request.');
-          log(
+          log.log('Please note that you can only register one iOS device per request.');
+          log.log(
             "After you register your device, we'll start building your client, and you'll receive an email when it's ready to install."
           );
         } else {
           urlOpts.printQRCode(result.statusUrl);
-          log('Your custom Expo client is being built! 🛠');
-          log(
+          log.log('Your custom Expo client is being built! 🛠');
+          log.log(
             'Open this link on your iOS device (or scan the QR code) to view build logs and install the client:'
           );
           log.newLine();
-          log(chalk.green(`${result.statusUrl}`));
+          log.log(chalk.green(`${result.statusUrl}`));
         }
         log.newLine();
       }
@@ -304,7 +304,7 @@ export default function (program: Command) {
         if (
           await Simulator.upgradeExpoAsync({ url: latestClient.url, version: latestClient.version })
         ) {
-          log('Done!');
+          log.log('Done!');
         } else {
           log.error(`Unable to install Expo client ${latestClient.version} for iOS.`);
         }
@@ -312,13 +312,13 @@ export default function (program: Command) {
       }
 
       if (!currentSdkVersion) {
-        log(
+        log.log(
           'Could not find your Expo project. If you run this from a project, we can help pick the right Expo client version!'
         );
       }
 
       if (currentSdk && !recommendedClient) {
-        log(
+        log.log(
           `You are currently using SDK ${currentSdkVersion}. Unfortunately, we couldn't detect the proper client version for this SDK.`
         );
       }
@@ -333,7 +333,7 @@ export default function (program: Command) {
             url: recommendedClient.url,
             version: recommendedClient.version,
           });
-          log('Done!');
+          log.log('Done!');
           return;
         }
       } else {
@@ -347,7 +347,7 @@ export default function (program: Command) {
             url: latestClient?.url,
             version: latestClient?.version,
           });
-          log('Done!');
+          log.log('Done!');
           return;
         }
       }
@@ -369,9 +369,9 @@ export default function (program: Command) {
             url: latestClient?.url,
             version: latestClient?.version,
           });
-          log('Done!');
+          log.log('Done!');
         } else {
-          log('No client to install');
+          log.log('No client to install');
         }
         return;
       }
@@ -383,7 +383,7 @@ export default function (program: Command) {
       });
 
       if (await Simulator.upgradeExpoAsync({ url: targetClient.clientUrl })) {
-        log('Done!');
+        log.log('Done!');
       }
     });
 
@@ -418,7 +418,7 @@ export default function (program: Command) {
         if (
           await Android.upgradeExpoAsync({ url: latestClient.url, version: latestClient.version })
         ) {
-          log('Done!');
+          log.log('Done!');
         } else {
           log.error(`Unable to install Expo client ${latestClient.version} for Android.`);
         }
@@ -427,13 +427,13 @@ export default function (program: Command) {
       }
 
       if (!currentSdkVersion) {
-        log(
+        log.log(
           'Could not find your Expo project. If you run this from a project, we can help pick the right Expo client version!'
         );
       }
 
       if (currentSdk && !recommendedClient) {
-        log(
+        log.log(
           `You are currently using SDK ${currentSdkVersion}. Unfortunately, we couldn't detect the proper client version for this SDK.`
         );
       }
@@ -448,7 +448,7 @@ export default function (program: Command) {
             url: recommendedClient.url,
             version: recommendedClient.version,
           });
-          log('Done!');
+          log.log('Done!');
           return;
         }
       } else {
@@ -462,7 +462,7 @@ export default function (program: Command) {
             url: latestClient?.url,
             version: latestClient?.version,
           });
-          log('Done!');
+          log.log('Done!');
           return;
         }
       }
@@ -484,9 +484,9 @@ export default function (program: Command) {
             url: latestClient?.url,
             version: latestClient?.version,
           });
-          log('Done!');
+          log.log('Done!');
         } else {
-          log('No client to install');
+          log.log('No client to install');
         }
         return;
       }
@@ -498,7 +498,7 @@ export default function (program: Command) {
       });
 
       if (await Android.upgradeExpoAsync({ url: targetClient.clientUrl })) {
-        log('Done!');
+        log.log('Done!');
       }
     });
 }

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -7,7 +7,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import prompts from 'prompts';
 
-import log from '../log';
+import Log from '../log';
 
 type Options = { force: boolean };
 
@@ -22,7 +22,7 @@ async function maybeWarnToCommitAsync(projectRoot: string) {
   }
 
   if (workingTreeStatus === 'dirty') {
-    log.log(
+    Log.log(
       chalk.yellow(
         'You should commit your changes before generating code into the root of your project.'
       )
@@ -63,7 +63,7 @@ async function generateFilesAsync({
       );
 
       if (file in dependencyMap) {
-        const packageManager = PackageManager.createForProject(projectDir, { log });
+        const packageManager = PackageManager.createForProject(projectDir, { log: Log });
         for (const dependency of dependencyMap[file]) {
           promises.push(packageManager.addDevAsync(dependency));
         }
@@ -117,7 +117,7 @@ export async function action(projectDir: string = './', options: Options = { for
   }
 
   if (!values.filter(({ disabled }) => !disabled).length) {
-    log.log(
+    Log.log(
       chalk.yellow('\nAll of the custom web files already exist.') +
         '\nTo regenerate the files run:' +
         chalk.bold(' expo customize:web --force\n')
@@ -139,7 +139,7 @@ export async function action(projectDir: string = './', options: Options = { for
     choices: values,
   });
   if (!answer || answer.length === 0) {
-    log.log('\n\u203A Exiting with no change...\n');
+    Log.log('\n\u203A Exiting with no change...\n');
     return;
   }
   await generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder });

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -22,7 +22,7 @@ async function maybeWarnToCommitAsync(projectRoot: string) {
   }
 
   if (workingTreeStatus === 'dirty') {
-    log(
+    log.log(
       chalk.yellow(
         'You should commit your changes before generating code into the root of your project.'
       )
@@ -117,7 +117,7 @@ export async function action(projectDir: string = './', options: Options = { for
   }
 
   if (!values.filter(({ disabled }) => !disabled).length) {
-    log(
+    log.log(
       chalk.yellow('\nAll of the custom web files already exist.') +
         '\nTo regenerate the files run:' +
         chalk.bold(' expo customize:web --force\n')
@@ -139,7 +139,7 @@ export async function action(projectDir: string = './', options: Options = { for
     choices: values,
   });
   if (!answer || answer.length === 0) {
-    log('\n\u203A Exiting with no change...\n');
+    log.log('\n\u203A Exiting with no change...\n');
     return;
   }
   await generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder });

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -63,7 +63,7 @@ async function generateFilesAsync({
       );
 
       if (file in dependencyMap) {
-        const packageManager = PackageManager.createForProject(projectDir, { log: Log });
+        const packageManager = PackageManager.createForProject(projectDir, { log: Log.log });
         for (const dependency of dependencyMap[file]) {
           promises.push(packageManager.addDevAsync(dependency));
         }

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -2,7 +2,7 @@ import { getDefaultTarget } from '@expo/config';
 import { Command } from 'commander';
 import envinfo from 'envinfo';
 
-import log from '../log';
+import Log from '../log';
 
 const packageJSON = require('../../package.json');
 
@@ -38,7 +38,7 @@ async function actionAsync(projectRoot: string): Promise<void> {
   const lines = info.split('\n');
   lines.pop();
   lines.push(`    Expo Workflow: ${workflow}`);
-  log.log(lines.join('\n') + '\n');
+  Log.log(lines.join('\n') + '\n');
 }
 
 export default function (program: Command) {

--- a/packages/expo-cli/src/commands/diagnostics.ts
+++ b/packages/expo-cli/src/commands/diagnostics.ts
@@ -38,7 +38,7 @@ async function actionAsync(projectRoot: string): Promise<void> {
   const lines = info.split('\n');
   lines.pop();
   lines.push(`    Expo Workflow: ${workflow}`);
-  log(lines.join('\n') + '\n');
+  log.log(lines.join('\n') + '\n');
 }
 
 export default function (program: Command) {

--- a/packages/expo-cli/src/commands/doctor/index.ts
+++ b/packages/expo-cli/src/commands/doctor/index.ts
@@ -11,7 +11,7 @@ async function action(projectDir: string) {
   await Doctor.validateExpoServersAsync(projectDir);
 
   if ((await Doctor.validateWithNetworkAsync(projectDir)) === Doctor.NO_ISSUES) {
-    log(`Didn't find any issues with the project!`);
+    log.log(`Didn't find any issues with the project!`);
   }
 }
 

--- a/packages/expo-cli/src/commands/doctor/index.ts
+++ b/packages/expo-cli/src/commands/doctor/index.ts
@@ -1,7 +1,7 @@
 import { Doctor } from '@expo/xdl';
 import { Command } from 'commander';
 
-import log from '../../log';
+import Log from '../../log';
 import { warnUponCmdExe } from './windows';
 
 async function action(projectDir: string) {
@@ -11,7 +11,7 @@ async function action(projectDir: string) {
   await Doctor.validateExpoServersAsync(projectDir);
 
   if ((await Doctor.validateWithNetworkAsync(projectDir)) === Doctor.NO_ISSUES) {
-    log.log(`Didn't find any issues with the project!`);
+    Log.log(`Didn't find any issues with the project!`);
   }
 }
 

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 
 import CommandError from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import { confirmAsync } from '../prompts';
 import * as Eject from './eject/Eject';
 import { platformsFromPlatform } from './eject/platformOptions';
@@ -42,7 +42,7 @@ export async function actionAsync(
       );
     }
   } else {
-    log.debug('Eject Mode: Latest');
+    Log.debug('Eject Mode: Latest');
     await Eject.ejectAsync(projectDir, {
       ...options,
       platforms: platformsFromPlatform(platform),

--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -3,7 +3,7 @@ import { UserManager } from '@expo/xdl';
 import got from 'got';
 
 import CommandError, { SilentError } from '../../CommandError';
-import log from '../../log';
+import Log from '../../log';
 import prompt, { confirmAsync } from '../../prompts';
 import { learnMore } from '../utils/TerminalLink';
 import { isUrlAvailableAsync } from '../utils/url';
@@ -72,9 +72,9 @@ async function getPackageNameWarningAsync(packageName: string): Promise<string |
     if (response.statusCode === 200) {
       // There is no JSON API for the Play Store so we can't concisely
       // locate the app name and developer to match the iOS warning.
-      const message = `⚠️  The package ${log.chalk.bold(
+      const message = `⚠️  The package ${Log.chalk.bold(
         packageName
-      )} is already in use. ${log.chalk.dim(learnMore(url))}`;
+      )} is already in use. ${Log.chalk.dim(learnMore(url))}`;
       cachedPackageNameResults[packageName] = message;
       return message;
     }
@@ -85,9 +85,9 @@ async function getPackageNameWarningAsync(packageName: string): Promise<string |
 }
 
 function formatInUseWarning(appName: string, author: string, id: string): string {
-  return `⚠️  The app ${log.chalk.bold(appName)} by ${log.chalk.italic(
+  return `⚠️  The app ${Log.chalk.bold(appName)} by ${Log.chalk.italic(
     author
-  )} is already using ${log.chalk.bold(id)}`;
+  )} is already using ${Log.chalk.bold(id)}`;
 }
 
 export async function getOrPromptForBundleIdentifier(projectRoot: string): Promise<string> {
@@ -116,13 +116,13 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
     }
   }
 
-  log.addNewLineIfNone();
-  log.log(
-    `${log.chalk.bold(`📝  iOS Bundle Identifier`)} ${log.chalk.dim(
+  Log.addNewLineIfNone();
+  Log.log(
+    `${Log.chalk.bold(`📝  iOS Bundle Identifier`)} ${Log.chalk.dim(
       learnMore('https://expo.fyi/bundle-identifier')
     )}`
   );
-  log.newLine();
+  Log.newLine();
   // Prompt the user for the bundle ID.
   // Even if the project is using a dynamic config we can still
   // prompt a better error message, recommend a default value, and help the user
@@ -144,16 +144,16 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
   // Warn the user if the bundle ID is already in use.
   const warning = await getBundleIdWarningAsync(bundleIdentifier);
   if (warning) {
-    log.newLine();
-    log.nestedWarn(warning);
-    log.newLine();
+    Log.newLine();
+    Log.nestedWarn(warning);
+    Log.newLine();
     if (
       !(await confirmAsync({
         message: `Continue?`,
         initial: true,
       }))
     ) {
-      log.newLine();
+      Log.newLine();
       return getOrPromptForBundleIdentifier(projectRoot);
     }
   }
@@ -197,13 +197,13 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
     }
   }
 
-  log.addNewLineIfNone();
-  log.log(
-    `${log.chalk.bold(`📝  Android package`)} ${log.chalk.dim(
+  Log.addNewLineIfNone();
+  Log.log(
+    `${Log.chalk.bold(`📝  Android package`)} ${Log.chalk.dim(
       learnMore('https://expo.fyi/android-package')
     )}`
   );
-  log.newLine();
+  Log.newLine();
 
   // Prompt the user for the android package.
   // Even if the project is using a dynamic config we can still
@@ -225,16 +225,16 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
   // Warn the user if the package name is already in use.
   const warning = await getPackageNameWarningAsync(packageName);
   if (warning) {
-    log.newLine();
-    log.nestedWarn(warning);
-    log.newLine();
+    Log.newLine();
+    Log.nestedWarn(warning);
+    Log.newLine();
     if (
       !(await confirmAsync({
         message: `Continue?`,
         initial: true,
       }))
     ) {
-      log.newLine();
+      Log.newLine();
       return getOrPromptForPackage(projectRoot);
     }
   }
@@ -262,25 +262,25 @@ async function attemptModification(
     skipSDKVersionRequirement: true,
   });
   if (modification.type === 'success') {
-    log.newLine();
+    Log.newLine();
   } else {
     warnAboutConfigAndThrow(modification.type, modification.message!, exactEdits);
   }
 }
 
 function logNoConfig() {
-  log.log(
-    log.chalk.yellow(
+  Log.log(
+    Log.chalk.yellow(
       'No Expo config was found. Please create an Expo config (`app.config.js` or `app.json`) in your project root.'
     )
   );
 }
 
 function warnAboutConfigAndThrow(type: string, message: string, edits: Partial<ExpoConfig>) {
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
   if (type === 'warn') {
     // The project is using a dynamic config, give the user a helpful log and bail out.
-    log.log(log.chalk.yellow(message));
+    Log.log(Log.chalk.yellow(message));
   } else {
     logNoConfig();
   }
@@ -290,8 +290,8 @@ function warnAboutConfigAndThrow(type: string, message: string, edits: Partial<E
 }
 
 function notifyAboutManualConfigEdits(edits: Partial<ExpoConfig>) {
-  log.log(log.chalk.cyan(`Please add the following to your Expo config, and try again... `));
-  log.newLine();
-  log.log(JSON.stringify(edits, null, 2));
-  log.newLine();
+  Log.log(Log.chalk.cyan(`Please add the following to your Expo config, and try again... `));
+  Log.newLine();
+  Log.log(JSON.stringify(edits, null, 2));
+  Log.newLine();
 }

--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -117,7 +117,7 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
   }
 
   log.addNewLineIfNone();
-  log(
+  log.log(
     `${log.chalk.bold(`📝  iOS Bundle Identifier`)} ${log.chalk.dim(
       learnMore('https://expo.fyi/bundle-identifier')
     )}`
@@ -198,7 +198,7 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
   }
 
   log.addNewLineIfNone();
-  log(
+  log.log(
     `${log.chalk.bold(`📝  Android package`)} ${log.chalk.dim(
       learnMore('https://expo.fyi/android-package')
     )}`
@@ -269,7 +269,7 @@ async function attemptModification(
 }
 
 function logNoConfig() {
-  log(
+  log.log(
     log.chalk.yellow(
       'No Expo config was found. Please create an Expo config (`app.config.js` or `app.json`) in your project root.'
     )
@@ -280,7 +280,7 @@ function warnAboutConfigAndThrow(type: string, message: string, edits: Partial<E
   log.addNewLineIfNone();
   if (type === 'warn') {
     // The project is using a dynamic config, give the user a helpful log and bail out.
-    log(log.chalk.yellow(message));
+    log.log(log.chalk.yellow(message));
   } else {
     logNoConfig();
   }
@@ -290,8 +290,8 @@ function warnAboutConfigAndThrow(type: string, message: string, edits: Partial<E
 }
 
 function notifyAboutManualConfigEdits(edits: Partial<ExpoConfig>) {
-  log(log.chalk.cyan(`Please add the following to your Expo config, and try again... `));
+  log.log(log.chalk.cyan(`Please add the following to your Expo config, and try again... `));
   log.newLine();
-  log(JSON.stringify(edits, null, 2));
+  log.log(JSON.stringify(edits, null, 2));
   log.newLine();
 }

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -371,7 +371,7 @@ async function ensureConfigAsync({
 
   if (exp.entryPoint) {
     delete exp.entryPoint;
-    log(`\u203A expo.entryPoint is not needed and has been removed.`);
+    log.log(`\u203A expo.entryPoint is not needed and has been removed.`);
   }
 
   // Read config again because prompting for bundle id or package name may have mutated the results.
@@ -597,7 +597,7 @@ async function updatePackageJSONAsync({
     'Updated package.json and added index.js entry point for iOS and Android.'
   );
   if (removedPkgMain) {
-    log(
+    log.log(
       `\u203A Removed ${chalk.bold(
         `"main": "${removedPkgMain}"`
       )} from package.json because we recommend using index.js as main instead.`
@@ -712,7 +712,7 @@ async function cloneNativeDirectoriesAsync({
     creatingNativeProjectStep.fail(
       'Failed to create the native project - see the output above for more information.'
     );
-    log(
+    log.log(
       chalk.yellow(
         'You may want to delete the `./ios` and/or `./android` directories before running eject again.'
       )

--- a/packages/expo-cli/src/commands/eject/Eject.ts
+++ b/packages/expo-cli/src/commands/eject/Eject.ts
@@ -13,7 +13,7 @@ import temporary from 'tempy';
 import terminalLink from 'terminal-link';
 
 import CommandError, { SilentError } from '../../CommandError';
-import log from '../../log';
+import Log from '../../log';
 import { extractTemplateAppAsync } from '../../utils/extractTemplateAppAsync';
 import configureProjectAsync, { expoManagedPlugins } from '../apply/configureProjectAsync';
 import * as CreateApp from '../utils/CreateApp';
@@ -83,12 +83,12 @@ export function ensureValidPlatforms(platforms: ModPlatform[]): ModPlatform[] {
   const isWindows = process.platform === 'win32';
   // Skip ejecting for iOS on Windows
   if (isWindows && platforms.includes('ios')) {
-    log.warn(
+    Log.warn(
       `⚠️  Skipping generating the iOS native project files. Run ${chalk.bold(
         'expo eject'
       )} again from macOS or Linux to generate the iOS project.`
     );
-    log.newLine();
+    Log.newLine();
     return platforms.filter(platform => platform !== 'ios');
   }
   return platforms;
@@ -164,7 +164,7 @@ export async function prebuildAsync(
   if (platforms.includes('ios') && shouldInstall && needsPodInstall) {
     podsInstalled = await CreateApp.installCocoaPodsAsync(projectRoot);
   } else {
-    log.debug('Skipped pod install');
+    Log.debug('Skipped pod install');
   }
 
   await warnIfDependenciesRequireAdditionalSetupAsync(
@@ -193,11 +193,11 @@ export function logNextSteps({
   nodeInstall,
   packageManager,
 }: PrebuildResults) {
-  log.newLine();
-  log.nested(`➡️  ${chalk.bold('Next steps')}`);
+  Log.newLine();
+  Log.nested(`➡️  ${chalk.bold('Next steps')}`);
 
   if (WarningAggregator.hasWarningsIOS() || WarningAggregator.hasWarningsAndroid()) {
-    log.nested(
+    Log.nested(
       `\u203A 👆 Review the logs above and look for any warnings (⚠️ ) that might need follow-up.`
     );
   }
@@ -205,38 +205,38 @@ export function logNextSteps({
   // Log a warning about needing to install node modules
   if (nodeInstall) {
     const installCmd = packageManager === 'npm' ? 'npm install' : 'yarn';
-    log.nested(`\u203A ⚠️  Install node modules: ${log.chalk.bold(installCmd)}`);
+    Log.nested(`\u203A ⚠️  Install node modules: ${Log.chalk.bold(installCmd)}`);
   }
   if (podInstall) {
-    log.nested(
+    Log.nested(
       `\u203A 🍫 When CocoaPods is installed, initialize the project workspace: ${chalk.bold(
         'npx pod-install'
       )}`
     );
   }
-  log.nested(
+  Log.nested(
     `\u203A 💡 You may want to run ${chalk.bold(
       'npx @react-native-community/cli doctor'
     )} to help install any tools that your app may need to run your native projects.`
   );
-  log.nested(
+  Log.nested(
     `\u203A 🔑 Download your Android keystore (if you're not sure if you need to, just run the command and see): ${chalk.bold(
       'expo fetch:android:keystore'
     )}`
   );
 
   if (hasAssetBundlePatterns) {
-    log.nested(
+    Log.nested(
       `\u203A 📁 The property ${chalk.bold(
         `assetBundlePatterns`
-      )} does not have the same effect in the bare workflow.\n  ${log.chalk.dim(
+      )} does not have the same effect in the bare workflow.\n  ${Log.chalk.dim(
         learnMore('https://docs.expo.io/bare/updating-your-app/#embedding-assets')
       )}`
     );
   }
 
   if (legacyUpdates) {
-    log.nested(
+    Log.nested(
       `\u203A 🚀 ${
         (terminalLink(
           'expo-updates',
@@ -247,28 +247,28 @@ export function logNextSteps({
         })
       } has been configured in your project. Before you do a release build, make sure you run ${chalk.bold(
         'expo publish'
-      )}. ${log.chalk.dim(learnMore('https://expo.fyi/release-builds-with-expo-updates'))}`
+      )}. ${Log.chalk.dim(learnMore('https://expo.fyi/release-builds-with-expo-updates'))}`
     );
   }
 
   if (hasNewProjectFiles) {
-    log.newLine();
-    log.nested(`☑️  ${chalk.bold('When you are ready to run your project')}`);
-    log.nested(
+    Log.newLine();
+    Log.nested(`☑️  ${chalk.bold('When you are ready to run your project')}`);
+    Log.nested(
       'To compile and run your project in development, execute one of the following commands:'
     );
 
     if (platforms.includes('ios')) {
-      log.nested(`\u203A ${chalk.bold(packageManager === 'npm' ? 'npm run ios' : 'yarn ios')}`);
+      Log.nested(`\u203A ${chalk.bold(packageManager === 'npm' ? 'npm run ios' : 'yarn ios')}`);
     }
 
     if (platforms.includes('android')) {
-      log.nested(
+      Log.nested(
         `\u203A ${chalk.bold(packageManager === 'npm' ? 'npm run android' : 'yarn android')}`
       );
     }
 
-    log.nested(`\u203A ${chalk.bold(packageManager === 'npm' ? 'npm run web' : 'yarn web')}`);
+    Log.nested(`\u203A ${chalk.bold(packageManager === 'npm' ? 'npm run web' : 'yarn web')}`);
   }
 }
 
@@ -356,7 +356,7 @@ async function ensureConfigAsync({
     }
   } catch (error) {
     // TODO(Bacon): Currently this is already handled in the command
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     throw new CommandError(`${error.message}\n`);
   }
 
@@ -371,7 +371,7 @@ async function ensureConfigAsync({
 
   if (exp.entryPoint) {
     delete exp.entryPoint;
-    log.log(`\u203A expo.entryPoint is not needed and has been removed.`);
+    Log.log(`\u203A expo.entryPoint is not needed and has been removed.`);
   }
 
   // Read config again because prompting for bundle id or package name may have mutated the results.
@@ -430,15 +430,15 @@ function writeMetroConfig({
       symbol: '⚠️ ',
       text: chalk.yellow('Metro bundler configuration not applied:'),
     });
-    log.nested(`\u203A ${e.message}`);
-    log.nested(
+    Log.nested(`\u203A ${e.message}`);
+    Log.nested(
       `\u203A You will need to add the ${chalk.bold(
         'hashAssetFiles'
-      )} plugin to your Metro configuration.\n  ${log.chalk.dim(
+      )} plugin to your Metro configuration.\n  ${Log.chalk.dim(
         learnMore('https://docs.expo.io/bare/installing-updates/')
       )}`
     );
-    log.newLine();
+    Log.newLine();
   }
 }
 
@@ -597,12 +597,12 @@ async function updatePackageJSONAsync({
     'Updated package.json and added index.js entry point for iOS and Android.'
   );
   if (removedPkgMain) {
-    log.log(
+    Log.log(
       `\u203A Removed ${chalk.bold(
         `"main": "${removedPkgMain}"`
       )} from package.json because we recommend using index.js as main instead.`
     );
-    log.newLine();
+    Log.newLine();
   }
 
   return results;
@@ -697,22 +697,22 @@ async function cloneNativeDirectoriesAsync({
     let message = `Created native project${platforms.length > 1 ? 's' : ''}`;
 
     if (skippedPaths.length) {
-      message += log.chalk.dim(
-        ` | ${skippedPaths.map(path => log.chalk.bold(`/${path}`)).join(', ')} already created`
+      message += Log.chalk.dim(
+        ` | ${skippedPaths.map(path => Log.chalk.bold(`/${path}`)).join(', ')} already created`
       );
     }
     if (!results?.didMerge) {
-      message += log.chalk.dim(` | gitignore already synced`);
+      message += Log.chalk.dim(` | gitignore already synced`);
     } else if (results.didMerge && results.didClear) {
-      message += log.chalk.dim(` | synced gitignore`);
+      message += Log.chalk.dim(` | synced gitignore`);
     }
     creatingNativeProjectStep.succeed(message);
   } catch (e) {
-    log.error(e.message);
+    Log.error(e.message);
     creatingNativeProjectStep.fail(
       'Failed to create the native project - see the output above for more information.'
     );
-    log.log(
+    Log.log(
       chalk.yellow(
         'You may want to delete the `./ios` and/or `./android` directories before running eject again.'
       )
@@ -826,7 +826,7 @@ async function warnIfDependenciesRequireAdditionalSetupAsync(
       'Constants.manifest'
     )} is not available in the bare workflow. You should replace it with ${chalk.bold(
       'Updates.manifest'
-    )}. ${log.chalk.dim(
+    )}. ${Log.chalk.dim(
       learnMore('https://docs.expo.io/versions/latest/sdk/updates/#updatesmanifest')
     )}`;
   }
@@ -839,7 +839,7 @@ async function warnIfDependenciesRequireAdditionalSetupAsync(
     return;
   }
 
-  log.newLine();
+  Log.newLine();
   const warnAdditionalSetupStep = CreateApp.logNewSection(
     'Checking if any additional setup steps are required for installed SDK packages.'
   );
@@ -856,7 +856,7 @@ async function warnIfDependenciesRequireAdditionalSetupAsync(
   });
 
   packagesToWarn.forEach(pkgName => {
-    log.nested(`\u203A ${chalk.bold(pkgName)}: ${pkgsWithExtraSetup[pkgName]}`);
+    Log.nested(`\u203A ${chalk.bold(pkgName)}: ${pkgsWithExtraSetup[pkgName]}`);
   });
 }
 

--- a/packages/expo-cli/src/commands/eject/platformOptions.ts
+++ b/packages/expo-cli/src/commands/eject/platformOptions.ts
@@ -1,7 +1,7 @@
 import { ModPlatform } from '@expo/config-plugins';
 
 import CommandError from '../../CommandError';
-import log from '../../log';
+import Log from '../../log';
 
 function getDefaultPlatforms(): ModPlatform[] {
   const platforms: ModPlatform[] = ['android'];
@@ -18,7 +18,7 @@ export function platformsFromPlatform(platform?: string): ModPlatform[] {
   switch (platform) {
     case 'ios':
       if (process.platform === 'win32') {
-        log.warn('Ejecting is unsupported locally on windows, use eas build instead');
+        Log.warn('Ejecting is unsupported locally on windows, use eas build instead');
         // continue anyways :shrug:
       }
       return ['ios'];

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -6,7 +6,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import CommandError, { SilentError } from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import prompt from '../prompts';
 import * as CreateApp from './utils/CreateApp';
 import { downloadAndDecompressAsync } from './utils/Tar';
@@ -54,7 +54,7 @@ export async function ensurePublicUrlAsync(url: any, isDev?: boolean): Promise<s
   if (!isDev && !UrlUtils.isHttps(url)) {
     throw new CommandError('INVALID_PUBLIC_URL', '--public-url must be a valid HTTPS URL.');
   } else if (!UrlUtils.isURL(url, { protocols: ['http', 'https'] })) {
-    log.nestedWarn(
+    Log.nestedWarn(
       `Dev Mode: --public-url ${url} does not conform to the required HTTP(S) protocol.`
     );
   }
@@ -107,7 +107,7 @@ async function mergeSourceDirectoriresAsync(
     return;
   }
   const srcDirs = options.mergeSrcDir.concat(options.mergeSrcUrl).join(' ');
-  log.nested(`Starting project merge of ${srcDirs} into ${options.outputDir}`);
+  Log.nested(`Starting project merge of ${srcDirs} into ${options.outputDir}`);
 
   // Merge app distributions
   await Project.mergeAppDistributions(
@@ -115,7 +115,7 @@ async function mergeSourceDirectoriresAsync(
     [...mergeSrcDirs, options.outputDir], // merge stuff in srcDirs and outputDir together
     options.outputDir
   );
-  log.nested(
+  Log.nested(
     `Project merge was successful. Your merged files can be found in ${options.outputDir}`
   );
 }
@@ -178,12 +178,12 @@ export async function action(projectDir: string, options: Options) {
       overwrite: options.force,
     }))
   ) {
-    const message = `Try using a new directory name with ${log.chalk.bold(
+    const message = `Try using a new directory name with ${Log.chalk.bold(
       '--output-dir'
-    )}, moving these files, or using ${log.chalk.bold('--force')} to overwrite them.`;
-    log.newLine();
-    log.nested(message);
-    log.newLine();
+    )}, moving these files, or using ${Log.chalk.bold('--force')} to overwrite them.`;
+    Log.newLine();
+    Log.nested(message);
+    Log.newLine();
     throw new SilentError(message);
   }
 
@@ -197,7 +197,7 @@ export async function action(projectDir: string, options: Options) {
 
   await mergeSourceDirectoriresAsync(projectDir, mergeSrcDirs, options);
 
-  log.log(`Export was successful. Your exported files can be found in ${options.outputDir}`);
+  Log.log(`Export was successful. Your exported files can be found in ${options.outputDir}`);
 }
 
 export default function (program: Command) {

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -197,7 +197,7 @@ export async function action(projectDir: string, options: Options) {
 
   await mergeSourceDirectoriresAsync(projectDir, mergeSrcDirs, options);
 
-  log(`Export was successful. Your exported files can be found in ${options.outputDir}`);
+  log.log(`Export was successful. Your exported files can be found in ${options.outputDir}`);
 }
 
 export default function (program: Command) {

--- a/packages/expo-cli/src/commands/fetch/android.ts
+++ b/packages/expo-cli/src/commands/fetch/android.ts
@@ -27,7 +27,7 @@ async function maybeRenameExistingFileAsync(projectRoot: string, filename: strin
     while (await fs.pathExists(path.resolve(projectRoot, `OLD_${num}_${filename}`))) {
       num++;
     }
-    log(
+    log.log(
       `\nA file already exists at "${desiredFilePath}"\n  Renaming the existing file to OLD_${num}_${filename}\n`
     );
     await fs.rename(desiredFilePath, path.resolve(projectRoot, `OLD_${num}_${filename}`));
@@ -84,7 +84,7 @@ export async function fetchAndroidHashesAsync(
         keyAlias: keystore.keyAlias,
         keyPassword: keystore.keyPassword,
       });
-      log(
+      log.log(
         `\nNote: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console.`
       );
     } else {
@@ -121,7 +121,7 @@ export async function fetchAndroidUploadCertAsync(
     const keystore = await ctx.android.fetchKeystore(experienceName);
 
     if (keystore) {
-      log(`Writing upload key to ${uploadKeyPath}`);
+      log.log(`Writing upload key to ${uploadKeyPath}`);
       await AndroidCredentials.exportCertBase64(
         {
           keystorePath,

--- a/packages/expo-cli/src/commands/fetch/android.ts
+++ b/packages/expo-cli/src/commands/fetch/android.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { Context } from '../../credentials';
 import { runCredentialsManager } from '../../credentials/route';
 import { DownloadKeystore } from '../../credentials/views/AndroidKeystore';
-import log from '../../log';
+import Log from '../../log';
 
 type Options = {
   parent?: {
@@ -27,7 +27,7 @@ async function maybeRenameExistingFileAsync(projectRoot: string, filename: strin
     while (await fs.pathExists(path.resolve(projectRoot, `OLD_${num}_${filename}`))) {
       num++;
     }
-    log.log(
+    Log.log(
       `\nA file already exists at "${desiredFilePath}"\n  Renaming the existing file to OLD_${num}_${filename}\n`
     );
     await fs.rename(desiredFilePath, path.resolve(projectRoot, `OLD_${num}_${filename}`));
@@ -84,11 +84,11 @@ export async function fetchAndroidHashesAsync(
         keyAlias: keystore.keyAlias,
         keyPassword: keystore.keyPassword,
       });
-      log.log(
+      Log.log(
         `\nNote: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console.`
       );
     } else {
-      log.warn('There is no valid Keystore defined for this app');
+      Log.warn('There is no valid Keystore defined for this app');
     }
   } finally {
     await fs.remove(outputPath);
@@ -121,7 +121,7 @@ export async function fetchAndroidUploadCertAsync(
     const keystore = await ctx.android.fetchKeystore(experienceName);
 
     if (keystore) {
-      log.log(`Writing upload key to ${uploadKeyPath}`);
+      Log.log(`Writing upload key to ${uploadKeyPath}`);
       await AndroidCredentials.exportCertBase64(
         {
           keystorePath,
@@ -131,7 +131,7 @@ export async function fetchAndroidUploadCertAsync(
         uploadKeyPath
       );
     } else {
-      log.warn('There is no valid Keystore defined for this app');
+      Log.warn('There is no valid Keystore defined for this app');
     }
   } finally {
     await fs.remove(keystorePath);

--- a/packages/expo-cli/src/commands/fetch/ios.ts
+++ b/packages/expo-cli/src/commands/fetch/ios.ts
@@ -21,7 +21,7 @@ async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
       projectName: ctx.manifest.slug,
       bundleIdentifier,
     };
-    log(
+    log.log(
       `Retrieving iOS credentials for @${app.accountName}/${app.projectName} (${bundleIdentifier})`
     );
     const appCredentials = await ctx.ios.getAppCredentials(app);
@@ -34,7 +34,7 @@ async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
       appCredentials?.credentials ?? {};
 
     if (teamId !== undefined) {
-      log(`These credentials are associated with Apple Team ID: ${teamId}`);
+      log.log(`These credentials are associated with Apple Team ID: ${teamId}`);
     }
     if (certP12) {
       const distPath = inProjectDir(`${app.projectName}_dist.p12`);
@@ -45,19 +45,19 @@ async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
       await fs.writeFile(distPrivateKeyPath, certPrivateSigningKey);
     }
     if (certP12 || certPrivateSigningKey) {
-      log('Wrote distribution cert credentials to disk.');
+      log.log('Wrote distribution cert credentials to disk.');
     }
     if (apnsKeyP8) {
       const apnsKeyP8Path = inProjectDir(`${app.projectName}_apns_key.p8`);
       await fs.writeFile(apnsKeyP8Path, apnsKeyP8);
-      log('Wrote push key credentials to disk.');
+      log.log('Wrote push key credentials to disk.');
     }
     if (pushP12) {
       const pushPath = inProjectDir(`${app.projectName}_push.p12`);
       await fs.writeFile(pushPath, Buffer.from(pushP12, 'base64'));
     }
     if (pushP12) {
-      log('Wrote push cert credentials to disk.');
+      log.log('Wrote push cert credentials to disk.');
     }
     if (provisioningProfile) {
       const provisioningProfilePath = path.resolve(
@@ -65,9 +65,9 @@ async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
         `${app.projectName}.mobileprovision`
       );
       await fs.writeFile(provisioningProfilePath, Buffer.from(provisioningProfile, 'base64'));
-      log('Wrote provisioning profile to disk');
+      log.log('Wrote provisioning profile to disk');
     }
-    log(`Save these important values as well:
+    log.log(`Save these important values as well:
 
 Distribution P12 password: ${
       certPassword ? chalk.bold(certPassword) : chalk.yellow('(not available)')
@@ -83,7 +83,7 @@ Push P12 password:         ${
     );
   }
 
-  log('All done!');
+  log.log('All done!');
 }
 
 export default fetchIosCertsAsync;

--- a/packages/expo-cli/src/commands/fetch/ios.ts
+++ b/packages/expo-cli/src/commands/fetch/ios.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import CommandError from '../../CommandError';
 import { Context } from '../../credentials/context';
-import log from '../../log';
+import Log from '../../log';
 import { getOrPromptForBundleIdentifier } from '../eject/ConfigValidation';
 
 async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
@@ -21,7 +21,7 @@ async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
       projectName: ctx.manifest.slug,
       bundleIdentifier,
     };
-    log.log(
+    Log.log(
       `Retrieving iOS credentials for @${app.accountName}/${app.projectName} (${bundleIdentifier})`
     );
     const appCredentials = await ctx.ios.getAppCredentials(app);
@@ -34,7 +34,7 @@ async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
       appCredentials?.credentials ?? {};
 
     if (teamId !== undefined) {
-      log.log(`These credentials are associated with Apple Team ID: ${teamId}`);
+      Log.log(`These credentials are associated with Apple Team ID: ${teamId}`);
     }
     if (certP12) {
       const distPath = inProjectDir(`${app.projectName}_dist.p12`);
@@ -45,19 +45,19 @@ async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
       await fs.writeFile(distPrivateKeyPath, certPrivateSigningKey);
     }
     if (certP12 || certPrivateSigningKey) {
-      log.log('Wrote distribution cert credentials to disk.');
+      Log.log('Wrote distribution cert credentials to disk.');
     }
     if (apnsKeyP8) {
       const apnsKeyP8Path = inProjectDir(`${app.projectName}_apns_key.p8`);
       await fs.writeFile(apnsKeyP8Path, apnsKeyP8);
-      log.log('Wrote push key credentials to disk.');
+      Log.log('Wrote push key credentials to disk.');
     }
     if (pushP12) {
       const pushPath = inProjectDir(`${app.projectName}_push.p12`);
       await fs.writeFile(pushPath, Buffer.from(pushP12, 'base64'));
     }
     if (pushP12) {
-      log.log('Wrote push cert credentials to disk.');
+      Log.log('Wrote push cert credentials to disk.');
     }
     if (provisioningProfile) {
       const provisioningProfilePath = path.resolve(
@@ -65,9 +65,9 @@ async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
         `${app.projectName}.mobileprovision`
       );
       await fs.writeFile(provisioningProfilePath, Buffer.from(provisioningProfile, 'base64'));
-      log.log('Wrote provisioning profile to disk');
+      Log.log('Wrote provisioning profile to disk');
     }
-    log.log(`Save these important values as well:
+    Log.log(`Save these important values as well:
 
 Distribution P12 password: ${
       certPassword ? chalk.bold(certPassword) : chalk.yellow('(not available)')
@@ -83,7 +83,7 @@ Push P12 password:         ${
     );
   }
 
-  log.log('All done!');
+  Log.log('All done!');
 }
 
 export default fetchIosCertsAsync;

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -366,7 +366,7 @@ export async function initGitRepoAsync(
     await spawnAsync('git', ['rev-parse', '--is-inside-work-tree'], {
       cwd: root,
     });
-    !flags.silent && log('New project is already inside of a git repo, skipping git init.');
+    !flags.silent && log.log('New project is already inside of a git repo, skipping git init.');
   } catch (e) {
     if (e.errno === 'ENOENT') {
       !flags.silent && log.warn('Unable to initialize git repo. `git` not in PATH.');
@@ -377,7 +377,7 @@ export async function initGitRepoAsync(
   // not in git tree, so let's init
   try {
     await spawnAsync('git', ['init'], { cwd: root });
-    !flags.silent && log('Initialized a git repository.');
+    !flags.silent && log.log('Initialized a git repository.');
 
     if (flags.commit) {
       await spawnAsync('git', ['add', '--all'], { cwd: root, stdio: 'ignore' });

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -13,7 +13,7 @@ import stripAnsi from 'strip-ansi';
 import terminalLink from 'terminal-link';
 
 import CommandError, { SilentError } from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import prompts, { selectAsync } from '../prompts';
 import { extractAndPrepareTemplateAppAsync } from '../utils/extractTemplateAppAsync';
 import * as CreateApp from './utils/CreateApp';
@@ -86,9 +86,9 @@ function parseOptions(command: Command): Options {
 async function assertFolderEmptyAsync(projectRoot: string, folderName?: string) {
   if (!(await CreateApp.assertFolderEmptyAsync({ projectRoot, folderName, overwrite: false }))) {
     const message = 'Try using a new directory name, or moving these files.';
-    log.newLine();
-    log.nested(message);
-    log.newLine();
+    Log.newLine();
+    Log.nested(message);
+    Log.newLine();
     throw new SilentError(message);
   }
 }
@@ -132,12 +132,12 @@ async function resolveProjectRootAsync(input?: string): Promise<string> {
     const message = [
       '',
       'Please choose your app name:',
-      `  ${log.chalk.green(`${program.name()} init`)} ${log.chalk.cyan('<app-name>')}`,
+      `  ${Log.chalk.green(`${program.name()} init`)} ${Log.chalk.cyan('<app-name>')}`,
       '',
-      `Run ${log.chalk.green(`${program.name()} init --help`)} for more info`,
+      `Run ${Log.chalk.green(`${program.name()} init --help`)} for more info`,
       '',
     ].join('\n');
-    log.nested(message);
+    Log.nested(message);
     throw new SilentError(message);
   }
 
@@ -313,7 +313,7 @@ async function action(projectDir: string, command: Command) {
 
   // Log info
 
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
   await logProjectReadyAsync({
     cdPath,
     packageManager,
@@ -366,10 +366,10 @@ export async function initGitRepoAsync(
     await spawnAsync('git', ['rev-parse', '--is-inside-work-tree'], {
       cwd: root,
     });
-    !flags.silent && log.log('New project is already inside of a git repo, skipping git init.');
+    !flags.silent && Log.log('New project is already inside of a git repo, skipping git init.');
   } catch (e) {
     if (e.errno === 'ENOENT') {
-      !flags.silent && log.warn('Unable to initialize git repo. `git` not in PATH.');
+      !flags.silent && Log.warn('Unable to initialize git repo. `git` not in PATH.');
       return false;
     }
   }
@@ -377,7 +377,7 @@ export async function initGitRepoAsync(
   // not in git tree, so let's init
   try {
     await spawnAsync('git', ['init'], { cwd: root });
-    !flags.silent && log.log('Initialized a git repository.');
+    !flags.silent && Log.log('Initialized a git repository.');
 
     if (flags.commit) {
       await spawnAsync('git', ['add', '--all'], { cwd: root, stdio: 'ignore' });
@@ -395,15 +395,15 @@ export async function initGitRepoAsync(
 
 // TODO: Use in eject
 function logNodeInstallWarning(cdPath: string, packageManager: 'yarn' | 'npm'): void {
-  log.newLine();
-  log.nested(`⚠️  Before running your app, make sure you have node modules installed:`);
-  log.nested('');
+  Log.newLine();
+  Log.nested(`⚠️  Before running your app, make sure you have node modules installed:`);
+  Log.nested('');
   if (cdPath) {
     // In the case of --yes the project can be created in place so there would be no need to change directories.
-    log.nested(`  cd ${cdPath}/`);
+    Log.nested(`  cd ${cdPath}/`);
   }
-  log.nested(`  ${packageManager === 'npm' ? 'npm install' : 'yarn'}`);
-  log.nested('');
+  Log.nested(`  ${packageManager === 'npm' ? 'npm install' : 'yarn'}`);
+  Log.nested('');
 }
 
 // TODO: Use in eject
@@ -411,17 +411,17 @@ function logCocoaPodsWarning(cdPath: string): void {
   if (process.platform !== 'darwin') {
     return;
   }
-  log.newLine();
-  log.nested(
+  Log.newLine();
+  Log.nested(
     `⚠️  Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:`
   );
-  log.nested('');
+  Log.nested('');
   if (cdPath) {
     // In the case of --yes the project can be created in place so there would be no need to change directories.
-    log.nested(`  cd ${cdPath}/`);
+    Log.nested(`  cd ${cdPath}/`);
   }
-  log.nested(`  npx pod-install`);
-  log.nested('');
+  Log.nested(`  npx pod-install`);
+  Log.nested('');
 }
 
 // TODO: Use in eject
@@ -440,29 +440,29 @@ function logProjectReadyAsync({
   didConfigureUpdatesProjectFiles?: boolean;
   username?: string | null;
 }) {
-  log.nested(chalk.bold(`✅ Your project is ready!`));
-  log.newLine();
+  Log.nested(chalk.bold(`✅ Your project is ready!`));
+  Log.newLine();
 
   // empty string if project was created in current directory
   if (cdPath) {
-    log.nested(
+    Log.nested(
       `To run your project, navigate to the directory and run one of the following ${packageManager} commands.`
     );
-    log.newLine();
-    log.nested(`- ${chalk.bold('cd ' + cdPath)}`);
+    Log.newLine();
+    Log.nested(`- ${chalk.bold('cd ' + cdPath)}`);
   } else {
-    log.nested(`To run your project, run one of the following ${packageManager} commands.`);
-    log.newLine();
+    Log.nested(`To run your project, run one of the following ${packageManager} commands.`);
+    Log.newLine();
   }
 
   if (workflow === 'managed') {
-    log.nested(
+    Log.nested(
       `- ${chalk.bold(`${packageManager} start`)} ${chalk.dim(
         `# you can open iOS, Android, or web from here, or run them directly with the commands below.`
       )}`
     );
   }
-  log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run android' : 'yarn android')}`);
+  Log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run android' : 'yarn android')}`);
 
   let macOSComment = '';
   if (!isMacOS && workflow === 'bare') {
@@ -471,22 +471,22 @@ function logProjectReadyAsync({
   } else if (!isMacOS && workflow === 'managed') {
     macOSComment = ' # requires an iOS device or macOS for access to an iOS simulator';
   }
-  log.nested(
+  Log.nested(
     `- ${chalk.bold(packageManager === 'npm' ? 'npm run ios' : 'yarn ios')}${macOSComment}`
   );
 
-  log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run web' : 'yarn web')}`);
+  Log.nested(`- ${chalk.bold(packageManager === 'npm' ? 'npm run web' : 'yarn web')}`);
 
   if (workflow === 'bare') {
-    log.newLine();
-    log.nested(
+    Log.newLine();
+    Log.nested(
       `💡 You can also open up the projects in the ${chalk.bold('ios')} and ${chalk.bold(
         'android'
       )} directories with their respective IDEs.`
     );
 
     if (showPublishBeforeBuildWarning) {
-      log.nested(
+      Log.nested(
         `🚀 ${terminalLink(
           'expo-updates',
           'https://github.com/expo/expo/blob/master/packages/expo-updates/README.md'
@@ -495,7 +495,7 @@ function logProjectReadyAsync({
         )}. ${terminalLink('Learn more.', 'https://expo.fyi/release-builds-with-expo-updates')}`
       );
     } else if (didConfigureUpdatesProjectFiles) {
-      log.nested(
+      Log.nested(
         `🚀 ${terminalLink(
           'expo-updates',
           'https://github.com/expo/expo/blob/master/packages/expo-updates/README.md'
@@ -504,7 +504,7 @@ function logProjectReadyAsync({
         )}, you'll need to update the configuration in Expo.plist and AndroidManifest.xml before making a release build.`
       );
     } else {
-      log.nested(
+      Log.nested(
         `🚀 ${terminalLink(
           'expo-updates',
           'https://github.com/expo/expo/blob/master/packages/expo-updates/README.md'

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -23,7 +23,7 @@ async function resolveExpoProjectRootAsync() {
     log.addNewLineIfNone();
     log.error(error.message);
     log.newLine();
-    log(log.chalk.cyan(`You can create a new project with ${log.chalk.bold(`expo init`)}`));
+    log.log(log.chalk.cyan(`You can create a new project with ${log.chalk.bold(`expo init`)}`));
     log.newLine();
     throw new SilentError(error);
   }
@@ -65,7 +65,7 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
     log.addNewLineIfNone();
     log.error(message);
     log.newLine();
-    log(log.chalk.cyan(`Current version: ${log.chalk.bold(exp.sdkVersion)}`));
+    log.log(log.chalk.cyan(`Current version: ${log.chalk.bold(exp.sdkVersion)}`));
     log.newLine();
     throw new SilentError(message);
   }
@@ -74,7 +74,9 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   // Every React project should have react installed...
   if (!resolveFrom.silent(projectRoot, 'react')) {
     log.addNewLineIfNone();
-    log(log.chalk.cyan(`node_modules not found, running ${packageManager.name} install command.`));
+    log.log(
+      log.chalk.cyan(`node_modules not found, running ${packageManager.name} install command.`)
+    );
     log.newLine();
     await packageManager.installAsync();
   }
@@ -124,7 +126,7 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   if (others.length > 0) {
     messages.push(`${others.length} other ${others.length === 1 ? 'package' : 'packages'}`);
   }
-  log(`Installing ${messages.join(' and ')} using ${packageManager.name}.`);
+  log.log(`Installing ${messages.join(' and ')} using ${packageManager.name}.`);
   await packageManager.addAsync(...versionedPackages);
 }
 

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -7,7 +7,7 @@ import npmPackageArg from 'npm-package-arg';
 import resolveFrom from 'resolve-from';
 
 import CommandError, { SilentError } from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import { findProjectRootAsync } from './utils/ProjectUtils';
 
 async function resolveExpoProjectRootAsync() {
@@ -20,11 +20,11 @@ async function resolveExpoProjectRootAsync() {
       throw error;
     }
     // This happens when an app.config exists but a package.json is not present.
-    log.addNewLineIfNone();
-    log.error(error.message);
-    log.newLine();
-    log.log(log.chalk.cyan(`You can create a new project with ${log.chalk.bold(`expo init`)}`));
-    log.newLine();
+    Log.addNewLineIfNone();
+    Log.error(error.message);
+    Log.newLine();
+    Log.log(Log.chalk.cyan(`You can create a new project with ${Log.chalk.bold(`expo init`)}`));
+    Log.newLine();
     throw new SilentError(error);
   }
 }
@@ -35,7 +35,7 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   const packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,
     yarn: options.yarn,
-    log,
+    log: Log,
   });
 
   const { exp, pkg } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
@@ -48,36 +48,36 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   }
 
   if (!exp.sdkVersion) {
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     throw new CommandError(
-      `The ${log.chalk.bold(`expo`)} package was found in your ${log.chalk.bold(
+      `The ${Log.chalk.bold(`expo`)} package was found in your ${Log.chalk.bold(
         `package.json`
-      )} but we couldn't resolve the Expo SDK version. Run ${log.chalk.bold(
+      )} but we couldn't resolve the Expo SDK version. Run ${Log.chalk.bold(
         `${packageManager.name.toLowerCase()} install`
       )} and then try this command again.\n`
     );
   }
 
   if (!Versions.gteSdkVersion(exp, '33.0.0')) {
-    const message = `${log.chalk.bold(
+    const message = `${Log.chalk.bold(
       `expo install`
     )} is only available for Expo SDK version 33 or higher.`;
-    log.addNewLineIfNone();
-    log.error(message);
-    log.newLine();
-    log.log(log.chalk.cyan(`Current version: ${log.chalk.bold(exp.sdkVersion)}`));
-    log.newLine();
+    Log.addNewLineIfNone();
+    Log.error(message);
+    Log.newLine();
+    Log.log(Log.chalk.cyan(`Current version: ${Log.chalk.bold(exp.sdkVersion)}`));
+    Log.newLine();
     throw new SilentError(message);
   }
 
   // This shouldn't be invoked because `findProjectRootAsync` will throw if node_modules are missing.
   // Every React project should have react installed...
   if (!resolveFrom.silent(projectRoot, 'react')) {
-    log.addNewLineIfNone();
-    log.log(
-      log.chalk.cyan(`node_modules not found, running ${packageManager.name} install command.`)
+    Log.addNewLineIfNone();
+    Log.log(
+      Log.chalk.cyan(`node_modules not found, running ${packageManager.name} install command.`)
     );
-    log.newLine();
+    Log.newLine();
     await packageManager.installAsync();
   }
 
@@ -87,11 +87,11 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   );
 
   if (!bundledNativeModulesPath) {
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     throw new CommandError(
-      `The dependency map ${log.chalk.bold(
+      `The dependency map ${Log.chalk.bold(
         `expo/bundledNativeModules.json`
-      )} cannot be found, please ensure you have the package "${log.chalk
+      )} cannot be found, please ensure you have the package "${Log.chalk
         .bold`expo`}" installed in your project.\n`
     );
   }
@@ -126,7 +126,7 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   if (others.length > 0) {
     messages.push(`${others.length} other ${others.length === 1 ? 'package' : 'packages'}`);
   }
-  log.log(`Installing ${messages.join(' and ')} using ${packageManager.name}.`);
+  Log.log(`Installing ${messages.join(' and ')} using ${packageManager.name}.`);
   await packageManager.addAsync(...versionedPackages);
 }
 

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -35,7 +35,7 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   const packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,
     yarn: options.yarn,
-    log: Log,
+    log: Log.log,
   });
 
   const { exp, pkg } = getConfig(projectRoot, { skipSDKVersionRequirement: true });

--- a/packages/expo-cli/src/commands/logout.ts
+++ b/packages/expo-cli/src/commands/logout.ts
@@ -15,7 +15,7 @@ async function action() {
 
   try {
     await UserManager.logoutAsync();
-    log('Logged out');
+    log.log('Logged out');
   } catch (e) {
     throw new CommandError(`Couldn't logout: ${e.message}`);
   }

--- a/packages/expo-cli/src/commands/logout.ts
+++ b/packages/expo-cli/src/commands/logout.ts
@@ -2,7 +2,7 @@ import { UserManager } from '@expo/xdl';
 import { Command } from 'commander';
 
 import CommandError from '../CommandError';
-import log from '../log';
+import Log from '../log';
 
 async function action() {
   const user = await UserManager.getCurrentUserAsync();
@@ -15,7 +15,7 @@ async function action() {
 
   try {
     await UserManager.logoutAsync();
-    log.log('Logged out');
+    Log.log('Logged out');
   } catch (e) {
     throw new CommandError(`Couldn't logout: ${e.message}`);
   }

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -1,6 +1,6 @@
 import dateFormat from 'dateformat';
 
-import log from '../log';
+import Log from '../log';
 import {
   DetailOptions,
   getPublicationDetailAsync,
@@ -36,7 +36,7 @@ export default (program: any) => {
         const result = await getPublishHistoryAsync(projectDir, options);
 
         if (options.raw) {
-          log.log(JSON.stringify(result));
+          Log.log(JSON.stringify(result));
           return;
         }
 
@@ -49,7 +49,7 @@ export default (program: any) => {
             },
             'General Info'
           );
-          log.log(generalTableString);
+          Log.log(generalTableString);
 
           // Print info specific to each publication
           const headers = [
@@ -76,7 +76,7 @@ export default (program: any) => {
             publishedTime: dateFormat(publication.publishedTime, 'ddd mmm dd yyyy HH:MM:ss Z'),
           }));
           const tableString = table.printTableJsonArray(headers, resultRows, colWidths);
-          log.log(tableString);
+          Log.log(tableString);
         } else {
           throw new Error('No records found matching your query.');
         }

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -36,7 +36,7 @@ export default (program: any) => {
         const result = await getPublishHistoryAsync(projectDir, options);
 
         if (options.raw) {
-          log(JSON.stringify(result));
+          log.log(JSON.stringify(result));
           return;
         }
 
@@ -49,7 +49,7 @@ export default (program: any) => {
             },
             'General Info'
           );
-          log(generalTableString);
+          log.log(generalTableString);
 
           // Print info specific to each publication
           const headers = [
@@ -76,7 +76,7 @@ export default (program: any) => {
             publishedTime: dateFormat(publication.publishedTime, 'ddd mmm dd yyyy HH:MM:ss Z'),
           }));
           const tableString = table.printTableJsonArray(headers, resultRows, colWidths);
-          log(tableString);
+          log.log(tableString);
         } else {
           throw new Error('No records found matching your query.');
         }

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import uniqBy from 'lodash/uniqBy';
 
 import * as table from '../commands/utils/cli-table';
-import log from '../log';
+import Log from '../log';
 import {
   getPublicationDetailAsync,
   getPublishHistoryAsync,
@@ -47,9 +47,9 @@ export default function (program: Command) {
             'Channel Set Status ',
             'SUCCESS'
           );
-          log.log(tableString);
+          Log.log(tableString);
         } catch (e) {
-          log.error(e);
+          Log.error(e);
         }
       },
       { checkConfig: true }
@@ -98,7 +98,7 @@ async function getUsageAsync(projectDir: string): Promise<string> {
   try {
     return await _getUsageAsync(projectDir);
   } catch (e) {
-    log.warn(e);
+    Log.warn(e);
     // couldn't print out warning for some reason
     return _getGenericUsage();
   }

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -47,7 +47,7 @@ export default function (program: Command) {
             'Channel Set Status ',
             'SUCCESS'
           );
-          log(tableString);
+          log.log(tableString);
         } catch (e) {
           log.error(e);
         }

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -7,7 +7,7 @@ import fs from 'fs';
 import path from 'path';
 
 import CommandError from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import { getProjectOwner } from '../projects';
 import * as sendTo from '../sendTo';
 import { getBuildStatusAsync } from './build/getBuildStatusAsync';
@@ -42,21 +42,21 @@ export async function action(
   const user = await UserManager.ensureLoggedInAsync();
   const owner = getProjectOwner(user, exp);
 
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 
   // Log building info before building.
   // This gives the user sometime to bail out if the info is unexpected.
 
   if (sdkVersion && target === 'managed') {
-    log.log(`- Expo SDK: ${log.chalk.bold(exp.sdkVersion)}`);
+    Log.log(`- Expo SDK: ${Log.chalk.bold(exp.sdkVersion)}`);
   }
-  log.log(`- Release channel: ${log.chalk.bold(options.releaseChannel)}`);
-  log.log(`- Workflow: ${log.chalk.bold(target.replace(/\b\w/g, l => l.toUpperCase()))}`);
+  Log.log(`- Release channel: ${Log.chalk.bold(options.releaseChannel)}`);
+  Log.log(`- Workflow: ${Log.chalk.bold(target.replace(/\b\w/g, l => l.toUpperCase()))}`);
   if (user.kind === 'robot') {
-    log.log(`- Owner: ${log.chalk.bold(owner)}`);
+    Log.log(`- Owner: ${Log.chalk.bold(owner)}`);
   }
 
-  log.newLine();
+  Log.newLine();
 
   // Log warnings.
 
@@ -77,11 +77,11 @@ export async function action(
     logBareWorkflowWarnings(pkg);
   }
 
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 
   // Build and publish the project.
 
-  log.log(`Building optimized bundles and generating sourcemaps...`);
+  Log.log(`Building optimized bundles and generating sourcemaps...`);
 
   if (options.quiet) {
     simpleSpinner.start();
@@ -100,8 +100,8 @@ export async function action(
     simpleSpinner.stop();
   }
 
-  log.log('Publish complete');
-  log.newLine();
+  Log.log('Publish complete');
+  Log.newLine();
 
   logManifestUrl({ url, sdkVersion: exp.sdkVersion });
 
@@ -124,7 +124,7 @@ export async function action(
     }
   }
 
-  log.newLine();
+  Log.newLine();
 
   return result;
 }
@@ -149,8 +149,8 @@ function assertValidReleaseChannel(releaseChannel?: string): void {
  */
 function logManifestUrl({ url, sdkVersion }: { url: string; sdkVersion?: string }) {
   const manifestUrl = getExampleManifestUrl(url, sdkVersion) ?? url;
-  log.log(
-    `📝  Manifest: ${log.chalk.bold(TerminalLink.fallbackToUrl(url, manifestUrl))} ${log.chalk.dim(
+  Log.log(
+    `📝  Manifest: ${Log.chalk.bold(TerminalLink.fallbackToUrl(url, manifestUrl))} ${Log.chalk.dim(
       TerminalLink.learnMore('https://expo.fyi/manifest-url')
     )}`
   );
@@ -168,16 +168,16 @@ function logProjectPageUrl({
   url: string;
   copiedToClipboard: boolean;
 }) {
-  let productionMessage = `⚙️   Project page: ${log.chalk.bold(
+  let productionMessage = `⚙️   Project page: ${Log.chalk.bold(
     TerminalLink.fallbackToUrl(url, url)
   )}`;
 
   if (copiedToClipboard) {
-    productionMessage += ` ${log.chalk.gray(`[copied to clipboard]`)}`;
+    productionMessage += ` ${Log.chalk.gray(`[copied to clipboard]`)}`;
   }
-  productionMessage += ` ${log.chalk.dim(TerminalLink.learnMore('https://expo.fyi/project-page'))}`;
+  productionMessage += ` ${Log.chalk.dim(TerminalLink.learnMore('https://expo.fyi/project-page'))}`;
 
-  log.log(productionMessage);
+  Log.log(productionMessage);
 }
 
 function getExampleManifestUrl(url: string, sdkVersion: string | undefined): string | null {
@@ -230,7 +230,7 @@ async function logSDKMismatchWarningsAsync({
   }
 
   // A convenient warning reminding people that they're publishing with an SDK that their published app does not support.
-  log.nestedWarn(
+  Log.nestedWarn(
     formatNamedWarning(
       'URL mismatch',
       `No standalone app has been built with SDK ${sdkVersion} and release channel "${releaseChannel}" for this project before.\n  OTA updates only work for native projects that have the same SDK version and release channel.`,
@@ -247,7 +247,7 @@ export function logExpoUpdatesWarnings(pkg: PackageJSONConfig): void {
     return;
   }
 
-  log.nestedWarn(
+  Log.nestedWarn(
     formatNamedWarning(
       'Conflicting Updates',
       `You have both the ${chalk.bold('expokit')} and ${chalk.bold(
@@ -266,7 +266,7 @@ export function logOptimizeWarnings({ projectRoot }: { projectRoot: string }): v
   if (hasOptimized) {
     return;
   }
-  log.nestedWarn(
+  Log.nestedWarn(
     formatNamedWarning(
       'Optimization',
       `Project may contain uncompressed images. Optimizing image assets can improve app size and performance.\n  To fix this, run ${chalk.bold(
@@ -296,7 +296,7 @@ export function logBareWorkflowWarnings(pkg: PackageJSONConfig) {
     return;
   }
 
-  log.nestedWarn(
+  Log.nestedWarn(
     formatNamedWarning(
       'Workflow target',
       `This is a ${chalk.bold(

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -48,12 +48,12 @@ export async function action(
   // This gives the user sometime to bail out if the info is unexpected.
 
   if (sdkVersion && target === 'managed') {
-    log(`- Expo SDK: ${log.chalk.bold(exp.sdkVersion)}`);
+    log.log(`- Expo SDK: ${log.chalk.bold(exp.sdkVersion)}`);
   }
-  log(`- Release channel: ${log.chalk.bold(options.releaseChannel)}`);
-  log(`- Workflow: ${log.chalk.bold(target.replace(/\b\w/g, l => l.toUpperCase()))}`);
+  log.log(`- Release channel: ${log.chalk.bold(options.releaseChannel)}`);
+  log.log(`- Workflow: ${log.chalk.bold(target.replace(/\b\w/g, l => l.toUpperCase()))}`);
   if (user.kind === 'robot') {
-    log(`- Owner: ${log.chalk.bold(owner)}`);
+    log.log(`- Owner: ${log.chalk.bold(owner)}`);
   }
 
   log.newLine();
@@ -81,7 +81,7 @@ export async function action(
 
   // Build and publish the project.
 
-  log(`Building optimized bundles and generating sourcemaps...`);
+  log.log(`Building optimized bundles and generating sourcemaps...`);
 
   if (options.quiet) {
     simpleSpinner.start();
@@ -100,7 +100,7 @@ export async function action(
     simpleSpinner.stop();
   }
 
-  log('Publish complete');
+  log.log('Publish complete');
   log.newLine();
 
   logManifestUrl({ url, sdkVersion: exp.sdkVersion });
@@ -149,7 +149,7 @@ function assertValidReleaseChannel(releaseChannel?: string): void {
  */
 function logManifestUrl({ url, sdkVersion }: { url: string; sdkVersion?: string }) {
   const manifestUrl = getExampleManifestUrl(url, sdkVersion) ?? url;
-  log(
+  log.log(
     `📝  Manifest: ${log.chalk.bold(TerminalLink.fallbackToUrl(url, manifestUrl))} ${log.chalk.dim(
       TerminalLink.learnMore('https://expo.fyi/manifest-url')
     )}`
@@ -177,7 +177,7 @@ function logProjectPageUrl({
   }
   productionMessage += ` ${log.chalk.dim(TerminalLink.learnMore('https://expo.fyi/project-page'))}`;
 
-  log(productionMessage);
+  log.log(productionMessage);
 }
 
 function getExampleManifestUrl(url: string, sdkVersion: string | undefined): string | null {

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -20,7 +20,7 @@ export default function (program: Command) {
       const experienceName = `@${ctx.projectOwner}/${ctx.manifest.slug}`;
 
       await ctx.android.updateFcmKey(experienceName, options.apiKey);
-      log('All done!');
+      log.log('All done!');
     });
 
   program
@@ -34,7 +34,7 @@ export default function (program: Command) {
 
       const fcmCredentials = await ctx.android.fetchFcmKey(experienceName);
       if (fcmCredentials?.fcmApiKey) {
-        log(`FCM API key: ${fcmCredentials?.fcmApiKey}`);
+        log.log(`FCM API key: ${fcmCredentials?.fcmApiKey}`);
       } else {
         throw new CommandError(`There is no FCM API key configured for this project`);
       }
@@ -50,6 +50,6 @@ export default function (program: Command) {
       const experienceName = `@${ctx.projectOwner}/${ctx.manifest.slug}`;
 
       await ctx.android.removeFcmKey(experienceName);
-      log('All done!');
+      log.log('All done!');
     });
 }

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 
 import CommandError from '../CommandError';
 import { Context } from '../credentials/context';
-import log from '../log';
+import Log from '../log';
 
 export default function (program: Command) {
   program
@@ -20,7 +20,7 @@ export default function (program: Command) {
       const experienceName = `@${ctx.projectOwner}/${ctx.manifest.slug}`;
 
       await ctx.android.updateFcmKey(experienceName, options.apiKey);
-      log.log('All done!');
+      Log.log('All done!');
     });
 
   program
@@ -34,7 +34,7 @@ export default function (program: Command) {
 
       const fcmCredentials = await ctx.android.fetchFcmKey(experienceName);
       if (fcmCredentials?.fcmApiKey) {
-        log.log(`FCM API key: ${fcmCredentials?.fcmApiKey}`);
+        Log.log(`FCM API key: ${fcmCredentials?.fcmApiKey}`);
       } else {
         throw new CommandError(`There is no FCM API key configured for this project`);
       }
@@ -50,6 +50,6 @@ export default function (program: Command) {
       const experienceName = `@${ctx.projectOwner}/${ctx.manifest.slug}`;
 
       await ctx.android.removeFcmKey(experienceName);
-      log.log('All done!');
+      Log.log('All done!');
     });
 }

--- a/packages/expo-cli/src/commands/send.ts
+++ b/packages/expo-cli/src/commands/send.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 
 import { askForSendToAsync } from '../askUser';
-import log from '../log';
+import Log from '../log';
 import * as sendTo from '../sendTo';
 import urlOpts, { URLOptions } from '../urlOpts';
 
@@ -14,7 +14,7 @@ async function action(projectRoot: string, options: Options) {
 
   const url = await UrlUtils.constructDeepLinkAsync(projectRoot);
 
-  log.nested('Project manifest URL\n\n' + chalk.underline(url) + '\n');
+  Log.nested('Project manifest URL\n\n' + chalk.underline(url) + '\n');
 
   if (await urlOpts.handleMobileOptsAsync(projectRoot, options)) {
     return;

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -200,7 +200,7 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
       log.newLine();
       urlOpts.printQRCode(url);
     }
-    log(`Your native app is running at ${chalk.underline(url)}`);
+    log.log(`Your native app is running at ${chalk.underline(url)}`);
   }
   log.nested(chalk.green('Logs for your project will appear below. Press Ctrl+C to exit.'));
 }
@@ -271,14 +271,14 @@ async function tryOpeningDevToolsAsync({
   options,
 }: OpenDevToolsOptions): Promise<void> {
   const devToolsUrl = await DevToolsServer.startAsync(rootPath);
-  log(`Expo DevTools is running at ${chalk.underline(devToolsUrl)}`);
+  log.log(`Expo DevTools is running at ${chalk.underline(devToolsUrl)}`);
 
   if (!options.nonInteractive && !exp.isDetached) {
     if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
-      log(`Opening DevTools in the browser... (press ${chalk.bold`shift-d`} to disable)`);
+      log.log(`Opening DevTools in the browser... (press ${chalk.bold`shift-d`} to disable)`);
       openBrowser(devToolsUrl);
     } else {
-      log(
+      log.log(
         `Press ${chalk.bold`d`} to open DevTools now, or ${chalk.bold`shift-d`} to always open it automatically.`
       );
     }
@@ -296,7 +296,7 @@ async function configureProjectAsync(
   }
   await urlOpts.optsAsync(projectDir, options);
 
-  log(chalk.gray(`Starting project at ${projectDir}`));
+  log.log(chalk.gray(`Starting project at ${projectDir}`));
 
   const projectConfig = getConfig(projectDir, {
     skipSDKVersionRequirement: options.webOnly,
@@ -306,7 +306,7 @@ async function configureProjectAsync(
   // TODO: move this function over to CLI
   // const message = getProjectConfigDescription(projectDir, projectConfig);
   // if (message) {
-  //   log(chalk.magenta(`\u203A ${message}`));
+  //   log.log(chalk.magenta(`\u203A ${message}`));
   // }
 
   const rootPath = path.resolve(projectDir);

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -11,7 +11,7 @@ import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
 import { installExitHooks } from '../exit';
-import log from '../log';
+import Log from '../log';
 import * as sendTo from '../sendTo';
 import urlOpts, { URLOptions } from '../urlOpts';
 import * as TerminalUI from './start/TerminalUI';
@@ -197,12 +197,12 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
     await TerminalUI.startAsync(projectDir, startOpts);
   } else {
     if (!exp.isDetached) {
-      log.newLine();
+      Log.newLine();
       urlOpts.printQRCode(url);
     }
-    log.log(`Your native app is running at ${chalk.underline(url)}`);
+    Log.log(`Your native app is running at ${chalk.underline(url)}`);
   }
-  log.nested(chalk.green('Logs for your project will appear below. Press Ctrl+C to exit.'));
+  Log.nested(chalk.green('Logs for your project will appear below. Press Ctrl+C to exit.'));
 }
 
 async function validateDependenciesVersions(
@@ -216,7 +216,7 @@ async function validateDependenciesVersions(
 
   const bundleNativeModulesPath = resolveFrom.silent(projectDir, 'expo/bundledNativeModules.json');
   if (!bundleNativeModulesPath) {
-    log.warn(
+    Log.warn(
       `Your project is in SDK version >= 33.0.0, but the ${chalk.underline(
         'expo'
       )} package version seems to be older.`
@@ -246,17 +246,17 @@ async function validateDependenciesVersions(
     }
   }
   if (incorrectDeps.length > 0) {
-    log.warn(
+    Log.warn(
       "Some of your project's dependencies are not compatible with currently installed expo package version:"
     );
     incorrectDeps.forEach(({ moduleName, expectedRange, actualRange }) => {
-      log.warn(
+      Log.warn(
         ` - ${chalk.underline(moduleName)} - expected version range: ${chalk.underline(
           expectedRange
         )} - actual version installed: ${chalk.underline(actualRange)}`
       );
     });
-    log.warn(
+    Log.warn(
       'Your project may not work correctly until you install the correct versions of the packages.\n' +
         `To install the correct versions of these packages, please run: ${chalk.inverse(
           'expo install [package-name ...]'
@@ -271,14 +271,14 @@ async function tryOpeningDevToolsAsync({
   options,
 }: OpenDevToolsOptions): Promise<void> {
   const devToolsUrl = await DevToolsServer.startAsync(rootPath);
-  log.log(`Expo DevTools is running at ${chalk.underline(devToolsUrl)}`);
+  Log.log(`Expo DevTools is running at ${chalk.underline(devToolsUrl)}`);
 
   if (!options.nonInteractive && !exp.isDetached) {
     if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
-      log.log(`Opening DevTools in the browser... (press ${chalk.bold`shift-d`} to disable)`);
+      Log.log(`Opening DevTools in the browser... (press ${chalk.bold`shift-d`} to disable)`);
       openBrowser(devToolsUrl);
     } else {
-      log.log(
+      Log.log(
         `Press ${chalk.bold`d`} to open DevTools now, or ${chalk.bold`shift-d`} to always open it automatically.`
       );
     }
@@ -296,7 +296,7 @@ async function configureProjectAsync(
   }
   await urlOpts.optsAsync(projectDir, options);
 
-  log.log(chalk.gray(`Starting project at ${projectDir}`));
+  Log.log(chalk.gray(`Starting project at ${projectDir}`));
 
   const projectConfig = getConfig(projectDir, {
     skipSDKVersionRequirement: options.webOnly,

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -161,7 +161,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         case 'A':
         case 'a':
           log.clear();
-          log('Opening the web project in Chrome on Android...');
+          log.log('Opening the web project in Chrome on Android...');
           await Android.openWebProjectAsync({
             projectRoot,
             shouldPrompt: !options.nonInteractive && key === 'A',
@@ -171,7 +171,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         case 'i':
         case 'I':
           log.clear();
-          log('Opening the web project in Safari on iOS...');
+          log.log('Opening the web project in Safari on iOS...');
           await Simulator.openWebProjectAsync({
             projectRoot,
             shouldPrompt: !options.nonInteractive && key === 'I',
@@ -186,7 +186,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           printHelp();
           break;
         case 'e':
-          log(chalk.red` ${BLT} Sending a URL is not supported in web-only mode`);
+          log.log(chalk.red` ${BLT} Sending a URL is not supported in web-only mode`);
           break;
       }
     } else {
@@ -198,7 +198,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           break;
         case 'a': {
           log.clear();
-          log('Opening on Android...');
+          log.log('Opening on Android...');
           await Android.openProjectAsync({ projectRoot });
           printHelp();
           break;
@@ -223,7 +223,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           // const shouldPrompt =
           //   !options.nonInteractive && (key === 'I' || !(await Simulator.isSimulatorBootedAsync()));
 
-          log('Opening on iOS...');
+          log.log('Opening on iOS...');
           await Simulator.openProjectAsync({
             projectRoot,
             shouldPrompt: false,
@@ -258,7 +258,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           };
           log.clear();
           process.stdin.addListener('keypress', handleKeypress);
-          log('Please enter your email address (press ESC to cancel) ');
+          log.log('Please enter your email address (press ESC to cancel) ');
           rl.question(
             defaultRecipient ? `[default: ${defaultRecipient}]> ` : '> ',
             async sendTo => {
@@ -271,15 +271,15 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
                 cancel();
                 return;
               }
-              log(`Sending ${lanAddress} to ${sendTo}...`);
+              log.log(`Sending ${lanAddress} to ${sendTo}...`);
 
               let sent = false;
               try {
                 await Exp.sendAsync(sendTo, lanAddress);
                 sent = true;
-                log(`Sent link successfully.`);
+                log.log(`Sent link successfully.`);
               } catch (err) {
-                log(`Could not send link. ${err}`);
+                log.log(`Could not send link. ${err}`);
               }
               printHelp();
               if (sent) {
@@ -309,7 +309,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
       }
       case 'w': {
         log.clear();
-        log('Attempting to open the project in a web browser...');
+        log.log('Attempting to open the project in a web browser...');
         await Webpack.openAsync(projectRoot);
         await printServerInfo(projectRoot, options);
         break;
@@ -321,7 +321,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
       }
       case 'd': {
         const { devToolsPort } = await ProjectSettings.readPackagerInfoAsync(projectRoot);
-        log('Opening DevTools in the browser...');
+        log.log('Opening DevTools in the browser...');
         openBrowser(`http://localhost:${devToolsPort}`);
         printHelp();
         break;
@@ -330,7 +330,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         log.clear();
         const enabled = !(await UserSettings.getAsync('openDevToolsAtStartup', true));
         await UserSettings.setAsync('openDevToolsAtStartup', enabled);
-        log(
+        log.log(
           `Automatically opening DevTools ${b(
             enabled ? 'enabled' : 'disabled'
           )}.\nPress ${b`d`} to open DevTools now.`
@@ -343,7 +343,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         const projectSettings = await ProjectSettings.readAsync(projectRoot);
         const dev = !projectSettings.dev;
         await ProjectSettings.setAsync(projectRoot, { dev, minify: !dev });
-        log(
+        log.log(
           `Metro bundler is now running in ${chalk.bold(
             dev ? 'development' : 'production'
           )}${chalk.reset(` mode.`)}
@@ -357,15 +357,15 @@ Please reload the project in the Expo app for the change to take effect.`
         log.clear();
         const reset = key === 'R';
         if (reset) {
-          log('Restarting Metro bundler and clearing cache...');
+          log.log('Restarting Metro bundler and clearing cache...');
         } else {
-          log('Restarting Metro bundler...');
+          log.log('Restarting Metro bundler...');
         }
         Project.startAsync(projectRoot, { ...options, reset });
         break;
       }
       case 'o':
-        log('Trying to open the project in your editor...');
+        log.log('Trying to open the project in your editor...');
         await openInEditorAsync(projectRoot);
     }
   }

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -16,7 +16,7 @@ import readline from 'readline';
 import wrapAnsi from 'wrap-ansi';
 
 import { loginOrRegisterIfLoggedOutAsync } from '../../accounts';
-import log from '../../log';
+import Log from '../../log';
 import urlOpts from '../../urlOpts';
 import { openInEditorAsync } from '../utils/openInEditorAsync';
 
@@ -36,8 +36,8 @@ type StartOptions = {
 };
 
 const printHelp = (): void => {
-  log.newLine();
-  log.nested(`Press ${b('?')} to show a list of all available commands.`);
+  Log.newLine();
+  Log.nested(`Press ${b('?')} to show a list of all available commands.`);
 };
 
 const div = chalk.dim(`│`);
@@ -69,7 +69,7 @@ const printUsage = async (projectDir: string, options: Pick<StartOptions, 'webOn
     !options.webOnly && ['e', `share the app link by email`],
   ];
 
-  log.nested(
+  Log.nested(
     ui
       .filter(Boolean)
       // @ts-ignore: filter doesn't work
@@ -98,22 +98,22 @@ export const printServerInfo = async (
     return;
   }
   const url = await UrlUtils.constructDeepLinkAsync(projectDir);
-  log.newLine();
-  log.nested(` ${u(url)}`);
-  log.newLine();
+  Log.newLine();
+  Log.nested(` ${u(url)}`);
+  Log.newLine();
   urlOpts.printQRCode(url);
   const wrapLength = process.stdout.columns || 80;
   const item = (text: string): string => ` ${BLT} ` + wrapAnsi(text, wrapLength).trimStart();
   const iosInfo = process.platform === 'darwin' ? `, or ${b('i')} for iOS simulator` : '';
   const webInfo = `${b`w`} to run on ${u`w`}eb`;
-  log.nested(wrapAnsi(u('To run the app, choose one of:'), wrapLength));
+  Log.nested(wrapAnsi(u('To run the app, choose one of:'), wrapLength));
 
   // TODO: if dev client, chanege this message!
-  log.nested(item(`Scan the QR code above with the Expo app (Android) or the Camera app (iOS).`));
+  Log.nested(item(`Scan the QR code above with the Expo app (Android) or the Camera app (iOS).`));
 
   // TODO: if no react-native-web in package.json then don't show web info
-  log.nested(item(`Press ${b`a`} for Android emulator${iosInfo}, or ${webInfo}.`));
-  log.nested(item(`Press ${b`e`} to send a link to your phone with email.`));
+  Log.nested(item(`Press ${b`a`} for Android emulator${iosInfo}, or ${webInfo}.`));
+  Log.nested(item(`Press ${b`e`} to send a link to your phone with email.`));
 
   Webpack.printConnectionInstructions(projectDir);
   printHelp();
@@ -160,8 +160,8 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
       switch (key) {
         case 'A':
         case 'a':
-          log.clear();
-          log.log('Opening the web project in Chrome on Android...');
+          Log.clear();
+          Log.log('Opening the web project in Chrome on Android...');
           await Android.openWebProjectAsync({
             projectRoot,
             shouldPrompt: !options.nonInteractive && key === 'A',
@@ -170,8 +170,8 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           break;
         case 'i':
         case 'I':
-          log.clear();
-          log.log('Opening the web project in Safari on iOS...');
+          Log.clear();
+          Log.log('Opening the web project in Safari on iOS...');
           await Simulator.openWebProjectAsync({
             projectRoot,
             shouldPrompt: !options.nonInteractive && key === 'I',
@@ -186,25 +186,25 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           printHelp();
           break;
         case 'e':
-          log.log(chalk.red` ${BLT} Sending a URL is not supported in web-only mode`);
+          Log.log(chalk.red` ${BLT} Sending a URL is not supported in web-only mode`);
           break;
       }
     } else {
       switch (key) {
         case 'A':
-          log.clear();
+          Log.clear();
           await Android.openProjectAsync({ projectRoot, shouldPrompt: true });
           printHelp();
           break;
         case 'a': {
-          log.clear();
-          log.log('Opening on Android...');
+          Log.clear();
+          Log.log('Opening on Android...');
           await Android.openProjectAsync({ projectRoot });
           printHelp();
           break;
         }
         case 'I':
-          log.clear();
+          Log.clear();
           await Simulator.openProjectAsync({
             projectRoot,
             shouldPrompt: true,
@@ -212,7 +212,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           printHelp();
           break;
         case 'i': {
-          log.clear();
+          Log.clear();
 
           // note(brentvatne): temporarily remove logic for picking the
           // simulator until we have parity for Android. this also ensures that we
@@ -223,7 +223,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           // const shouldPrompt =
           //   !options.nonInteractive && (key === 'I' || !(await Simulator.isSimulatorBootedAsync()));
 
-          log.log('Opening on iOS...');
+          Log.log('Opening on iOS...');
           await Simulator.openProjectAsync({
             projectRoot,
             shouldPrompt: false,
@@ -253,12 +253,12 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
             startWaitingForCommand();
           };
           const cancel = async () => {
-            log.clear();
+            Log.clear();
             printHelp();
           };
-          log.clear();
+          Log.clear();
           process.stdin.addListener('keypress', handleKeypress);
-          log.log('Please enter your email address (press ESC to cancel) ');
+          Log.log('Please enter your email address (press ESC to cancel) ');
           rl.question(
             defaultRecipient ? `[default: ${defaultRecipient}]> ` : '> ',
             async sendTo => {
@@ -271,15 +271,15 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
                 cancel();
                 return;
               }
-              log.log(`Sending ${lanAddress} to ${sendTo}...`);
+              Log.log(`Sending ${lanAddress} to ${sendTo}...`);
 
               let sent = false;
               try {
                 await Exp.sendAsync(sendTo, lanAddress);
                 sent = true;
-                log.log(`Sent link successfully.`);
+                Log.log(`Sent link successfully.`);
               } catch (err) {
-                log.log(`Could not send link. ${err}`);
+                Log.log(`Could not send link. ${err}`);
               }
               printHelp();
               if (sent) {
@@ -300,7 +300,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         break;
       }
       case CTRL_L: {
-        log.clear();
+        Log.clear();
         break;
       }
       case '?': {
@@ -308,29 +308,29 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         break;
       }
       case 'w': {
-        log.clear();
-        log.log('Attempting to open the project in a web browser...');
+        Log.clear();
+        Log.log('Attempting to open the project in a web browser...');
         await Webpack.openAsync(projectRoot);
         await printServerInfo(projectRoot, options);
         break;
       }
       case 'c': {
-        log.clear();
+        Log.clear();
         await printServerInfo(projectRoot, options);
         break;
       }
       case 'd': {
         const { devToolsPort } = await ProjectSettings.readPackagerInfoAsync(projectRoot);
-        log.log('Opening DevTools in the browser...');
+        Log.log('Opening DevTools in the browser...');
         openBrowser(`http://localhost:${devToolsPort}`);
         printHelp();
         break;
       }
       case 'D': {
-        log.clear();
+        Log.clear();
         const enabled = !(await UserSettings.getAsync('openDevToolsAtStartup', true));
         await UserSettings.setAsync('openDevToolsAtStartup', enabled);
-        log.log(
+        Log.log(
           `Automatically opening DevTools ${b(
             enabled ? 'enabled' : 'disabled'
           )}.\nPress ${b`d`} to open DevTools now.`
@@ -339,11 +339,11 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         break;
       }
       case 'p': {
-        log.clear();
+        Log.clear();
         const projectSettings = await ProjectSettings.readAsync(projectRoot);
         const dev = !projectSettings.dev;
         await ProjectSettings.setAsync(projectRoot, { dev, minify: !dev });
-        log.log(
+        Log.log(
           `Metro bundler is now running in ${chalk.bold(
             dev ? 'development' : 'production'
           )}${chalk.reset(` mode.`)}
@@ -354,18 +354,18 @@ Please reload the project in the Expo app for the change to take effect.`
       }
       case 'r':
       case 'R': {
-        log.clear();
+        Log.clear();
         const reset = key === 'R';
         if (reset) {
-          log.log('Restarting Metro bundler and clearing cache...');
+          Log.log('Restarting Metro bundler and clearing cache...');
         } else {
-          log.log('Restarting Metro bundler...');
+          Log.log('Restarting Metro bundler...');
         }
         Project.startAsync(projectRoot, { ...options, reset });
         break;
       }
       case 'o':
-        log.log('Trying to open the project in your editor...');
+        Log.log('Trying to open the project in your editor...');
         await openInEditorAsync(projectRoot);
     }
   }

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -525,7 +525,7 @@ export async function upgradeAsync(
   const packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,
     yarn: options.yarn,
-    log: Log,
+    log: Log.log,
     silent: !getenv.boolish('EXPO_DEBUG', false),
   });
 

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -292,7 +292,7 @@ async function stopExpoServerAsync(projectRoot: string): Promise<void> {
   const status = await ProjectSettings.getCurrentStatusAsync(projectRoot);
   if (status === 'running') {
     await Project.stopAsync(projectRoot);
-    log(
+    log.log(
       chalk.bold.underline(
         'We found an existing expo-cli instance running for this project and closed it to continue.'
       )
@@ -319,7 +319,7 @@ async function shouldBailWhenUsingLatest(
     });
 
     if (!answer) {
-      log('Follow the Expo blog at https://blog.expo.io for new release information!');
+      log.log('Follow the Expo blog at https://blog.expo.io for new release information!');
       log.newLine();
       return true;
     }
@@ -662,13 +662,13 @@ export async function upgradeAsync(
   }
 
   log.newLine();
-  log(chalk.bold.green(`👏 Automated upgrade steps complete.`));
-  log(chalk.bold.grey(`...but this doesn't mean everything is done yet!`));
+  log.log(chalk.bold.green(`👏 Automated upgrade steps complete.`));
+  log.log(chalk.bold.grey(`...but this doesn't mean everything is done yet!`));
   log.newLine();
 
   // List packages that were updated
-  log(chalk.bold(`✅ The following packages were updated:`));
-  log(chalk.grey.bold([...Object.keys(updates), ...['expo']].join(', ')));
+  log.log(chalk.bold(`✅ The following packages were updated:`));
+  log.log(chalk.grey.bold([...Object.keys(updates), ...['expo']].join(', ')));
   log.addNewLineIfNone();
 
   // List packages that were not updated
@@ -679,14 +679,14 @@ export async function upgradeAsync(
   ]);
   if (untouchedDependencies.length) {
     log.addNewLineIfNone();
-    log(
+    log.log(
       chalk.bold(
         `🚨 The following packages were ${chalk.underline(
           'not'
         )} updated. You should check the READMEs for those repositories to determine what version is compatible with your new set of packages:`
       )
     );
-    log(chalk.grey.bold(untouchedDependencies.join(', ')));
+    log.log(chalk.grey.bold(untouchedDependencies.join(', ')));
     log.addNewLineIfNone();
   }
 
@@ -712,19 +712,19 @@ export async function upgradeAsync(
       const upgradeHelperUrl = `https://react-native-community.github.io/upgrade-helper/`;
 
       if (semver.lt(previousReactNativeVersion, newReactNativeVersion)) {
-        log(
+        log.log(
           chalk.bold(
             `⬆️  To finish your react-native upgrade, update your native projects as outlined here:
 ${chalk.gray(`${upgradeHelperUrl}?from=${previousReactNativeVersion}&to=${newReactNativeVersion}`)}`
           )
         );
       } else {
-        log(
+        log.log(
           chalk.bold(
             `👉 react-native has been changed from ${previousReactNativeVersion} to ${newReactNativeVersion} because this is the version used in SDK ${targetSdkVersionString}.`
           )
         );
-        log(
+        log.log(
           chalk.bold(
             chalk.grey(
               `Bare workflow apps are free to adjust their react-native version at the developer's discretion. You may want to re-install react-native@${previousReactNativeVersion} before proceeding.`
@@ -736,7 +736,7 @@ ${chalk.gray(`${upgradeHelperUrl}?from=${previousReactNativeVersion}&to=${newRea
       log.newLine();
     }
 
-    log(
+    log.log(
       chalk.bold(
         `🏗  Run ${chalk.grey(
           'pod install'
@@ -747,10 +747,10 @@ ${chalk.gray(`${upgradeHelperUrl}?from=${previousReactNativeVersion}&to=${newRea
   }
 
   if (targetSdkVersion && targetSdkVersion.releaseNoteUrl) {
-    log(
+    log.log(
       `Please refer to the release notes for information on any further required steps to update and information about breaking changes:`
     );
-    log(chalk.bold(targetSdkVersion.releaseNoteUrl));
+    log.log(chalk.bold(targetSdkVersion.releaseNoteUrl));
   } else {
     if (getenv.boolish('EXPO_BETA', false)) {
       log.gray(
@@ -779,14 +779,14 @@ ${chalk.gray(`${upgradeHelperUrl}?from=${previousReactNativeVersion}&to=${newRea
       .filter(releaseNoteUrl => releaseNoteUrl)
       .reverse();
     if (releaseNotesUrls.length === 1) {
-      log(`You should also look at the breaking changes from a release that you skipped:`);
-      log(chalk.bold(`- ${releaseNotesUrls[0]}`));
+      log.log(`You should also look at the breaking changes from a release that you skipped:`);
+      log.log(chalk.bold(`- ${releaseNotesUrls[0]}`));
     } else {
-      log(
+      log.log(
         `In addition to the most recent release notes, you should go over the breaking changes from skipped releases:`
       );
       releaseNotesUrls.forEach(url => {
-        log(chalk.bold(`- ${url}`));
+        log.log(chalk.bold(`- ${url}`));
       });
     }
   }

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -15,7 +15,7 @@ import semver from 'semver';
 import terminalLink from 'terminal-link';
 
 import CommandError from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import { confirmAsync, selectAsync } from '../prompts';
 import { findProjectRootAsync } from './utils/ProjectUtils';
 import maybeBailOnGitStatusAsync from './utils/maybeBailOnGitStatusAsync';
@@ -146,8 +146,8 @@ export function getDependenciesFromBundledNativeModules({
   }
 
   if (!targetSdkVersion) {
-    log.newLine();
-    log.warn(
+    Log.newLine();
+    Log.warn(
       `Supported react, react-native, and react-dom versions are unknown because we don't have version information for the target SDK, please update them manually.`
     );
     return result;
@@ -268,7 +268,7 @@ async function maybeBailOnUnsafeFunctionalityAsync(
   // Give people a chance to bail out if they're updating from a super old version because YMMV
   if (!Versions.gteSdkVersion(exp, '33.0.0')) {
     if (program.nonInteractive) {
-      log.warn(
+      Log.warn(
         `This command works best on SDK 33 and higher. Because the command is running in nonInteractive mode it'll continue regardless.`
       );
       return true;
@@ -282,7 +282,7 @@ async function maybeBailOnUnsafeFunctionalityAsync(
       return true;
     }
 
-    log.newLine();
+    Log.newLine();
   }
   return false;
 }
@@ -292,12 +292,12 @@ async function stopExpoServerAsync(projectRoot: string): Promise<void> {
   const status = await ProjectSettings.getCurrentStatusAsync(projectRoot);
   if (status === 'running') {
     await Project.stopAsync(projectRoot);
-    log.log(
+    Log.log(
       chalk.bold.underline(
         'We found an existing expo-cli instance running for this project and closed it to continue.'
       )
     );
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
   }
 }
 
@@ -308,10 +308,10 @@ async function shouldBailWhenUsingLatest(
   // Maybe bail out early if people are trying to update to the current version
   if (targetSdkVersionString === currentSdkVersionString) {
     if (program.nonInteractive) {
-      log.warn(
+      Log.warn(
         `You are already using the latest SDK version but the command will continue because nonInteractive is enabled.`
       );
-      log.newLine();
+      Log.newLine();
       return false;
     }
     const answer = await confirmAsync({
@@ -319,12 +319,12 @@ async function shouldBailWhenUsingLatest(
     });
 
     if (!answer) {
-      log.log('Follow the Expo blog at https://blog.expo.io for new release information!');
-      log.newLine();
+      Log.log('Follow the Expo blog at https://blog.expo.io for new release information!');
+      Log.newLine();
       return true;
     }
 
-    log.newLine();
+    Log.newLine();
   }
 
   return false;
@@ -336,7 +336,7 @@ async function shouldUpgradeSimulatorAsync(): Promise<boolean> {
     return false;
   }
   if (program.nonInteractive) {
-    log.warn(`Skipping attempt to upgrade the client app on iOS simulator.`);
+    Log.warn(`Skipping attempt to upgrade the client app on iOS simulator.`);
     return false;
   }
 
@@ -345,7 +345,7 @@ async function shouldUpgradeSimulatorAsync(): Promise<boolean> {
     initial: false,
   });
 
-  log.newLine();
+  Log.newLine();
   return answer;
 }
 
@@ -357,12 +357,12 @@ async function maybeUpgradeSimulatorAsync(sdkVersion: TargetSDKVersion) {
       version: sdkVersion.iosClientVersion,
     });
     if (!result) {
-      log.error(
+      Log.error(
         "The upgrade of your simulator didn't go as planned. You might have to reinstall it manually with expo client:install:ios."
       );
     }
 
-    log.newLine();
+    Log.newLine();
   }
 }
 
@@ -372,7 +372,7 @@ async function shouldUpgradeEmulatorAsync(): Promise<boolean> {
     return false;
   }
   if (program.nonInteractive) {
-    log.warn(`Skipping attempt to upgrade the Expo app on the Android emulator.`);
+    Log.warn(`Skipping attempt to upgrade the Expo app on the Android emulator.`);
     return false;
   }
 
@@ -381,7 +381,7 @@ async function shouldUpgradeEmulatorAsync(): Promise<boolean> {
     initial: false,
   });
 
-  log.newLine();
+  Log.newLine();
   return answer;
 }
 
@@ -393,11 +393,11 @@ async function maybeUpgradeEmulatorAsync(sdkVersion: TargetSDKVersion) {
       version: sdkVersion.androidClientVersion,
     });
     if (!result) {
-      log.error(
+      Log.error(
         "The upgrade of your Android client didn't go as planned. You might have to reinstall it manually with expo client:install:android."
       );
     }
-    log.newLine();
+    Log.newLine();
   }
 }
 
@@ -469,7 +469,7 @@ export async function upgradeAsync(
       message: `You are currently using SDK ${currentSdkVersionString}. Would you like to update to the latest version, ${latestSdkVersion.version}?`,
     });
 
-    log.newLine();
+    Log.newLine();
 
     if (!answer) {
       const selectedSdkVersionString = await promptSelectSDKVersionAsync(
@@ -480,7 +480,7 @@ export async function upgradeAsync(
       // This has to exist because it's based on keys already present in sdkVersions
       targetSdkVersion = sdkVersions[selectedSdkVersionString];
       targetSdkVersionString = selectedSdkVersionString;
-      log.newLine();
+      Log.newLine();
     }
   } else if (!targetSdkVersion) {
     // This is useful when testing the beta internally, before actually
@@ -525,11 +525,11 @@ export async function upgradeAsync(
   const packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,
     yarn: options.yarn,
-    log,
+    log: Log,
     silent: !getenv.boolish('EXPO_DEBUG', false),
   });
 
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 
   const expoPackageToInstall = getenv.boolish('EXPO_BETA', false)
     ? `expo@next`
@@ -542,7 +542,7 @@ export async function upgradeAsync(
     const installingPackageStep = logNewSection(
       `Installing the ${expoPackageToInstall} package...`
     );
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
     try {
       await packageManager.addAsync(expoPackageToInstall);
     } catch (e) {
@@ -561,7 +561,7 @@ export async function upgradeAsync(
       !Versions.gteSdkVersion(currentExp, targetSdkVersionString) &&
       currentExp.sdkVersion !== 'UNVERSIONED'
     ) {
-      log.addNewLineIfNone();
+      Log.addNewLineIfNone();
       removingSdkVersionStep.warn(
         'Please manually delete the sdkVersion field in your project app config file. It is now automatically determined based on the expo package version in your package.json.'
       );
@@ -572,7 +572,7 @@ export async function upgradeAsync(
     try {
       const { rootConfig } = await readConfigJsonAsync(projectRoot);
       if (rootConfig.expo.sdkVersion && rootConfig.expo.sdkVersion !== 'UNVERSIONED') {
-        log.addNewLineIfNone();
+        Log.addNewLineIfNone();
         await writeConfigJsonAsync(projectRoot, { sdkVersion: undefined });
         removingSdkVersionStep.succeed('Removed deprecated sdkVersion field from app.json.');
       } else {
@@ -592,7 +592,7 @@ export async function upgradeAsync(
     'Updating packages to compatible versions (where known).'
   );
 
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 
   // Get all updated packages
   const updates = await getUpdatedDependenciesAsync(
@@ -661,15 +661,15 @@ export async function upgradeAsync(
     clearingCacheStep.succeed('Cleared packager cache.');
   }
 
-  log.newLine();
-  log.log(chalk.bold.green(`👏 Automated upgrade steps complete.`));
-  log.log(chalk.bold.grey(`...but this doesn't mean everything is done yet!`));
-  log.newLine();
+  Log.newLine();
+  Log.log(chalk.bold.green(`👏 Automated upgrade steps complete.`));
+  Log.log(chalk.bold.grey(`...but this doesn't mean everything is done yet!`));
+  Log.newLine();
 
   // List packages that were updated
-  log.log(chalk.bold(`✅ The following packages were updated:`));
-  log.log(chalk.grey.bold([...Object.keys(updates), ...['expo']].join(', ')));
-  log.addNewLineIfNone();
+  Log.log(chalk.bold(`✅ The following packages were updated:`));
+  Log.log(chalk.grey.bold([...Object.keys(updates), ...['expo']].join(', ')));
+  Log.addNewLineIfNone();
 
   // List packages that were not updated
   const allDependencies = { ...pkg.dependencies, ...pkg.devDependencies };
@@ -678,21 +678,21 @@ export async function upgradeAsync(
     'expo',
   ]);
   if (untouchedDependencies.length) {
-    log.addNewLineIfNone();
-    log.log(
+    Log.addNewLineIfNone();
+    Log.log(
       chalk.bold(
         `🚨 The following packages were ${chalk.underline(
           'not'
         )} updated. You should check the READMEs for those repositories to determine what version is compatible with your new set of packages:`
       )
     );
-    log.log(chalk.grey.bold(untouchedDependencies.join(', ')));
-    log.addNewLineIfNone();
+    Log.log(chalk.grey.bold(untouchedDependencies.join(', ')));
+    Log.addNewLineIfNone();
   }
 
   // Add some basic additional instructions for bare workflow
   if (workflow === 'bare') {
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
 
     // The upgrade helper only accepts exact version, so in case we use version range expressions in our
     // versions data let's read the version from the source of truth - package.json in node_modules.
@@ -712,19 +712,19 @@ export async function upgradeAsync(
       const upgradeHelperUrl = `https://react-native-community.github.io/upgrade-helper/`;
 
       if (semver.lt(previousReactNativeVersion, newReactNativeVersion)) {
-        log.log(
+        Log.log(
           chalk.bold(
             `⬆️  To finish your react-native upgrade, update your native projects as outlined here:
 ${chalk.gray(`${upgradeHelperUrl}?from=${previousReactNativeVersion}&to=${newReactNativeVersion}`)}`
           )
         );
       } else {
-        log.log(
+        Log.log(
           chalk.bold(
             `👉 react-native has been changed from ${previousReactNativeVersion} to ${newReactNativeVersion} because this is the version used in SDK ${targetSdkVersionString}.`
           )
         );
-        log.log(
+        Log.log(
           chalk.bold(
             chalk.grey(
               `Bare workflow apps are free to adjust their react-native version at the developer's discretion. You may want to re-install react-native@${previousReactNativeVersion} before proceeding.`
@@ -733,31 +733,31 @@ ${chalk.gray(`${upgradeHelperUrl}?from=${previousReactNativeVersion}&to=${newRea
         );
       }
 
-      log.newLine();
+      Log.newLine();
     }
 
-    log.log(
+    Log.log(
       chalk.bold(
         `🏗  Run ${chalk.grey(
           'pod install'
         )} in your iOS directory and then re-build your native projects to compile the updated dependencies.`
       )
     );
-    log.addNewLineIfNone();
+    Log.addNewLineIfNone();
   }
 
   if (targetSdkVersion && targetSdkVersion.releaseNoteUrl) {
-    log.log(
+    Log.log(
       `Please refer to the release notes for information on any further required steps to update and information about breaking changes:`
     );
-    log.log(chalk.bold(targetSdkVersion.releaseNoteUrl));
+    Log.log(chalk.bold(targetSdkVersion.releaseNoteUrl));
   } else {
     if (getenv.boolish('EXPO_BETA', false)) {
-      log.gray(
+      Log.gray(
         `Release notes are not available for beta releases. Please refer to the CHANGELOG: https://github.com/expo/expo/blob/master/CHANGELOG.md.`
       );
     } else {
-      log.gray(
+      Log.gray(
         `Unable to find release notes for ${targetSdkVersionString}, please try to find them on https://blog.expo.io to learn more about other potentially important upgrade steps and breaking changes.`
       );
     }
@@ -772,21 +772,21 @@ ${chalk.gray(`${upgradeHelperUrl}?from=${previousReactNativeVersion}&to=${newRea
 
   const skippedSdkVersionKeys = Object.keys(skippedSdkVersions);
   if (skippedSdkVersionKeys.length) {
-    log.newLine();
+    Log.newLine();
 
     const releaseNotesUrls = Object.values(skippedSdkVersions)
       .map(data => data.releaseNoteUrl)
       .filter(releaseNoteUrl => releaseNoteUrl)
       .reverse();
     if (releaseNotesUrls.length === 1) {
-      log.log(`You should also look at the breaking changes from a release that you skipped:`);
-      log.log(chalk.bold(`- ${releaseNotesUrls[0]}`));
+      Log.log(`You should also look at the breaking changes from a release that you skipped:`);
+      Log.log(chalk.bold(`- ${releaseNotesUrls[0]}`));
     } else {
-      log.log(
+      Log.log(
         `In addition to the most recent release notes, you should go over the breaking changes from skipped releases:`
       );
       releaseNotesUrls.forEach(url => {
-        log.log(chalk.bold(`- ${url}`));
+        Log.log(chalk.bold(`- ${url}`));
       });
     }
   }

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -101,12 +101,12 @@ export default function (program: Command) {
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: any) => {
       const logItem = (name: string, link: string) => {
-        log(`\u203A ${TerminalLink.linkedText(name, link)}`);
+        log.log(`\u203A ${TerminalLink.linkedText(name, link)}`);
       };
 
       log.newLine();
-      log(chalk.yellow('expo upload:ios is no longer supported'));
-      log('Please use one of the following');
+      log.log(chalk.yellow('expo upload:ios is no longer supported'));
+      log.log('Please use one of the following');
       log.newLine();
       logItem(chalk.cyan.bold('eas submit'), 'https://docs.expo.io/submit/ios');
       logItem('Transporter', 'https://apps.apple.com/us/app/transporter/id1450874784');

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
 
-import log from '../log';
+import Log from '../log';
 import AndroidSubmitCommand from './upload/submission-service/android/AndroidSubmitCommand';
 import { AndroidSubmitCommandOptions } from './upload/submission-service/android/types';
 import * as TerminalLink from './utils/TerminalLink';
@@ -42,7 +42,7 @@ export default function (program: Command) {
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: AndroidSubmitCommandOptions) => {
       if (options.useSubmissionService) {
-        log.warn(
+        Log.warn(
           '\n`--use-submission-service is now the default and the flag will be deprecated in the future.`'
         );
       }
@@ -101,19 +101,19 @@ export default function (program: Command) {
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
     .asyncActionProjectDir(async (projectDir: string, options: any) => {
       const logItem = (name: string, link: string) => {
-        log.log(`\u203A ${TerminalLink.linkedText(name, link)}`);
+        Log.log(`\u203A ${TerminalLink.linkedText(name, link)}`);
       };
 
-      log.newLine();
-      log.log(chalk.yellow('expo upload:ios is no longer supported'));
-      log.log('Please use one of the following');
-      log.newLine();
+      Log.newLine();
+      Log.log(chalk.yellow('expo upload:ios is no longer supported'));
+      Log.log('Please use one of the following');
+      Log.newLine();
       logItem(chalk.cyan.bold('eas submit'), 'https://docs.expo.io/submit/ios');
       logItem('Transporter', 'https://apps.apple.com/us/app/transporter/id1450874784');
       logItem(
         'Fastlane deliver',
         'https://docs.fastlane.tools/getting-started/ios/appstore-deployment'
       );
-      log.newLine();
+      Log.newLine();
     });
 }

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitCommand.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitCommand.ts
@@ -1,7 +1,7 @@
 import { Result, result } from '@expo/results';
 import { UserManager } from '@expo/xdl';
 
-import log from '../../../../log';
+import Log from '../../../../log';
 import { isUUID } from '../../../utils/isUUID';
 import {
   ArchiveFileSource,
@@ -33,7 +33,7 @@ class AndroidSubmitCommand {
   async runAsync(): Promise<void> {
     if (!(await UserManager.getCurrentUserAsync())) {
       await UserManager.ensureLoggedInAsync();
-      log.addNewLineIfNone();
+      Log.addNewLineIfNone();
     }
 
     const submissionOptions = this.getAndroidSubmissionOptions();
@@ -57,7 +57,7 @@ class AndroidSubmitCommand {
     ].filter(r => !r.ok);
     if (errored.length > 0) {
       const message = errored.map(err => err.reason?.message).join('\n');
-      log.error(message);
+      Log.error(message);
       throw new Error('Failed to submit the app');
     }
 

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
@@ -6,7 +6,7 @@ import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import ora from 'ora';
 
-import log from '../../../../log';
+import Log from '../../../../log';
 import { ensureProjectExistsAsync, getProjectOwner } from '../../../../projects';
 import { sleep } from '../../../utils/promise';
 import SubmissionService, { DEFAULT_CHECK_INTERVAL_MS } from '../SubmissionService';
@@ -202,7 +202,7 @@ function printSummary(summary: Summary): void {
   table.push([
     {
       colSpan: 2,
-      content: log.chalk.bold('Android Submission Summary'),
+      content: Log.chalk.bold('Android Submission Summary'),
       hAlign: 'center',
     },
   ]);
@@ -211,7 +211,7 @@ function printSummary(summary: Summary): void {
     const displayValue = SummaryHumanReadableValues[key as keyof Summary]?.(value) ?? value;
     table.push([displayKey, displayValue]);
   }
-  log.log(table.toString());
+  Log.log(table.toString());
 }
 
 export default AndroidSubmitter;

--- a/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/AndroidSubmitter.ts
@@ -211,7 +211,7 @@ function printSummary(summary: Summary): void {
     const displayValue = SummaryHumanReadableValues[key as keyof Summary]?.(value) ?? value;
     table.push([displayKey, displayValue]);
   }
-  log(table.toString());
+  log.log(table.toString());
 }
 
 export default AndroidSubmitter;

--- a/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
@@ -1,4 +1,4 @@
-import log from '../../../../log';
+import Log from '../../../../log';
 import prompt from '../../../../prompts';
 import { existingFile } from '../../../../validators';
 import { learnMore } from '../../../utils/TerminalLink';
@@ -36,7 +36,7 @@ async function getServiceAccountAsync(source: ServiceAccountSource): Promise<str
 
 async function handlePathSourceAsync(source: ServiceAccountPathSource): Promise<string> {
   if (!(await existingFile(source.path))) {
-    log.warn(`File ${source.path} doesn't exist.`);
+    Log.warn(`File ${source.path} doesn't exist.`);
     return await getServiceAccountAsync({ sourceType: ServiceAccountSourceType.prompt });
   }
   return source.path;
@@ -51,11 +51,11 @@ async function handlePromptSourceAsync(_source: ServiceAccountPromptSource): Pro
 }
 
 async function askForServiceAccountPathAsync(): Promise<string> {
-  log.log(
-    `${log.chalk.bold(
+  Log.log(
+    `${Log.chalk.bold(
       'A Google Service Account JSON key is required to upload your app to Google Play Store'
     )}.\n` +
-      `If you're not sure what this is or how to create one, ${log.chalk.dim(
+      `If you're not sure what this is or how to create one, ${Log.chalk.dim(
         learnMore('https://expo.fyi/creating-google-service-account')
       )}.`
   );

--- a/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/ServiceAccountSource.ts
@@ -51,7 +51,7 @@ async function handlePromptSourceAsync(_source: ServiceAccountPromptSource): Pro
 }
 
 async function askForServiceAccountPathAsync(): Promise<string> {
-  log(
+  log.log(
     `${log.chalk.bold(
       'A Google Service Account JSON key is required to upload your app to Google Play Store'
     )}.\n` +

--- a/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveFileSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveFileSource.ts
@@ -1,7 +1,7 @@
 import { Platform } from '@expo/config';
 import { StandaloneBuild, UrlUtils } from '@expo/xdl';
 
-import log from '../../../../log';
+import Log from '../../../../log';
 import prompt from '../../../../prompts';
 import { existingFile } from '../../../../validators';
 import { isUUID } from '../../../utils/isUUID';
@@ -87,7 +87,7 @@ async function getArchiveLocationForUrlAsync(url: string): Promise<string> {
   if (!pathIsTar(url)) {
     return url;
   } else {
-    log.log('Downloading your app archive');
+    Log.log('Downloading your app archive');
     return downloadAppArchiveAsync(url);
   }
 }
@@ -95,7 +95,7 @@ async function getArchiveLocationForUrlAsync(url: string): Promise<string> {
 async function getArchiveLocationForPathAsync(path: string): Promise<string> {
   const resolvedPath = await extractLocalArchiveAsync(path);
 
-  log.log('Uploading your app archive to the Expo Submission Service');
+  Log.log('Uploading your app archive to the Expo Submission Service');
   return await uploadAppArchiveAsync(resolvedPath);
 }
 
@@ -114,8 +114,8 @@ async function handleLatestSourceAsync(source: ArchiveFileLatestSource): Promise
     1
   );
   if (builds.length === 0) {
-    log.error(
-      log.chalk.bold(
+    Log.error(
+      Log.chalk.bold(
         "Couldn't find any builds for this project on Expo servers. It looks like you haven't run expo build:android yet."
       )
     );
@@ -130,7 +130,7 @@ async function handleLatestSourceAsync(source: ArchiveFileLatestSource): Promise
 
 async function handlePathSourceAsync(source: ArchiveFilePathSource): Promise<string> {
   if (!(await existingFile(source.path))) {
-    log.error(log.chalk.bold(`${source.path} doesn't exist`));
+    Log.error(Log.chalk.bold(`${source.path} doesn't exist`));
     return getArchiveFileLocationAsync({
       sourceType: ArchiveFileSourceType.prompt,
       platform: source.platform,
@@ -151,12 +151,12 @@ async function handleBuildIdSourceAsync(source: ArchiveFileBuildIdSource): Promi
       slug,
     });
   } catch (err) {
-    log.error(err);
+    Log.error(err);
     throw err;
   }
 
   if (!build) {
-    log.error(log.chalk.bold(`Couldn't find build for id ${source.id}`));
+    Log.error(Log.chalk.bold(`Couldn't find build for id ${source.id}`));
     return getArchiveFileLocationAsync({
       sourceType: ArchiveFileSourceType.prompt,
       platform: source.platform,

--- a/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveFileSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveFileSource.ts
@@ -87,7 +87,7 @@ async function getArchiveLocationForUrlAsync(url: string): Promise<string> {
   if (!pathIsTar(url)) {
     return url;
   } else {
-    log('Downloading your app archive');
+    log.log('Downloading your app archive');
     return downloadAppArchiveAsync(url);
   }
 }
@@ -95,7 +95,7 @@ async function getArchiveLocationForUrlAsync(url: string): Promise<string> {
 async function getArchiveLocationForPathAsync(path: string): Promise<string> {
   const resolvedPath = await extractLocalArchiveAsync(path);
 
-  log('Uploading your app archive to the Expo Submission Service');
+  log.log('Uploading your app archive to the Expo Submission Service');
   return await uploadAppArchiveAsync(resolvedPath);
 }
 

--- a/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveTypeSource.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/archive-source/ArchiveTypeSource.ts
@@ -1,4 +1,4 @@
-import log from '../../../../log';
+import Log from '../../../../log';
 import prompt from '../../../../prompts';
 import { ArchiveType } from '../android/AndroidSubmissionConfig';
 
@@ -52,7 +52,7 @@ async function handleInferSourceAsync(
   if (inferredArchiveType) {
     return inferredArchiveType;
   } else {
-    log.warn("We couldn't autodetect the archive type");
+    Log.warn("We couldn't autodetect the archive type");
     return getArchiveTypeAsync({ sourceType: ArchiveTypeSourceType.prompt }, location);
   }
 }
@@ -66,7 +66,7 @@ async function handleParameterSourceAsync(
     if (source.archiveType === inferredArchiveType) {
       return source.archiveType;
     } else {
-      log.warn(
+      Log.warn(
         `The archive seems to be .${inferredArchiveType} and you passed: --type ${source.archiveType}`
       );
       return getArchiveTypeAsync({ sourceType: ArchiveTypeSourceType.prompt }, location);

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
@@ -1,4 +1,4 @@
-import log from '../../../../log';
+import Log from '../../../../log';
 import { learnMore } from '../../../utils/TerminalLink';
 import { SubmissionError } from '../SubmissionService.types';
 
@@ -20,25 +20,25 @@ const SubmissionErrorMessages: Record<SubmissionErrorCode, string> = {
     "We couldn't figure out what went wrong. Please see logs to learn more.",
   [SubmissionErrorCode.ANDROID_FIRST_UPLOAD_ERROR]:
     "You haven't submitted this app to Google Play Store yet. The first submission of the app needs to be performed manually.\n" +
-    `${log.chalk.dim(learnMore('https://expo.fyi/first-android-submission'))}.`,
+    `${Log.chalk.dim(learnMore('https://expo.fyi/first-android-submission'))}.`,
   [SubmissionErrorCode.ANDROID_OLD_VERSION_CODE_ERROR]:
     "You've already submitted this version of the app.\n" +
     'Versions are identified by Android version code (expo.android.versionCode in app.json).\n' +
     "If you're submitting a managed Expo project, increment the version code in app.json and build the project with expo build:android.\n" +
-    `${log.chalk.dim(learnMore('https://expo.fyi/bumping-android-version-code'))}.`,
+    `${Log.chalk.dim(learnMore('https://expo.fyi/bumping-android-version-code'))}.`,
   [SubmissionErrorCode.ANDROID_MISSING_PRIVACY_POLICY]:
     'The app has permissions that require a privacy policy set for the app.\n' +
-    `${log.chalk.dim(learnMore('https://expo.fyi/missing-privacy-policy'))}.`,
+    `${Log.chalk.dim(learnMore('https://expo.fyi/missing-privacy-policy'))}.`,
 };
 
 function printSubmissionError(error: SubmissionError): boolean {
   if ((Object.values(SubmissionErrorCode) as string[]).includes(error.errorCode)) {
     const errorCode = error.errorCode as SubmissionErrorCode;
-    log.addNewLineIfNone();
-    log.error(SubmissionErrorMessages[errorCode]);
+    Log.addNewLineIfNone();
+    Log.error(SubmissionErrorMessages[errorCode]);
     return errorCode === SubmissionErrorCode.ANDROID_UNKNOWN_ERROR;
   } else {
-    log.log(error.message);
+    Log.log(error.message);
     return true;
   }
 }

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/errors.ts
@@ -38,7 +38,7 @@ function printSubmissionError(error: SubmissionError): boolean {
     log.error(SubmissionErrorMessages[errorCode]);
     return errorCode === SubmissionErrorCode.ANDROID_UNKNOWN_ERROR;
   } else {
-    log(error.message);
+    log.log(error.message);
     return true;
   }
 }

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/logs.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/logs.ts
@@ -1,6 +1,6 @@
 import got from 'got';
 
-import log from '../../../../log';
+import Log from '../../../../log';
 import { Submission, SubmissionStatus } from '../SubmissionService.types';
 import { printSubmissionError } from './errors';
 
@@ -24,16 +24,16 @@ async function downloadAndPrintSubmissionLogs(submission: Submission): Promise<v
   }
   const { body: data } = await got.get(submission.submissionInfo.logsUrl);
   const logs = parseLogs(data);
-  log.addNewLineIfNone();
-  const prefix = log.chalk.blueBright('[logs] ');
+  Log.addNewLineIfNone();
+  const prefix = Log.chalk.blueBright('[logs] ');
   for (const { level, msg } of logs) {
     const msgWithPrefix = `${prefix}${msg}`;
     if (level === 'error') {
-      log.error(msgWithPrefix);
+      Log.error(msgWithPrefix);
     } else if (level === 'warn') {
-      log.warn(msgWithPrefix);
+      Log.warn(msgWithPrefix);
     } else {
-      log.log(msgWithPrefix);
+      Log.log(msgWithPrefix);
     }
   }
 }

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/logs.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/logs.ts
@@ -1,6 +1,6 @@
 import got from 'got';
 
-import Log from '../../../../log';
+import { default as Logger } from '../../../../log';
 import { Submission, SubmissionStatus } from '../SubmissionService.types';
 import { printSubmissionError } from './errors';
 
@@ -24,16 +24,16 @@ async function downloadAndPrintSubmissionLogs(submission: Submission): Promise<v
   }
   const { body: data } = await got.get(submission.submissionInfo.logsUrl);
   const logs = parseLogs(data);
-  Log.addNewLineIfNone();
-  const prefix = Log.chalk.blueBright('[logs] ');
+  Logger.addNewLineIfNone();
+  const prefix = Logger.chalk.blueBright('[logs] ');
   for (const { level, msg } of logs) {
     const msgWithPrefix = `${prefix}${msg}`;
     if (level === 'error') {
-      Log.error(msgWithPrefix);
+      Logger.error(msgWithPrefix);
     } else if (level === 'warn') {
-      Log.warn(msgWithPrefix);
+      Logger.warn(msgWithPrefix);
     } else {
-      Log.log(msgWithPrefix);
+      Logger.log(msgWithPrefix);
     }
   }
 }

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/logs.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/logs.ts
@@ -33,7 +33,7 @@ async function downloadAndPrintSubmissionLogs(submission: Submission): Promise<v
     } else if (level === 'warn') {
       log.warn(msgWithPrefix);
     } else {
-      log(msgWithPrefix);
+      log.log(msgWithPrefix);
     }
   }
 }

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -67,7 +67,7 @@ async function action(projectDir: string, options: ProjectUrlOptions & URLOption
   log.newLine();
   urlOpts.printQRCode(url);
 
-  log('Your URL is\n\n' + chalk.underline(url) + '\n');
+  log.log('Your URL is\n\n' + chalk.underline(url) + '\n');
 
   if (!options.web) {
     await printRunInstructionsAsync();

--- a/packages/expo-cli/src/commands/url.ts
+++ b/packages/expo-cli/src/commands/url.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 
 import CommandError from '../CommandError';
-import log from '../log';
+import Log from '../log';
 import printRunInstructionsAsync from '../printRunInstructionsAsync';
 import urlOpts, { URLOptions } from '../urlOpts';
 import { BuildJobFields, getBuildStatusAsync } from './build/getBuildStatusAsync';
@@ -32,7 +32,7 @@ const logArtifactUrl = (platform: 'ios' | 'android') => async (
   const url = result.jobs?.filter((job: BuildJobFields) => job.platform === platform)[0]?.artifacts
     ?.url;
   if (url) {
-    log.nested(url);
+    Log.nested(url);
   } else {
     throw new Error(
       `No ${platform} binary file found. Use "expo build:${platform}" to create one.`
@@ -64,10 +64,10 @@ async function action(projectDir: string, options: ProjectUrlOptions & URLOption
     ? await getWebAppUrlAsync(projectDir)
     : await UrlUtils.constructDeepLinkAsync(projectDir);
 
-  log.newLine();
+  Log.newLine();
   urlOpts.printQRCode(url);
 
-  log.log('Your URL is\n\n' + chalk.underline(url) + '\n');
+  Log.log('Your URL is\n\n' + chalk.underline(url) + '\n');
 
   if (!options.web) {
     await printRunInstructionsAsync();

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -7,7 +7,7 @@ import ora from 'ora';
 import * as path from 'path';
 import semver from 'semver';
 
-import log from '../../log';
+import Log from '../../log';
 
 export function validateName(name?: string): string | true {
   if (typeof name !== 'string' || name === '') {
@@ -60,16 +60,16 @@ export async function assertFolderEmptyAsync({
 }): Promise<boolean> {
   const conflicts = getConflictsForDirectory(projectRoot);
   if (conflicts.length) {
-    log.addNewLineIfNone();
-    log.nested(`The directory ${log.chalk.green(folderName)} has files that might be overwritten:`);
-    log.newLine();
+    Log.addNewLineIfNone();
+    Log.nested(`The directory ${Log.chalk.green(folderName)} has files that might be overwritten:`);
+    Log.newLine();
     for (const file of conflicts) {
-      log.nested(`  ${file}`);
+      Log.nested(`  ${file}`);
     }
 
     if (overwrite) {
-      log.newLine();
-      log.nested(`Removing existing files from ${log.chalk.green(folderName)}`);
+      Log.newLine();
+      Log.nested(`Removing existing files from ${Log.chalk.green(folderName)}`);
       await Promise.all(conflicts.map(conflict => fs.remove(path.join(projectRoot, conflict))));
       return true;
     }
@@ -93,7 +93,7 @@ export function resolvePackageManager(options: {
     packageManager = 'npm';
   }
   if (options.install) {
-    log.log(
+    Log.log(
       packageManager === 'yarn'
         ? `🧶 Using Yarn to install packages. ${chalk.dim('Pass --npm to use npm instead.')}`
         : '📦 Using npm to install packages.'
@@ -131,10 +131,10 @@ export async function installNodeDependenciesAsync(
       const config = yamlString ? yaml.safeLoad(yamlString) : {};
       config.nodeLinker = 'node-modules';
       !flags.silent &&
-        log.warn(
+        Log.warn(
           `Yarn v${version} detected, enabling experimental Yarn v2 support using the node-modules plugin.`
         );
-      !flags.silent && log.log(`Writing ${yarnRc}...`);
+      !flags.silent && Log.log(`Writing ${yarnRc}...`);
       fs.writeFileSync(yarnRc, yaml.safeDump(config));
     }
     await yarn.installAsync();
@@ -144,9 +144,9 @@ export async function installNodeDependenciesAsync(
 }
 
 export function logNewSection(title: string) {
-  const spinner = ora(log.chalk.bold(title));
+  const spinner = ora(Log.chalk.bold(title));
   // respect loading indicators
-  log.setSpinner(spinner);
+  Log.setSpinner(spinner);
   spinner.start();
   return spinner;
 }
@@ -160,7 +160,7 @@ export function getChangeDirectoryPath(projectRoot: string): string {
 }
 
 export async function installCocoaPodsAsync(projectRoot: string) {
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
   let step = logNewSection('Installing CocoaPods...');
   if (process.platform !== 'darwin') {
     step.succeed('Skipped installing CocoaPods because operating system is not on macOS.');
@@ -169,7 +169,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
 
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
-    log,
+    log: Log,
     silent: !EXPO_DEBUG,
   });
 
@@ -187,14 +187,14 @@ export async function installCocoaPodsAsync(projectRoot: string) {
     } catch (e) {
       step.stopAndPersist({
         symbol: '⚠️ ',
-        text: log.chalk.red(
+        text: Log.chalk.red(
           'Unable to install the CocoaPods CLI. Continuing with project sync, you can install CocoaPods CLI afterwards.'
         ),
       });
       if (e instanceof PackageManager.CocoaPodsError) {
-        log.log(e.message);
+        Log.log(e.message);
       } else {
-        log.log(`Unknown error: ${e.message}`);
+        Log.log(`Unknown error: ${e.message}`);
       }
       return false;
     }
@@ -207,14 +207,14 @@ export async function installCocoaPodsAsync(projectRoot: string) {
   } catch (e) {
     step.stopAndPersist({
       symbol: '⚠️ ',
-      text: log.chalk.red(
+      text: Log.chalk.red(
         'Something went wrong running `pod install` in the `ios` directory. Continuing with project sync, you can debug this afterwards.'
       ),
     });
     if (e instanceof PackageManager.CocoaPodsError) {
-      log.log(e.message);
+      Log.log(e.message);
     } else {
-      log.log(`Unknown error: ${e.message}`);
+      Log.log(`Unknown error: ${e.message}`);
     }
     return false;
   }

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -169,7 +169,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
 
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
-    log: Log,
+    log: Log.log,
     silent: !EXPO_DEBUG,
   });
 

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -93,7 +93,7 @@ export function resolvePackageManager(options: {
     packageManager = 'npm';
   }
   if (options.install) {
-    log(
+    log.log(
       packageManager === 'yarn'
         ? `🧶 Using Yarn to install packages. ${chalk.dim('Pass --npm to use npm instead.')}`
         : '📦 Using npm to install packages.'
@@ -134,7 +134,7 @@ export async function installNodeDependenciesAsync(
         log.warn(
           `Yarn v${version} detected, enabling experimental Yarn v2 support using the node-modules plugin.`
         );
-      !flags.silent && log(`Writing ${yarnRc}...`);
+      !flags.silent && log.log(`Writing ${yarnRc}...`);
       fs.writeFileSync(yarnRc, yaml.safeDump(config));
     }
     await yarn.installAsync();
@@ -192,9 +192,9 @@ export async function installCocoaPodsAsync(projectRoot: string) {
         ),
       });
       if (e instanceof PackageManager.CocoaPodsError) {
-        log(e.message);
+        log.log(e.message);
       } else {
-        log(`Unknown error: ${e.message}`);
+        log.log(`Unknown error: ${e.message}`);
       }
       return false;
     }
@@ -212,9 +212,9 @@ export async function installCocoaPodsAsync(projectRoot: string) {
       ),
     });
     if (e instanceof PackageManager.CocoaPodsError) {
-      log(e.message);
+      log.log(e.message);
     } else {
-      log(`Unknown error: ${e.message}`);
+      log.log(`Unknown error: ${e.message}`);
     }
     return false;
   }

--- a/packages/expo-cli/src/commands/utils/ProjectUtils.ts
+++ b/packages/expo-cli/src/commands/utils/ProjectUtils.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import semver from 'semver';
 
 import CommandError from '../../CommandError';
-import log from '../../log';
+import Log from '../../log';
 
 export async function findProjectRootAsync(
   base: string
@@ -73,20 +73,20 @@ export async function validateGitStatusAsync(): Promise<boolean> {
   }
 
   if (workingTreeStatus === 'clean') {
-    log.nested(`Your git working tree is ${chalk.green('clean')}`);
-    log.nested('To revert the changes after this command completes, you can run the following:');
-    log.nested('  git clean --force && git reset --hard');
+    Log.nested(`Your git working tree is ${chalk.green('clean')}`);
+    Log.nested('To revert the changes after this command completes, you can run the following:');
+    Log.nested('  git clean --force && git reset --hard');
     return true;
   } else if (workingTreeStatus === 'dirty') {
-    log.nested(`${chalk.bold('Warning!')} Your git working tree is ${chalk.red('dirty')}.`);
-    log.nested(
+    Log.nested(`${chalk.bold('Warning!')} Your git working tree is ${chalk.red('dirty')}.`);
+    Log.nested(
       `It's recommended to ${chalk.bold(
         'commit all your changes before proceeding'
       )}, so you can revert the changes made by this command if necessary.`
     );
   } else {
-    log.nested("We couldn't find a git repository in your project directory.");
-    log.nested("It's recommended to back up your project before proceeding.");
+    Log.nested("We couldn't find a git repository in your project directory.");
+    Log.nested("It's recommended to back up your project before proceeding.");
   }
 
   return false;

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -2,7 +2,7 @@ import { getConfig } from '@expo/config';
 import { ApiV2, UserManager } from '@expo/xdl';
 import ora from 'ora';
 
-import log from '../../log';
+import Log from '../../log';
 import { getProjectOwner } from '../../projects';
 import { confirmAsync } from '../../prompts';
 import * as table from './cli-table';
@@ -178,7 +178,7 @@ export async function rollbackPublicationFromChannelAsync(
     }
   } catch (e) {
     if (completedPlatforms.length > 0) {
-      log.error(
+      Log.error(
         `The platforms ${platforms.filter(
           platform => !completedPlatforms.includes(platform)
         )} have not been rolled back. You can complete the missing platforms by running \`expo publish:rollback\` with the --platform flag`
@@ -242,7 +242,7 @@ export async function printPublicationDetailAsync(
   options: DetailOptions
 ) {
   if (options.raw) {
-    log.log(JSON.stringify(detail));
+    Log.log(JSON.stringify(detail));
     return;
   }
 
@@ -251,9 +251,9 @@ export async function printPublicationDetailAsync(
 
   // Print general release info
   const generalTableString = table.printTableJson(detail, 'Release Description');
-  log.log(generalTableString);
+  Log.log(generalTableString);
 
   // Print manifest info
   const manifestTableString = table.printTableJson(manifest, 'Manifest Details');
-  log.log(manifestTableString);
+  Log.log(manifestTableString);
 }

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -242,7 +242,7 @@ export async function printPublicationDetailAsync(
   options: DetailOptions
 ) {
   if (options.raw) {
-    log(JSON.stringify(detail));
+    log.log(JSON.stringify(detail));
     return;
   }
 
@@ -251,9 +251,9 @@ export async function printPublicationDetailAsync(
 
   // Print general release info
   const generalTableString = table.printTableJson(detail, 'Release Description');
-  log(generalTableString);
+  log.log(generalTableString);
 
   // Print manifest info
   const manifestTableString = table.printTableJson(manifest, 'Manifest Details');
-  log(manifestTableString);
+  log.log(manifestTableString);
 }

--- a/packages/expo-cli/src/commands/utils/TerminalLink.ts
+++ b/packages/expo-cli/src/commands/utils/TerminalLink.ts
@@ -1,6 +1,6 @@
 import terminalLink from 'terminal-link';
 
-import log from '../../log';
+import Log from '../../log';
 
 /**
  * When linking isn't available, fallback to displaying the URL beside the
@@ -39,15 +39,15 @@ export function fallbackToUrl(text: string, url: string): string {
  * @param url
  */
 export function learnMore(url: string): string {
-  return terminalLink(log.chalk.underline('Learn more.'), url, {
-    fallback: (text, url) => `Learn more: ${log.chalk.underline(url)}`,
+  return terminalLink(Log.chalk.underline('Learn more.'), url, {
+    fallback: (text, url) => `Learn more: ${Log.chalk.underline(url)}`,
   });
 }
 
 export function linkedText(text: string, url: string): string {
   return terminalLink(text, url, {
     fallback: (text, url) => {
-      return `${text} ${log.chalk.dim.underline(url)}`;
+      return `${text} ${Log.chalk.dim.underline(url)}`;
     },
   });
 }

--- a/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
@@ -1,14 +1,14 @@
 import { WarningAggregator } from '@expo/config-plugins';
 import chalk from 'chalk';
 
-import log from '../../log';
+import Log from '../../log';
 import * as TerminalLink from './TerminalLink';
 
 export function logConfigWarningsIOS() {
   const warningsIOS = WarningAggregator.flushWarningsIOS();
   if (warningsIOS.length) {
     warningsIOS.forEach(([property, warning, link]) => {
-      log.nested(formatNamedWarning(property, warning, link));
+      Log.nested(formatNamedWarning(property, warning, link));
     });
   }
 
@@ -19,7 +19,7 @@ export function logConfigWarningsAndroid() {
   const warningsAndroid = WarningAggregator.flushWarningsAndroid();
   if (warningsAndroid.length) {
     warningsAndroid.forEach(([property, warning, link]) => {
-      log.nested(formatNamedWarning(property, warning, link));
+      Log.nested(formatNamedWarning(property, warning, link));
     });
   }
 
@@ -28,7 +28,7 @@ export function logConfigWarningsAndroid() {
 
 export function formatNamedWarning(property: string, warning: string, link?: string) {
   return `- ${chalk.bold(property)}: ${warning}${
-    link ? getSpacer(warning) + log.chalk.dim(TerminalLink.learnMore(link)) : ''
+    link ? getSpacer(warning) + Log.chalk.dim(TerminalLink.learnMore(link)) : ''
   }`;
 }
 

--- a/packages/expo-cli/src/commands/utils/maybeBailOnGitStatusAsync.ts
+++ b/packages/expo-cli/src/commands/utils/maybeBailOnGitStatusAsync.ts
@@ -1,17 +1,17 @@
 import program from 'commander';
 
-import log from '../../log';
+import Log from '../../log';
 import { confirmAsync } from '../../prompts';
 import { validateGitStatusAsync } from './ProjectUtils';
 
 export default async function maybeBailOnGitStatusAsync(): Promise<boolean> {
   const isGitStatusClean = await validateGitStatusAsync();
-  log.newLine();
+  Log.newLine();
 
   // Give people a chance to bail out if git working tree is dirty
   if (!isGitStatusClean) {
     if (program.nonInteractive) {
-      log.warn(
+      Log.warn(
         `Git status is dirty but the command will continue because nonInteractive is enabled.`
       );
       return false;
@@ -25,7 +25,7 @@ export default async function maybeBailOnGitStatusAsync(): Promise<boolean> {
       return true;
     }
 
-    log.newLine();
+    Log.newLine();
   }
   return false;
 }

--- a/packages/expo-cli/src/commands/utils/openInEditorAsync.ts
+++ b/packages/expo-cli/src/commands/utils/openInEditorAsync.ts
@@ -2,7 +2,7 @@ import * as osascript from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
 import editors from 'env-editor';
 
-import log from '../../log';
+import Log from '../../log';
 
 function guessEditor() {
   if (process.env.EXPO_EDITOR) {
@@ -26,7 +26,7 @@ export async function openInEditorAsync(path: string, options: { editor?: string
   }
 
   if (!editor) {
-    log.error(
+    Log.error(
       'Could not find your editor, you can set it by defining $EXPO_EDITOR environment variable (e.g. "code" or "atom")'
     );
     return;

--- a/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import wrapAnsi from 'wrap-ansi';
 
 import CommandError from '../../../CommandError';
-import log from '../../../log';
+import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
 import { logNewSection } from '../CreateApp';
 import {
@@ -20,7 +20,7 @@ import { isTypeScriptSetupDisabled, updateTSConfigAsync } from './updateTSConfig
 
 export async function ensureTypeScriptSetupAsync(projectRoot: string): Promise<void> {
   if (isTypeScriptSetupDisabled) {
-    log.log(chalk.dim('\u203A Skipping TypeScript verification'));
+    Log.log(chalk.dim('\u203A Skipping TypeScript verification'));
     return;
   }
 
@@ -169,12 +169,12 @@ async function installPackagesAsync(
 ) {
   const packageManager = PackageManager.createForProject(projectRoot, {
     yarn: isYarn,
-    log,
-    silent: !log.isDebug,
+    log: Log,
+    silent: !Log.isDebug,
   });
 
   const packagesStr = chalk.bold(devPackages.join(', '));
-  log.newLine();
+  Log.newLine();
   const installingPackageStep = logNewSection(`Installing ${packagesStr}`);
   try {
     await packageManager.addDevAsync(...devPackages);

--- a/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
@@ -169,7 +169,7 @@ async function installPackagesAsync(
 ) {
   const packageManager = PackageManager.createForProject(projectRoot, {
     yarn: isYarn,
-    log: Log,
+    log: Log.log,
     silent: !Log.isDebug,
   });
 

--- a/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/ensureTypeScriptSetup.ts
@@ -20,7 +20,7 @@ import { isTypeScriptSetupDisabled, updateTSConfigAsync } from './updateTSConfig
 
 export async function ensureTypeScriptSetupAsync(projectRoot: string): Promise<void> {
   if (isTypeScriptSetupDisabled) {
-    log(chalk.dim('\u203A Skipping TypeScript verification'));
+    log.log(chalk.dim('\u203A Skipping TypeScript verification'));
     return;
   }
 

--- a/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
@@ -68,9 +68,9 @@ export async function updateTSConfigAsync({
   log.addNewLineIfNone();
 
   if (isBootstrapping) {
-    log(`${chalk.bold`TypeScript`}: A ${chalk.cyan('tsconfig.json')} has been auto-generated`);
+    log.log(`${chalk.bold`TypeScript`}: A ${chalk.cyan('tsconfig.json')} has been auto-generated`);
   } else {
-    log(
+    log.log(
       `${chalk.bold`TypeScript`}: The ${chalk.cyan(
         'tsconfig.json'
       )} has been updated ${chalk.dim`(Use ${TS_FEATURE_FLAG} to skip)`}`
@@ -83,7 +83,9 @@ export async function updateTSConfigAsync({
 function logModifications(modifications: string[][]) {
   log.newLine();
 
-  log(`\u203A ${chalk.bold('Required')} modifications made to the ${chalk.cyan('tsconfig.json')}:`);
+  log.log(
+    `\u203A ${chalk.bold('Required')} modifications made to the ${chalk.cyan('tsconfig.json')}:`
+  );
 
   log.newLine();
 
@@ -97,6 +99,6 @@ function printTable(items: string[][]) {
   const tableFormat = (name: string, msg: string) =>
     `  ${chalk.bold`${name}`} is now ${chalk.cyan(msg)}`;
   for (const [key, value] of items) {
-    log(tableFormat(key, value));
+    log.log(tableFormat(key, value));
   }
 }

--- a/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
@@ -2,7 +2,7 @@ import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
 import { boolish } from 'getenv';
 
-import log from '../../../log';
+import Log from '../../../log';
 import { baseTSConfigName, resolveBaseTSConfig } from './resolveModules';
 
 const TS_FEATURE_FLAG = 'EXPO_NO_TYPESCRIPT_SETUP';
@@ -65,40 +65,40 @@ export async function updateTSConfigAsync({
   // Write changes and log out a summary of what changed
   await JsonFile.writeAsync(tsConfigPath, projectTSConfig);
 
-  log.addNewLineIfNone();
+  Log.addNewLineIfNone();
 
   if (isBootstrapping) {
-    log.log(`${chalk.bold`TypeScript`}: A ${chalk.cyan('tsconfig.json')} has been auto-generated`);
+    Log.log(`${chalk.bold`TypeScript`}: A ${chalk.cyan('tsconfig.json')} has been auto-generated`);
   } else {
-    log.log(
+    Log.log(
       `${chalk.bold`TypeScript`}: The ${chalk.cyan(
         'tsconfig.json'
       )} has been updated ${chalk.dim`(Use ${TS_FEATURE_FLAG} to skip)`}`
     );
     logModifications(modifications);
   }
-  log.newLine();
+  Log.newLine();
 }
 
 function logModifications(modifications: string[][]) {
-  log.newLine();
+  Log.newLine();
 
-  log.log(
+  Log.log(
     `\u203A ${chalk.bold('Required')} modifications made to the ${chalk.cyan('tsconfig.json')}:`
   );
 
-  log.newLine();
+  Log.newLine();
 
   // Sort the items based on key name length
   printTable(modifications.sort((a, b) => a[0].length - b[0].length));
 
-  log.newLine();
+  Log.newLine();
 }
 
 function printTable(items: string[][]) {
   const tableFormat = (name: string, msg: string) =>
     `  ${chalk.bold`${name}`} is now ${chalk.cyan(msg)}`;
   for (const [key, value] of items) {
-    log.log(tableFormat(key, value));
+    Log.log(tableFormat(key, value));
   }
 }

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -65,10 +65,10 @@ async function listAsync(projectRoot: string) {
   if (webhooks.length) {
     const table = new CliTable({ head: ['Webhook ID', 'URL', 'Event'] });
     table.push(...webhooks.map((hook: Webhook) => [hook.id, hook.url, hook.event]));
-    log(table.toString());
+    log.log(table.toString());
   } else {
-    log(`${chalk.bold(experienceName)} has no webhooks.`);
-    log('Use `expo webhooks:add` to add one.');
+    log.log(`${chalk.bold(experienceName)} has no webhooks.`);
+    log.log('Use `expo webhooks:add` to add one.');
   }
 }
 
@@ -132,8 +132,8 @@ function validateSecret({ secret }: { secret?: string }): string | null {
 function generateSecret() {
   // Create a 60 characters long secret from 30 random bytes.
   const randomSecret = crypto.randomBytes(30).toString('hex');
-  log(chalk.underline('Webhook signing secret:'));
-  log(randomSecret);
+  log.log(chalk.underline('Webhook signing secret:'));
+  log.log(randomSecret);
   return randomSecret;
 }
 

--- a/packages/expo-cli/src/commands/webhooks.ts
+++ b/packages/expo-cli/src/commands/webhooks.ts
@@ -8,7 +8,7 @@ import ora from 'ora';
 
 import CommandError, { ErrorCodes } from '../CommandError';
 import { assert } from '../assert';
-import log from '../log';
+import Log from '../log';
 
 const SECRET_MIN_LENGTH = 16;
 const SECRET_MAX_LENGTH = 1000;
@@ -65,10 +65,10 @@ async function listAsync(projectRoot: string) {
   if (webhooks.length) {
     const table = new CliTable({ head: ['Webhook ID', 'URL', 'Event'] });
     table.push(...webhooks.map((hook: Webhook) => [hook.id, hook.url, hook.event]));
-    log.log(table.toString());
+    Log.log(table.toString());
   } else {
-    log.log(`${chalk.bold(experienceName)} has no webhooks.`);
-    log.log('Use `expo webhooks:add` to add one.');
+    Log.log(`${chalk.bold(experienceName)} has no webhooks.`);
+    Log.log('Use `expo webhooks:add` to add one.');
   }
 }
 
@@ -132,8 +132,8 @@ function validateSecret({ secret }: { secret?: string }): string | null {
 function generateSecret() {
   // Create a 60 characters long secret from 30 random bytes.
   const randomSecret = crypto.randomBytes(30).toString('hex');
-  log.log(chalk.underline('Webhook signing secret:'));
-  log.log(randomSecret);
+  Log.log(chalk.underline('Webhook signing secret:'));
+  Log.log(randomSecret);
   return randomSecret;
 }
 

--- a/packages/expo-cli/src/commands/whoami.ts
+++ b/packages/expo-cli/src/commands/whoami.ts
@@ -10,10 +10,10 @@ async function action(command: Command) {
     if (command.parent?.nonInteractive) {
       log.nested(user.username);
     } else {
-      log(`Logged in as ${chalk.cyan(user.username)}`);
+      log.log(`Logged in as ${chalk.cyan(user.username)}`);
     }
   } else {
-    log(`\u203A Not logged in, run ${chalk.cyan`expo login`} to authenticate`);
+    log.log(`\u203A Not logged in, run ${chalk.cyan`expo login`} to authenticate`);
     process.exit(1);
   }
 }

--- a/packages/expo-cli/src/commands/whoami.ts
+++ b/packages/expo-cli/src/commands/whoami.ts
@@ -2,18 +2,18 @@ import { UserManager } from '@expo/xdl';
 import chalk from 'chalk';
 import { Command } from 'commander';
 
-import log from '../log';
+import Log from '../log';
 
 async function action(command: Command) {
   const user = await UserManager.getCurrentUserAsync({ silent: true });
   if (user) {
     if (command.parent?.nonInteractive) {
-      log.nested(user.username);
+      Log.nested(user.username);
     } else {
-      log.log(`Logged in as ${chalk.cyan(user.username)}`);
+      Log.log(`Logged in as ${chalk.cyan(user.username)}`);
     }
   } else {
-    log.log(`\u203A Not logged in, run ${chalk.cyan`expo login`} to authenticate`);
+    Log.log(`\u203A Not logged in, run ${chalk.cyan`expo login`} to authenticate`);
     process.exit(1);
   }
 }

--- a/packages/expo-cli/src/credentials/actions/list.ts
+++ b/packages/expo-cli/src/credentials/actions/list.ts
@@ -24,7 +24,7 @@ export function displayProjectCredentials(
   const experienceName = `@${appLookupParams.accountName}/${appLookupParams.projectName}`;
   const bundleIdentifier = appLookupParams.bundleIdentifier;
   if (!appCredentials) {
-    log(
+    log.log(
       chalk.bold(
         `No credentials configured for app ${experienceName} with bundle identifier ${bundleIdentifier}\n`
       )
@@ -32,10 +32,10 @@ export function displayProjectCredentials(
     return;
   }
 
-  log();
-  log(chalk.bold('Project Credential Configuration:'));
+  log.log();
+  log.log(chalk.bold('Project Credential Configuration:'));
   displayIosAppCredentials(appCredentials);
-  log();
+  log.log();
 
   if (distCert) {
     displayIosUserCredentials(distCert);
@@ -47,48 +47,48 @@ export function displayProjectCredentials(
 }
 
 export async function displayIosCredentials(credentials: IosCredentials) {
-  log(chalk.bold('Available credentials for iOS apps\n'));
+  log.log(chalk.bold('Available credentials for iOS apps\n'));
 
-  log(chalk.bold('Application credentials\n'));
+  log.log(chalk.bold('Application credentials\n'));
   for (const cred of credentials.appCredentials) {
     displayIosAppCredentials(cred);
-    log();
+    log.log();
   }
 
-  log();
-  log(chalk.bold('User credentials\n'));
+  log.log();
+  log.log(chalk.bold('User credentials\n'));
   for (const cred of credentials.userCredentials) {
     displayIosUserCredentials(cred, credentials);
-    log();
+    log.log();
   }
-  log();
-  log();
+  log.log();
+  log.log();
 }
 
 export function displayIosAppCredentials(appCredentials: IosAppCredentials) {
-  log(
+  log.log(
     `  Experience: ${chalk.bold(appCredentials.experienceName)}, bundle identifier: ${
       appCredentials.bundleIdentifier
     }`
   );
   if (appCredentials.credentials.provisioningProfile) {
-    log(
+    log.log(
       `    Provisioning profile (ID: ${chalk.green(
         appCredentials.credentials.provisioningProfileId || '---------'
       )})`
     );
   } else {
-    log('    Provisioning profile is missing. It will be generated during the next build');
+    log.log('    Provisioning profile is missing. It will be generated during the next build');
   }
   if (appCredentials.credentials.teamId || appCredentials.credentials.teamName) {
-    log(
+    log.log(
       `    Apple Team ID: ${chalk.green(
         appCredentials.credentials.teamId || '---------'
       )},  Apple Team Name: ${chalk.green(appCredentials.credentials.teamName || '---------')}`
     );
   }
   if (appCredentials.credentials.pushP12 && appCredentials.credentials.pushPassword) {
-    log(
+    log.log(
       `    (deprecated) Push Certificate (Push ID: ${chalk.green(
         appCredentials.credentials.pushId || '-----'
       )})`
@@ -101,9 +101,9 @@ export function displayIosUserCredentials(
   credentials?: IosCredentials
 ) {
   if (userCredentials.type === 'push-key') {
-    log(`  Push Notifications Key - Key ID: ${chalk.green(userCredentials.apnsKeyId)}`);
+    log.log(`  Push Notifications Key - Key ID: ${chalk.green(userCredentials.apnsKeyId)}`);
   } else if (userCredentials.type === 'dist-cert') {
-    log(
+    log.log(
       `  Distribution Certificate - Certificate ID: ${chalk.green(
         userCredentials.certId || '-----'
       )}`
@@ -111,7 +111,7 @@ export function displayIosUserCredentials(
   } else {
     log.warn(`  Unknown key type ${(userCredentials as any).type}`);
   }
-  log(
+  log.log(
     `    Apple Team ID: ${chalk.green(
       userCredentials.teamId || '---------'
     )},  Apple Team Name: ${chalk.green(userCredentials.teamName || '---------')}`
@@ -127,13 +127,13 @@ export function displayIosUserCredentials(
       ),
     ].join(',\n      ');
     const usedByAppsText = usedByApps ? `used by\n      ${usedByApps}` : 'not used by any apps';
-    log(`    ${chalk.gray(usedByAppsText)}`);
+    log.log(`    ${chalk.gray(usedByAppsText)}`);
   }
 }
 
 export async function displayAndroidCredentials(credentialsList: AndroidCredentials[]) {
-  log(chalk.bold('Available Android credentials'));
-  log();
+  log.log(chalk.bold('Available Android credentials'));
+  log.log();
   for (const credentials of credentialsList) {
     await displayAndroidAppCredentials(credentials);
   }
@@ -142,8 +142,8 @@ export async function displayAndroidCredentials(credentialsList: AndroidCredenti
 export async function displayAndroidAppCredentials(credentials: AndroidCredentials) {
   const tmpFilename = path.join(os.tmpdir(), `expo_tmp_keystore_${uuid()}file.jks`);
   try {
-    log(chalk.green(credentials.experienceName));
-    log(chalk.bold('  Upload Keystore hashes'));
+    log.log(chalk.green(credentials.experienceName));
+    log.log(chalk.bold('  Upload Keystore hashes'));
     if (credentials.keystore?.keystore) {
       const storeBuf = Buffer.from(credentials.keystore.keystore, 'base64');
       await fs.writeFile(tmpFilename, storeBuf);
@@ -155,14 +155,14 @@ export async function displayAndroidAppCredentials(credentials: AndroidCredentia
         '    '
       );
     } else {
-      log('    -----------------------');
+      log.log('    -----------------------');
     }
-    log(chalk.bold('  Push Notifications credentials'));
-    log('    FCM Api Key: ', credentials.pushCredentials?.fcmApiKey ?? '---------------------');
-    log('\n');
+    log.log(chalk.bold('  Push Notifications credentials'));
+    log.log('    FCM Api Key: ', credentials.pushCredentials?.fcmApiKey ?? '---------------------');
+    log.log('\n');
   } catch (error) {
     log.error('  Failed to parse the Keystore', error);
-    log('\n');
+    log.log('\n');
   } finally {
     await fs.remove(tmpFilename);
   }

--- a/packages/expo-cli/src/credentials/actions/list.ts
+++ b/packages/expo-cli/src/credentials/actions/list.ts
@@ -5,7 +5,7 @@ import os from 'os';
 import path from 'path';
 import { v4 as uuid } from 'uuid';
 
-import log from '../../log';
+import Log from '../../log';
 import { AppLookupParams } from '../api/IosApi';
 import {
   AndroidCredentials,
@@ -24,7 +24,7 @@ export function displayProjectCredentials(
   const experienceName = `@${appLookupParams.accountName}/${appLookupParams.projectName}`;
   const bundleIdentifier = appLookupParams.bundleIdentifier;
   if (!appCredentials) {
-    log.log(
+    Log.log(
       chalk.bold(
         `No credentials configured for app ${experienceName} with bundle identifier ${bundleIdentifier}\n`
       )
@@ -32,10 +32,10 @@ export function displayProjectCredentials(
     return;
   }
 
-  log.log();
-  log.log(chalk.bold('Project Credential Configuration:'));
+  Log.log();
+  Log.log(chalk.bold('Project Credential Configuration:'));
   displayIosAppCredentials(appCredentials);
-  log.log();
+  Log.log();
 
   if (distCert) {
     displayIosUserCredentials(distCert);
@@ -47,48 +47,48 @@ export function displayProjectCredentials(
 }
 
 export async function displayIosCredentials(credentials: IosCredentials) {
-  log.log(chalk.bold('Available credentials for iOS apps\n'));
+  Log.log(chalk.bold('Available credentials for iOS apps\n'));
 
-  log.log(chalk.bold('Application credentials\n'));
+  Log.log(chalk.bold('Application credentials\n'));
   for (const cred of credentials.appCredentials) {
     displayIosAppCredentials(cred);
-    log.log();
+    Log.log();
   }
 
-  log.log();
-  log.log(chalk.bold('User credentials\n'));
+  Log.log();
+  Log.log(chalk.bold('User credentials\n'));
   for (const cred of credentials.userCredentials) {
     displayIosUserCredentials(cred, credentials);
-    log.log();
+    Log.log();
   }
-  log.log();
-  log.log();
+  Log.log();
+  Log.log();
 }
 
 export function displayIosAppCredentials(appCredentials: IosAppCredentials) {
-  log.log(
+  Log.log(
     `  Experience: ${chalk.bold(appCredentials.experienceName)}, bundle identifier: ${
       appCredentials.bundleIdentifier
     }`
   );
   if (appCredentials.credentials.provisioningProfile) {
-    log.log(
+    Log.log(
       `    Provisioning profile (ID: ${chalk.green(
         appCredentials.credentials.provisioningProfileId || '---------'
       )})`
     );
   } else {
-    log.log('    Provisioning profile is missing. It will be generated during the next build');
+    Log.log('    Provisioning profile is missing. It will be generated during the next build');
   }
   if (appCredentials.credentials.teamId || appCredentials.credentials.teamName) {
-    log.log(
+    Log.log(
       `    Apple Team ID: ${chalk.green(
         appCredentials.credentials.teamId || '---------'
       )},  Apple Team Name: ${chalk.green(appCredentials.credentials.teamName || '---------')}`
     );
   }
   if (appCredentials.credentials.pushP12 && appCredentials.credentials.pushPassword) {
-    log.log(
+    Log.log(
       `    (deprecated) Push Certificate (Push ID: ${chalk.green(
         appCredentials.credentials.pushId || '-----'
       )})`
@@ -101,17 +101,17 @@ export function displayIosUserCredentials(
   credentials?: IosCredentials
 ) {
   if (userCredentials.type === 'push-key') {
-    log.log(`  Push Notifications Key - Key ID: ${chalk.green(userCredentials.apnsKeyId)}`);
+    Log.log(`  Push Notifications Key - Key ID: ${chalk.green(userCredentials.apnsKeyId)}`);
   } else if (userCredentials.type === 'dist-cert') {
-    log.log(
+    Log.log(
       `  Distribution Certificate - Certificate ID: ${chalk.green(
         userCredentials.certId || '-----'
       )}`
     );
   } else {
-    log.warn(`  Unknown key type ${(userCredentials as any).type}`);
+    Log.warn(`  Unknown key type ${(userCredentials as any).type}`);
   }
-  log.log(
+  Log.log(
     `    Apple Team ID: ${chalk.green(
       userCredentials.teamId || '---------'
     )},  Apple Team Name: ${chalk.green(userCredentials.teamName || '---------')}`
@@ -127,13 +127,13 @@ export function displayIosUserCredentials(
       ),
     ].join(',\n      ');
     const usedByAppsText = usedByApps ? `used by\n      ${usedByApps}` : 'not used by any apps';
-    log.log(`    ${chalk.gray(usedByAppsText)}`);
+    Log.log(`    ${chalk.gray(usedByAppsText)}`);
   }
 }
 
 export async function displayAndroidCredentials(credentialsList: AndroidCredentials[]) {
-  log.log(chalk.bold('Available Android credentials'));
-  log.log();
+  Log.log(chalk.bold('Available Android credentials'));
+  Log.log();
   for (const credentials of credentialsList) {
     await displayAndroidAppCredentials(credentials);
   }
@@ -142,8 +142,8 @@ export async function displayAndroidCredentials(credentialsList: AndroidCredenti
 export async function displayAndroidAppCredentials(credentials: AndroidCredentials) {
   const tmpFilename = path.join(os.tmpdir(), `expo_tmp_keystore_${uuid()}file.jks`);
   try {
-    log.log(chalk.green(credentials.experienceName));
-    log.log(chalk.bold('  Upload Keystore hashes'));
+    Log.log(chalk.green(credentials.experienceName));
+    Log.log(chalk.bold('  Upload Keystore hashes'));
     if (credentials.keystore?.keystore) {
       const storeBuf = Buffer.from(credentials.keystore.keystore, 'base64');
       await fs.writeFile(tmpFilename, storeBuf);
@@ -155,14 +155,14 @@ export async function displayAndroidAppCredentials(credentials: AndroidCredentia
         '    '
       );
     } else {
-      log.log('    -----------------------');
+      Log.log('    -----------------------');
     }
-    log.log(chalk.bold('  Push Notifications credentials'));
-    log.log('    FCM Api Key: ', credentials.pushCredentials?.fcmApiKey ?? '---------------------');
-    log.log('\n');
+    Log.log(chalk.bold('  Push Notifications credentials'));
+    Log.log('    FCM Api Key: ', credentials.pushCredentials?.fcmApiKey ?? '---------------------');
+    Log.log('\n');
   } catch (error) {
-    log.error('  Failed to parse the Keystore', error);
-    log.log('\n');
+    Log.error('  Failed to parse the Keystore', error);
+    Log.log('\n');
   } finally {
     await fs.remove(tmpFilename);
   }

--- a/packages/expo-cli/src/credentials/actions/promptForCredentials.ts
+++ b/packages/expo-cli/src/credentials/actions/promptForCredentials.ts
@@ -3,7 +3,7 @@ import once from 'lodash/once';
 import path from 'path';
 import untildify from 'untildify';
 
-import log from '../../log';
+import Log from '../../log';
 import prompts, { Question as PromptQuestion } from '../../prompts';
 import * as validators from '../../validators';
 
@@ -36,7 +36,7 @@ export type CredentialSchema<T> = {
 };
 
 const EXPERT_PROMPT = once(() =>
-  log.warn(`
+  Log.warn(`
 WARNING! In this mode, we won't be able to make sure that your credentials are valid.
 Please double check that you're uploading valid files for your app otherwise you may encounter strange errors!
 

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -89,7 +89,7 @@ export class Context {
   logOwnerAndProject() {
     // Figure out if User A is configuring credentials as admin for User B's project
     const isProxyUser = this.manifest.owner && this.manifest.owner !== this.user.username;
-    log(
+    log.log(
       `Accessing credentials ${isProxyUser ? 'on behalf of' : 'for'} ${
         this.projectOwner
       } in project ${this.manifest.slug}`

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -3,7 +3,7 @@ import { ApiV2, RobotUser, User, UserManager } from '@expo/xdl';
 import pick from 'lodash/pick';
 
 import { AppleCtx, authenticateAsync } from '../appleApi';
-import log from '../log';
+import Log from '../log';
 import { getProjectOwner } from '../projects';
 import AndroidApi from './api/AndroidApi';
 import IosApi from './api/IosApi';
@@ -89,7 +89,7 @@ export class Context {
   logOwnerAndProject() {
     // Figure out if User A is configuring credentials as admin for User B's project
     const isProxyUser = this.manifest.owner && this.manifest.owner !== this.user.username;
-    log.log(
+    Log.log(
       `Accessing credentials ${isProxyUser ? 'on behalf of' : 'for'} ${
         this.projectOwner
       } in project ${this.manifest.slug}`

--- a/packages/expo-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/expo-cli/src/credentials/credentialsJson/update.ts
@@ -42,7 +42,7 @@ export async function updateAndroidCredentialsAsync(ctx: Context) {
 
   const keystorePath =
     rawCredentialsJsonObject?.android?.keystore?.keystorePath ?? 'android/keystores/keystore.jks';
-  log(`Writing Keystore to ${keystorePath}`);
+  log.log(`Writing Keystore to ${keystorePath}`);
   await updateFileAsync(ctx.projectDir, keystorePath, keystore.keystore);
   const shouldWarnKeystore = await isFileUntrackedAsync(keystorePath);
 
@@ -115,7 +115,7 @@ export async function updateIosCredentialsAsync(ctx: Context, bundleIdentifier: 
     }
   }
 
-  log(`Writing Provisioning Profile to ${pprofilePath}`);
+  log.log(`Writing Provisioning Profile to ${pprofilePath}`);
   await updateFileAsync(
     ctx.projectDir,
     pprofilePath,
@@ -123,7 +123,7 @@ export async function updateIosCredentialsAsync(ctx: Context, bundleIdentifier: 
   );
   const shouldWarnPProfile = await isFileUntrackedAsync(pprofilePath);
 
-  log(`Writing Distribution Certificate to ${distCertPath}`);
+  log.log(`Writing Distribution Certificate to ${distCertPath}`);
   await updateFileAsync(ctx.projectDir, distCertPath, distCredentials?.certP12);
   const shouldWarnDistCert = await isFileUntrackedAsync(distCertPath);
 

--- a/packages/expo-cli/src/credentials/credentialsJson/update.ts
+++ b/packages/expo-cli/src/credentials/credentialsJson/update.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { gitStatusAsync } from '../../git';
-import log from '../../log';
+import Log from '../../log';
 import { confirmAsync } from '../../prompts';
 import { Context } from '../context';
 
@@ -14,15 +14,15 @@ export async function updateAndroidCredentialsAsync(ctx: Context) {
       const rawFile = await fs.readFile(credentialsJsonFilePath, 'utf-8');
       rawCredentialsJsonObject = JSON.parse(rawFile);
     } catch (error) {
-      log.error(`There was an error while reading credentials.json [${error}]`);
-      log.error('Make sure that file is correct (or remove it) and rerun this command.');
+      Log.error(`There was an error while reading credentials.json [${error}]`);
+      Log.error('Make sure that file is correct (or remove it) and rerun this command.');
       throw error;
     }
   }
   const experienceName = `@${ctx.projectOwner}/${ctx.manifest.slug}`;
   const keystore = await ctx.android.fetchKeystore(experienceName);
   if (!keystore) {
-    log.error('There are no credentials configured for this project on Expo servers');
+    Log.error('There are no credentials configured for this project on Expo servers');
     return;
   }
 
@@ -35,14 +35,14 @@ export async function updateAndroidCredentialsAsync(ctx: Context) {
         'Credentials on Expo servers might be invalid or incomplete. Are you sure you want to continue?',
     });
     if (!confirm) {
-      log.warn('Aborting...');
+      Log.warn('Aborting...');
       return;
     }
   }
 
   const keystorePath =
     rawCredentialsJsonObject?.android?.keystore?.keystorePath ?? 'android/keystores/keystore.jks';
-  log.log(`Writing Keystore to ${keystorePath}`);
+  Log.log(`Writing Keystore to ${keystorePath}`);
   await updateFileAsync(ctx.projectDir, keystorePath, keystore.keystore);
   const shouldWarnKeystore = await isFileUntrackedAsync(keystorePath);
 
@@ -77,8 +77,8 @@ export async function updateIosCredentialsAsync(ctx: Context, bundleIdentifier: 
       const rawFile = await fs.readFile(credentialsJsonFilePath, 'utf-8');
       rawCredentialsJsonObject = JSON.parse(rawFile);
     } catch (error) {
-      log.error(`There was an error while reading credentials.json [${error}]`);
-      log.error('Make sure that file is correct (or remove it) and rerun this command.');
+      Log.error(`There was an error while reading credentials.json [${error}]`);
+      Log.error('Make sure that file is correct (or remove it) and rerun this command.');
       throw error;
     }
   }
@@ -95,7 +95,7 @@ export async function updateIosCredentialsAsync(ctx: Context, bundleIdentifier: 
   const appCredentials = await ctx.ios.getAppCredentials(appLookupParams);
   const distCredentials = await ctx.ios.getDistCert(appLookupParams);
   if (!appCredentials?.credentials?.provisioningProfile && !distCredentials) {
-    log.error('There are no credentials configured for this project on Expo servers');
+    Log.error('There are no credentials configured for this project on Expo servers');
     return;
   }
 
@@ -110,12 +110,12 @@ export async function updateIosCredentialsAsync(ctx: Context, bundleIdentifier: 
         'Credentials on Expo servers might be invalid or incomplete. Are you sure you want to continue?',
     });
     if (!confirm) {
-      log.warn('Aborting...');
+      Log.warn('Aborting...');
       return;
     }
   }
 
-  log.log(`Writing Provisioning Profile to ${pprofilePath}`);
+  Log.log(`Writing Provisioning Profile to ${pprofilePath}`);
   await updateFileAsync(
     ctx.projectDir,
     pprofilePath,
@@ -123,7 +123,7 @@ export async function updateIosCredentialsAsync(ctx: Context, bundleIdentifier: 
   );
   const shouldWarnPProfile = await isFileUntrackedAsync(pprofilePath);
 
-  log.log(`Writing Distribution Certificate to ${distCertPath}`);
+  Log.log(`Writing Distribution Certificate to ${distCertPath}`);
   await updateFileAsync(ctx.projectDir, distCertPath, distCredentials?.certP12);
   const shouldWarnDistCert = await isFileUntrackedAsync(distCertPath);
 
@@ -181,11 +181,11 @@ async function isFileUntrackedAsync(path: string): Promise<boolean> {
 
 function displayUntrackedFilesWarning(newFilePaths: string[]) {
   if (newFilePaths.length === 1) {
-    log.warn(
+    Log.warn(
       `File ${newFilePaths[0]} is currently untracked, remember to add it to .gitignore or to encrypt it. (e.g. with git-crypt)`
     );
   } else if (newFilePaths.length > 1) {
-    log.warn(
+    Log.warn(
       `Files ${newFilePaths.join(
         ', '
       )} are currently untracked, remember to add them to .gitignore or to encrypt them. (e.g. with git-crypt)`

--- a/packages/expo-cli/src/credentials/route.ts
+++ b/packages/expo-cli/src/credentials/route.ts
@@ -1,5 +1,5 @@
 import { sleep } from '../commands/utils/promise';
-import log from '../log';
+import Log from '../log';
 import { Context, IView } from './context';
 import { AskQuit, DoQuit, IQuit, QuitError } from './views/Select';
 
@@ -52,7 +52,7 @@ export class CredentialsManager {
           throw error;
         } else {
           // fallback to interactive Quit View
-          log.log(error);
+          Log.log(error);
           await sleep(1000);
           this._currentView = await this._quit.runAsync(this._mainView);
         }

--- a/packages/expo-cli/src/credentials/route.ts
+++ b/packages/expo-cli/src/credentials/route.ts
@@ -52,7 +52,7 @@ export class CredentialsManager {
           throw error;
         } else {
           // fallback to interactive Quit View
-          log(error);
+          log.log(error);
           await sleep(1000);
           this._currentView = await this._quit.runAsync(this._mainView);
         }

--- a/packages/expo-cli/src/credentials/utils/validateKeystore.ts
+++ b/packages/expo-cli/src/credentials/utils/validateKeystore.ts
@@ -3,7 +3,7 @@ import commandExists from 'command-exists';
 import temporary from 'tempy';
 import terminalLink from 'terminal-link';
 
-import log from '../../log';
+import Log from '../../log';
 
 export default async function validateKeystoreAsync({
   keystore: keystoreBase64,
@@ -17,7 +17,7 @@ export default async function validateKeystoreAsync({
   try {
     await commandExists('keytool');
   } catch (e) {
-    log.warn(
+    Log.warn(
       `Couldn't validate the provided Android keystore because the 'keytool' command is not available. Make sure that you have a Java Development Kit installed. See ${terminalLink(
         'https://openjdk.java.net',
         'https://openjdk.java.net'

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 
-import log from '../../log';
+import Log from '../../log';
 import prompt from '../../prompts';
 import { displayAndroidAppCredentials } from '../actions/list';
 import { Context, IView } from '../context';
@@ -14,11 +14,11 @@ class ExperienceView implements IView {
     const credentials = await ctx.android.fetchCredentials(this.experienceName);
 
     if (isEmpty(credentials.keystore) && isEmpty(credentials.pushCredentials)) {
-      log.log(`No credentials available for ${this.experienceName} experience.\n`);
+      Log.log(`No credentials available for ${this.experienceName} experience.\n`);
     } else if (this.experienceName) {
-      log.newLine();
+      Log.newLine();
       await displayAndroidAppCredentials(credentials);
-      log.newLine();
+      Log.newLine();
     }
 
     const { action } = await prompt({

--- a/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidCredentials.ts
@@ -14,7 +14,7 @@ class ExperienceView implements IView {
     const credentials = await ctx.android.fetchCredentials(this.experienceName);
 
     if (isEmpty(credentials.keystore) && isEmpty(credentials.pushCredentials)) {
-      log(`No credentials available for ${this.experienceName} experience.\n`);
+      log.log(`No credentials available for ${this.experienceName} experience.\n`);
     } else if (this.experienceName) {
       log.newLine();
       await displayAndroidAppCredentials(credentials);

--- a/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import { v4 as uuid } from 'uuid';
 
 import CommandError from '../../CommandError';
-import log from '../../log';
+import Log from '../../log';
 import { confirmAsync } from '../../prompts';
 import { askForUserProvided } from '../actions/promptForCredentials';
 import { Context, IView } from '../context';
@@ -44,7 +44,7 @@ class UpdateKeystore implements IView {
       await validateKeystoreAsync(keystore);
     }
     await ctx.android.updateKeystore(this.experienceName, keystore);
-    log.log(chalk.green('Keystore updated successfully'));
+    Log.log(chalk.green('Keystore updated successfully'));
     return null;
   }
 
@@ -53,7 +53,7 @@ class UpdateKeystore implements IView {
     if (providedKeystore) {
       return providedKeystore;
     } else if (this.options.bestEffortKeystoreGeneration && !(await keytoolCommandExists())) {
-      log.warn(
+      Log.warn(
         'The `keytool` utility was not found in your PATH. A new Keystore will be generated on Expo servers.'
       );
       return null;
@@ -76,7 +76,7 @@ class UpdateKeystore implements IView {
         keystore: await fs.readFile(tmpKeystoreName, 'base64'),
       };
     } catch (error) {
-      log.warn(
+      Log.warn(
         'Failed to generate Android Keystore, it will be generated on Expo servers during the build'
       );
       throw error;
@@ -86,13 +86,13 @@ class UpdateKeystore implements IView {
   }
 
   async displayWarning() {
-    log.newLine();
-    log.warn(
+    Log.newLine();
+    Log.warn(
       `⚠️  Updating your Android build credentials will remove previous version from our servers, this is a ${chalk.red(
         'PERMANENT and IRREVERSIBLE action.'
       )}`
     );
-    log.warn(
+    Log.warn(
       chalk.bold(
         'Android Keystore must be identical to the one previously used to submit your app to the Google Play Store.'
       )
@@ -105,7 +105,7 @@ class RemoveKeystore implements IView {
 
   async open(ctx: Context): Promise<IView | null> {
     if (!(await ctx.android.fetchKeystore(this.experienceName))) {
-      log.warn('There is no valid Keystore defined for this app');
+      Log.warn('There is no valid Keystore defined for this app');
       return null;
     }
 
@@ -123,38 +123,38 @@ class RemoveKeystore implements IView {
       initial: false,
     });
     if (answers) {
-      log.log('Backing up your Android Keystore now...');
+      Log.log('Backing up your Android Keystore now...');
       await new DownloadKeystore(this.experienceName, {
         displayCredentials: true,
         outputPath: `${this.experienceName}.bak.jks`.replace('/', '__'),
       }).open(ctx);
 
       await ctx.android.removeKeystore(this.experienceName);
-      log.log(chalk.green('Keystore removed successfully'));
+      Log.log(chalk.green('Keystore removed successfully'));
     }
     return null;
   }
 
   async displayWarning() {
-    log.newLine();
-    log.warn(
+    Log.newLine();
+    Log.warn(
       `⚠️  Clearing your Android build credentials from our build servers is a ${chalk.red(
         'PERMANENT and IRREVERSIBLE action.'
       )}`
     );
-    log.warn(
+    Log.warn(
       chalk.bold(
         'Android Keystore must be identical to the one previously used to submit your app to the Google Play Store.'
       )
     );
-    log.warn(
+    Log.warn(
       'Please read https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android for more info before proceeding.'
     );
-    log.newLine();
-    log.warn(
+    Log.newLine();
+    Log.warn(
       chalk.bold('Your Keystore will be backed up to your current directory if you continue.')
     );
-    log.newLine();
+    Log.newLine();
   }
 }
 
@@ -189,7 +189,7 @@ class DownloadKeystore implements IView {
     const { keystore, keystorePassword, keyAlias, keyPassword }: any = keystoreObj || {};
     if (!keystore || !keystorePassword || !keyAlias || !keyPassword) {
       if (!this.options?.quiet) {
-        log.warn('There is no valid Keystore defined for this app');
+        Log.warn('There is no valid Keystore defined for this app');
       }
       return null;
     }
@@ -199,13 +199,13 @@ class DownloadKeystore implements IView {
 
     await maybeRenameExistingFile(ctx.projectDir, keystorePath);
     if (!this.options?.quiet) {
-      log.log(chalk.green(`Saving Keystore to ${keystorePath}`));
+      Log.log(chalk.green(`Saving Keystore to ${keystorePath}`));
     }
     const storeBuf = Buffer.from(keystore, 'base64');
     await fs.writeFile(keystorePath, storeBuf);
 
     if (this.options?.displayCredentials ?? displayCredentials) {
-      log.log(`Keystore credentials
+      Log.log(`Keystore credentials
   Keystore password: ${chalk.bold(keystorePassword)}
   Key alias:         ${chalk.bold(keyAlias)}
   Key password:      ${chalk.bold(keyPassword)}
@@ -230,7 +230,7 @@ async function getKeystoreFromParams(options: {
   }
 
   if (!keystorePath || !keyAlias || !keystorePassword || !keyPassword) {
-    log.log(keystorePath, keyAlias, keystorePassword, keyPassword);
+    Log.log(keystorePath, keyAlias, keystorePassword, keyPassword);
     throw new Error(
       'In order to provide a Keystore through the CLI parameters, you have to pass --keystore-alias, --keystore-path parameters and set EXPO_ANDROID_KEY_PASSWORD and EXPO_ANDROID_KEYSTORE_PASSWORD environment variables.'
     );
@@ -244,7 +244,7 @@ async function getKeystoreFromParams(options: {
       keyPassword,
     };
   } catch (err) {
-    log.error(`Error while reading file ${keystorePath}`);
+    Log.error(`Error while reading file ${keystorePath}`);
     throw err;
   }
 }
@@ -271,7 +271,7 @@ async function maybeRenameExistingFile(projectDir: string, filename: string) {
     while (await fs.pathExists(path.resolve(projectDir, `OLD_${num}_${filename}`))) {
       num++;
     }
-    log.log(
+    Log.log(
       `\nA file already exists at "${desiredFilePath}"\n  Renaming the existing file to OLD_${num}_${filename}\n`
     );
     await fs.rename(desiredFilePath, path.resolve(projectDir, `OLD_${num}_${filename}`));

--- a/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
@@ -44,7 +44,7 @@ class UpdateKeystore implements IView {
       await validateKeystoreAsync(keystore);
     }
     await ctx.android.updateKeystore(this.experienceName, keystore);
-    log(chalk.green('Keystore updated successfully'));
+    log.log(chalk.green('Keystore updated successfully'));
     return null;
   }
 
@@ -123,14 +123,14 @@ class RemoveKeystore implements IView {
       initial: false,
     });
     if (answers) {
-      log('Backing up your Android Keystore now...');
+      log.log('Backing up your Android Keystore now...');
       await new DownloadKeystore(this.experienceName, {
         displayCredentials: true,
         outputPath: `${this.experienceName}.bak.jks`.replace('/', '__'),
       }).open(ctx);
 
       await ctx.android.removeKeystore(this.experienceName);
-      log(chalk.green('Keystore removed successfully'));
+      log.log(chalk.green('Keystore removed successfully'));
     }
     return null;
   }
@@ -199,13 +199,13 @@ class DownloadKeystore implements IView {
 
     await maybeRenameExistingFile(ctx.projectDir, keystorePath);
     if (!this.options?.quiet) {
-      log(chalk.green(`Saving Keystore to ${keystorePath}`));
+      log.log(chalk.green(`Saving Keystore to ${keystorePath}`));
     }
     const storeBuf = Buffer.from(keystore, 'base64');
     await fs.writeFile(keystorePath, storeBuf);
 
     if (this.options?.displayCredentials ?? displayCredentials) {
-      log(`Keystore credentials
+      log.log(`Keystore credentials
   Keystore password: ${chalk.bold(keystorePassword)}
   Key alias:         ${chalk.bold(keyAlias)}
   Key password:      ${chalk.bold(keyPassword)}
@@ -230,7 +230,7 @@ async function getKeystoreFromParams(options: {
   }
 
   if (!keystorePath || !keyAlias || !keystorePassword || !keyPassword) {
-    log(keystorePath, keyAlias, keystorePassword, keyPassword);
+    log.log(keystorePath, keyAlias, keystorePassword, keyPassword);
     throw new Error(
       'In order to provide a Keystore through the CLI parameters, you have to pass --keystore-alias, --keystore-path parameters and set EXPO_ANDROID_KEY_PASSWORD and EXPO_ANDROID_KEYSTORE_PASSWORD environment variables.'
     );
@@ -271,7 +271,7 @@ async function maybeRenameExistingFile(projectDir: string, filename: string) {
     while (await fs.pathExists(path.resolve(projectDir, `OLD_${num}_${filename}`))) {
       num++;
     }
-    log(
+    log.log(
       `\nA file already exists at "${desiredFilePath}"\n  Renaming the existing file to OLD_${num}_${filename}\n`
     );
     await fs.rename(desiredFilePath, path.resolve(projectDir, `OLD_${num}_${filename}`));

--- a/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
@@ -24,7 +24,7 @@ export class UpdateFcmKey implements IView {
     });
 
     await ctx.android.updateFcmKey(this.experienceName, fcmApiKey);
-    log(chalk.green('Updated successfully'));
+    log.log(chalk.green('Updated successfully'));
     return null;
   }
 }

--- a/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidPushCredentials.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
 import CommandError from '../../CommandError';
-import log from '../../log';
+import Log from '../../log';
 import prompt from '../../prompts';
 import { Context, IView } from '../context';
 
@@ -24,7 +24,7 @@ export class UpdateFcmKey implements IView {
     });
 
     await ctx.android.updateFcmKey(this.experienceName, fcmApiKey);
-    log.log(chalk.green('Updated successfully'));
+    Log.log(chalk.green('Updated successfully'));
     return null;
   }
 }

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -7,7 +7,7 @@ import terminalLink from 'terminal-link';
 
 import CommandError from '../../CommandError';
 import { DistCert, DistCertInfo, DistCertManager, isDistCert } from '../../appleApi';
-import log from '../../log';
+import Log from '../../log';
 import prompt, { confirmAsync, Question } from '../../prompts';
 import { displayIosUserCredentials } from '../actions/list';
 import { askForUserProvided, CredentialSchema } from '../actions/promptForCredentials';
@@ -35,9 +35,9 @@ export class CreateIosDist implements IView {
   async open(ctx: Context): Promise<IView | null> {
     const distCert = await this.create(ctx);
 
-    log.log(chalk.green('Successfully created Distribution Certificate\n'));
+    Log.log(chalk.green('Successfully created Distribution Certificate\n'));
     displayIosUserCredentials(distCert);
-    log.log();
+    Log.log();
     return null;
   }
 
@@ -60,7 +60,7 @@ export class RemoveIosDist implements IView {
     const selected = await selectDistCertFromList(ctx, this.accountName);
     if (selected) {
       await this.removeSpecific(ctx, selected);
-      log.log(chalk.green('Successfully removed Distribution Certificate\n'));
+      Log.log(chalk.green('Successfully removed Distribution Certificate\n'));
     }
     return null;
   }
@@ -71,17 +71,17 @@ export class RemoveIosDist implements IView {
     const appsList = apps.map(appCred => chalk.green(appCred.experienceName)).join(', ');
 
     if (appsList && !ctx.nonInteractive) {
-      log.log('Removing Distribution Certificate');
+      Log.log('Removing Distribution Certificate');
       const confirm = await confirmAsync({
         message: `You are removing certificate used by ${appsList}. Do you want to continue?`,
       });
       if (!confirm) {
-        log.log('Aborting');
+        Log.log('Aborting');
         return;
       }
     }
 
-    log.log('Removing Distribution Certificate...\n');
+    Log.log('Removing Distribution Certificate...\n');
     await ctx.ios.deleteDistCert(selected.id, this.accountName);
 
     let shouldRevoke = this.shouldRevoke;
@@ -107,7 +107,7 @@ export class RemoveIosDist implements IView {
       if (!(await ctx.ios.getProvisioningProfile(appLookupParams))) {
         continue;
       }
-      log.log(
+      Log.log(
         `Removing Provisioning Profile for ${appCredentials.experienceName} (${appCredentials.bundleIdentifier})`
       );
       const view = new RemoveProvisioningProfile(this.accountName, shouldRevoke);
@@ -124,13 +124,13 @@ export class UpdateIosDist implements IView {
     if (selected) {
       await this.updateSpecific(ctx, selected);
 
-      log.log(chalk.green('Successfully updated Distribution Certificate\n'));
+      Log.log(chalk.green('Successfully updated Distribution Certificate\n'));
       const credentials = await ctx.ios.getAllCredentials(this.accountName);
       const updated = credentials.userCredentials.find(i => i.id === selected.id);
       if (updated) {
         displayIosUserCredentials(updated);
       }
-      log.log();
+      Log.log();
     }
     return null;
   }
@@ -152,7 +152,7 @@ export class UpdateIosDist implements IView {
         message: `You are updating certificate used by ${appsList}. Do you want to continue?`,
       });
       if (!confirm) {
-        log.log('Aborting update process');
+        Log.log('Aborting update process');
         return;
       }
     }
@@ -161,7 +161,7 @@ export class UpdateIosDist implements IView {
     await ctx.ios.updateDistCert(selected.id, this.accountName, newDistCert);
 
     for (const appCredentials of apps) {
-      log.log(
+      Log.log(
         `Removing Provisioning Profile for ${appCredentials.experienceName} (${appCredentials.bundleIdentifier})`
       );
       const appLookupParams = getAppLookupParams(
@@ -194,7 +194,7 @@ export class UseExistingDistributionCert implements IView {
     });
     if (selected) {
       await ctx.ios.useDistCert(this.app, selected.id);
-      log.log(
+      Log.log(
         chalk.green(
           `Successfully assigned Distribution Certificate to @${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
         )
@@ -209,7 +209,7 @@ export class CreateOrReuseDistributionCert implements IView {
 
   async assignDistCert(ctx: Context, userCredentialsId: number) {
     await ctx.ios.useDistCert(this.app, userCredentialsId);
-    log.log(
+    Log.log(
       chalk.green(
         `Successfully assigned Distribution Certificate to @${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
       )
@@ -250,7 +250,7 @@ export class CreateOrReuseDistributionCert implements IView {
     }
 
     // Use autosuggested push key
-    log.log(`Using Distribution Certificate: ${autoselectedCertificate.certId || '-----'}`);
+    Log.log(`Using Distribution Certificate: ${autoselectedCertificate.certId || '-----'}`);
     await this.assignDistCert(ctx, autoselectedCertificate.id);
     return null;
   }
@@ -291,7 +291,7 @@ async function getValidDistCerts(iosCredentials: IosCredentials, ctx: Context) {
     (cred): cred is IosDistCredentials => cred.type === 'dist-cert'
   );
   if (!ctx.hasAppleCtx()) {
-    log.log(chalk.yellow(`Unable to determine validity of Distribution Certificates.`));
+    Log.log(chalk.yellow(`Unable to determine validity of Distribution Certificates.`));
     return distCerts;
   }
   const distCertManager = new DistCertManager(ctx.appleCtx);
@@ -338,7 +338,7 @@ async function selectDistCertFromList(
   distCerts = options.filterInvalid && validDistCerts ? validDistCerts : distCerts;
 
   if (distCerts.length === 0) {
-    log.warn('There are no Distribution Certificates available in your expo account');
+    Log.warn('There are no Distribution Certificates available in your expo account');
     return null;
   }
 
@@ -431,8 +431,8 @@ async function generateDistCert(ctx: Context, accountName: string): Promise<Dist
   } catch (e) {
     if (e.code === 'APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR') {
       const certs = await manager.list();
-      log.warn('Maximum number of Distribution Certificates generated on Apple Developer Portal.');
-      log.warn(APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR);
+      Log.warn('Maximum number of Distribution Certificates generated on Apple Developer Portal.');
+      Log.warn(APPLE_DIST_CERTS_TOO_MANY_GENERATED_ERROR);
 
       if (ctx.nonInteractive) {
         throw new CommandError(
@@ -451,11 +451,11 @@ async function generateDistCert(ctx: Context, accountName: string): Promise<Dist
 
       // https://docs.expo.io/distribution/app-signing/#summary
       const here = terminalLink('here', 'https://bit.ly/3cfJJkQ');
-      log.log(
+      Log.log(
         chalk.grey(`✅  Distribution Certificates can be revoked with no production side effects`)
       );
-      log.log(chalk.grey(`ℹ️  Learn more ${here}`));
-      log.log();
+      Log.log(chalk.grey(`ℹ️  Learn more ${here}`));
+      Log.log();
 
       const { revoke } = await prompt([
         {
@@ -521,16 +521,16 @@ async function _getDistCertWithSerial(distCert: DistCert): Promise<DistCert> {
       distCert.certPassword
     );
   } catch (error) {
-    log.warn('Unable to access certificate serial number.');
-    log.warn('Make sure that certificate and password are correct.');
-    log.warn(error);
+    Log.warn('Unable to access certificate serial number.');
+    Log.warn('Make sure that certificate and password are correct.');
+    Log.warn(error);
   }
   return distCert;
 }
 
 export async function validateDistributionCertificate(ctx: Context, distributionCert: DistCert) {
   if (!ctx.hasAppleCtx()) {
-    log.warn('Unable to validate distribution certificate due to insufficient Apple Credentials');
+    Log.warn('Unable to validate distribution certificate due to insufficient Apple Credentials');
     return true;
   }
   const spinner = ora(
@@ -630,7 +630,7 @@ export async function useDistCertFromParams(
   const iosDistCredentials = await ctx.ios.createDistCert(app.accountName, distCert);
 
   await ctx.ios.useDistCert(app, iosDistCredentials.id);
-  log.log(
+  Log.log(
     chalk.green(
       `Successfully assigned Distribution Certificate to @${app.accountName}/${app.projectName} (${app.bundleIdentifier})`
     )

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -35,9 +35,9 @@ export class CreateIosDist implements IView {
   async open(ctx: Context): Promise<IView | null> {
     const distCert = await this.create(ctx);
 
-    log(chalk.green('Successfully created Distribution Certificate\n'));
+    log.log(chalk.green('Successfully created Distribution Certificate\n'));
     displayIosUserCredentials(distCert);
-    log();
+    log.log();
     return null;
   }
 
@@ -60,7 +60,7 @@ export class RemoveIosDist implements IView {
     const selected = await selectDistCertFromList(ctx, this.accountName);
     if (selected) {
       await this.removeSpecific(ctx, selected);
-      log(chalk.green('Successfully removed Distribution Certificate\n'));
+      log.log(chalk.green('Successfully removed Distribution Certificate\n'));
     }
     return null;
   }
@@ -71,17 +71,17 @@ export class RemoveIosDist implements IView {
     const appsList = apps.map(appCred => chalk.green(appCred.experienceName)).join(', ');
 
     if (appsList && !ctx.nonInteractive) {
-      log('Removing Distribution Certificate');
+      log.log('Removing Distribution Certificate');
       const confirm = await confirmAsync({
         message: `You are removing certificate used by ${appsList}. Do you want to continue?`,
       });
       if (!confirm) {
-        log('Aborting');
+        log.log('Aborting');
         return;
       }
     }
 
-    log('Removing Distribution Certificate...\n');
+    log.log('Removing Distribution Certificate...\n');
     await ctx.ios.deleteDistCert(selected.id, this.accountName);
 
     let shouldRevoke = this.shouldRevoke;
@@ -107,7 +107,7 @@ export class RemoveIosDist implements IView {
       if (!(await ctx.ios.getProvisioningProfile(appLookupParams))) {
         continue;
       }
-      log(
+      log.log(
         `Removing Provisioning Profile for ${appCredentials.experienceName} (${appCredentials.bundleIdentifier})`
       );
       const view = new RemoveProvisioningProfile(this.accountName, shouldRevoke);
@@ -124,13 +124,13 @@ export class UpdateIosDist implements IView {
     if (selected) {
       await this.updateSpecific(ctx, selected);
 
-      log(chalk.green('Successfully updated Distribution Certificate\n'));
+      log.log(chalk.green('Successfully updated Distribution Certificate\n'));
       const credentials = await ctx.ios.getAllCredentials(this.accountName);
       const updated = credentials.userCredentials.find(i => i.id === selected.id);
       if (updated) {
         displayIosUserCredentials(updated);
       }
-      log();
+      log.log();
     }
     return null;
   }
@@ -152,7 +152,7 @@ export class UpdateIosDist implements IView {
         message: `You are updating certificate used by ${appsList}. Do you want to continue?`,
       });
       if (!confirm) {
-        log('Aborting update process');
+        log.log('Aborting update process');
         return;
       }
     }
@@ -161,7 +161,7 @@ export class UpdateIosDist implements IView {
     await ctx.ios.updateDistCert(selected.id, this.accountName, newDistCert);
 
     for (const appCredentials of apps) {
-      log(
+      log.log(
         `Removing Provisioning Profile for ${appCredentials.experienceName} (${appCredentials.bundleIdentifier})`
       );
       const appLookupParams = getAppLookupParams(
@@ -194,7 +194,7 @@ export class UseExistingDistributionCert implements IView {
     });
     if (selected) {
       await ctx.ios.useDistCert(this.app, selected.id);
-      log(
+      log.log(
         chalk.green(
           `Successfully assigned Distribution Certificate to @${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
         )
@@ -209,7 +209,7 @@ export class CreateOrReuseDistributionCert implements IView {
 
   async assignDistCert(ctx: Context, userCredentialsId: number) {
     await ctx.ios.useDistCert(this.app, userCredentialsId);
-    log(
+    log.log(
       chalk.green(
         `Successfully assigned Distribution Certificate to @${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
       )
@@ -250,7 +250,7 @@ export class CreateOrReuseDistributionCert implements IView {
     }
 
     // Use autosuggested push key
-    log(`Using Distribution Certificate: ${autoselectedCertificate.certId || '-----'}`);
+    log.log(`Using Distribution Certificate: ${autoselectedCertificate.certId || '-----'}`);
     await this.assignDistCert(ctx, autoselectedCertificate.id);
     return null;
   }
@@ -291,7 +291,7 @@ async function getValidDistCerts(iosCredentials: IosCredentials, ctx: Context) {
     (cred): cred is IosDistCredentials => cred.type === 'dist-cert'
   );
   if (!ctx.hasAppleCtx()) {
-    log(chalk.yellow(`Unable to determine validity of Distribution Certificates.`));
+    log.log(chalk.yellow(`Unable to determine validity of Distribution Certificates.`));
     return distCerts;
   }
   const distCertManager = new DistCertManager(ctx.appleCtx);
@@ -451,11 +451,11 @@ async function generateDistCert(ctx: Context, accountName: string): Promise<Dist
 
       // https://docs.expo.io/distribution/app-signing/#summary
       const here = terminalLink('here', 'https://bit.ly/3cfJJkQ');
-      log(
+      log.log(
         chalk.grey(`✅  Distribution Certificates can be revoked with no production side effects`)
       );
-      log(chalk.grey(`ℹ️  Learn more ${here}`));
-      log();
+      log.log(chalk.grey(`ℹ️  Learn more ${here}`));
+      log.log();
 
       const { revoke } = await prompt([
         {
@@ -630,7 +630,7 @@ export async function useDistCertFromParams(
   const iosDistCredentials = await ctx.ios.createDistCert(app.accountName, distCert);
 
   await ctx.ios.useDistCert(app, iosDistCredentials.id);
-  log(
+  log.log(
     chalk.green(
       `Successfully assigned Distribution Certificate to @${app.accountName}/${app.projectName} (${app.bundleIdentifier})`
     )

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -13,7 +13,7 @@ import {
   ProvisioningProfileManager,
 } from '../../appleApi';
 import { assert } from '../../assert';
-import log from '../../log';
+import Log from '../../log';
 import prompt, { confirmAsync, Question } from '../../prompts';
 import { displayIosAppCredentials } from '../actions/list';
 import { askForUserProvided } from '../actions/promptForCredentials';
@@ -36,7 +36,7 @@ export class RemoveProvisioningProfile implements IView {
     if (selected) {
       const app = getAppLookupParams(selected.experienceName, selected.bundleIdentifier);
       await this.removeSpecific(ctx, app);
-      log.log(
+      Log.log(
         chalk.green(
           `Successfully removed Provisioning Profile for ${selected.experienceName} (${selected.bundleIdentifier})`
         )
@@ -46,7 +46,7 @@ export class RemoveProvisioningProfile implements IView {
   }
 
   async removeSpecific(ctx: Context, app: AppLookupParams) {
-    log.log('Removing Provisioning Profile...\n');
+    Log.log('Removing Provisioning Profile...\n');
     await ctx.ios.deleteProvisioningProfile(app);
 
     let shouldRevoke = this.shouldRevoke;
@@ -76,10 +76,10 @@ export class CreateProvisioningProfile implements IView {
   async open(ctx: Context): Promise<IView | null> {
     await this.create(ctx);
 
-    log.log(chalk.green('Successfully created Provisioning Profile\n'));
+    Log.log(chalk.green('Successfully created Provisioning Profile\n'));
     const appCredentials = await ctx.ios.getAppCredentials(this.app);
     displayIosAppCredentials(appCredentials);
-    log.log();
+    Log.log();
     return null;
   }
 
@@ -88,7 +88,7 @@ export class CreateProvisioningProfile implements IView {
       const userProvided = await askForUserProvided(provisioningProfileSchema);
       if (userProvided) {
         // userProvided profiles don't come with ProvisioningProfileId's (only accessible from Apple Portal API)
-        log.log(chalk.yellow('Provisioning profile: Unable to validate specified profile.'));
+        Log.log(chalk.yellow('Provisioning profile: Unable to validate specified profile.'));
         return {
           ...userProvided,
           ...provisioningProfileUtils.readAppleTeam(userProvided.provisioningProfile),
@@ -175,7 +175,7 @@ export class CreateOrReuseProvisioningProfile implements IView {
       }
     }
 
-    log.log(`Using Provisioning Profile: ${autoselectedProfile.provisioningProfileId}`);
+    Log.log(`Using Provisioning Profile: ${autoselectedProfile.provisioningProfileId}`);
     await configureAndUpdateProvisioningProfile(ctx, this.app, distCert, autoselectedProfile);
     return null;
   }
@@ -216,7 +216,7 @@ async function selectProfileFromApple(
   const ppManager = new ProvisioningProfileManager(appleCtx);
   const profiles = await ppManager.list(bundleIdentifier);
   if (profiles.length === 0) {
-    log.warn(
+    Log.warn(
       `There are no Provisioning Profiles available in your apple account for bundleIdentifier: ${bundleIdentifier}`
     );
     return null;
@@ -242,7 +242,7 @@ async function selectProfileFromExpo(
     ({ credentials }) => !!credentials.provisioningProfile && !!credentials.provisioningProfileId
   );
   if (profiles.length === 0) {
-    log.warn('There are no Provisioning Profiles available in your account');
+    Log.warn('There are no Provisioning Profiles available in your account');
     return null;
   }
 
@@ -325,7 +325,7 @@ export async function getAppleInfo(
   profile: ProvisioningProfile
 ): Promise<ProvisioningProfileInfo | null> {
   if (!profile.provisioningProfileId) {
-    log.log(
+    Log.log(
       chalk.yellow('Provisioning Profile: cannot look up profile on Apple Servers - there is no id')
     );
     return null;
@@ -365,7 +365,7 @@ export async function configureAndUpdateProvisioningProfile(
     profileFromApple,
     distCert
   );
-  log.log(
+  Log.log(
     chalk.green(
       `Successfully configured Provisioning Profile ${
         profileFromApple.provisioningProfileId
@@ -375,7 +375,7 @@ export async function configureAndUpdateProvisioningProfile(
 
   // Update profile on expo servers
   await ctx.ios.updateProvisioningProfile(app, updatedProfile);
-  log.log(
+  Log.log(
     chalk.green(
       `Successfully assigned Provisioning Profile to @${app.accountName}/${app.projectName} (${app.bundleIdentifier})`
     )

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfile.ts
@@ -36,7 +36,7 @@ export class RemoveProvisioningProfile implements IView {
     if (selected) {
       const app = getAppLookupParams(selected.experienceName, selected.bundleIdentifier);
       await this.removeSpecific(ctx, app);
-      log(
+      log.log(
         chalk.green(
           `Successfully removed Provisioning Profile for ${selected.experienceName} (${selected.bundleIdentifier})`
         )
@@ -46,7 +46,7 @@ export class RemoveProvisioningProfile implements IView {
   }
 
   async removeSpecific(ctx: Context, app: AppLookupParams) {
-    log('Removing Provisioning Profile...\n');
+    log.log('Removing Provisioning Profile...\n');
     await ctx.ios.deleteProvisioningProfile(app);
 
     let shouldRevoke = this.shouldRevoke;
@@ -76,10 +76,10 @@ export class CreateProvisioningProfile implements IView {
   async open(ctx: Context): Promise<IView | null> {
     await this.create(ctx);
 
-    log(chalk.green('Successfully created Provisioning Profile\n'));
+    log.log(chalk.green('Successfully created Provisioning Profile\n'));
     const appCredentials = await ctx.ios.getAppCredentials(this.app);
     displayIosAppCredentials(appCredentials);
-    log();
+    log.log();
     return null;
   }
 
@@ -88,7 +88,7 @@ export class CreateProvisioningProfile implements IView {
       const userProvided = await askForUserProvided(provisioningProfileSchema);
       if (userProvided) {
         // userProvided profiles don't come with ProvisioningProfileId's (only accessible from Apple Portal API)
-        log(chalk.yellow('Provisioning profile: Unable to validate specified profile.'));
+        log.log(chalk.yellow('Provisioning profile: Unable to validate specified profile.'));
         return {
           ...userProvided,
           ...provisioningProfileUtils.readAppleTeam(userProvided.provisioningProfile),
@@ -175,7 +175,7 @@ export class CreateOrReuseProvisioningProfile implements IView {
       }
     }
 
-    log(`Using Provisioning Profile: ${autoselectedProfile.provisioningProfileId}`);
+    log.log(`Using Provisioning Profile: ${autoselectedProfile.provisioningProfileId}`);
     await configureAndUpdateProvisioningProfile(ctx, this.app, distCert, autoselectedProfile);
     return null;
   }
@@ -325,7 +325,7 @@ export async function getAppleInfo(
   profile: ProvisioningProfile
 ): Promise<ProvisioningProfileInfo | null> {
   if (!profile.provisioningProfileId) {
-    log(
+    log.log(
       chalk.yellow('Provisioning Profile: cannot look up profile on Apple Servers - there is no id')
     );
     return null;
@@ -365,7 +365,7 @@ export async function configureAndUpdateProvisioningProfile(
     profileFromApple,
     distCert
   );
-  log(
+  log.log(
     chalk.green(
       `Successfully configured Provisioning Profile ${
         profileFromApple.provisioningProfileId
@@ -375,7 +375,7 @@ export async function configureAndUpdateProvisioningProfile(
 
   // Update profile on expo servers
   await ctx.ios.updateProvisioningProfile(app, updatedProfile);
-  log(
+  log.log(
     chalk.green(
       `Successfully assigned Provisioning Profile to @${app.accountName}/${app.projectName} (${app.bundleIdentifier})`
     )

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfileAdhoc.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfileAdhoc.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import { ProvisioningProfile } from '../../appleApi';
 import { ProvisioningProfileAdhocManager } from '../../appleApi/provisioningProfileAdhoc';
-import log from '../../log';
+import Log from '../../log';
 import { AppLookupParams } from '../api/IosApi';
 import { Context, IView } from '../context';
 
@@ -23,7 +23,7 @@ export class CreateOrReuseProvisioningProfileAdhoc implements IView {
 
   async assignProvisioningProfile(ctx: Context, provisioningProfile: ProvisioningProfile) {
     await ctx.ios.updateProvisioningProfile(this.app, provisioningProfile);
-    log.log(
+    Log.log(
       chalk.green(
         `Successfully assigned Provisioning Profile id: ${provisioningProfile.provisioningProfileId} to @${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
       )

--- a/packages/expo-cli/src/credentials/views/IosProvisioningProfileAdhoc.ts
+++ b/packages/expo-cli/src/credentials/views/IosProvisioningProfileAdhoc.ts
@@ -23,7 +23,7 @@ export class CreateOrReuseProvisioningProfileAdhoc implements IView {
 
   async assignProvisioningProfile(ctx: Context, provisioningProfile: ProvisioningProfile) {
     await ctx.ios.updateProvisioningProfile(this.app, provisioningProfile);
-    log(
+    log.log(
       chalk.green(
         `Successfully assigned Provisioning Profile id: ${provisioningProfile.provisioningProfileId} to @${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
       )

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -5,7 +5,7 @@ import terminalLink from 'terminal-link';
 
 import CommandError from '../../CommandError';
 import { isPushKey, PushKey, PushKeyInfo, PushKeyManager } from '../../appleApi';
-import log from '../../log';
+import Log from '../../log';
 import prompt, { confirmAsync, Question } from '../../prompts';
 import { displayIosUserCredentials } from '../actions/list';
 import { askForUserProvided, CredentialSchema } from '../actions/promptForCredentials';
@@ -35,9 +35,9 @@ export class CreateIosPush implements IView {
   async open(ctx: Context): Promise<IView | null> {
     const pushKey = await this.create(ctx);
 
-    log.log('Successfully created Push Notification Key\n');
+    Log.log('Successfully created Push Notification Key\n');
     displayIosUserCredentials(pushKey);
-    log.log();
+    Log.log();
 
     return null;
   }
@@ -79,13 +79,13 @@ export class CreateAndAssignIosPush extends CreateIosPush {
   async open(ctx: Context): Promise<IView | null> {
     const pushKey = await super.create(ctx);
 
-    log.log('Successfully created Push Notification Key\n');
+    Log.log('Successfully created Push Notification Key\n');
     displayIosUserCredentials(pushKey);
-    log.log();
+    Log.log();
 
     if (ctx.hasProjectContext && pushKey) {
       await this.assignToCurrentProject(ctx, pushKey.id);
-      log.log();
+      Log.log();
     }
 
     return null;
@@ -104,7 +104,7 @@ export class CreateAndAssignIosPush extends CreateIosPush {
 
       const app = getAppLookupParams(experienceName, bundleIdentifier);
       await ctx.ios.usePushKey(app, pushKeyId);
-      log.log(
+      Log.log(
         chalk.green(`Successfully assigned Push Key to ${experienceName} (${bundleIdentifier})`)
       );
     }
@@ -127,17 +127,17 @@ export class RemoveIosPush implements IView {
       if (!('type' in selected)) {
         const app = getAppLookupParams(selected.experienceName, selected.bundleIdentifier);
         await this.removePushCert(ctx, app);
-        log.log(chalk.green('Successfully removed Push Certificate'));
+        Log.log(chalk.green('Successfully removed Push Certificate'));
       } else {
         await this.removeSpecific(ctx, selected as IosPushCredentials);
-        log.log(chalk.green('Successfully removed Push Notification Key'));
+        Log.log(chalk.green('Successfully removed Push Notification Key'));
       }
     }
     return null;
   }
 
   async removePushCert(ctx: Context, app: AppLookupParams): Promise<void> {
-    log.log('Removing Push Certificate');
+    Log.log('Removing Push Certificate');
     await ctx.ios.deletePushCert(app);
   }
 
@@ -147,17 +147,17 @@ export class RemoveIosPush implements IView {
     const appsList = apps.map(appCred => appCred.experienceName).join(', ');
 
     if (appsList && !ctx.nonInteractive) {
-      log.log('Removing Push Key');
+      Log.log('Removing Push Key');
       const confirm = await confirmAsync({
         message: `Removing this key/cert will disable notifications in ${appsList}. Do you want to continue?`,
       });
       if (!confirm) {
-        log.log('Aborting');
+        Log.log('Aborting');
         return;
       }
     }
 
-    log.log('Removing Push Key...\n');
+    Log.log('Removing Push Key...\n');
     await ctx.ios.deletePushKey(selected.id, this.accountName);
 
     let shouldRevoke = this.shouldRevoke;
@@ -192,13 +192,13 @@ export class UpdateIosPush implements IView {
     if (selected) {
       await this.updateSpecific(ctx, selected);
 
-      log.log(chalk.green('Successfully updated Push Notification Key.\n'));
+      Log.log(chalk.green('Successfully updated Push Notification Key.\n'));
       const credentials = await ctx.ios.getAllCredentials(this.accountName);
       const updated = credentials.userCredentials.find(i => i.id === selected.id);
       if (updated) {
         displayIosUserCredentials(updated);
       }
-      log.log();
+      Log.log();
     }
     return null;
   }
@@ -220,7 +220,7 @@ export class UpdateIosPush implements IView {
         message: `Update will affect all applications that are using this key (${appsList}). Do you want to continue?`,
       });
       if (!confirm) {
-        log.warn('Aborting update process');
+        Log.warn('Aborting update process');
         return;
       }
     }
@@ -255,7 +255,7 @@ export class UseExistingPushNotification implements IView {
     })) as IosPushCredentials;
     if (selected) {
       await ctx.ios.usePushKey(this.app, selected.id);
-      log.log(
+      Log.log(
         chalk.green(
           `Successfully assigned Push Notifactions Key to ${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
         )
@@ -270,7 +270,7 @@ export class CreateOrReusePushKey implements IView {
 
   async assignPushKey(ctx: Context, userCredentialsId: number) {
     await ctx.ios.usePushKey(this.app, userCredentialsId);
-    log.log(
+    Log.log(
       chalk.green(
         `Successfully assigned Push Key to ${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
       )
@@ -311,7 +311,7 @@ export class CreateOrReusePushKey implements IView {
     }
 
     // Use autosuggested push key
-    log.log(`Using Push Key: ${autoselectedPushKey.apnsKeyId}`);
+    Log.log(`Using Push Key: ${autoselectedPushKey.apnsKeyId}`);
     await this.assignPushKey(ctx, autoselectedPushKey.id);
     return null;
   }
@@ -351,7 +351,7 @@ async function getValidPushKeys(iosCredentials: IosCredentials, ctx: Context) {
     (cred): cred is IosPushCredentials => cred.type === 'push-key'
   );
   if (!ctx.hasAppleCtx()) {
-    log.log(
+    Log.log(
       chalk.yellow(
         `Unable to determine validity of Push Keys due to insufficient Apple Credentials`
       )
@@ -403,7 +403,7 @@ async function selectPushCredFromList(
     : [];
   const pushCredentials = [...pushCerts, ...pushKeys];
   if (pushCredentials.length === 0) {
-    log.warn('There are no push credentials available in your account');
+    Log.warn('There are no push credentials available in your account');
     return null;
   }
 
@@ -512,8 +512,8 @@ async function generatePushKey(ctx: Context, accountName: string): Promise<PushK
   } catch (e) {
     if (e.code === 'APPLE_PUSH_KEYS_TOO_MANY_GENERATED_ERROR') {
       const keys = await manager.list();
-      log.warn('Maximum number of Push Notifications Keys generated on Apple Developer Portal.');
-      log.warn(APPLE_KEYS_TOO_MANY_GENERATED_ERROR);
+      Log.warn('Maximum number of Push Notifications Keys generated on Apple Developer Portal.');
+      Log.warn(APPLE_KEYS_TOO_MANY_GENERATED_ERROR);
 
       if (ctx.nonInteractive) {
         throw new CommandError(
@@ -532,9 +532,9 @@ async function generatePushKey(ctx: Context, accountName: string): Promise<PushK
 
       // https://docs.expo.io/distribution/app-signing/#summary
       const here = terminalLink('here', 'https://bit.ly/3cfJJkQ');
-      log.log(chalk.grey(`⚠️  Revoking a Push Key will affect other apps that rely on it`));
-      log.log(chalk.grey(`ℹ️  Learn more ${here}`));
-      log.log();
+      Log.log(chalk.grey(`⚠️  Revoking a Push Key will affect other apps that rely on it`));
+      Log.log(chalk.grey(`ℹ️  Learn more ${here}`));
+      Log.log();
 
       const { revoke } = await prompt([
         {
@@ -566,7 +566,7 @@ async function generatePushKey(ctx: Context, accountName: string): Promise<PushK
 
 export async function validatePushKey(ctx: Context, pushKey: PushKey) {
   if (!ctx.hasAppleCtx()) {
-    log.warn('Unable to validate Push Keys due to insufficient Apple Credentials');
+    Log.warn('Unable to validate Push Keys due to insufficient Apple Credentials');
     return true;
   }
   const spinner = ora(`Checking validity of push key on Apple Developer Portal...`).start();
@@ -636,7 +636,7 @@ export async function usePushKeyFromParams(
   const iosPushCredentials = await ctx.ios.createPushKey(app.accountName, pushKey);
 
   await ctx.ios.usePushKey(app, iosPushCredentials.id);
-  log.log(
+  Log.log(
     chalk.green(
       `Successfully assigned Push Key to ${app.accountName}/${app.projectName} (${app.bundleIdentifier})`
     )

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -35,9 +35,9 @@ export class CreateIosPush implements IView {
   async open(ctx: Context): Promise<IView | null> {
     const pushKey = await this.create(ctx);
 
-    log('Successfully created Push Notification Key\n');
+    log.log('Successfully created Push Notification Key\n');
     displayIosUserCredentials(pushKey);
-    log();
+    log.log();
 
     return null;
   }
@@ -79,13 +79,13 @@ export class CreateAndAssignIosPush extends CreateIosPush {
   async open(ctx: Context): Promise<IView | null> {
     const pushKey = await super.create(ctx);
 
-    log('Successfully created Push Notification Key\n');
+    log.log('Successfully created Push Notification Key\n');
     displayIosUserCredentials(pushKey);
-    log();
+    log.log();
 
     if (ctx.hasProjectContext && pushKey) {
       await this.assignToCurrentProject(ctx, pushKey.id);
-      log();
+      log.log();
     }
 
     return null;
@@ -104,7 +104,9 @@ export class CreateAndAssignIosPush extends CreateIosPush {
 
       const app = getAppLookupParams(experienceName, bundleIdentifier);
       await ctx.ios.usePushKey(app, pushKeyId);
-      log(chalk.green(`Successfully assigned Push Key to ${experienceName} (${bundleIdentifier})`));
+      log.log(
+        chalk.green(`Successfully assigned Push Key to ${experienceName} (${bundleIdentifier})`)
+      );
     }
   }
 }
@@ -125,17 +127,17 @@ export class RemoveIosPush implements IView {
       if (!('type' in selected)) {
         const app = getAppLookupParams(selected.experienceName, selected.bundleIdentifier);
         await this.removePushCert(ctx, app);
-        log(chalk.green('Successfully removed Push Certificate'));
+        log.log(chalk.green('Successfully removed Push Certificate'));
       } else {
         await this.removeSpecific(ctx, selected as IosPushCredentials);
-        log(chalk.green('Successfully removed Push Notification Key'));
+        log.log(chalk.green('Successfully removed Push Notification Key'));
       }
     }
     return null;
   }
 
   async removePushCert(ctx: Context, app: AppLookupParams): Promise<void> {
-    log('Removing Push Certificate');
+    log.log('Removing Push Certificate');
     await ctx.ios.deletePushCert(app);
   }
 
@@ -145,17 +147,17 @@ export class RemoveIosPush implements IView {
     const appsList = apps.map(appCred => appCred.experienceName).join(', ');
 
     if (appsList && !ctx.nonInteractive) {
-      log('Removing Push Key');
+      log.log('Removing Push Key');
       const confirm = await confirmAsync({
         message: `Removing this key/cert will disable notifications in ${appsList}. Do you want to continue?`,
       });
       if (!confirm) {
-        log('Aborting');
+        log.log('Aborting');
         return;
       }
     }
 
-    log('Removing Push Key...\n');
+    log.log('Removing Push Key...\n');
     await ctx.ios.deletePushKey(selected.id, this.accountName);
 
     let shouldRevoke = this.shouldRevoke;
@@ -190,13 +192,13 @@ export class UpdateIosPush implements IView {
     if (selected) {
       await this.updateSpecific(ctx, selected);
 
-      log(chalk.green('Successfully updated Push Notification Key.\n'));
+      log.log(chalk.green('Successfully updated Push Notification Key.\n'));
       const credentials = await ctx.ios.getAllCredentials(this.accountName);
       const updated = credentials.userCredentials.find(i => i.id === selected.id);
       if (updated) {
         displayIosUserCredentials(updated);
       }
-      log();
+      log.log();
     }
     return null;
   }
@@ -253,7 +255,7 @@ export class UseExistingPushNotification implements IView {
     })) as IosPushCredentials;
     if (selected) {
       await ctx.ios.usePushKey(this.app, selected.id);
-      log(
+      log.log(
         chalk.green(
           `Successfully assigned Push Notifactions Key to ${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
         )
@@ -268,7 +270,7 @@ export class CreateOrReusePushKey implements IView {
 
   async assignPushKey(ctx: Context, userCredentialsId: number) {
     await ctx.ios.usePushKey(this.app, userCredentialsId);
-    log(
+    log.log(
       chalk.green(
         `Successfully assigned Push Key to ${this.app.accountName}/${this.app.projectName} (${this.app.bundleIdentifier})`
       )
@@ -309,7 +311,7 @@ export class CreateOrReusePushKey implements IView {
     }
 
     // Use autosuggested push key
-    log(`Using Push Key: ${autoselectedPushKey.apnsKeyId}`);
+    log.log(`Using Push Key: ${autoselectedPushKey.apnsKeyId}`);
     await this.assignPushKey(ctx, autoselectedPushKey.id);
     return null;
   }
@@ -349,7 +351,7 @@ async function getValidPushKeys(iosCredentials: IosCredentials, ctx: Context) {
     (cred): cred is IosPushCredentials => cred.type === 'push-key'
   );
   if (!ctx.hasAppleCtx()) {
-    log(
+    log.log(
       chalk.yellow(
         `Unable to determine validity of Push Keys due to insufficient Apple Credentials`
       )
@@ -530,9 +532,9 @@ async function generatePushKey(ctx: Context, accountName: string): Promise<PushK
 
       // https://docs.expo.io/distribution/app-signing/#summary
       const here = terminalLink('here', 'https://bit.ly/3cfJJkQ');
-      log(chalk.grey(`⚠️  Revoking a Push Key will affect other apps that rely on it`));
-      log(chalk.grey(`ℹ️  Learn more ${here}`));
-      log();
+      log.log(chalk.grey(`⚠️  Revoking a Push Key will affect other apps that rely on it`));
+      log.log(chalk.grey(`ℹ️  Learn more ${here}`));
+      log.log();
 
       const { revoke } = await prompt([
         {
@@ -634,7 +636,7 @@ export async function usePushKeyFromParams(
   const iosPushCredentials = await ctx.ios.createPushKey(app.accountName, pushKey);
 
   await ctx.ios.usePushKey(app, iosPushCredentials.id);
-  log(
+  log.log(
     chalk.green(
       `Successfully assigned Push Key to ${app.accountName}/${app.projectName} (${app.bundleIdentifier})`
     )

--- a/packages/expo-cli/src/credentials/views/SetupAndroidKeystore.ts
+++ b/packages/expo-cli/src/credentials/views/SetupAndroidKeystore.ts
@@ -1,4 +1,4 @@
-import log from '../../log';
+import Log from '../../log';
 import { Context, IView } from '../context';
 import * as credentialsJsonReader from '../credentialsJson/read';
 import validateKeystoreAsync from '../utils/validateKeystore';
@@ -21,7 +21,7 @@ export class SetupAndroidKeystore implements IView {
     }
     if (this.options.nonInteractive) {
       if (this.options.allowMissingKeystore) {
-        log.warn(
+        Log.warn(
           'There is no valid Keystore defined for this app, new one will be generated on Expo servers.'
         );
         return null;
@@ -48,7 +48,7 @@ export class SetupAndroidBuildCredentialsFromLocal implements IView {
     try {
       localCredentials = await credentialsJsonReader.readAndroidCredentialsAsync(ctx.projectDir);
     } catch (error) {
-      log.error(
+      Log.error(
         'Reading credentials from credentials.json failed. Make sure this file is correct and all credentials are present there.'
       );
       throw error;

--- a/packages/expo-cli/src/credentials/views/SetupIosBuildCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosBuildCredentials.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import CommandError from '../../CommandError';
 import * as appleApi from '../../appleApi';
-import log from '../../log';
+import Log from '../../log';
 import prompts, { confirmAsync } from '../../prompts';
 import { AppLookupParams } from '../api/IosApi';
 import { Context, IView } from '../context';
@@ -26,7 +26,7 @@ export class SetupIosBuildCredentials implements IView {
     try {
       await runCredentialsManager(ctx, new SetupIosDist(this.app));
     } catch (error) {
-      log.error('Failed to set up Distribution Certificate');
+      Log.error('Failed to set up Distribution Certificate');
       throw error;
     }
 
@@ -41,7 +41,7 @@ export class SetupIosBuildCredentials implements IView {
     try {
       await runCredentialsManager(ctx, new SetupIosProvisioningProfile(this.app));
     } catch (error) {
-      log.error('Failed to set up Provisioning Profile');
+      Log.error('Failed to set up Provisioning Profile');
       throw error;
     }
 
@@ -66,7 +66,7 @@ export class SetupIosBuildCredentials implements IView {
     if (confirm) {
       return await ctx.ensureAppleCtx();
     } else {
-      log.log(
+      Log.log(
         chalk.green(
           'No problem! 👌 \nWe can’t auto-generate credentials if you don’t have access to the main Apple account. \nBut we can still set it up if you upload your credentials.'
         )
@@ -83,7 +83,7 @@ export class SetupIosBuildCredentialsFromLocal implements IView {
     try {
       localCredentials = await credentialsJsonReader.readIosCredentialsAsync(ctx.projectDir);
     } catch (error) {
-      log.error(
+      Log.error(
         'Reading credentials from credentials.json failed. Make sure this file is correct and all credentials are present there.'
       );
       throw error;

--- a/packages/expo-cli/src/credentials/views/SetupIosBuildCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosBuildCredentials.ts
@@ -66,7 +66,7 @@ export class SetupIosBuildCredentials implements IView {
     if (confirm) {
       return await ctx.ensureAppleCtx();
     } else {
-      log(
+      log.log(
         chalk.green(
           'No problem! 👌 \nWe can’t auto-generate credentials if you don’t have access to the main Apple account. \nBut we can still set it up if you upload your credentials.'
         )

--- a/packages/expo-cli/src/credentials/views/SetupIosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosProvisioningProfile.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import log from '../../log';
+import Log from '../../log';
 import { AppLookupParams } from '../api/IosApi';
 import { Context, IView } from '../context';
 import { IosDistCredentials } from '../credentials';
@@ -52,7 +52,7 @@ export class SetupIosProvisioningProfile implements IView {
 
     // User uploaded profiles dont have ids - do best effort validation here
     if (!configuredProfile.provisioningProfileId) {
-      log.log(
+      Log.log(
         chalk.yellow(
           "The provisioning profile we have on file cannot be validated on Apple's servers."
         )

--- a/packages/expo-cli/src/credentials/views/SetupIosProvisioningProfile.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosProvisioningProfile.ts
@@ -52,7 +52,7 @@ export class SetupIosProvisioningProfile implements IView {
 
     // User uploaded profiles dont have ids - do best effort validation here
     if (!configuredProfile.provisioningProfileId) {
-      log(
+      log.log(
         chalk.yellow(
           "The provisioning profile we have on file cannot be validated on Apple's servers."
         )

--- a/packages/expo-cli/src/credentials/views/SetupIosPush.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosPush.ts
@@ -30,7 +30,7 @@ export class SetupIosPush implements IView {
         message: `We've detected legacy Push Certificates on file. Would you like to upgrade to the newer standard?`,
       });
       if (!confirm) {
-        log(`Using Deprecated Push Cert: ${deprecatedPushId} on file`);
+        log.log(`Using Deprecated Push Cert: ${deprecatedPushId} on file`);
         return null;
       }
     }

--- a/packages/expo-cli/src/credentials/views/SetupIosPush.ts
+++ b/packages/expo-cli/src/credentials/views/SetupIosPush.ts
@@ -1,5 +1,5 @@
 import CommandError from '../../CommandError';
-import log from '../../log';
+import Log from '../../log';
 import { confirmAsync } from '../../prompts';
 import { AppLookupParams } from '../api/IosApi';
 import { Context, IView } from '../context';
@@ -30,7 +30,7 @@ export class SetupIosPush implements IView {
         message: `We've detected legacy Push Certificates on file. Would you like to upgrade to the newer standard?`,
       });
       if (!confirm) {
-        log.log(`Using Deprecated Push Cert: ${deprecatedPushId} on file`);
+        Log.log(`Using Deprecated Push Cert: ${deprecatedPushId} on file`);
         return null;
       }
     }

--- a/packages/expo-cli/src/exit.ts
+++ b/packages/expo-cli/src/exit.ts
@@ -1,7 +1,7 @@
 import { Project } from '@expo/xdl';
 import chalk from 'chalk';
 
-import log from './log';
+import Log from './log';
 
 export function installExitHooks(
   projectDir: string,
@@ -10,9 +10,9 @@ export function installExitHooks(
   const killSignals: ['SIGINT', 'SIGTERM'] = ['SIGINT', 'SIGTERM'];
   for (const signal of killSignals) {
     process.on(signal, () => {
-      log.nested(chalk.blue('\nStopping packager...'));
+      Log.nested(chalk.blue('\nStopping packager...'));
       onStop(projectDir).then(() => {
-        log.nested(chalk.green('Packager stopped.'));
+        Log.nested(chalk.green('Packager stopped.'));
         process.exit();
       });
     });

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -34,7 +34,7 @@ import wrapAnsi from 'wrap-ansi';
 import { AbortCommandError, SilentError } from './CommandError';
 import { loginOrRegisterAsync } from './accounts';
 import { registerCommands } from './commands';
-import log from './log';
+import Log from './log';
 import update from './update';
 import urlOpts from './urlOpts';
 
@@ -320,9 +320,9 @@ Command.prototype.commandHelp = function () {
 };
 
 program.on('--help', () => {
-  log.log(`  Run a command with --help for more info 💡`);
-  log.log(`    $ expo start --help`);
-  log.log();
+  Log.log(`  Run a command with --help for more info 💡`);
+  Log.log(`    $ expo start --help`);
+  Log.log();
 });
 
 export type Action = (...args: any[]) => void;
@@ -352,24 +352,24 @@ Command.prototype.asyncAction = function (asyncFn: Action, skipUpdateCheck: bool
       if (err instanceof AbortCommandError || err instanceof SilentError) {
         // Do nothing when a prompt is cancelled or the error is logged in a pretty way.
       } else if (err.isCommandError) {
-        log.error(err.message);
+        Log.error(err.message);
       } else if (err._isApiError) {
-        log.error(chalk.red(err.message));
+        Log.error(chalk.red(err.message));
       } else if (err.isXDLError) {
-        log.error(err.message);
+        Log.error(err.message);
       } else if (err.isJsonFileError || err.isConfigError || err.isPackageManagerError) {
         if (err.code === 'EJSONEMPTY') {
           // Empty JSON is an easy bug to debug. Often this is thrown for package.json or app.json being empty.
-          log.error(err.message);
+          Log.error(err.message);
         } else {
-          log.addNewLineIfNone();
-          log.error(err.message);
+          Log.addNewLineIfNone();
+          Log.error(err.message);
           const stacktrace = formatStackTrace(err.stack, this.name());
-          log.error(chalk.gray(stacktrace));
+          Log.error(chalk.gray(stacktrace));
         }
       } else {
-        log.error(err.message);
-        log.error(chalk.gray(err.stack));
+        Log.error(err.message);
+        Log.error(chalk.gray(err.stack));
       }
 
       process.exit(1);
@@ -461,12 +461,12 @@ Command.prototype.asyncActionProjectDir = function (
     if (opts.config) {
       // @ts-ignore: This guards against someone passing --config without a path.
       if (opts.config === true) {
-        log.addNewLineIfNone();
-        log.log('Please specify your custom config path:');
-        log.log(
-          log.chalk.green(`  expo ${this.name()} --config ${log.chalk.cyan(`<app-config>`)}`)
+        Log.addNewLineIfNone();
+        Log.log('Please specify your custom config path:');
+        Log.log(
+          Log.chalk.green(`  expo ${this.name()} --config ${Log.chalk.cyan(`<app-config>`)}`)
         );
-        log.newLine();
+        Log.newLine();
         process.exit(1);
       }
 
@@ -474,15 +474,15 @@ Command.prototype.asyncActionProjectDir = function (
       // Warn the user when the custom config path they provided does not exist.
       if (!fs.existsSync(pathToConfig)) {
         const relativeInput = path.relative(process.cwd(), opts.config);
-        const formattedPath = log.chalk
+        const formattedPath = Log.chalk
           .reset(pathToConfig)
-          .replace(relativeInput, log.chalk.bold(relativeInput));
-        log.addNewLineIfNone();
-        log.nestedWarn(`Custom config file does not exist:\n${formattedPath}`);
-        log.newLine();
-        const helpCommand = log.chalk.green(`expo ${this.name()} --help`);
-        log.log(`Run ${helpCommand} for more info`);
-        log.newLine();
+          .replace(relativeInput, Log.chalk.bold(relativeInput));
+        Log.addNewLineIfNone();
+        Log.nestedWarn(`Custom config file does not exist:\n${formattedPath}`);
+        Log.newLine();
+        const helpCommand = Log.chalk.green(`expo ${this.name()} --help`);
+        Log.log(`Run ${helpCommand} for more info`);
+        Log.newLine();
         process.exit(1);
         // throw new Error(`File at provided config path does not exist: ${pathToConfig}`);
       }
@@ -512,7 +512,7 @@ Command.prototype.asyncActionProjectDir = function (
       }
 
       const { message, stack } = traceInfo;
-      log.addNewLineIfNone();
+      Log.addNewLineIfNone();
       logFn(chalk.bold(message));
 
       const isLibraryFrame = (line: string) => {
@@ -554,7 +554,7 @@ Command.prototype.asyncActionProjectDir = function (
         nestedLogFn(`- ... ${unloggedFrames} more stack frames from framework internals`);
       }
 
-      log.printNewLineBeforeNextLog();
+      Log.printNewLineBeforeNextLog();
     };
 
     const logWithLevel = (chunk: LogRecord) => {
@@ -563,21 +563,21 @@ Command.prototype.asyncActionProjectDir = function (
       }
       if (chunk.level <= bunyan.INFO) {
         if (chunk.includesStack) {
-          logStackTrace(chunk, log, log.nested);
+          logStackTrace(chunk, Log, Log.nested);
         } else {
-          logLines(chunk.msg, log);
+          logLines(chunk.msg, Log);
         }
       } else if (chunk.level === bunyan.WARN) {
         if (chunk.includesStack) {
-          logStackTrace(chunk, log.warn, log.nestedWarn);
+          logStackTrace(chunk, Log.warn, Log.nestedWarn);
         } else {
-          logLines(chunk.msg, log.warn);
+          logLines(chunk.msg, Log.warn);
         }
       } else {
         if (chunk.includesStack) {
-          logStackTrace(chunk, log.error, log.nestedError);
+          logStackTrace(chunk, Log.error, Log.nestedError);
         } else {
-          logLines(chunk.msg, log.error);
+          logLines(chunk.msg, Log.error);
         }
       }
     };
@@ -595,7 +595,7 @@ Command.prototype.asyncActionProjectDir = function (
           incomplete: ' ',
         });
 
-        log.setBundleProgressBar(bar);
+        Log.setBundleProgressBar(bar);
       },
       onProgressBuildBundle: (percent: number) => {
         if (!bar || bar.complete) return;
@@ -608,14 +608,14 @@ Command.prototype.asyncActionProjectDir = function (
         }
 
         if (bar) {
-          log.setBundleProgressBar(null);
+          Log.setBundleProgressBar(null);
           bar.terminate();
           bar = null;
 
           if (err) {
-            log.log(chalk.red('Failed building JavaScript bundle.'));
+            Log.log(chalk.red('Failed building JavaScript bundle.'));
           } else {
-            log.log(
+            Log.log(
               chalk.green(
                 `Finished building JavaScript bundle in ${
                   endTime.getTime() - startTime.getTime()
@@ -660,7 +660,7 @@ Command.prototype.asyncActionProjectDir = function (
       (await ProjectSettings.getCurrentStatusAsync(projectDir)) !== 'running'
     ) {
       const spinner = ora('Making sure project is set up correctly...').start();
-      log.setSpinner(spinner);
+      Log.setSpinner(spinner);
       // validate that this is a good projectDir before we try anything else
 
       const status = await Doctor.validateWithoutNetworkAsync(projectDir, {
@@ -670,7 +670,7 @@ Command.prototype.asyncActionProjectDir = function (
         throw new Error(`There is an error with your project. See above logs for information.`);
       }
       spinner.stop();
-      log.setSpinner(null);
+      Log.setSpinner(null);
     }
 
     // the existing CLI modules only pass one argument to this function, so skipProjectValidation
@@ -716,7 +716,7 @@ function runAsync(programName: string) {
     registerCommands(program);
 
     program.on('command:detach', () => {
-      log.warn('To eject your project to ExpoKit (previously "detach"), use `expo eject`.');
+      Log.warn('To eject your project to ExpoKit (previously "detach"), use `expo eject`.');
       process.exit(0);
     });
 
@@ -730,7 +730,7 @@ function runAsync(programName: string) {
       if (suggestion) {
         msg = `"${subCommand}" is not an expo command -- did you mean ${suggestion}?\n See "expo --help" for the full list of commands.`;
       }
-      log.warn(msg);
+      Log.warn(msg);
     });
 
     if (typeof program.nonInteractive === 'undefined') {
@@ -745,7 +745,7 @@ function runAsync(programName: string) {
       program.help();
     }
   } catch (e) {
-    log.error(e);
+    Log.error(e);
     throw e;
   }
 }
@@ -753,7 +753,7 @@ function runAsync(programName: string) {
 async function checkCliVersionAsync() {
   const { updateIsAvailable, current, latest, deprecated } = await update.checkForUpdateAsync();
   if (updateIsAvailable) {
-    log.nestedWarn(
+    Log.nestedWarn(
       boxen(
         chalk.green(`There is a new version of ${packageJSON.name} available (${latest}).
 You are currently using ${packageJSON.name} ${current}
@@ -765,7 +765,7 @@ for example: \`npm install -g ${packageJSON.name}\` to get the latest version`),
   }
 
   if (deprecated) {
-    log.nestedWarn(
+    Log.nestedWarn(
       boxen(
         chalk.red(
           `This version of expo-cli is not supported anymore.
@@ -798,11 +798,11 @@ function _registerLogs() {
         }
 
         if (chunk.level === bunyan.INFO) {
-          log.log(chunk.msg);
+          Log.log(chunk.msg);
         } else if (chunk.level === bunyan.WARN) {
-          log.warn(chunk.msg);
+          Log.warn(chunk.msg);
         } else if (chunk.level >= bunyan.ERROR) {
-          log.error(chunk.msg);
+          Log.error(chunk.msg);
         }
       },
     },
@@ -828,7 +828,7 @@ export function run(programName: string) {
   (async function () {
     await Promise.all([writePathAsync(), runAsync(programName)]);
   })().catch(e => {
-    log.error('Uncaught Error', e);
+    Log.error('Uncaught Error', e);
     process.exit(1);
   });
 }

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -320,9 +320,9 @@ Command.prototype.commandHelp = function () {
 };
 
 program.on('--help', () => {
-  log(`  Run a command with --help for more info 💡`);
-  log(`    $ expo start --help`);
-  log();
+  log.log(`  Run a command with --help for more info 💡`);
+  log.log(`    $ expo start --help`);
+  log.log();
 });
 
 export type Action = (...args: any[]) => void;
@@ -462,8 +462,10 @@ Command.prototype.asyncActionProjectDir = function (
       // @ts-ignore: This guards against someone passing --config without a path.
       if (opts.config === true) {
         log.addNewLineIfNone();
-        log('Please specify your custom config path:');
-        log(log.chalk.green(`  expo ${this.name()} --config ${log.chalk.cyan(`<app-config>`)}`));
+        log.log('Please specify your custom config path:');
+        log.log(
+          log.chalk.green(`  expo ${this.name()} --config ${log.chalk.cyan(`<app-config>`)}`)
+        );
         log.newLine();
         process.exit(1);
       }
@@ -479,7 +481,7 @@ Command.prototype.asyncActionProjectDir = function (
         log.nestedWarn(`Custom config file does not exist:\n${formattedPath}`);
         log.newLine();
         const helpCommand = log.chalk.green(`expo ${this.name()} --help`);
-        log(`Run ${helpCommand} for more info`);
+        log.log(`Run ${helpCommand} for more info`);
         log.newLine();
         process.exit(1);
         // throw new Error(`File at provided config path does not exist: ${pathToConfig}`);
@@ -611,9 +613,9 @@ Command.prototype.asyncActionProjectDir = function (
           bar = null;
 
           if (err) {
-            log(chalk.red('Failed building JavaScript bundle.'));
+            log.log(chalk.red('Failed building JavaScript bundle.'));
           } else {
-            log(
+            log.log(
               chalk.green(
                 `Finished building JavaScript bundle in ${
                   endTime.getTime() - startTime.getTime()
@@ -796,7 +798,7 @@ function _registerLogs() {
         }
 
         if (chunk.level === bunyan.INFO) {
-          log(chunk.msg);
+          log.log(chunk.msg);
         } else if (chunk.level === bunyan.WARN) {
           log.warn(chunk.msg);
         } else if (chunk.level >= bunyan.ERROR) {

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -563,9 +563,9 @@ Command.prototype.asyncActionProjectDir = function (
       }
       if (chunk.level <= bunyan.INFO) {
         if (chunk.includesStack) {
-          logStackTrace(chunk, Log, Log.nested);
+          logStackTrace(chunk, Log.log, Log.nested);
         } else {
-          logLines(chunk.msg, Log);
+          logLines(chunk.msg, Log.log);
         }
       } else if (chunk.level === bunyan.WARN) {
         if (chunk.includesStack) {

--- a/packages/expo-cli/src/log.ts
+++ b/packages/expo-cli/src/log.ts
@@ -106,41 +106,41 @@ function withPrefix(args: any[], chalkColor = chalk.gray) {
   }
 }
 
-const log = {} as any;
+const Log = {} as any;
 
-log.log = function (...args: any[]) {
+Log.log = function (...args: any[]) {
   respectProgressBars(() => {
     consoleLog(...withPrefix(args));
   });
 };
 
-log.nested = function (message: any) {
+Log.nested = function (message: any) {
   respectProgressBars(() => {
     consoleLog(message);
   });
 };
 
-log.newLine = function newLine() {
+Log.newLine = function newLine() {
   respectProgressBars(() => {
     consoleLog();
   });
 };
 
-log.addNewLineIfNone = function addNewLineIfNone() {
+Log.addNewLineIfNone = function addNewLineIfNone() {
   if (!_isLastLineNewLine && !_printNewLineBeforeNextLog) {
-    log.newLine();
+    Log.newLine();
   }
 };
 
-log.printNewLineBeforeNextLog = function printNewLineBeforeNextLog() {
+Log.printNewLineBeforeNextLog = function printNewLineBeforeNextLog() {
   _printNewLineBeforeNextLog = true;
 };
 
-log.setBundleProgressBar = function setBundleProgressBar(bar: any) {
+Log.setBundleProgressBar = function setBundleProgressBar(bar: any) {
   _bundleProgressBar = bar;
 };
 
-log.setSpinner = function setSpinner(oraSpinner: Ora | null) {
+Log.setSpinner = function setSpinner(oraSpinner: Ora | null) {
   _oraSpinner = oraSpinner;
   if (_oraSpinner) {
     const originalStart = _oraSpinner.start.bind(_oraSpinner);
@@ -153,34 +153,34 @@ log.setSpinner = function setSpinner(oraSpinner: Ora | null) {
     const originalStop = _oraSpinner.stop.bind(_oraSpinner);
     _oraSpinner.stop = () => {
       // Reset the target spinner
-      log.setSpinner(null);
+      Log.setSpinner(null);
       return originalStop();
     };
   }
 };
 
-log.error = function error(...args: any[]) {
+Log.error = function error(...args: any[]) {
   respectProgressBars(() => {
     consoleError(...withPrefixAndTextColor(args, chalk.red));
   });
 };
 
-log.nestedError = function (message: string) {
+Log.nestedError = function (message: string) {
   respectProgressBars(() => {
     consoleError(chalk.red(message));
   });
 };
 
-log.warn = function warn(...args: any[]) {
+Log.warn = function warn(...args: any[]) {
   respectProgressBars(() => {
     consoleWarn(...withPrefixAndTextColor(args, chalk.yellow));
   });
 };
 
-log.isDebug = EXPO_DEBUG;
+Log.isDebug = EXPO_DEBUG;
 
 // Only show these logs when EXPO_DEBUG is active
-log.debug = function debug(...args: any[]) {
+Log.debug = function debug(...args: any[]) {
   if (!EXPO_DEBUG) {
     return;
   }
@@ -189,7 +189,7 @@ log.debug = function debug(...args: any[]) {
   });
 };
 
-log.info = function info(...args: any[]) {
+Log.info = function info(...args: any[]) {
   if (!EXPO_DEBUG) {
     return;
   }
@@ -198,23 +198,23 @@ log.info = function info(...args: any[]) {
   });
 };
 
-log.nestedWarn = function (message: string) {
+Log.nestedWarn = function (message: string) {
   respectProgressBars(() => {
     consoleWarn(chalk.yellow(message));
   });
 };
 
-log.gray = function (...args: any[]) {
+Log.gray = function (...args: any[]) {
   respectProgressBars(() => {
     consoleLog(...withPrefixAndTextColor(args));
   });
 };
 
-log.clear = function () {
+Log.clear = function () {
   process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
 };
 
-log.chalk = chalk;
-log.terminalLink = terminalLink;
+Log.chalk = chalk;
+Log.terminalLink = terminalLink;
 
-export default log;
+export default Log;

--- a/packages/expo-cli/src/log.ts
+++ b/packages/expo-cli/src/log.ts
@@ -4,217 +4,212 @@ import { boolish } from 'getenv';
 import { Ora } from 'ora';
 import terminalLink from 'terminal-link';
 
-const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
-
 type Color = (...text: string[]) => string;
 
-let _bundleProgressBar: any;
-let _oraSpinner: any;
+export default class Log {
+  public static readonly chalk = chalk;
+  public static readonly terminalLink = terminalLink;
+  public static readonly isDebug = boolish('EXPO_DEBUG', false);
 
-let _printNewLineBeforeNextLog = false;
-let _isLastLineNewLine = false;
-function _updateIsLastLineNewLine(args: any[]) {
-  if (args.length === 0) {
-    _isLastLineNewLine = true;
-  } else {
-    const lastArg = args[args.length - 1];
-    if (typeof lastArg === 'string' && (lastArg === '' || lastArg.match(/[\r\n]$/))) {
-      _isLastLineNewLine = true;
+  public static log(...args: any[]) {
+    Log.respectProgressBars(() => {
+      Log.consoleLog(...Log.withPrefix(args));
+    });
+  }
+
+  public static nested(message: any) {
+    Log.respectProgressBars(() => {
+      Log.consoleLog(message);
+    });
+  }
+
+  public static newLine() {
+    Log.respectProgressBars(() => {
+      Log.consoleLog();
+    });
+  }
+
+  public static addNewLineIfNone() {
+    if (!Log._isLastLineNewLine && !Log._printNewLineBeforeNextLog) {
+      Log.newLine();
+    }
+  }
+
+  public static printNewLineBeforeNextLog() {
+    Log._printNewLineBeforeNextLog = true;
+  }
+
+  public static setBundleProgressBar(bar: any) {
+    Log._bundleProgressBar = bar;
+  }
+
+  public static setSpinner(oraSpinner: Ora | null) {
+    Log._oraSpinner = oraSpinner;
+    if (Log._oraSpinner) {
+      const originalStart = Log._oraSpinner.start.bind(Log._oraSpinner);
+      Log._oraSpinner.start = (text: any) => {
+        // Reset the new line tracker
+        Log._isLastLineNewLine = false;
+        return originalStart(text);
+      };
+      // All other methods of stopping will invoke the stop method.
+      const originalStop = Log._oraSpinner.stop.bind(Log._oraSpinner);
+      Log._oraSpinner.stop = () => {
+        // Reset the target spinner
+        Log.setSpinner(null);
+        return originalStop();
+      };
+    }
+  }
+
+  public static error(...args: any[]) {
+    Log.respectProgressBars(() => {
+      Log.consoleError(...Log.withPrefixAndTextColor(args, chalk.red));
+    });
+  }
+
+  public static nestedError(message: string) {
+    Log.respectProgressBars(() => {
+      Log.consoleError(chalk.red(message));
+    });
+  }
+
+  public static warn(...args: any[]) {
+    Log.respectProgressBars(() => {
+      Log.consoleWarn(...Log.withPrefixAndTextColor(args, chalk.yellow));
+    });
+  }
+
+  // Only show these logs when EXPO_DEBUG is active
+  public static debug(...args: any[]) {
+    if (!Log.isDebug) {
+      return;
+    }
+    Log.respectProgressBars(() => {
+      Log.consoleDebug(...Log.withPrefixAndTextColor(args));
+    });
+  }
+
+  public static info(...args: any[]) {
+    if (!Log.isDebug) {
+      return;
+    }
+    Log.respectProgressBars(() => {
+      Log.consoleInfo(...args);
+    });
+  }
+
+  public static nestedWarn(message: string) {
+    Log.respectProgressBars(() => {
+      Log.consoleWarn(chalk.yellow(message));
+    });
+  }
+
+  public static gray(...args: any[]) {
+    Log.respectProgressBars(() => {
+      Log.consoleLog(...Log.withPrefixAndTextColor(args));
+    });
+  }
+
+  public static clear() {
+    process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
+  }
+
+  private static _bundleProgressBar: any;
+  private static _oraSpinner: any;
+
+  private static _printNewLineBeforeNextLog = false;
+  private static _isLastLineNewLine = false;
+  private static _updateIsLastLineNewLine(args: any[]) {
+    if (args.length === 0) {
+      Log._isLastLineNewLine = true;
     } else {
-      _isLastLineNewLine = false;
+      const lastArg = args[args.length - 1];
+      if (typeof lastArg === 'string' && (lastArg === '' || lastArg.match(/[\r\n]$/))) {
+        Log._isLastLineNewLine = true;
+      } else {
+        Log._isLastLineNewLine = false;
+      }
+    }
+  }
+
+  private static _maybePrintNewLine() {
+    if (Log._printNewLineBeforeNextLog) {
+      Log._printNewLineBeforeNextLog = false;
+      console.log(); // eslint-disable-line no-console
+    }
+  }
+
+  private static consoleDebug(...args: any[]) {
+    Log._maybePrintNewLine();
+    Log._updateIsLastLineNewLine(args);
+
+    console.debug(...args); // eslint-disable-line no-console
+  }
+
+  private static consoleInfo(...args: any[]) {
+    Log._maybePrintNewLine();
+    Log._updateIsLastLineNewLine(args);
+
+    console.info(...args); // eslint-disable-line no-console
+  }
+
+  private static consoleLog(...args: any[]) {
+    Log._maybePrintNewLine();
+    Log._updateIsLastLineNewLine(args);
+
+    console.log(...args); // eslint-disable-line no-console
+  }
+
+  private static consoleWarn(...args: any[]) {
+    Log._maybePrintNewLine();
+    Log._updateIsLastLineNewLine(args);
+
+    console.warn(...args); // eslint-disable-line no-console
+  }
+
+  private static consoleError(...args: any[]) {
+    Log._maybePrintNewLine();
+    Log._updateIsLastLineNewLine(args);
+
+    console.error(...args); // eslint-disable-line no-console
+  }
+
+  private static respectProgressBars(commitLogs: () => void) {
+    if (Log._bundleProgressBar) {
+      Log._bundleProgressBar.terminate();
+      Log._bundleProgressBar.lastDraw = '';
+    }
+    if (Log._oraSpinner) {
+      Log._oraSpinner.stop();
+    }
+    commitLogs();
+
+    if (Log._bundleProgressBar) {
+      Log._bundleProgressBar.render();
+    }
+    if (Log._oraSpinner) {
+      Log._oraSpinner.start();
+    }
+  }
+
+  private static getPrefix(chalkColor: Color) {
+    return chalkColor(`[${new Date().toTimeString().slice(0, 8)}]`);
+  }
+
+  private static withPrefixAndTextColor(args: any[], chalkColor: Color = chalk.gray) {
+    if (program.nonInteractive) {
+      return [Log.getPrefix(chalkColor), ...args.map(arg => chalkColor(arg))];
+    } else {
+      return args.map(arg => chalkColor(arg));
+    }
+  }
+
+  private static withPrefix(args: any[], chalkColor = chalk.gray) {
+    if (program.nonInteractive) {
+      return [Log.getPrefix(chalkColor), ...args];
+    } else {
+      return args;
     }
   }
 }
-
-function _maybePrintNewLine() {
-  if (_printNewLineBeforeNextLog) {
-    _printNewLineBeforeNextLog = false;
-    console.log(); // eslint-disable-line no-console
-  }
-}
-
-function consoleDebug(...args: any[]) {
-  _maybePrintNewLine();
-  _updateIsLastLineNewLine(args);
-
-  console.debug(...args); // eslint-disable-line no-console
-}
-
-function consoleInfo(...args: any[]) {
-  _maybePrintNewLine();
-  _updateIsLastLineNewLine(args);
-
-  console.info(...args); // eslint-disable-line no-console
-}
-
-function consoleLog(...args: any[]) {
-  _maybePrintNewLine();
-  _updateIsLastLineNewLine(args);
-
-  console.log(...args); // eslint-disable-line no-console
-}
-
-function consoleWarn(...args: any[]) {
-  _maybePrintNewLine();
-  _updateIsLastLineNewLine(args);
-
-  console.warn(...args); // eslint-disable-line no-console
-}
-
-function consoleError(...args: any[]) {
-  _maybePrintNewLine();
-  _updateIsLastLineNewLine(args);
-
-  console.error(...args); // eslint-disable-line no-console
-}
-
-function respectProgressBars(commitLogs: () => void) {
-  if (_bundleProgressBar) {
-    _bundleProgressBar.terminate();
-    _bundleProgressBar.lastDraw = '';
-  }
-  if (_oraSpinner) {
-    _oraSpinner.stop();
-  }
-  commitLogs();
-
-  if (_bundleProgressBar) {
-    _bundleProgressBar.render();
-  }
-  if (_oraSpinner) {
-    _oraSpinner.start();
-  }
-}
-
-function getPrefix(chalkColor: Color) {
-  return chalkColor(`[${new Date().toTimeString().slice(0, 8)}]`);
-}
-
-function withPrefixAndTextColor(args: any[], chalkColor: Color = chalk.gray) {
-  if (program.nonInteractive) {
-    return [getPrefix(chalkColor), ...args.map(arg => chalkColor(arg))];
-  } else {
-    return args.map(arg => chalkColor(arg));
-  }
-}
-
-function withPrefix(args: any[], chalkColor = chalk.gray) {
-  if (program.nonInteractive) {
-    return [getPrefix(chalkColor), ...args];
-  } else {
-    return args;
-  }
-}
-
-const Log = {} as any;
-
-Log.log = function (...args: any[]) {
-  respectProgressBars(() => {
-    consoleLog(...withPrefix(args));
-  });
-};
-
-Log.nested = function (message: any) {
-  respectProgressBars(() => {
-    consoleLog(message);
-  });
-};
-
-Log.newLine = function newLine() {
-  respectProgressBars(() => {
-    consoleLog();
-  });
-};
-
-Log.addNewLineIfNone = function addNewLineIfNone() {
-  if (!_isLastLineNewLine && !_printNewLineBeforeNextLog) {
-    Log.newLine();
-  }
-};
-
-Log.printNewLineBeforeNextLog = function printNewLineBeforeNextLog() {
-  _printNewLineBeforeNextLog = true;
-};
-
-Log.setBundleProgressBar = function setBundleProgressBar(bar: any) {
-  _bundleProgressBar = bar;
-};
-
-Log.setSpinner = function setSpinner(oraSpinner: Ora | null) {
-  _oraSpinner = oraSpinner;
-  if (_oraSpinner) {
-    const originalStart = _oraSpinner.start.bind(_oraSpinner);
-    _oraSpinner.start = (text: any) => {
-      // Reset the new line tracker
-      _isLastLineNewLine = false;
-      return originalStart(text);
-    };
-    // All other methods of stopping will invoke the stop method.
-    const originalStop = _oraSpinner.stop.bind(_oraSpinner);
-    _oraSpinner.stop = () => {
-      // Reset the target spinner
-      Log.setSpinner(null);
-      return originalStop();
-    };
-  }
-};
-
-Log.error = function error(...args: any[]) {
-  respectProgressBars(() => {
-    consoleError(...withPrefixAndTextColor(args, chalk.red));
-  });
-};
-
-Log.nestedError = function (message: string) {
-  respectProgressBars(() => {
-    consoleError(chalk.red(message));
-  });
-};
-
-Log.warn = function warn(...args: any[]) {
-  respectProgressBars(() => {
-    consoleWarn(...withPrefixAndTextColor(args, chalk.yellow));
-  });
-};
-
-Log.isDebug = EXPO_DEBUG;
-
-// Only show these logs when EXPO_DEBUG is active
-Log.debug = function debug(...args: any[]) {
-  if (!EXPO_DEBUG) {
-    return;
-  }
-  respectProgressBars(() => {
-    consoleDebug(...withPrefixAndTextColor(args));
-  });
-};
-
-Log.info = function info(...args: any[]) {
-  if (!EXPO_DEBUG) {
-    return;
-  }
-  respectProgressBars(() => {
-    consoleInfo(...args);
-  });
-};
-
-Log.nestedWarn = function (message: string) {
-  respectProgressBars(() => {
-    consoleWarn(chalk.yellow(message));
-  });
-};
-
-Log.gray = function (...args: any[]) {
-  respectProgressBars(() => {
-    consoleLog(...withPrefixAndTextColor(args));
-  });
-};
-
-Log.clear = function () {
-  process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
-};
-
-Log.chalk = chalk;
-Log.terminalLink = terminalLink;
-
-export default Log;

--- a/packages/expo-cli/src/log.ts
+++ b/packages/expo-cli/src/log.ts
@@ -106,11 +106,13 @@ function withPrefix(args: any[], chalkColor = chalk.gray) {
   }
 }
 
-function log(...args: any[]) {
+const log = {} as any;
+
+log.log = function (...args: any[]) {
   respectProgressBars(() => {
     consoleLog(...withPrefix(args));
   });
-}
+};
 
 log.nested = function (message: any) {
   respectProgressBars(() => {

--- a/packages/expo-cli/src/printRunInstructionsAsync.ts
+++ b/packages/expo-cli/src/printRunInstructionsAsync.ts
@@ -1,17 +1,17 @@
 import { UserManager } from '@expo/xdl';
 import chalk from 'chalk';
 
-import log from './log';
+import Log from './log';
 
 export default async function printRunInstructionsAsync(): Promise<void> {
   const user = await UserManager.getCurrentUserAsync();
 
   // If no user, we are offline and can't connect
   if (user) {
-    log.newLine();
-    log.log(chalk.bold('Instructions to open this project on a physical device'));
-    log.log(`${chalk.underline('Android devices')}: scan the above QR code.`);
-    log.log(
+    Log.newLine();
+    Log.log(chalk.bold('Instructions to open this project on a physical device'));
+    Log.log(`${chalk.underline('Android devices')}: scan the above QR code.`);
+    Log.log(
       `${chalk.underline('iOS devices')}: run ${chalk.bold(
         'expo send -s <your-email-address>'
       )} in this project directory in another terminal window to send the URL to your device.`
@@ -25,12 +25,12 @@ export default async function printRunInstructionsAsync(): Promise<void> {
     // );
   }
 
-  log.newLine();
-  log.log(chalk.bold('Instructions to open this project on a simulator'));
-  log.log(
+  Log.newLine();
+  Log.log(chalk.bold('Instructions to open this project on a simulator'));
+  Log.log(
     `If you already have the simulator installed, run ${chalk.bold('expo ios')} or ${chalk.bold(
       'expo android'
     )} in this project directory in another terminal window.`
   );
-  log.newLine();
+  Log.newLine();
 }

--- a/packages/expo-cli/src/printRunInstructionsAsync.ts
+++ b/packages/expo-cli/src/printRunInstructionsAsync.ts
@@ -9,16 +9,16 @@ export default async function printRunInstructionsAsync(): Promise<void> {
   // If no user, we are offline and can't connect
   if (user) {
     log.newLine();
-    log(chalk.bold('Instructions to open this project on a physical device'));
-    log(`${chalk.underline('Android devices')}: scan the above QR code.`);
-    log(
+    log.log(chalk.bold('Instructions to open this project on a physical device'));
+    log.log(`${chalk.underline('Android devices')}: scan the above QR code.`);
+    log.log(
       `${chalk.underline('iOS devices')}: run ${chalk.bold(
         'expo send -s <your-email-address>'
       )} in this project directory in another terminal window to send the URL to your device.`
     );
 
     // NOTE(brentvatne) Uncomment this when we update iOS client
-    // log(
+    // log.log(
     //   `Alternatively, sign in to your account (${chalk.bold(
     //     user.username
     //   )}) in the latest version of Expo Go on your iOS or Android device. Your projects will automatically appear in the "Projects" tab.`
@@ -26,8 +26,8 @@ export default async function printRunInstructionsAsync(): Promise<void> {
   }
 
   log.newLine();
-  log(chalk.bold('Instructions to open this project on a simulator'));
-  log(
+  log.log(chalk.bold('Instructions to open this project on a simulator'));
+  log.log(
     `If you already have the simulator installed, run ${chalk.bold('expo ios')} or ${chalk.bold(
       'expo android'
     )} in this project directory in another terminal window.`

--- a/packages/expo-cli/src/projects.ts
+++ b/packages/expo-cli/src/projects.ts
@@ -3,7 +3,7 @@ import { ApiV2, RobotUser, User } from '@expo/xdl';
 import ora from 'ora';
 
 import CommandError from './CommandError';
-import log from './log';
+import Log from './log';
 
 interface ProjectData {
   accountName: string;
@@ -18,7 +18,7 @@ async function ensureProjectExistsAsync(
   const projectFullName = `@${accountName}/${projectName}`;
 
   const spinner = ora(
-    `Ensuring project ${log.chalk.bold(projectFullName)} is registered on Expo servers`
+    `Ensuring project ${Log.chalk.bold(projectFullName)} is registered on Expo servers`
   ).start();
 
   const client = ApiV2.clientForUser(user);
@@ -29,7 +29,7 @@ async function ensureProjectExistsAsync(
   } catch (err) {
     if (err.code !== 'EXPERIENCE_NOT_FOUND') {
       spinner.fail(
-        `Something went wrong when looking for project ${log.chalk.bold(
+        `Something went wrong when looking for project ${Log.chalk.bold(
           projectFullName
         )} on Expo servers`
       );
@@ -37,7 +37,7 @@ async function ensureProjectExistsAsync(
     }
   }
   try {
-    spinner.text = `Registering project ${log.chalk.bold(projectFullName)} on Expo servers`;
+    spinner.text = `Registering project ${Log.chalk.bold(projectFullName)} on Expo servers`;
     const { id } = await client.postAsync('projects', {
       accountName,
       projectName,

--- a/packages/expo-cli/src/schemes.ts
+++ b/packages/expo-cli/src/schemes.ts
@@ -44,12 +44,12 @@ export async function getDevClientSchemeAsync(projectRoot: string): Promise<stri
     log.warn(
       '\nDev Client: No common URI schemes could be found for the native ios and android projects, this is required for opening the project\n'
     );
-    log(
+    log.log(
       `Add a common scheme with ${log.chalk.cyan(
         'npx uri-scheme add my-scheme'
       )} or provide a scheme with the ${log.chalk.cyan('--scheme')} flag\n`
     );
-    log(
+    log.log(
       log.chalk.dim(
         `You can see all of the existing schemes for your native projects by running ${log.chalk.cyan(
           'npx uri-scheme list'

--- a/packages/expo-cli/src/schemes.ts
+++ b/packages/expo-cli/src/schemes.ts
@@ -3,7 +3,7 @@ import plist from '@expo/plist';
 import * as fs from 'fs-extra';
 
 import { AbortCommandError } from './CommandError';
-import log from './log';
+import Log from './log';
 
 async function getSchemesForIosAsync(projectRoot: string) {
   try {
@@ -41,17 +41,17 @@ export async function getDevClientSchemeAsync(projectRoot: string): Promise<stri
 
   const [matching] = intersecting(ios, android);
   if (!matching) {
-    log.warn(
+    Log.warn(
       '\nDev Client: No common URI schemes could be found for the native ios and android projects, this is required for opening the project\n'
     );
-    log.log(
-      `Add a common scheme with ${log.chalk.cyan(
+    Log.log(
+      `Add a common scheme with ${Log.chalk.cyan(
         'npx uri-scheme add my-scheme'
-      )} or provide a scheme with the ${log.chalk.cyan('--scheme')} flag\n`
+      )} or provide a scheme with the ${Log.chalk.cyan('--scheme')} flag\n`
     );
-    log.log(
-      log.chalk.dim(
-        `You can see all of the existing schemes for your native projects by running ${log.chalk.cyan(
+    Log.log(
+      Log.chalk.dim(
+        `You can see all of the existing schemes for your native projects by running ${Log.chalk.cyan(
           'npx uri-scheme list'
         )}\n`
       )

--- a/packages/expo-cli/src/sendTo.ts
+++ b/packages/expo-cli/src/sendTo.ts
@@ -2,7 +2,7 @@ import { Exp, UserSettings } from '@expo/xdl';
 import ora from 'ora';
 
 import { askForSendToAsync } from './askUser';
-import log from './log';
+import Log from './log';
 
 export async function getRecipient(sendTo?: string | boolean): Promise<string> {
   let recipient: string | null = '';
@@ -21,7 +21,7 @@ export async function getRecipient(sendTo?: string | boolean): Promise<string> {
   return recipient;
 }
 export async function sendUrlAsync(url: string, recipient: string) {
-  const email = log.chalk.bold(recipient);
+  const email = Log.chalk.bold(recipient);
   const spinner = ora(`Sending URL to ${email}`).start();
   try {
     var result = await Exp.sendAsync(recipient, url);

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -5,7 +5,7 @@ import indentString from 'indent-string';
 import qrcodeTerminal from 'qrcode-terminal';
 
 import CommandError, { AbortCommandError } from './CommandError';
-import log from './log';
+import Log from './log';
 import { getDevClientSchemeAsync } from './schemes';
 
 // NOTE: if you update this, you should also update assertValidOptions in UrlUtils.ts
@@ -75,10 +75,10 @@ async function optsAsync(projectDir: string, options: any) {
   if (options.devClient) {
     const defaultTarget = getDefaultTarget(projectDir);
     if (defaultTarget !== 'bare') {
-      log.warn(
-        `\nOption ${log.chalk.cyan(
+      Log.warn(
+        `\nOption ${Log.chalk.cyan(
           '--dev-client'
-        )} can only be used in bare workflow apps. Run ${log.chalk.cyan(
+        )} can only be used in bare workflow apps. Run ${Log.chalk.cyan(
           'expo eject'
         )} and try again\n`
       );
@@ -103,7 +103,7 @@ async function optsAsync(projectDir: string, options: any) {
 }
 
 function printQRCode(url: string) {
-  qrcodeTerminal.generate(url, code => log.log(`${indentString(code, 1)}\n`));
+  qrcodeTerminal.generate(url, code => Log.log(`${indentString(code, 1)}\n`));
 }
 
 async function handleMobileOptsAsync(

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -103,7 +103,7 @@ async function optsAsync(projectDir: string, options: any) {
 }
 
 function printQRCode(url: string) {
-  qrcodeTerminal.generate(url, code => log(`${indentString(code, 1)}\n`));
+  qrcodeTerminal.generate(url, code => log.log(`${indentString(code, 1)}\n`));
 }
 
 async function handleMobileOptsAsync(

--- a/packages/expo-cli/src/validators.ts
+++ b/packages/expo-cli/src/validators.ts
@@ -12,7 +12,7 @@ const existingFile = async (filePath: string, verbose = true) => {
     return stats.isFile();
   } catch (e) {
     if (verbose) {
-      log('\nFile does not exist.');
+      log.log('\nFile does not exist.');
     }
     return false;
   }

--- a/packages/expo-cli/src/validators.ts
+++ b/packages/expo-cli/src/validators.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 
-import log from './log';
+import Log from './log';
 
 function nonEmptyInput(val: string) {
   return val !== '';
@@ -12,7 +12,7 @@ const existingFile = async (filePath: string, verbose = true) => {
     return stats.isFile();
   } catch (e) {
     if (verbose) {
-      log.log('\nFile does not exist.');
+      Log.log('\nFile does not exist.');
     }
     return false;
   }


### PR DESCRIPTION
# Why

Mocking `log` and verifying results is a common way to unit test the CLI. Until this PR, the only way to mock the `log` module was to do the following due to the way it was set up (custom properties on a function instance, which was copied from expo-cli):
```typescript
const mockLog = {	
  __esModule: true, // this property makes it work	
  default: jest.fn(toLog => toLog),	
};	
(mockLog.default as any).newLine = jest.fn();	
jest.mock('../../../../log', () => mockLog);
```

Or to just not use the default `log` export and use one of the `nested` or other properties, which didn't require the weird esmodule mock thing. This is the strategy that I took with the `OTP` testing. This was bad since it required changing the behavior of the actual code just to make testing easier.

This PR makes it a better default export (class) for cleaner mocking. The corresponding `eas-cli` change was https://github.com/expo/eas-cli/pull/223.

# How

This should be reviewed as a single commit, but the process for generating it is as follows (making use of TypeScript refactoring):
1. Make the default export of `log.ts` an object instead of a function, and create a property on that object called `log`. Find/replace all `log(` with `log.log(`.
2. TypeScript refactor the name of the object to `Log` (uppercase)
3. Convert object to class with static methods, fix `tsc`.

# Test Plan

`yarn tsc`
`yarn test`
