### PR TITLE
Add a command to build and run the dev client on iOS simulator

### DIFF
--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -1,7 +1,6 @@
 import { pathExistsSync, readFileSync } from 'fs-extra';
 import { sync as globSync } from 'glob';
 import * as path from 'path';
-import { project } from 'xcode';
 
 import { UnexpectedError } from '../utils/errors';
 import * as WarningAggregator from '../utils/warnings';

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -1,6 +1,7 @@
 import { pathExistsSync, readFileSync } from 'fs-extra';
 import { sync as globSync } from 'glob';
 import * as path from 'path';
+import { project } from 'xcode';
 
 import { UnexpectedError } from '../utils/errors';
 import * as WarningAggregator from '../utils/warnings';
@@ -95,6 +96,30 @@ export function getXcodeProjectPath(projectRoot: string): string {
   }
 
   return using;
+}
+
+export function getXcodeWorkspacePath(projectRoot: string): string {
+  const workspacePaths = globSync('ios/*.xcworkspace', {
+    absolute: true,
+    cwd: projectRoot,
+    ignore: ignoredPaths,
+  });
+
+  if (workspacePaths.length === 0) {
+    throw new UnexpectedError(
+      `Failed to locate the ios/*.xcworkspace file relative to path "${projectRoot}".`
+    );
+  }
+  if (workspacePaths.length >= 1) {
+    warnMultipleFiles({
+      tag: 'project-pbxproj',
+      fileName: 'project.pbxproj',
+      projectRoot,
+      using: workspacePaths[0],
+      extra: workspacePaths.slice(1),
+    });
+  }
+  return workspacePaths[0];
 }
 
 export function getAllPBXProjectPaths(projectRoot: string): string[] {

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -76,6 +76,7 @@
     "@expo/results": "^1.0.0",
     "@expo/simple-spinner": "1.0.2",
     "@expo/spawn-async": "1.5.0",
+    "@expo/xcpretty": "^1.0.0",
     "@expo/xdl": "59.0.25-alpha.0",
     "@hapi/joi": "^17.1.1",
     "babel-runtime": "6.26.0",

--- a/packages/expo-cli/src/commands/index.ts
+++ b/packages/expo-cli/src/commands/index.ts
@@ -22,6 +22,7 @@ const COMMANDS = [
   require('./publish-modify'),
   require('./push-creds'),
   require('./register'),
+  require('./run'),
   require('./send'),
   require('./start'),
   require('./upgrade'),

--- a/packages/expo-cli/src/commands/run/buildIosClientAsync.ts
+++ b/packages/expo-cli/src/commands/run/buildIosClientAsync.ts
@@ -1,0 +1,59 @@
+import { IOSConfig } from '@expo/config-plugins';
+import spawnAsync from '@expo/spawn-async';
+import { SimControl, Simulator, UrlUtils } from '@expo/xdl';
+import ora from 'ora';
+import path from 'path';
+
+import CommandError from '../../CommandError';
+
+type Options = {
+  scheme?: string;
+  udid?: string;
+};
+
+export default async function buildIosClientAsync(
+  projectRoot: string,
+  options: Options
+): Promise<void> {
+  const workspace = IOSConfig.Paths.getXcodeWorkspacePath(projectRoot);
+  const scheme = options.scheme ?? path.basename(workspace, '.xcworkspace');
+
+  if (!(await Simulator.ensureXcodeInstalledAsync())) {
+    throw new CommandError('XCODE_NOT_INSTALLED', 'Xcode and Simulator need to be installed.');
+  }
+  let udid = options.udid;
+  if (!udid) {
+    const devices = await Simulator.getSelectableSimulatorsAsync();
+    const device = await Simulator.promptForSimulatorAsync(devices);
+    if (!device) {
+      return;
+    }
+    udid = device.udid;
+  }
+
+  const spinner = ora('Building app ').start();
+
+  await spawnAsync(
+    'xcodebuild',
+    [
+      '-workspace',
+      workspace,
+      '-configuration',
+      'Debug',
+      '-scheme',
+      scheme,
+      '-destination',
+      `id=${udid}`,
+    ],
+    { stdio: 'inherit' }
+  );
+
+  spinner.text = 'Starting the development client...';
+  await Simulator.ensureSimulatorOpenAsync();
+  const url = await UrlUtils.constructDeepLinkAsync(projectRoot, {
+    hostType: 'localhost',
+  });
+  await SimControl.openURLAsync({ udid, url });
+
+  spinner.succeed();
+}

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+
+import buildIosClientAsync from './buildIosClientAsync';
+
+type Options = object;
+
+async function runAsync(projectRoot: string, options: Options) {
+  await buildIosClientAsync(projectRoot, options);
+}
+
+export default function (program: Command) {
+  program
+    .command('run [path]')
+    .helpGroup('experimental')
+    .description('Build a development client and run it in a simulator.')
+    .asyncActionProjectDir(runAsync);
+}

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -4,14 +4,14 @@ import buildIosClientAsync from './buildIosClientAsync';
 
 type Options = object;
 
-async function runAsync(projectRoot: string, options: Options) {
+async function runIosAsync(projectRoot: string, options: Options) {
   await buildIosClientAsync(projectRoot, options);
 }
 
 export default function (program: Command) {
   program
-    .command('run [path]')
-    .helpGroup('experimental')
+    .command('run:ios [path]')
+    .helpGroup('internal')
     .description('Build a development client and run it in a simulator.')
-    .asyncActionProjectDir(runAsync);
+    .asyncActionProjectDir(runIosAsync);
 }

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -224,7 +224,7 @@ export async function ensureSimulatorOpenAsync(
 /**
  * Get all simulators supported by Expo (iOS only).
  */
-async function getSelectableSimulatorsAsync(): Promise<SimControl.SimulatorDevice[]> {
+export async function getSelectableSimulatorsAsync(): Promise<SimControl.SimulatorDevice[]> {
   const simulators = await getSimulatorsAsync();
   return simulators.filter(device => device.isAvailable && device.osType === 'iOS');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,6 +2201,14 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
+"@expo/xcpretty@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-1.0.0.tgz#2306cb05769e403825131062a05a2ef033d7e7ea"
+  integrity sha512-3ShonI6/PC2iBi3D6LB4avHRihOIkKO+4eCCD1rjcsbnXh+RrMreZ9E0cqRwP0BytfzHDv7EUKiLR9Y+j+KiEg==
+  dependencies:
+    "@babel/code-frame" "7.10.4"
+    chalk "^4.1.0"
+
 "@gulp-sourcemaps/map-sources@1.X":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz#890ae7c5d8c877f6d384860215ace9d7ec945bda"


### PR DESCRIPTION
# Why

This command makes it more seamless to run dev client apps on the simulator, because instead of building/installing with Xcode, starting the dev server with Expo CLI and running

# How

Added code that builds the app using `xcodebuild` and launches it in the simulator.

## TODO

- [ ] Make logs nice (with help from @EvanBacon's JS port of `xcpretty`?)
- [ ] Figure out which `xcodebuild` flags to expose through command-line flags / configuration
- [ ] Name the command (currently `expo run`, but need to figure out if it works with Android / bigger picture)
- [ ] Test Plan

# Test Plan

TBD