### PR TITLE
[expo-cli][prebuild] Clean up debug error messages

### DIFF
--- a/packages/config-plugins/src/plugins/static-plugins.ts
+++ b/packages/config-plugins/src/plugins/static-plugins.ts
@@ -10,6 +10,14 @@ import {
 
 const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
+function isModuleMissingError(name: string, error: Error): boolean {
+  // @ts-ignore
+  if (error.code === 'MODULE_NOT_FOUND') {
+    return true;
+  }
+  return error.message.includes(`Cannot find module '${name}'`);
+}
+
 /**
  * Resolves static module plugin and potentially falls back on a provided plugin if the module cannot be resolved
  *
@@ -45,8 +53,19 @@ export const withStaticPlugin: ConfigPlugin<{
       withPlugin = resolveConfigPluginFunction(projectRoot, pluginResolve);
     } catch (error) {
       if (EXPO_DEBUG) {
-        // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
-        console.log(`Error resolving plugin "${pluginResolve}"`, error);
+        if (isModuleMissingError(pluginResolve, error)) {
+          // Prevent causing log spew for basic resolution errors.
+          console.log(`Could not find plugin "${pluginResolve}"`);
+        } else if (error instanceof SyntaxError) {
+          console.log(`Error resolving plugin "${pluginResolve}"`);
+          // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
+          console.log(error);
+          console.log();
+        } else {
+          console.log(`Error resolving plugin "${pluginResolve}"`);
+          // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
+          console.log(error);
+        }
       }
       // TODO: Maybe allow for `PluginError`s to be thrown so external plugins can assert invalid options.
 

--- a/packages/config-plugins/src/plugins/static-plugins.ts
+++ b/packages/config-plugins/src/plugins/static-plugins.ts
@@ -56,15 +56,11 @@ export const withStaticPlugin: ConfigPlugin<{
         if (isModuleMissingError(pluginResolve, error)) {
           // Prevent causing log spew for basic resolution errors.
           console.log(`Could not find plugin "${pluginResolve}"`);
-        } else if (error instanceof SyntaxError) {
-          console.log(`Error resolving plugin "${pluginResolve}"`);
+        } else {
           // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
+          console.log(`Error resolving plugin "${pluginResolve}"`);
           console.log(error);
           console.log();
-        } else {
-          console.log(`Error resolving plugin "${pluginResolve}"`);
-          // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
-          console.log(error);
         }
       }
       // TODO: Maybe allow for `PluginError`s to be thrown so external plugins can assert invalid options.


### PR DESCRIPTION
# Why

In EAS build, the debug error messages are always shown. If the legacy built-in plugins aren't installed they log massive error messages (that are expected).

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

If a plugin with a fallback fails to resolve (like `expo-ads-admob`), it'll log a one-liner:

```
Could not find plugin "expo-ads-admob"
```

Instead of the current:

```
Error resolving plugin "expo-ads-admob" Error: Cannot find module 'expo-ads-admob'
Require stack:
- /Users/evanbacon/Documents/GitHub/lab/yolo3/noop.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:966:15)
    at resolveFileName (/Users/evanbacon/Documents/GitHub/cli/node_modules/resolve-from/index.js:29:39)
    at resolveFrom (/Users/evanbacon/Documents/GitHub/cli/node_modules/resolve-from/index.js:43:9)
    at Object.module.exports [as default] (/Users/evanbacon/Documents/GitHub/cli/node_modules/resolve-from/index.js:46:47)
    at resolvePluginForModule (/Users/evanbacon/Documents/GitHub/cli/packages/config-plugins/src/utils/plugin-resolver.ts:19:31)
    at Object.resolveConfigPluginFunction (/Users/evanbacon/Documents/GitHub/cli/packages/config-plugins/src/utils/plugin-resolver.ts:97:26)
    at Object.exports.withStaticPlugin (/Users/evanbacon/Documents/GitHub/cli/packages/config-plugins/src/plugins/static-plugins.ts:45:20)
    at exports.withAdMob (/Users/evanbacon/Documents/GitHub/cli/packages/config-plugins/src/plugins/unversioned/expo-ads-admob.ts:10:10)
    at Object.exports.withStaticPlugin (/Users/evanbacon/Documents/GitHub/cli/packages/config-plugins/src/plugins/static-plugins.ts:72:12)
    at /Users/evanbacon/Documents/GitHub/cli/packages/config-plugins/src/plugins/core-plugins.ts:33:12
    at Array.reduce (<anonymous>)
    at Object.exports.withPlugins (/Users/evanbacon/Documents/GitHub/cli/packages/config-plugins/src/plugins/core-plugins.ts:32:18)
    at Object.exports.withExpoVersionedSDKPlugins (/Users/evanbacon/Documents/GitHub/cli/packages/config-plugins/src/plugins/expo-plugins.ts:112:10)
    at Object.configureManagedProjectAsync [as default] (/Users/evanbacon/Documents/GitHub/cli/packages/expo-cli/src/commands/apply/configureProjectAsync.ts:89:12)
    at prebuildAsync (/Users/evanbacon/Documents/GitHub/cli/packages/expo-cli/src/commands/eject/Eject.ts:146:25)
    at Object.ejectAsync (/Users/evanbacon/Documents/GitHub/cli/packages/expo-cli/src/commands/eject/Eject.ts:78:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/evanbacon/Documents/GitHub/lab/yolo3/noop.js' ]
}
```

Of course, if the plugin doesn't have a fallback, then the entire error will be thrown (most plugins that aren't optional built-in expo plugins).

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `EXPO_DEBUG=1 expod eject --no-install` should log better debug messages.
