### PR TITLE
[config-plugins] add function for getting build configuration for scheme + refactor

### DIFF
--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -62,6 +62,16 @@ export function findSchemeNames(projectRoot: string): string[] {
   return schemePaths.map(schemePath => path.basename(schemePath).split('.')[0]);
 }
 
+export function findSchemePath(projectRoot: string, scheme: string): string {
+  const allSchemePaths = findSchemePaths(projectRoot);
+  const re = new RegExp(`/${scheme}.xcscheme`);
+  const schemePath = allSchemePaths.find(i => re.exec(i));
+  if (!schemePath) {
+    throw new Error(`scheme '${scheme}' does not exist`);
+  }
+  return schemePath;
+}
+
 export function getAllXcodeProjectPaths(projectRoot: string): string[] {
   const iosFolder = 'ios';
   const pbxprojPaths = globSync('**/*.xcodeproj', { cwd: projectRoot, ignore: ignoredPaths })

--- a/packages/config-plugins/src/ios/Scheme.ts
+++ b/packages/config-plugins/src/ios/Scheme.ts
@@ -2,7 +2,6 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { createInfoPlistPlugin } from '../plugins/ios-plugins';
 import { InfoPlist, URLScheme } from './IosConfig.types';
-import { findSchemeNames } from './Paths';
 
 export const withScheme = createInfoPlistPlugin(setScheme, 'withScheme');
 
@@ -102,8 +101,4 @@ export function getSchemesFromPlist(infoPlist: InfoPlist): string[] {
     }, []);
   }
   return [];
-}
-
-export function getSchemesFromXcodeproj(projectRoot: string): string[] {
-  return findSchemeNames(projectRoot);
 }

--- a/packages/config-plugins/src/ios/__tests__/BuildScheme-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/BuildScheme-test.ts
@@ -2,7 +2,11 @@ import fs from 'fs';
 import { vol } from 'memfs';
 import path from 'path';
 
-import { getApplicationTargetForSchemeAsync } from '../Target';
+import {
+  BuildConfiguration,
+  getApplicationTargetForSchemeAsync,
+  getBuildConfigurationForSchemeAsync,
+} from '../BuildScheme';
 
 const fsReal = jest.requireActual('fs') as typeof fs;
 
@@ -63,6 +67,54 @@ describe(getApplicationTargetForSchemeAsync, () => {
       await expect(() =>
         getApplicationTargetForSchemeAsync('/app', 'nonexistentscheme')
       ).rejects.toThrow(/does not exist/);
+    });
+  });
+});
+
+describe(getBuildConfigurationForSchemeAsync, () => {
+  describe('release build', () => {
+    beforeAll(async () => {
+      vol.fromJSON(
+        {
+          'ios/testproject.xcodeproj/xcshareddata/xcschemes/testproject.xcscheme': fsReal.readFileSync(
+            path.join(__dirname, 'fixtures/testproject.xcscheme'),
+            'utf-8'
+          ),
+        },
+        '/app'
+      );
+    });
+
+    afterAll(() => {
+      vol.reset();
+    });
+
+    it('reads the build configuration properly', async () => {
+      const buildConfiguration = await getBuildConfigurationForSchemeAsync('/app', 'testproject');
+      expect(buildConfiguration).toBe(BuildConfiguration.RELEASE);
+    });
+  });
+
+  describe('debug build', () => {
+    beforeAll(async () => {
+      vol.fromJSON(
+        {
+          'ios/testproject.xcodeproj/xcshareddata/xcschemes/testproject.xcscheme': fsReal.readFileSync(
+            path.join(__dirname, 'fixtures/testproject-3.xcscheme'),
+            'utf-8'
+          ),
+        },
+        '/app'
+      );
+    });
+
+    afterAll(() => {
+      vol.reset();
+    });
+
+    it('reads the build configuration properly', async () => {
+      const buildConfiguration = await getBuildConfigurationForSchemeAsync('/app', 'testproject');
+      expect(buildConfiguration).toBe(BuildConfiguration.DEBUG);
     });
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/fixtures/testproject-3.xcscheme
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/testproject-3.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "testproject.app"
+               BlueprintName = "testproject"
+               ReferencedContainer = "container:testproject.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
+               BuildableName = "testprojectTests.xctest"
+               BlueprintName = "testprojectTests"
+               ReferencedContainer = "container:testproject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "testproject.app"
+            BlueprintName = "testproject"
+            ReferencedContainer = "container:testproject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "testproject.app"
+            BlueprintName = "testproject"
+            ReferencedContainer = "container:testproject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/config-plugins/src/ios/index.ts
+++ b/packages/config-plugins/src/ios/index.ts
@@ -1,5 +1,6 @@
 import * as AdMob from './AdMob';
 import * as Branch from './Branch';
+import * as BuildScheme from './BuildScheme';
 import * as BundleIdentifier from './BundleIdentifier';
 import * as CustomInfoPlistEntries from './CustomInfoPlistEntries';
 import * as DeviceFamily from './DeviceFamily';
@@ -17,7 +18,6 @@ import * as ProvisioningProfile from './ProvisioningProfile';
 import * as RequiresFullScreen from './RequiresFullScreen';
 import * as Scheme from './Scheme';
 import * as SplashScreen from './SplashScreen';
-import * as Target from './Target';
 import * as Updates from './Updates';
 import * as UserInterfaceStyle from './UserInterfaceStyle';
 import * as UsesNonExemptEncryption from './UsesNonExemptEncryption';
@@ -30,6 +30,7 @@ import * as XcodeUtils from './utils/Xcodeproj';
 export {
   AdMob,
   Branch,
+  BuildScheme,
   BundleIdentifier,
   CustomInfoPlistEntries,
   DeviceFamily,
@@ -48,7 +49,6 @@ export {
   Permissions,
   RequiresFullScreen,
   Scheme,
-  Target,
   Updates,
   UserInterfaceStyle,
   UsesNonExemptEncryption,


### PR DESCRIPTION
# Why

Part of https://linear.app/expo/issue/ENG-27/buildconfiguration-option-for-ios-builds

We want to allow users to override the build configuration (release/debug) for a particular build scheme.

# How

- I added a function for getting the build configuration for a build scheme. We need that to determine the default value in the project.
- I moved all functions reading values from build schemes to a new module - `BuildScheme`. Previously, we had one function - `getSchemesFromXcodeproj` - in `Scheme` and it was confusing.

# Test Plan

- Added new unit test.
- Existing tests are still passing.