### PR TITLE
[expo cli] redesign startup logs

### DIFF
--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -202,7 +202,7 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
     }
     Log.log(`Your native app is running at ${chalk.underline(url)}`);
   }
-  Log.nested(chalk.green('Logs for your project will appear below. Press Ctrl+C to exit.'));
+  Log.nested(`Logs for your project will appear below. ${chalk.dim(`Press Ctrl+C to exit.`)}`);
 }
 
 async function validateDependenciesVersions(
@@ -275,19 +275,7 @@ async function tryOpeningDevToolsAsync({
 
   if (!options.nonInteractive && !exp.isDetached) {
     if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
-      if (openBrowser(devToolsUrl)) {
-        Log.log(
-          `Opening developer tools in the browser... ${chalk.dim(
-            `(press ${chalk.bold`shift-d`} to disable)`
-          )}`
-        );
-      } else {
-        Log.warn(`Unable to open developer tools in the browser`);
-      }
-    } else {
-      Log.log(
-        `Press ${chalk.bold`d`} to open DevTools now, or ${chalk.bold`shift-d`} to always open it automatically.`
-      );
+      TerminalUI.openDeveloperTools(devToolsUrl);
     }
   }
 }

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -271,12 +271,19 @@ async function tryOpeningDevToolsAsync({
   options,
 }: OpenDevToolsOptions): Promise<void> {
   const devToolsUrl = await DevToolsServer.startAsync(rootPath);
-  Log.log(`Expo DevTools is running at ${chalk.underline(devToolsUrl)}`);
+  Log.log(`Developer tools running on ${chalk.underline(devToolsUrl)}`);
 
   if (!options.nonInteractive && !exp.isDetached) {
     if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
-      Log.log(`Opening DevTools in the browser... (press ${chalk.bold`shift-d`} to disable)`);
-      openBrowser(devToolsUrl);
+      if (openBrowser(devToolsUrl)) {
+        Log.log(
+          `Opening developer tools in the browser... ${chalk.dim(
+            `(press ${chalk.bold`shift-d`} to disable)`
+          )}`
+        );
+      } else {
+        Log.warn(`Unable to open developer tools in the browser`);
+      }
     } else {
       Log.log(
         `Press ${chalk.bold`d`} to open DevTools now, or ${chalk.bold`shift-d`} to always open it automatically.`
@@ -311,7 +318,7 @@ async function configureProjectAsync(
 
   const rootPath = path.resolve(projectDir);
 
-  await tryOpeningDevToolsAsync({
+  tryOpeningDevToolsAsync({
     rootPath,
     exp,
     options,

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -6,7 +6,6 @@ import { Project, ProjectSettings, UrlUtils, UserSettings, Versions } from '@exp
 import chalk from 'chalk';
 import intersection from 'lodash/intersection';
 import path from 'path';
-import openBrowser from 'react-dev-utils/openBrowser';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -126,7 +126,7 @@ const printServerInfo = async (
   Log.nested(item(`Waiting on ${u(url)}`));
   // Log.newLine();
   // TODO: if dev client, change this message!
-  Log.nested(item(`Scan the QR code above with the Expo app (Android) or the Camera app (iOS)`));
+  Log.nested(item(`Scan the QR code above with Expo Go (Android) or the Camera app (iOS)`));
 
   await printBasicUsageAsync(options);
   Webpack.printConnectionInstructions(projectRoot);
@@ -362,17 +362,8 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
         const enabled = !(await UserSettings.getAsync('openDevToolsAtStartup', true));
         await UserSettings.setAsync('openDevToolsAtStartup', enabled);
         const currentToggle = enabled ? 'enabled' : 'disabled';
-
-        logCommandsTable([
-          ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
-          ['d', `open developer tools now`],
-        ]);
-        // Log.log(
-        //   `Automatically opening DevTools ${b(
-        //     enabled ? 'enabled' : 'disabled'
-        //   )}.\nPress ${b`d`} to open DevTools now.`
-        // );
-        // printHelp();
+        Log.log(`Auto opening developer tools on startup: ${chalk.bold(currentToggle)}`);
+        logCommandsTable([['d', `open developer tools now`]]);
         break;
       }
       case 'p': {
@@ -384,7 +375,7 @@ export const startAsync = async (projectRoot: string, options: StartOptions) => 
           `Metro bundler is now running in ${chalk.bold(
             dev ? 'development' : 'production'
           )}${chalk.reset(` mode.`)}
-Please reload the project in the Expo app for the change to take effect.`
+Please reload the project in Expo Go for the change to take effect.`
         );
         printHelp();
         break;


### PR DESCRIPTION
# Why

Attempt to make startup logs more readable, and tie them closer to the other logs in the CLI

# How

- "Expo DevTools" -> "Developer tools"
- Group developer tools commands (d, shift+d) with other commands under the QR code. This is because the QR code often shifts all the logs up a lot, many users could end up missing them.
- Remove random colors.
- Move QR URL to under the QR and add some message.

## Before

<img width="845" alt="Screen Shot 2021-02-09 at 7 23 02 PM" src="https://user-images.githubusercontent.com/9664363/107460046-42d58080-6b0c-11eb-8572-4455d61dd362.png">

## After

<img width="845" alt="Screen Shot 2021-02-09 at 7 13 38 PM" src="https://user-images.githubusercontent.com/9664363/107459951-14f03c00-6b0c-11eb-9c4a-89f777da4e45.png">

# Test Plan

- `shift+d` to toggle the developer tools