### PR TITLE
Update web index.html height style

### DIFF
--- a/packages/webpack-config/web-default/index.html
+++ b/packages/webpack-config/web-default/index.html
@@ -40,7 +40,7 @@
         scroll-behavior: smooth;
         /* Prevent text size change on orientation change https://gist.github.com/tfausak/2222823#file-ios-8-web-app-html-L138 */
         -webkit-text-size-adjust: 100%;
-        height: 100%;
+        height: calc(100% + env(safe-area-inset-top));
       }
 
       body {


### PR DESCRIPTION
# Why

Fixed the screen height in the web when the statusBar is transparent. Before this change, in the web was displayed an extra white space in the bottom of the screen.

# Test Plan

It works perfectly with react-navigation bottom tabs and header, and also with SafeArea component:
![image](https://user-images.githubusercontent.com/63528825/107284337-69c48180-6a3c-11eb-829d-e3a37b767974.png)

Landscape mode:
![image](https://user-images.githubusercontent.com/63528825/107284379-7b0d8e00-6a3c-11eb-8ff2-7c517220fb1a.png)

In iPhone 6/7/8 works normally:
![image](https://user-images.githubusercontent.com/63528825/107284422-92e51200-6a3c-11eb-944d-2cfda1e94891.jpeg)
