### PR TITLE
[expo-cli][start] deprecate .expo extension for start command

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -1,6 +1,7 @@
 import { ModConfig } from '@expo/config-plugins';
 import JsonFile, { JSONObject } from '@expo/json-file';
 import fs from 'fs-extra';
+import { boolish } from 'getenv';
 import { sync as globSync } from 'glob';
 import path from 'path';
 import resolveFrom from 'resolve-from';
@@ -618,3 +619,5 @@ export function getProjectConfigDescription(
 }
 
 export * from './Config.types';
+
+export { isLegacyImportsEnabled } from './isLegacyImportsEnabled';

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -1,7 +1,6 @@
 import { ModConfig } from '@expo/config-plugins';
 import JsonFile, { JSONObject } from '@expo/json-file';
 import fs from 'fs-extra';
-import { boolish } from 'getenv';
 import { sync as globSync } from 'glob';
 import path from 'path';
 import resolveFrom from 'resolve-from';

--- a/packages/config/src/isLegacyImportsEnabled.ts
+++ b/packages/config/src/isLegacyImportsEnabled.ts
@@ -1,0 +1,37 @@
+import { boolish } from 'getenv';
+import semver from 'semver';
+
+import { ExpoConfig } from './Config.types';
+
+/**
+ * Should the bundler use .expo file extensions.
+ *
+ * @param exp
+ */
+export function isLegacyImportsEnabled(exp: Pick<ExpoConfig, 'sdkVersion'>) {
+  if (boolish('EXPO_LEGACY_IMPORTS', false)) {
+    console.warn(
+      'Dangerously enabled deprecated `.expo` extensions, this functionality may be removed between SDK cycles.'
+    );
+    return true;
+  }
+  // Only allow target if the SDK version is available and it's less 41.
+  // This is optimized for making future projects work.
+  return lteSdkVersion(exp, '40.0.0');
+}
+
+function lteSdkVersion(expJson: Pick<ExpoConfig, 'sdkVersion'>, sdkVersion: string): boolean {
+  if (!expJson.sdkVersion) {
+    return false;
+  }
+
+  if (expJson.sdkVersion === 'UNVERSIONED') {
+    return false;
+  }
+
+  try {
+    return semver.lte(expJson.sdkVersion, sdkVersion);
+  } catch (e) {
+    throw new Error(`${expJson.sdkVersion} is not a valid version. Must be in the form of x.y.z`);
+  }
+}

