### PR TITLE
[config-plugins] fix detecting application target

### DIFF
--- a/packages/config-plugins/src/ios/__tests__/Target-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Target-test.ts
@@ -9,30 +9,60 @@ const fsReal = jest.requireActual('fs') as typeof fs;
 jest.mock('fs');
 
 describe(getApplicationTargetForSchemeAsync, () => {
-  beforeAll(async () => {
-    vol.fromJSON(
-      {
-        'ios/testproject.xcodeproj/xcshareddata/xcschemes/testproject.xcscheme': fsReal.readFileSync(
-          path.join(__dirname, 'fixtures/testproject.xcscheme'),
-          'utf-8'
-        ),
-      },
-      '/app'
-    );
-  });
+  describe('single build action entry', () => {
+    beforeAll(async () => {
+      vol.fromJSON(
+        {
+          'ios/testproject.xcodeproj/xcshareddata/xcschemes/testproject.xcscheme': fsReal.readFileSync(
+            path.join(__dirname, 'fixtures/testproject.xcscheme'),
+            'utf-8'
+          ),
+        },
+        '/app'
+      );
+    });
 
-  afterAll(() => {
-    vol.reset();
-  });
+    afterAll(() => {
+      vol.reset();
+    });
 
-  it('returns the target name for existing scheme', async () => {
-    const target = await getApplicationTargetForSchemeAsync('/app', 'testproject');
-    expect(target).toBe('testproject');
-  });
+    it('returns the target name for existing scheme', async () => {
+      const target = await getApplicationTargetForSchemeAsync('/app', 'testproject');
+      expect(target).toBe('testproject');
+    });
 
-  it('throws if the scheme does not exist', async () => {
-    await expect(() =>
-      getApplicationTargetForSchemeAsync('/app', 'nonexistentscheme')
-    ).rejects.toThrow(/does not exist/);
+    it('throws if the scheme does not exist', async () => {
+      await expect(() =>
+        getApplicationTargetForSchemeAsync('/app', 'nonexistentscheme')
+      ).rejects.toThrow(/does not exist/);
+    });
+  });
+  describe('multiple build action entries', () => {
+    beforeAll(async () => {
+      vol.fromJSON(
+        {
+          'ios/testproject.xcodeproj/xcshareddata/xcschemes/testproject.xcscheme': fsReal.readFileSync(
+            path.join(__dirname, 'fixtures/testproject-2.xcscheme'),
+            'utf-8'
+          ),
+        },
+        '/app'
+      );
+    });
+
+    afterAll(() => {
+      vol.reset();
+    });
+
+    it('returns the target name for existing scheme', async () => {
+      const target = await getApplicationTargetForSchemeAsync('/app', 'testproject');
+      expect(target).toBe('testproject');
+    });
+
+    it('throws if the scheme does not exist', async () => {
+      await expect(() =>
+        getApplicationTargetForSchemeAsync('/app', 'nonexistentscheme')
+      ).rejects.toThrow(/does not exist/);
+    });
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/fixtures/testproject-2.xcscheme
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/testproject-2.xcscheme
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "82CBBA2D1A601D0E00E9B172"
+               BuildableName = "libReact.a"
+               BlueprintName = "React"
+               ReferencedContainer = "container:../node_modules/react-native/React/React.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "testproject.app"
+               BlueprintName = "testproject"
+               ReferencedContainer = "container:testproject.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
+               BuildableName = "testprojectTests.xctest"
+               BlueprintName = "testprojectTests"
+               ReferencedContainer = "container:testproject.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "testproject.app"
+            BlueprintName = "testproject"
+            ReferencedContainer = "container:testproject.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
+               BuildableName = "testprojectTests.xctest"
+               BlueprintName = "testprojectTests"
+               ReferencedContainer = "container:testproject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "testproject.app"
+            BlueprintName = "testproject"
+            ReferencedContainer = "container:testproject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "testproject.app"
+            BlueprintName = "testproject"
+            ReferencedContainer = "container:testproject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C010FFEQF0A/p1611929974023600

There are iOS projects that have multiple `BuildActionEntries` defined in .xcscheme. Previously, we would take the first entry and use `BlueprintName` as the target name. Unfortunately, this is not correct behavior. The application target is not always the first entry but looking for it is quite simple. Its buildable name ends with `.app`.

# How

Instead of taking the first entry, I added a `.find` that looks for an entry ending with `.app`. 

# Test Plan

- Tested against the project from Slack.
- Added unit test.

# After merging

Bump @expo/config-plugins in eas-cli.