### PR TITLE
Improves CONTRIBUTING.md file for newer developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Keeping the `master` releasable means that changes merged to it need to be:
 3. Run `git config commit.template .github/.COMMIT_TEMPLATE` (Sets you up with our commit message template)
 4. Run `yarn build` to build all packages before start watching.
 5. Run `yarn start` in the root folder. (Start watching and automatically re-building packages when there are new changes.)
-6. Open another terminal at the same top level folder that `expo-cli` repository is located, then run `node ~/code/expo-cli/packages/expo-cli/bin/expo.js init`, if everything is correct, it should create the repository `my-app`.
-7. Finally, run `node ~/code/expo-cli/packages/expo-cli/bin/expo.js start` inside the `my-app` repository you have just created, if it starts, the `expo-cli` repository is correctly configured and you're ready for start developing.
+6. Open another terminal at the same top level folder that `expo-cli` repository is located, then run `node ~/code/expo-cli/packages/expo-cli/bin/expo.js init` (you may even want to create an alias to this file), if everything is correct, it should create the repository `my-app`. 
+7. Finally, run `node ~/code/expo-cli/packages/expo-cli/bin/expo.js start` inside the `my-app` repository you have just created. If it starts, the `expo-cli` repository is correctly configured and you're ready for start developing.
 
 ## Submitting a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,10 @@ Keeping the `master` releasable means that changes merged to it need to be:
 1. Clone the repository.
 2. Run `yarn`. (Installs dependencies and links packages in the workspace.)
 3. Run `git config commit.template .github/.COMMIT_TEMPLATE` (Sets you up with our commit message template)
-4. Run `yarn start` in the root folder. (Start watching and automatically re-building packages when there are new changes.)
+4. Run `yarn build` to build all packages before start watching.
+5. Run `yarn start` in the root folder. (Start watching and automatically re-building packages when there are new changes.)
+6. Open another terminal to test the `expo-cli`, then run `node expo-cli/packages/expo-cli/bin/expo.js init` outside the `expo-cli` repository to create an test repository, if everything is correct, it should create the repository `my-app`.
+7. Finally, run `node expo-cli/packages/expo-cli/bin/expo.js start my-app` outside the `expo-cli` to start the test repository, if it starts, the repository is correctly configured and you can start developing.
 
 ## Submitting a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Keeping the `master` releasable means that changes merged to it need to be:
 3. Run `git config commit.template .github/.COMMIT_TEMPLATE` (Sets you up with our commit message template)
 4. Run `yarn build` to build all packages before start watching.
 5. Run `yarn start` in the root folder. (Start watching and automatically re-building packages when there are new changes.)
-6. Open another terminal to test the `expo-cli`, then run `node expo-cli/packages/expo-cli/bin/expo.js init` outside the `expo-cli` repository to create an test repository, if everything is correct, it should create the repository `my-app`.
-7. Finally, run `node expo-cli/packages/expo-cli/bin/expo.js start my-app` outside the `expo-cli` to start the test repository, if it starts, the repository is correctly configured and you can start developing.
+6. Open another terminal at the same top level folder that `expo-cli` repository is located, then run `node ~/code/expo-cli/packages/expo-cli/bin/expo.js init`, if everything is correct, it should create the repository `my-app`.
+7. Finally, run `node ~/code/expo-cli/packages/expo-cli/bin/expo.js start` inside the `my-app` repository you have just created, if it starts, the `expo-cli` repository is correctly configured and you're ready for start developing.
 
 ## Submitting a pull request
 


### PR DESCRIPTION
# Why
I had some issues while trying to begin working with the `expo-cli` repository, it was unclear how to use the `expo-cli` itself, didn't know which script to run, the steps seemed to be incomplete. I've reached out @brentvatne that was helping on other issue, explaning that I couldn't begin the feature because I couldn't even configure the repository correctly. He helped me with some steps and managed to make the repository start running as it should. After that, I suggested including the steps at the `CONTRIBUTING.md` file, so that other developers won't need to pass the same as I did.

# Test-plan
Clone the `expo-cli` repository from GitHub, follow the steps, if all of them worked as expect and you managed to start the test repository, it should be working fine.