### PR TITLE
fix: unhandled JS exception if no foregroundImage defined for adaptiv…

### DIFF
--- a/packages/xdl/src/detach/AndroidIcons.ts
+++ b/packages/xdl/src/detach/AndroidIcons.ts
@@ -176,6 +176,34 @@ async function createAndWriteIconsToPathAsync(
         iconForegroundUrl,
         isDetached
       );
+
+      // Adaptive icon background image or color
+      if (iconBackgroundUrl) {
+        await _resizeIconsAsync(
+          context,
+          resPath,
+          'mipmap-',
+          108,
+          'ic_background.png',
+          iconBackgroundUrl,
+          isDetached
+        );
+
+        await _regexFileInResSubfoldersAsync(
+          '@color/iconBackground',
+          '@mipmap/ic_background',
+          resPath,
+          'mipmap-',
+          '-v26',
+          'ic_launcher.xml'
+        );
+      } else if (iconBackgroundColor) {
+        await regexFileAsync(
+          '"iconBackground">#FFFFFF',
+          `"iconBackground">${iconBackgroundColor}`,
+          path.join(resPath, 'values', 'colors.xml')
+        );
+      }
     } else {
       // the OS's default method of coercing normal app icons to adaptive
       // makes them look quite different from using an actual adaptive icon (with xml)
@@ -202,34 +230,6 @@ async function createAndWriteIconsToPathAsync(
         // so just fail silently here
       }
     }
-  }
-
-  // Adaptive icon background image or color
-  if (iconBackgroundUrl) {
-    await _resizeIconsAsync(
-      context,
-      resPath,
-      'mipmap-',
-      108,
-      'ic_background.png',
-      iconBackgroundUrl,
-      isDetached
-    );
-
-    await _regexFileInResSubfoldersAsync(
-      '@color/iconBackground',
-      '@mipmap/ic_background',
-      resPath,
-      'mipmap-',
-      '-v26',
-      'ic_launcher.xml'
-    );
-  } else if (iconBackgroundColor) {
-    await regexFileAsync(
-      '"iconBackground">#FFFFFF',
-      `"iconBackground">${iconBackgroundColor}`,
-      path.join(resPath, 'values', 'colors.xml')
-    );
   }
 
   // Remove Expo client notification icon resources


### PR DESCRIPTION
…e icon

# Why

fixes https://github.com/expo/expo/issues/11940

# How

before, we were deleting the directories if no foreground image is specified, _then_ modifying those directories for background image/color, and build logs wouldn't show but turtle would spit out- 
```
"err":{"message":"spawn /bin/cp ENOENT","name":"Error","stack":"Error: spawn /bin/cp ENOENT\n    at Process.ChildProcess._handle.onexit (internal/child_process.js:267:19)\n    at onErrorNT (internal/child_process.js:469:16)\n    at processTicksAndRejections (internal/process/task_queues.js:84:21)","code":"ENOENT","signal":null},"msg":"Unhandled promise rejection",
```


# Test Plan

made changes, no more unhandled JS exception