### PR TITLE
[pwa-manifest] add `crossorigin="use-credentials"` attribute

### DIFF
--- a/packages/webpack-config/src/plugins/PwaManifestWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/PwaManifestWebpackPlugin.ts
@@ -77,6 +77,7 @@ export default class PwaManifestWebpackPlugin extends JsonWebpackPlugin {
                 attributes: {
                   rel: this.rel,
                   href: joinUrlPath(this.pwaOptions.publicPath, this.pwaOptions.path),
+                  crossorigin: 'use-credentials',
                 },
               });
 


### PR DESCRIPTION
# Why

If the PWA is served with basic authentication, it will result in a 401 when getting the manifest file unless this attribute is included.

# How

Add `crossorigin="use-credentials"` attribute to the <link> element for the manifest file


See explanation [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_webmanifest_with_credentials).

# Test Plan

Serve the generated PWA with basic auth on and see a 401 being returned without this change.