### PR TITLE
[expo-cli] Added profiling

### DIFF
--- a/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
@@ -21,10 +21,14 @@ export function queryFirstProjectTypeScriptFileAsync(projectRoot: string): Promi
   // Bail out as soon as a single match is found.
   return new Promise((resolve, reject) => {
     const mg = new Glob(
-      '**/*.{ts,tsx}',
+      '**/*.@(ts|tsx)',
       {
         cwd: projectRoot,
-        ignore: ['**/@(Carthage|Pods|node_modules)/**', '**/*.d.ts', '/{ios,android}/**'],
+        ignore: [
+          '**/@(Carthage|Pods|node_modules)/**',
+          '**/*.d.ts',
+          '@(ios|android|web|web-build|dist)/**',
+        ],
       },
       (error, matches) => {
         if (error) {

--- a/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
@@ -3,6 +3,8 @@ import { Glob } from 'glob';
 import * as path from 'path';
 import resolveFrom from 'resolve-from';
 
+import Log from '../../../log';
+
 async function fileExistsAsync(file: string): Promise<boolean> {
   return (await stat(file).catch(() => null))?.isFile() ?? false;
 }
@@ -17,9 +19,11 @@ const requiredPackages = [
 
 export const baseTSConfigName = 'expo/tsconfig.base';
 
-export function queryFirstProjectTypeScriptFileAsync(projectRoot: string): Promise<null | string> {
-  // Bail out as soon as a single match is found.
-  return new Promise((resolve, reject) => {
+export async function queryFirstProjectTypeScriptFileAsync(
+  projectRoot: string
+): Promise<null | string> {
+  Log.time('queryFirstProjectTypeScriptFileAsync');
+  const results = await new Promise<null | string>((resolve, reject) => {
     const mg = new Glob(
       '**/*.@(ts|tsx)',
       {
@@ -43,6 +47,9 @@ export function queryFirstProjectTypeScriptFileAsync(projectRoot: string): Promi
       resolve(matched);
     });
   });
+  Log.timeEnd('queryFirstProjectTypeScriptFileAsync');
+  // Bail out as soon as a single match is found.
+  return results;
 }
 
 export function resolveBaseTSConfig(projectRoot: string): string | null {

--- a/packages/expo-cli/src/log.ts
+++ b/packages/expo-cli/src/log.ts
@@ -6,10 +6,18 @@ import terminalLink from 'terminal-link';
 
 type Color = (...text: string[]) => string;
 
+const isProfiling = boolish('EXPO_PROFILE', false);
+
+// eslint-disable-next-line no-console
+const consoleTime: (label?: string) => void = isProfiling ? console.time : () => {};
+// eslint-disable-next-line no-console
+const consoleTimeEnd: (label?: string) => void = isProfiling ? console.timeEnd : () => {};
+
 export default class Log {
   public static readonly chalk = chalk;
   public static readonly terminalLink = terminalLink;
   public static readonly isDebug = boolish('EXPO_DEBUG', false);
+  public static readonly isProfiling = isProfiling;
 
   public static log(...args: any[]) {
     Log.respectProgressBars(() => {
@@ -22,6 +30,10 @@ export default class Log {
       Log.consoleLog(message);
     });
   }
+
+  public static time = consoleTime;
+
+  public static timeEnd = consoleTimeEnd;
 
   public static newLine() {
     Log.respectProgressBars(() => {


### PR DESCRIPTION
# Why

- Make it easier to debug the startup speed
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Added `EXPO_PROFILE` which enables the printing of `console.time` and `console.timeEnd` statements.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

`EXPO_PROFILE=true expo start` should print `queryFirstProjectTypeScriptFileAsync: XXXms`
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->