--- a/packages/config/src/isLegacyImportsEnabled.ts
+++ b/packages/config/src/isLegacyImportsEnabled.ts
@@ -11,7 +11,7 @@ import { ExpoConfig } from './Config.types';
 export function isLegacyImportsEnabled(exp: Pick<ExpoConfig, 'sdkVersion'>) {
   if (boolish('EXPO_LEGACY_IMPORTS', false)) {
     console.warn(
-      'Dangerously enabled deprecated `.expo` extensions, this functionality may be removed between SDK cycles.'
+      'Dangerously enabled the deprecated `.expo` extensions feature, this functionality may be removed between SDK cycles.'
     );
     return true;
   }

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -68,6 +68,7 @@ export async function runMetroDevServerAsync(
 
 let nextBuildID = 0;
 
+// TODO: deprecate options.target
 export async function bundleAsync(
   projectRoot: string,
   options: MetroDevServerOptions,

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -89,6 +89,7 @@
     "dateformat": "3.0.3",
     "env-editor": "^0.4.1",
     "envinfo": "7.5.0",
+    "find-yarn-workspace-root": "~2.0.0",
     "form-data": "^2.3.2",
     "fs-extra": "9.0.0",
     "getenv": "0.7.0",

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -1,4 +1,4 @@
-import { getDefaultTarget, ProjectTarget } from '@expo/config';
+import { ProjectTarget } from '@expo/config';
 import { Project, UrlUtils } from '@expo/xdl';
 import program, { Command } from 'commander';
 import crypto from 'crypto';
@@ -85,7 +85,7 @@ async function exportFilesAsync(
     isDev: options.dev,
     publishOptions: {
       resetCache: !!options.clear,
-      target: options.target ?? getDefaultTarget(projectRoot),
+      target: options.target,
     },
   };
   return await Project.exportAppAsync(

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -88,6 +88,7 @@ async function exportFilesAsync(
       target: options.target,
     },
   };
+
   return await Project.exportAppAsync(
     projectRoot,
     options.publicUrl!,
@@ -98,7 +99,7 @@ async function exportFilesAsync(
   );
 }
 
-async function mergeSourceDirectoriresAsync(
+async function mergeSourceDirectoriesAsync(
   projectDir: string,
   mergeSrcDirs: string[],
   options: Pick<Options, 'mergeSrcUrl' | 'mergeSrcDir' | 'outputDir'>
@@ -160,14 +161,14 @@ function collect<T>(val: T, memo: T[]): T[] {
   return memo;
 }
 
-export async function action(projectDir: string, options: Options) {
+export async function action(projectRoot: string, options: Options) {
   if (!options.experimentalBundle) {
     // Ensure URL
     options.publicUrl = await ensurePublicUrlAsync(options.publicUrl, options.dev);
   }
 
   // Ensure the output directory is created
-  const outputPath = path.resolve(projectDir, options.outputDir);
+  const outputPath = path.resolve(projectRoot, options.outputDir);
   await fs.ensureDir(outputPath);
 
   // Assert if the folder has contents
@@ -188,14 +189,17 @@ export async function action(projectDir: string, options: Options) {
   }
 
   // Wrap the XDL method for exporting assets
-  await exportFilesAsync(projectDir, options);
+  await exportFilesAsync(projectRoot, options);
 
   // Merge src dirs/urls into a multimanifest if specified
-  const mergeSrcDirs: string[] = await collectMergeSourceUrlsAsync(projectDir, options.mergeSrcUrl);
+  const mergeSrcDirs: string[] = await collectMergeSourceUrlsAsync(
+    projectRoot,
+    options.mergeSrcUrl
+  );
   // add any local src dirs to be merged
   mergeSrcDirs.push(...options.mergeSrcDir);
 
-  await mergeSourceDirectoriresAsync(projectDir, mergeSrcDirs, options);
+  await mergeSourceDirectoriesAsync(projectRoot, mergeSrcDirs, options);
 
   Log.log(`Export was successful. Your exported files can be found in ${options.outputDir}`);
 }

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -146,14 +146,9 @@ function parseStartOptions(options: NormalizedOptions, exp: ExpoConfig): Project
   }
 
   if (isLegacyImportsEnabled(exp)) {
-    if (options.devClient) {
-      // TODO: is this redundant?
-      startOpts.target = 'bare';
-    } else {
-      // For `expo start`, the default target is 'managed', for both managed *and* bare apps.
-      // See: https://docs.expo.io/bare/using-expo-client
-      startOpts.target = 'managed';
-    }
+    // For `expo start`, the default target is 'managed', for both managed *and* bare apps.
+    // See: https://docs.expo.io/bare/using-expo-client
+    startOpts.target = options.devClient ? 'bare' : 'managed';
     Log.debug('Using target: ', startOpts.target);
   }
 

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -14,6 +14,7 @@ import Log from '../log';
 import * as sendTo from '../sendTo';
 import urlOpts, { URLOptions } from '../urlOpts';
 import * as TerminalUI from './start/TerminalUI';
+import { assertProjectHasExpoExtensionFilesAsync } from './utils/deprecatedExtensionWarnings';
 import { ensureTypeScriptSetupAsync } from './utils/typescript/ensureTypeScriptSetup';
 
 type NormalizedOptions = URLOptions & {
@@ -162,6 +163,8 @@ async function startWebAction(projectDir: string, options: NormalizedOptions): P
   }
   const startOpts = parseStartOptions(options, exp);
 
+  // No need to warn about extensions for web.
+
   await Project.startAsync(rootPath, { ...startOpts, exp });
   await urlOpts.handleMobileOptsAsync(projectDir, options);
 
@@ -181,6 +184,13 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
   await validateDependenciesVersions(projectDir, exp, pkg);
 
   const startOpts = parseStartOptions(options, exp);
+
+  // Warn about expo extensions.
+  if (!isLegacyImportsEnabled(exp)) {
+    // Adds a few seconds in basic projects so we should
+    // drop this in favor of the upgrade version as soon as possible.
+    await assertProjectHasExpoExtensionFilesAsync(projectDir);
+  }
 
   await Project.startAsync(rootPath, { ...startOpts, exp });
 

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -1,4 +1,9 @@
-import { getConfig, readConfigJsonAsync, writeConfigJsonAsync } from '@expo/config';
+import {
+  getConfig,
+  isLegacyImportsEnabled,
+  readConfigJsonAsync,
+  writeConfigJsonAsync,
+} from '@expo/config';
 import { ExpoConfig } from '@expo/config-types';
 import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
@@ -18,6 +23,7 @@ import CommandError from '../CommandError';
 import Log from '../log';
 import { confirmAsync, selectAsync } from '../prompts';
 import { findProjectRootAsync } from './utils/ProjectUtils';
+import { assertProjectHasExpoExtensionFilesAsync } from './utils/deprecatedExtensionWarnings';
 import maybeBailOnGitStatusAsync from './utils/maybeBailOnGitStatusAsync';
 
 type DependencyList = Record<string, string>;
@@ -659,6 +665,11 @@ export async function upgradeAsync(
     } catch {}
 
     clearingCacheStep.succeed('Cleared packager cache.');
+  }
+
+  // Warn about extensions out of sync. Remove after dropping support for SDK 41
+  if (!isLegacyImportsEnabled(exp)) {
+    await assertProjectHasExpoExtensionFilesAsync(projectRoot, true);
   }
 
   Log.newLine();

--- a/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
@@ -30,32 +30,30 @@ export async function assertProjectHasExpoExtensionFilesAsync(
   checkNodeModules: boolean = false
 ) {
   if (checkNodeModules) {
-    return await assertModulesHasExpoExtensionFilesAsync(projectRoot);
+    await assertModulesHasExpoExtensionFilesAsync(projectRoot);
+  } else {
+    Log.time('assertProjectHasExpoExtensionFilesAsync');
+    const matches = await queryExpoExtensionFilesAsync(projectRoot, [
+      `**/@(Carthage|Pods|node_modules|ts-declarations|.expo)/**`,
+      '@(ios|android|web)/**',
+    ]).catch(() => [] as string[]);
+    Log.timeEnd('assertProjectHasExpoExtensionFilesAsync');
+    if (matches.length) {
+      await promptMatchesAsync(matches);
+    }
   }
-
-  //   console.time('count');
-  const matches = await queryExpoExtensionFilesAsync(projectRoot, [
-    `**/@(Carthage|Pods|node_modules|ts-declarations|.expo)/**`,
-    '@(ios|android|web)/**',
-  ]).catch(() => [] as string[]);
-  //   console.timeEnd('count');
-  if (!matches.length) {
-    return;
-  }
-
-  await promptMatchesAsync(matches);
 }
 
 async function assertModulesHasExpoExtensionFilesAsync(projectRoot: string) {
   const spinner = ora('Checking project for deprecated features, this may take a moment.').start();
   const root = findWorkspaceRoot(projectRoot) || projectRoot;
 
-  //   console.time('count');
+  Log.time('assertModulesHasExpoExtensionFilesAsync');
   let matches = await queryExpoExtensionFilesAsync(root, [
     `**/@(Carthage|Pods|ts-declarations|.expo)/**`,
     '@(ios|android|web)/**',
   ]).catch(() => [] as string[]);
-  //   console.timeEnd('count');
+  Log.timeEnd('assertModulesHasExpoExtensionFilesAsync');
   matches = matches.filter(value => {
     if (value.includes('node_modules')) {
       // Remove duplicate files from packages compiled with bob

--- a/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
@@ -82,7 +82,11 @@ async function promptMatchesAsync(matches: string[]) {
     ) +
       chalk.reset(
         matches.map(match => `- ${match}`).join('\n') +
-          `\n\nLearn more: http://expo.fyi/expo-extension-migration\n`
+          chalk.dim(
+            `\n\nDangerously disable this check with ${chalk.bold(
+              `EXPO_LEGACY_IMPORTS=1`
+            )}\nLearn more: http://expo.fyi/expo-extension-migration\n`
+          )
       )
   );
 

--- a/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
@@ -1,0 +1,82 @@
+import chalk from 'chalk';
+import program from 'commander';
+import findWorkspaceRoot from 'find-yarn-workspace-root';
+import glob from 'glob';
+import ora from 'ora';
+
+import { SilentError } from '../../CommandError';
+import Log from '../../log';
+import { confirmAsync } from '../../prompts';
+
+function queryExpoExtensionFilesAsync(projectRoot: string, ignore: string[]): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    glob(
+      '**/*.expo.{js,jsx,ts,tsx}',
+      {
+        absolute: true,
+        ignore,
+        cwd: projectRoot,
+      },
+      (error, matches) => {
+        if (error) reject(error);
+        else resolve(matches);
+      }
+    );
+  });
+}
+
+export async function assertProjectHasExpoExtensionFilesAsync(
+  projectRoot: string,
+  checkNodeModules: boolean = false
+) {
+  const spinner = ora('Checking project for deprecated features, this may take a moment.').start();
+  const root = checkNodeModules ? findWorkspaceRoot(projectRoot) || projectRoot : projectRoot;
+
+  let matches = await queryExpoExtensionFilesAsync(root, [
+    `**/@(Carthage|Pods${checkNodeModules ? `` : `|node_modules`})/**`,
+    '/{ios,android}/**',
+  ]).catch(() => [] as string[]);
+
+  if (checkNodeModules) {
+    matches = matches.filter(value => {
+      if (value.includes('node_modules')) {
+        // Remove duplicate files from packages compiled with bob
+        return !value.match(/node_modules\/.*\/lib\/commonjs/g);
+      }
+      return true;
+    });
+  }
+  if (!matches) {
+    spinner.succeed('Validated project');
+    return;
+  } else {
+    spinner.fail('Found project files with deprecated features');
+  }
+
+  await promptMatchesAsync(matches);
+}
+
+async function promptMatchesAsync(matches: string[]) {
+  const hasNodeModules = matches.find(match => match.includes('node_modules/'));
+  Log.error(
+    chalk.red(
+      `Project is using deprecated ${chalk.bold`.expo.*`} file extensions.\nPlease refactor the following files${
+        hasNodeModules ? ' and upgrade modules' : ''
+      } accordingly:\n\n`
+    ) +
+      chalk.reset(
+        matches.map(match => `- ${match}`).join('\n') +
+          `\n\nLearn more: http://expo.fyi/expo-extension-migration\n`
+      )
+  );
+
+  // Skip in nonInteractive to give users a bypass
+  if (
+    program.nonInteractive ||
+    (await confirmAsync({ message: 'Would you like to continue anyways?', initial: false }))
+  ) {
+    return;
+  }
+
+  throw new SilentError();
+}

--- a/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
@@ -38,6 +38,10 @@ export async function assertProjectHasExpoExtensionFilesAsync(
     '/{ios,android}/**',
   ]).catch(() => [] as string[]);
 
+  if (!matches.length) {
+    return;
+  }
+
   await promptMatchesAsync(matches);
 }
 

--- a/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
@@ -11,7 +11,7 @@ import { confirmAsync } from '../../prompts';
 function queryExpoExtensionFilesAsync(projectRoot: string, ignore: string[]): Promise<string[]> {
   return new Promise((resolve, reject) => {
     glob(
-      '**/*.expo.{js,jsx,ts,tsx}',
+      '**/*.expo.@(js|jsx|ts|tsx)',
       {
         absolute: true,
         ignore,
@@ -33,11 +33,12 @@ export async function assertProjectHasExpoExtensionFilesAsync(
     return await assertModulesHasExpoExtensionFilesAsync(projectRoot);
   }
 
+  //   console.time('count');
   const matches = await queryExpoExtensionFilesAsync(projectRoot, [
-    `**/@(Carthage|Pods|node_modules)/**`,
-    '/{ios,android}/**',
+    `**/@(Carthage|Pods|node_modules|ts-declarations|.expo)/**`,
+    '@(ios|android|web)/**',
   ]).catch(() => [] as string[]);
-
+  //   console.timeEnd('count');
   if (!matches.length) {
     return;
   }
@@ -49,11 +50,12 @@ async function assertModulesHasExpoExtensionFilesAsync(projectRoot: string) {
   const spinner = ora('Checking project for deprecated features, this may take a moment.').start();
   const root = findWorkspaceRoot(projectRoot) || projectRoot;
 
+  //   console.time('count');
   let matches = await queryExpoExtensionFilesAsync(root, [
-    `**/@(Carthage|Pods)/**`,
-    '/{ios,android}/**',
+    `**/@(Carthage|Pods|ts-declarations|.expo)/**`,
+    '@(ios|android|web)/**',
   ]).catch(() => [] as string[]);
-
+  //   console.timeEnd('count');
   matches = matches.filter(value => {
     if (value.includes('node_modules')) {
       // Remove duplicate files from packages compiled with bob

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -76,11 +76,11 @@ async function optsAsync(projectDir: string, options: any) {
     const defaultTarget = getDefaultTarget(projectDir);
     if (defaultTarget !== 'bare') {
       Log.warn(
-        `\nOption ${Log.chalk.cyan(
+        `\nOption ${Log.chalk.bold(
           '--dev-client'
-        )} can only be used in bare workflow apps. Run ${Log.chalk.cyan(
+        )} can only be used in bare workflow apps. Run ${Log.chalk.bold(
           'expo eject'
-        )} and try again\n`
+        )} and try again.\n`
       );
       throw new AbortCommandError();
     }

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -35,6 +35,8 @@
   ],
   "dependencies": {
     "@expo/config": "3.3.28",
+    "getenv": "^0.7.0",
+    "chalk": "^4.1.0",
     "metro-react-native-babel-transformer": "^0.58.0"
   },
   "devDependencies": {

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -56,14 +56,14 @@ export function getDefaultConfig(
     if (!isLegacy) {
       console.warn(
         chalk.yellow(
-          `The target option is deprecated. Learn More: http://expo.fyi/expo-extension-migration`
+          `The target option is deprecated. Learn more: http://expo.fyi/expo-extension-migration`
         )
       );
       delete options.target;
     }
   } else if (process.env.EXPO_TARGET) {
     console.error(
-      'EXPO_TARGET is deprecated. Learn More: http://expo.fyi/expo-extension-migration'
+      'EXPO_TARGET is deprecated. Learn more: http://expo.fyi/expo-extension-migration'
     );
     if (isLegacy) {
       // EXPO_TARGET is used by @expo/metro-config to determine the target when getDefaultConfig is

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -1,9 +1,13 @@
 import { getConfig, getDefaultTarget, isLegacyImportsEnabled, ProjectTarget } from '@expo/config';
 import { getBareExtensions, getManagedExtensions } from '@expo/config/paths';
+import chalk from 'chalk';
+import { boolish } from 'getenv';
 import { Reporter } from 'metro';
 import type MetroConfig from 'metro-config';
 import path from 'path';
 import resolveFrom from 'resolve-from';
+
+export const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
 // Import only the types here, the values will be imported from the project, at runtime.
 const INTERNAL_CALLSITES_REGEX = new RegExp(
@@ -51,7 +55,9 @@ export function getDefaultConfig(
   if (options.target) {
     if (!isLegacy) {
       console.warn(
-        `The target option is deprecated. Learn More: http://expo.fyi/expo-extension-migration`
+        chalk.yellow(
+          `The target option is deprecated. Learn More: http://expo.fyi/expo-extension-migration`
+        )
       );
       delete options.target;
     }
@@ -95,6 +101,15 @@ export function getDefaultConfig(
       ? getBareExtensions([], sourceExtsConfig)
       : getManagedExtensions([], sourceExtsConfig);
 
+  if (EXPO_DEBUG) {
+    console.log();
+    console.log(`Expo Metro config:`);
+    console.log(`- Bundler target: ${target}`);
+    console.log(`- Legacy: ${isLegacy}`);
+    console.log(`- Extensions: ${sourceExts.join(', ')}`);
+    console.log(`- React Native: ${reactNativePath}`);
+    console.log();
+  }
   const metroDefaultValues = MetroConfig.getDefaultConfig.getDefaultValues(projectRoot);
   // Merge in the default config from Metro here, even though loadConfig uses it as defaults.
   // This is a convenience for getDefaultConfig use in metro.config.js, e.g. to modify assetExts.

--- a/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -4,7 +4,15 @@ import { getDefaultConfig, loadAsync } from '../ExpoMetroConfig';
 
 const projectRoot = path.join(__dirname, '__fixtures__', 'hello-world');
 
+const consoleError = console.error;
+
+beforeEach(() => {
+  delete process.env.EXPO_TARGET;
+});
 describe('getDefaultConfig', () => {
+  afterAll(() => {
+    console.error = consoleError;
+  });
   it('loads default configuration', () => {
     expect(getDefaultConfig(projectRoot)).toEqual(
       expect.objectContaining({
@@ -28,6 +36,12 @@ describe('getDefaultConfig', () => {
       // @ts-ignore incorrect `target` value passed on purpose
       getDefaultConfig(projectRoot, { target: 'blooper' })
     ).toThrowErrorMatchingSnapshot();
+  });
+  it('logs an error if the environment variable is used', () => {
+    console.error = jest.fn();
+    process.env.EXPO_TARGET = 'bare';
+    getDefaultConfig(projectRoot, {});
+    expect(console.error).toBeCalled();
   });
 });
 

--- a/packages/metro-config/src/__tests__/__snapshots__/ExpoMetroConfig-test.ts.snap
+++ b/packages/metro-config/src/__tests__/__snapshots__/ExpoMetroConfig-test.ts.snap
@@ -4,7 +4,6 @@ exports[`getDefaultConfig complains about an invalid target setting 1`] = `
 "Invalid target: 'blooper'. Debug info: 
 {
   \\"options.target\\": \\"blooper\\",
-  \\"EXPO_TARGET\\": \\"bare\\",
   \\"default\\": \\"managed\\"
 }"
 `;

--- a/packages/xdl/src/Env.ts
+++ b/packages/xdl/src/Env.ts
@@ -8,6 +8,10 @@ export function home(): string {
   return os.homedir();
 }
 
+export function isDebug(): boolean {
+  return getenv.boolish('EXPO_DEBUG', false);
+}
+
 export function isStaging(): boolean {
   return getenv.boolish('EXPO_STAGING', false);
 }

--- a/packages/xdl/src/project/exportAppAsync.ts
+++ b/packages/xdl/src/project/exportAppAsync.ts
@@ -10,7 +10,7 @@ import urljoin from 'url-join';
 import uuid from 'uuid';
 
 import * as EmbeddedAssets from '../EmbeddedAssets';
-import { shouldUseDevServer } from '../Env';
+import { isDebug, shouldUseDevServer } from '../Env';
 import logger from '../Logger';
 import { Asset, exportAssetsAsync } from '../ProjectAssets';
 import UserManager, { ANONYMOUS_USERNAME } from '../User';
@@ -72,6 +72,13 @@ export async function exportAppAsync(
   const absoluteOutputDir = path.resolve(process.cwd(), outputDir);
   const defaultTarget = getDefaultTarget(projectRoot);
   const target = options.publishOptions?.target ?? defaultTarget;
+
+  if (isDebug()) {
+    console.log();
+    console.log('Export Assets:');
+    console.log(`- Asset target: ${target}`);
+    console.log();
+  }
 
   // build the bundles
   // make output dirs if not exists

--- a/packages/xdl/src/project/getPublishExpConfigAsync.ts
+++ b/packages/xdl/src/project/getPublishExpConfigAsync.ts
@@ -20,7 +20,7 @@ export type PublishOptions = {
 
 export async function getPublishExpConfigAsync(
   projectRoot: string,
-  options: PublishOptions
+  options: Pick<PublishOptions, 'releaseChannel'>
 ): Promise<{
   exp: ExpoAppManifest;
   pkg: PackageJSONConfig;

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -31,17 +31,14 @@ export async function startDevServerAsync(projectRoot: string, startOptions: Sta
   const options: MetroDevServerOptions = {
     port,
     logger: ProjectUtils.getLogger(projectRoot),
+    // @deprecated
+    target: startOptions.target,
   };
   if (startOptions.reset) {
     options.resetCache = true;
   }
   if (startOptions.maxWorkers != null) {
     options.maxWorkers = startOptions.maxWorkers;
-  }
-  if (startOptions.target) {
-    // EXPO_TARGET is used by @expo/metro-config to determine the target when getDefaultConfig is
-    // called from metro.config.js.
-    process.env.EXPO_TARGET = startOptions.target;
   }
 
   const { server, middleware } = await runMetroDevServerAsync(projectRoot, options);

--- a/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
+++ b/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
@@ -134,7 +134,9 @@ export async function startReactNativeServerAsync({
 
   let packagerPort = await getFreePortAsync(19001); // Create packager options
 
-  const customLogReporterPath: string = require.resolve(path.join(__dirname, '../build/reporter'));
+  const customLogReporterPath: string = require.resolve(
+    path.join(__dirname, '../../build/reporter')
+  );
 
   // TODO: Bacon: Support .mjs (short-lived JS modules extension that some packages use)
   const sourceExtsConfig = { isTS: true, isReact: true, isModern: false };


### PR DESCRIPTION
# How

- Consolidate all logic for determining which target to use, this was all over the place before but should be much easier to follow now.
- Create a method to determine if .expo extensions are deprecated in the user's version of Expo or not. 
  - If the user doesn't have expo installed or an sdk version, .expo will be disabled.
  - If `EXPO_LEGACY_IMPORTS` is enabled, then managed could be used. 
  - If the SDK <= 40 then managed could be used.
- Add an aggressive warning on `expo start` if any project files are using the `.expo` extension. Adds some time to startup.
- Add a more aggressive warning on `expo upgrade` if any project files or node modules are using the `.expo` extension.

# Test Plan

- To test how this works on the unreleased SDK 41, you can lower the cutoff version in `packages/config/src/isLegacyImportsEnabled`.

## Deprecation warnings

This PR adds strict deprecation warnings when a project is using a `.expo` extension. 

### expo start


- Lowering the legacy version to something less than your project version.
- In a project with `foo.expo.js`
- `expo start`
- Should show warning about `foo.expo.js`
- You will be prompted about if you want to continue or not.

### expo upgrade

- TBD

## Targets

The bundle target 

### expo start

You can only use `bare` target with `expo start` when the app is ejected and `--dev-client` is used. The `EXPO_TARGET` env variable is completely ignored in `expo start`. This means we only need to ensure that bare target is used in managed projects after SDK 40. `managed` target should still be allowed when `EXPO_LEGACY_IMPORTS=1` is enabled.

- SDK next
  - managed project
    - `expo start`
      - Bundler target: bare
    - `EXPO_LEGACY_IMPORTS=1 expo start`
      - Bundler target: managed (only time it should be managed in `expo start`)
  - bare project
    - `expo start --dev-client`
      - Bundler target: bare
    - `EXPO_LEGACY_IMPORTS=1 expo start --dev-client`
      - Bundler target: bare (special case)
- SDK 40
  - managed project
    - `expo start`
      - Bundler target: managed
    - `EXPO_LEGACY_IMPORTS=1 expo start`
      - Bundler target: managed
  - bare project
    - `expo start --dev-client`
      - Bundler target: bare
    - `EXPO_LEGACY_IMPORTS=1 expo start --dev-client`
      - Bundler target: bare (special case)


- Lowered the minimum legacy version to `38` and tried running `expo start` (with node modules check) in a basic project, and some more complex projects to see the error messages:
  - expo init blank
  - expo ejected project
  - expo/home
  - pillar-valley
- Ensure warnings don't catch `/.expo`, `/.expo.js`, `/expo.js`

### expo export/publish

There are now two different `target`s. Bundler target refers to the target value passed to the metro config, it dictates if `.expo` files should be used. Asset target is basically everything else, it refers to how assets should be bundled in the project during export/publish. 

- We support both target props as best we can but the list of combos are long. 
- In SDK 41, there should be no bundler target, but the asset target needs to stay.
- The asset target should almost exclusively be determined automatically based on if native folders exist.

The following combo's should be expected: (export and publish need to be tested individually)

- In managed (no ios/android folders)
  - SDK 41
    - `expo export`
      - Asset target: managed
      - Bundler target: bare
    - `expo export --target managed` -- should warn
      - Asset target: managed
      - Bundler target: bare
    - `expo export --target bare` -- should warn
      - Asset target: bare
      - Bundler target: bare
    - `EXPO_LEGACY_IMPORTS=1 expo export`
      - Asset target: managed
      - Bundler target: managed
  - SDK 40 
    - `expo export` -- no warning
      - Asset target: managed
      - Bundler target: managed
    - `expo export --target bare` -- no warning
      - Asset target: bare
      - Bundler target: bare
    - `expo export --target managed` -- no warning
      - Asset target: managed
      - Bundler target: managed
- In bare (has ios/android folders)
  - SDK 41
    - `expo export`
      - Asset target: bare
      - Bundler target: bare
    - `expo export --target managed` -- should warn
      - Asset target: managed
      - Bundler target: bare
    - `expo export --target bare` -- should warn
      - Asset target: bare
      - Bundler target: bare
    - `EXPO_LEGACY_IMPORTS=1 expo export`
      - Asset target: bare
      - Bundler target: managed
  - SDK 40 
    - `expo export`
      - Asset target: bare
      - Bundler target: bare
    - `expo export --target bare` -- no warning
      - Asset target: bare
      - Bundler target: bare
    - `expo export --target managed` -- no warning
      - Asset target: managed
      - Bundler target: managed
