### PR TITLE
[expo-cli] Improve server stopping

### DIFF
--- a/packages/expo-cli/src/exit.ts
+++ b/packages/expo-cli/src/exit.ts
@@ -10,11 +10,11 @@ export function installExitHooks(
   const killSignals: ['SIGINT', 'SIGTERM'] = ['SIGINT', 'SIGTERM'];
   for (const signal of killSignals) {
     process.on(signal, () => {
-      const spinner = ora('Stopping server').start();
+      const spinner = ora({ text: 'Stopping server', color: 'white' }).start();
       Log.setSpinner(spinner);
       onStop(projectRoot)
         .then(() => {
-          spinner.succeed('Stopped server');
+          spinner.stopAndPersist({ text: 'Stopped server', symbol: `\u203A` });
           process.exit();
         })
         .catch(error => {

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -229,8 +229,12 @@ export async function startAsync(
 
 export async function stopAsync(projectRoot: string): Promise<void> {
   if (webpackDevServerInstance) {
-    ProjectUtils.logInfo(projectRoot, WEBPACK_LOG_TAG, '\u203A Closing Webpack server');
-    webpackDevServerInstance.close();
+    await new Promise(res => {
+      if (webpackDevServerInstance) {
+        ProjectUtils.logInfo(projectRoot, WEBPACK_LOG_TAG, '\u203A Stopping Webpack server');
+        webpackDevServerInstance.close(res);
+      }
+    });
     webpackDevServerInstance = null;
     devServerInfo = null;
     webpackServerPort = null;

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -44,6 +44,7 @@ export async function startDevServerAsync(projectRoot: string, startOptions: Sta
     process.env.EXPO_TARGET = startOptions.target;
   }
 
-  const { middleware } = await runMetroDevServerAsync(projectRoot, options);
+  const { server, middleware } = await runMetroDevServerAsync(projectRoot, options);
   middleware.use(getManifestHandler(projectRoot));
+  return server;
 }


### PR DESCRIPTION
# Why

- Server stopping is slow, verbose, and seems to be only closing the new dev server by accident.

# How

- Save dev server instance and stop it manually.
- Parallelize stopping tasks.
- Use a spinner to indicate the entire stopping task.

# Test Plan

- `expod start` then stop it with `ctrl+c`
  - should only see spinner
- `expod start --tunnel --web` then stop it with `ctrl+c`
  - spinner shouldn't be interrupted by webpack log