### PR TITLE
Improve native globs

### DIFF
--- a/packages/config-plugins/src/android/Paths.ts
+++ b/packages/config-plugins/src/android/Paths.ts
@@ -21,7 +21,7 @@ async function getProjectFileAsync(
   name: string
 ): Promise<ApplicationProjectFile> {
   const mainActivityJavaPath = globSync(
-    path.join(projectRoot, `android/app/src/main/java/**/${name}.{java,kt}`)
+    path.join(projectRoot, `android/app/src/main/java/**/${name}.@(java|kt)`)
   )[0];
   assert(
     mainActivityJavaPath,

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -16,7 +16,7 @@ interface ProjectFile<L extends string = string> {
 export type AppDelegateProjectFile = ProjectFile<'objc' | 'swift'>;
 
 export function getAppDelegate(projectRoot: string): AppDelegateProjectFile {
-  const [using, ...extra] = globSync('ios/*/AppDelegate.{m,swift}', {
+  const [using, ...extra] = globSync('ios/*/AppDelegate.@(m|swift)', {
     absolute: true,
     cwd: projectRoot,
     ignore: ignoredPaths,


### PR DESCRIPTION
# Why

- faster
  - iOS glob 
    - 6.428ms -> 4.840ms
    - 2.613ms -> 1.488ms