### PR TITLE
[expo-cli] refactor and test start command

### DIFF
--- a/packages/dev-tools/server/dev-server.ts
+++ b/packages/dev-tools/server/dev-server.ts
@@ -41,7 +41,17 @@ async function run(): Promise<void> {
     });
     startGraphQLServer(projectRoot, httpServer, authenticationContext);
     console.log('Starting project...');
-    await Project.startAsync(projectRoot);
+    await Project.startAsync(projectRoot, {
+      reset: false,
+      webOnly: false,
+      nonInteractive: false,
+      // TODO: deprecate
+      devClient: false,
+      // TODO: deprecate
+      target: 'managed',
+      // TODO: deprecate
+      nonPersistent: false,
+    });
     const url = `http://localhost:${PORT}`;
     console.log(`Development server running at ${url}`);
     openBrowser(url);

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -131,10 +131,8 @@ export default (program: any) => {
     .allowOffline()
     .asyncActionProjectDir(
       async (projectRoot: string, options: RawStartOptions): Promise<void> => {
-        const normalizedOptions = await normalizeOptionsAsync(projectRoot, {
-          ...options,
-          webOnly: true,
-        });
+        const normalizedOptions = await normalizeOptionsAsync(projectRoot, options);
+        normalizedOptions.webOnly = true;
         return await action(projectRoot, normalizedOptions);
       }
     );

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -3,11 +3,11 @@ import { Project, UrlUtils, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import path from 'path';
 
-import { installExitHooks } from '../exit';
 import Log from '../log';
 import * as sendTo from '../sendTo';
 import urlOpts from '../urlOpts';
 import * as TerminalUI from './start/TerminalUI';
+import { installExitHooks } from './start/installExitHooks';
 import { tryOpeningDevToolsAsync } from './start/openDevTools';
 import {
   NormalizedOptions,
@@ -35,6 +35,7 @@ async function action(projectRoot: string, options: NormalizedOptions): Promise<
   // TODO: This is useless on mac, check if useless on win32
   const rootPath = path.resolve(projectRoot);
 
+  // Optionally open the developer tools UI.
   await tryOpeningDevToolsAsync(rootPath, {
     exp,
     options,

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -27,25 +27,17 @@ const CTRL_L = '\u000C';
 const BLT = `\u203A`;
 const { bold: b, italic: i, underline: u } = chalk;
 
-type StartOptions = {
-  devClient?: boolean;
-  reset?: boolean;
-  nonInteractive?: boolean;
-  nonPersistent?: boolean;
-  maxWorkers?: number;
-  webOnly?: boolean;
-};
-
 const printHelp = (): void => {
   logCommandsTable([[], ['?', 'show all commands']]);
 };
 
 const div = chalk.dim(`│`);
 
-const printUsageAsync = async (
-  projectRoot: string,
-  options: Pick<StartOptions, 'webOnly'> = {}
-) => {
+type UsageOptions = {
+  webOnly?: boolean;
+};
+
+const printUsageAsync = async (projectRoot: string, options: UsageOptions = {}) => {
   const { dev } = await ProjectSettings.readAsync(projectRoot);
   const openDevToolsAtStartup = await UserSettings.getAsync('openDevToolsAtStartup', true);
   const devMode = dev ? 'development' : 'production';
@@ -73,7 +65,7 @@ const printUsageAsync = async (
   ]);
 };
 
-const printBasicUsageAsync = async (options: Pick<StartOptions, 'webOnly'> = {}) => {
+const printBasicUsageAsync = async (options: UsageOptions = {}) => {
   const isMac = process.platform === 'darwin';
   const openDevToolsAtStartup = await UserSettings.getAsync('openDevToolsAtStartup', true);
   const currentToggle = openDevToolsAtStartup ? 'enabled' : 'disabled';
@@ -111,10 +103,7 @@ function logCommandsTable(ui: (false | string[])[]) {
   );
 }
 
-const printServerInfo = async (
-  projectRoot: string,
-  options: Pick<StartOptions, 'webOnly'> = {}
-) => {
+const printServerInfo = async (projectRoot: string, options: UsageOptions = {}) => {
   if (options.webOnly) {
     Webpack.printConnectionInstructions(projectRoot);
     return;
@@ -142,7 +131,7 @@ export function openDeveloperTools(url: string) {
   }
 }
 
-export const startAsync = async (projectRoot: string, options: StartOptions) => {
+export const startAsync = async (projectRoot: string, options: Project.StartOptions) => {
   const { stdin } = process;
   const startWaitingForCommand = () => {
     if (!stdin.setRawMode) {

--- a/packages/expo-cli/src/commands/start/__tests__/parseStartOptions-test.ts
+++ b/packages/expo-cli/src/commands/start/__tests__/parseStartOptions-test.ts
@@ -1,0 +1,35 @@
+import { parseRawArguments, setBooleanArg } from '../parseStartOptions';
+
+describe(setBooleanArg, () => {
+  it(`uses fallback`, () => {
+    expect(setBooleanArg('dev', [], true)).toBe(true);
+  });
+  it(`uses true value first`, () => {
+    expect(setBooleanArg('dev', ['--no-dev', '--dev'])).toBe(true);
+  });
+  it(`uses false value`, () => {
+    expect(setBooleanArg('dev', ['--no-dev'])).toBe(false);
+  });
+});
+
+describe(parseRawArguments, () => {
+  it(`args overwrite incoming options`, () => {
+    expect(
+      parseRawArguments(
+        {
+          dev: true,
+        },
+        ['--no-dev']
+      ).dev
+    ).toBe(false);
+
+    expect(
+      parseRawArguments(
+        {
+          dev: false,
+        },
+        []
+      ).dev
+    ).toBe(true);
+  });
+});

--- a/packages/expo-cli/src/commands/start/installExitHooks.ts
+++ b/packages/expo-cli/src/commands/start/installExitHooks.ts
@@ -1,18 +1,15 @@
 import { Project } from '@expo/xdl';
 import ora from 'ora';
 
-import Log from './log';
+import Log from '../../log';
 
-export function installExitHooks(
-  projectRoot: string,
-  onStop: (projectRoot: string) => Promise<void> = Project.stopAsync
-): void {
+export function installExitHooks(projectRoot: string): void {
   const killSignals: ['SIGINT', 'SIGTERM'] = ['SIGINT', 'SIGTERM'];
   for (const signal of killSignals) {
     process.on(signal, () => {
       const spinner = ora({ text: 'Stopping server', color: 'white' }).start();
       Log.setSpinner(spinner);
-      onStop(projectRoot)
+      Project.stopAsync(projectRoot)
         .then(() => {
           spinner.stopAndPersist({ text: 'Stopped server', symbol: `\u203A` });
           process.exit();

--- a/packages/expo-cli/src/commands/start/openDevTools.ts
+++ b/packages/expo-cli/src/commands/start/openDevTools.ts
@@ -1,0 +1,29 @@
+import { ExpoConfig } from '@expo/config';
+// @ts-ignore: not typed
+import { DevToolsServer } from '@expo/dev-tools';
+import { UserSettings } from '@expo/xdl';
+import chalk from 'chalk';
+
+import Log from '../../log';
+import * as TerminalUI from './TerminalUI';
+import { NormalizedOptions } from './parseStartOptions';
+
+export async function tryOpeningDevToolsAsync(
+  projectRoot: string,
+  {
+    exp,
+    options,
+  }: {
+    exp: Pick<ExpoConfig, 'isDetached'>;
+    options: Pick<NormalizedOptions, 'nonInteractive'>;
+  }
+): Promise<void> {
+  const devToolsUrl = await DevToolsServer.startAsync(projectRoot);
+  Log.log(`Developer tools running on ${chalk.underline(devToolsUrl)}`);
+
+  if (!options.nonInteractive && !exp.isDetached) {
+    if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
+      TerminalUI.openDeveloperTools(devToolsUrl);
+    }
+  }
+}

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -16,26 +16,14 @@ export type RawStartOptions = NormalizedOptions & {
   parent?: { nonInteractive: boolean; rawArgs: string[] };
 };
 
-function hasBooleanArg(rawArgs: string[], argName: string): boolean {
-  return rawArgs.includes('--' + argName) || rawArgs.includes('--no-' + argName);
-}
-
-function getBooleanArg(rawArgs: string[], argName: string): boolean {
-  if (rawArgs.includes('--' + argName)) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
 function setBooleanArg(
   rawArgs: string[],
   argName: string,
   fallback?: boolean
 ): boolean | undefined {
-  if (rawArgs.includes('--' + argName)) {
+  if (rawArgs.includes(`--${argName}`)) {
     return true;
-  } else if (rawArgs.includes('--no-' + argName)) {
+  } else if (rawArgs.includes(`--no-${argName}`)) {
     return false;
   } else {
     return fallback;
@@ -57,40 +45,31 @@ export async function normalizeOptionsAsync(
 
   const rawArgs = options.parent?.rawArgs || [];
 
+  // dev server
   opts.dev = setBooleanArg(rawArgs, 'dev', true);
   opts.minify = setBooleanArg(rawArgs, 'minify', false);
   opts.https = setBooleanArg(rawArgs, 'https', false);
 
-  if (hasBooleanArg(rawArgs, 'android')) {
-    opts.android = getBooleanArg(rawArgs, 'android');
-  }
+  // platforms
+  opts.android = setBooleanArg(rawArgs, 'android');
+  opts.ios = setBooleanArg(rawArgs, 'ios');
+  opts.web = setBooleanArg(rawArgs, 'web');
 
-  if (hasBooleanArg(rawArgs, 'ios')) {
-    opts.ios = getBooleanArg(rawArgs, 'ios');
-  }
-
-  if (hasBooleanArg(rawArgs, 'web')) {
-    opts.web = getBooleanArg(rawArgs, 'web');
-  }
-
-  if (hasBooleanArg(rawArgs, 'localhost')) {
-    opts.localhost = getBooleanArg(rawArgs, 'localhost');
-  }
-
-  if (hasBooleanArg(rawArgs, 'lan')) {
-    opts.lan = getBooleanArg(rawArgs, 'lan');
-  }
-
-  if (hasBooleanArg(rawArgs, 'tunnel')) {
-    opts.tunnel = getBooleanArg(rawArgs, 'tunnel');
-  }
+  // url
+  // TODO: auto convert to `host`
+  opts.localhost = setBooleanArg(rawArgs, 'localhost');
+  opts.lan = setBooleanArg(rawArgs, 'lan');
+  opts.tunnel = setBooleanArg(rawArgs, 'tunnel');
 
   await cacheOptionsAsync(projectRoot, opts);
   return opts;
 }
 
-async function cacheOptionsAsync(projectDir: string, options: NormalizedOptions): Promise<void> {
-  await ProjectSettings.setAsync(projectDir, {
+async function cacheOptionsAsync(
+  projectRoot: string,
+  options: Pick<NormalizedOptions, 'devClient' | 'scheme' | 'dev' | 'minify' | 'https'>
+): Promise<void> {
+  await ProjectSettings.setAsync(projectRoot, {
     devClient: options.devClient,
     scheme: options.scheme,
     dev: options.dev,

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -1,0 +1,119 @@
+import { Project, ProjectSettings } from '@expo/xdl';
+
+import { URLOptions } from '../../urlOpts';
+
+export type NormalizedOptions = URLOptions &
+  Pick<Project.StartOptions, 'webOnly' | 'nonInteractive' | 'maxWorkers'> & {
+    dev?: boolean;
+    minify?: boolean;
+    https?: boolean;
+    clear?: boolean;
+    sendTo?: string;
+    host?: string;
+  };
+
+export type RawStartOptions = NormalizedOptions & {
+  parent?: { nonInteractive: boolean; rawArgs: string[] };
+};
+
+function hasBooleanArg(rawArgs: string[], argName: string): boolean {
+  return rawArgs.includes('--' + argName) || rawArgs.includes('--no-' + argName);
+}
+
+function getBooleanArg(rawArgs: string[], argName: string): boolean {
+  if (rawArgs.includes('--' + argName)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function setBooleanArg(
+  rawArgs: string[],
+  argName: string,
+  fallback?: boolean
+): boolean | undefined {
+  if (rawArgs.includes('--' + argName)) {
+    return true;
+  } else if (rawArgs.includes('--no-' + argName)) {
+    return false;
+  } else {
+    return fallback;
+  }
+}
+
+// The main purpose of this function is to take existing options object and
+// support boolean args with as defined in the hasBooleanArg and getBooleanArg
+// functions.
+export async function normalizeOptionsAsync(
+  projectRoot: string,
+  options: RawStartOptions
+): Promise<NormalizedOptions> {
+  const opts: NormalizedOptions = {
+    ...options, // This is necessary to ensure we don't drop any options
+    webOnly: !!options.webOnly, // This is only ever true in the start:web command
+    nonInteractive: !!options.parent?.nonInteractive,
+  };
+
+  const rawArgs = options.parent?.rawArgs || [];
+
+  opts.dev = setBooleanArg(rawArgs, 'dev', true);
+  opts.minify = setBooleanArg(rawArgs, 'minify', false);
+  opts.https = setBooleanArg(rawArgs, 'https', false);
+
+  if (hasBooleanArg(rawArgs, 'android')) {
+    opts.android = getBooleanArg(rawArgs, 'android');
+  }
+
+  if (hasBooleanArg(rawArgs, 'ios')) {
+    opts.ios = getBooleanArg(rawArgs, 'ios');
+  }
+
+  if (hasBooleanArg(rawArgs, 'web')) {
+    opts.web = getBooleanArg(rawArgs, 'web');
+  }
+
+  if (hasBooleanArg(rawArgs, 'localhost')) {
+    opts.localhost = getBooleanArg(rawArgs, 'localhost');
+  }
+
+  if (hasBooleanArg(rawArgs, 'lan')) {
+    opts.lan = getBooleanArg(rawArgs, 'lan');
+  }
+
+  if (hasBooleanArg(rawArgs, 'tunnel')) {
+    opts.tunnel = getBooleanArg(rawArgs, 'tunnel');
+  }
+
+  await cacheOptionsAsync(projectRoot, opts);
+  return opts;
+}
+
+async function cacheOptionsAsync(projectDir: string, options: NormalizedOptions): Promise<void> {
+  await ProjectSettings.setAsync(projectDir, {
+    devClient: options.devClient,
+    scheme: options.scheme,
+    dev: options.dev,
+    minify: options.minify,
+    https: options.https,
+  });
+}
+
+export function parseStartOptions(options: NormalizedOptions): Project.StartOptions {
+  const startOpts: Project.StartOptions = {
+    nonPersistent: false,
+    reset: !!options.clear,
+    devClient: !!options.devClient,
+    nonInteractive: !!options.nonInteractive,
+    webOnly: !!options.webOnly,
+    // TODO: is this redundant?
+    // For `expo start`, the default target is 'managed', for both managed *and* bare apps.
+    // See: https://docs.expo.io/bare/using-expo-client
+    target: options.devClient ? 'bare' : 'managed',
+  };
+  if (options.maxWorkers) {
+    startOpts.maxWorkers = options.maxWorkers;
+  }
+
+  return startOpts;
+}

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -37,31 +37,23 @@ export async function normalizeOptionsAsync(
   projectRoot: string,
   options: RawStartOptions
 ): Promise<NormalizedOptions> {
-  const opts: NormalizedOptions = {
-    ...options, // This is necessary to ensure we don't drop any options
-    webOnly: !!options.webOnly, // This is only ever true in the start:web command
-    nonInteractive: !!options.parent?.nonInteractive,
-  };
-
   const rawArgs = options.parent?.rawArgs || [];
 
-  // dev server
-  opts.dev = setBooleanArg(rawArgs, 'dev', true);
-  opts.minify = setBooleanArg(rawArgs, 'minify', false);
-  opts.https = setBooleanArg(rawArgs, 'https', false);
+  const opts: NormalizedOptions = {
+    // ios, android, web, localhost, lan, tunnel added automatically
+    // This is necessary to ensure we don't drop any options
+    ...options,
+    nonInteractive: !!options.parent?.nonInteractive,
+    // setBooleanArg is used to flip the default commander logic which automatically sets a value to `true` if the inverse option isn't provided.
+    // ex: `dev == true` if `--no-dev` is a possible flag, but `--no-dev` was not provided in the command.
+    dev: setBooleanArg(rawArgs, 'dev', true),
+    minify: setBooleanArg(rawArgs, 'minify', false),
+    https: setBooleanArg(rawArgs, 'https', false),
+  };
 
-  // platforms
-  opts.android = setBooleanArg(rawArgs, 'android');
-  opts.ios = setBooleanArg(rawArgs, 'ios');
-  opts.web = setBooleanArg(rawArgs, 'web');
-
-  // url
-  // TODO: auto convert to `host`
-  opts.localhost = setBooleanArg(rawArgs, 'localhost');
-  opts.lan = setBooleanArg(rawArgs, 'lan');
-  opts.tunnel = setBooleanArg(rawArgs, 'tunnel');
-
+  // Side-effect
   await cacheOptionsAsync(projectRoot, opts);
+
   return opts;
 }
 

--- a/packages/expo-cli/src/commands/start/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/start/validateDependenciesVersions.ts
@@ -8,10 +8,8 @@ import semver from 'semver';
 
 import Log from '../../log';
 
-// @ts-ignore: not typed
-
 export async function validateDependenciesVersionsAsync(
-  projectDir: string,
+  projectRoot: string,
   exp: ExpoConfig,
   pkg: PackageJSONConfig
 ): Promise<void> {
@@ -19,7 +17,7 @@ export async function validateDependenciesVersionsAsync(
     return;
   }
 
-  const bundleNativeModulesPath = resolveFrom.silent(projectDir, 'expo/bundledNativeModules.json');
+  const bundleNativeModulesPath = resolveFrom.silent(projectRoot, 'expo/bundledNativeModules.json');
   if (!bundleNativeModulesPath) {
     Log.warn(
       `Your project is in SDK version >= 33.0.0, but the ${chalk.underline(

--- a/packages/expo-cli/src/commands/start/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/start/validateDependenciesVersions.ts
@@ -1,0 +1,69 @@
+import { ExpoConfig, PackageJSONConfig } from '@expo/config';
+import JsonFile from '@expo/json-file';
+import { Versions } from '@expo/xdl';
+import chalk from 'chalk';
+import intersection from 'lodash/intersection';
+import resolveFrom from 'resolve-from';
+import semver from 'semver';
+
+import Log from '../../log';
+
+// @ts-ignore: not typed
+
+export async function validateDependenciesVersionsAsync(
+  projectDir: string,
+  exp: ExpoConfig,
+  pkg: PackageJSONConfig
+): Promise<void> {
+  if (!Versions.gteSdkVersion(exp, '33.0.0')) {
+    return;
+  }
+
+  const bundleNativeModulesPath = resolveFrom.silent(projectDir, 'expo/bundledNativeModules.json');
+  if (!bundleNativeModulesPath) {
+    Log.warn(
+      `Your project is in SDK version >= 33.0.0, but the ${chalk.underline(
+        'expo'
+      )} package version seems to be older.`
+    );
+    return;
+  }
+
+  const bundledNativeModules = await JsonFile.readAsync(bundleNativeModulesPath);
+  const bundledNativeModulesNames = Object.keys(bundledNativeModules);
+  const projectDependencies = Object.keys(pkg.dependencies || []);
+
+  const modulesToCheck = intersection(bundledNativeModulesNames, projectDependencies);
+  const incorrectDeps = [];
+  for (const moduleName of modulesToCheck) {
+    const expectedRange = bundledNativeModules[moduleName];
+    const actualRange = pkg.dependencies[moduleName];
+    if (
+      (semver.valid(actualRange) || semver.validRange(actualRange)) &&
+      typeof expectedRange === 'string' &&
+      !semver.intersects(expectedRange, actualRange)
+    ) {
+      incorrectDeps.push({
+        moduleName,
+        expectedRange,
+        actualRange,
+      });
+    }
+  }
+  if (incorrectDeps.length > 0) {
+    Log.warn('Some dependencies are incompatible with the installed expo package version:');
+    incorrectDeps.forEach(({ moduleName, expectedRange, actualRange }) => {
+      Log.warn(
+        ` - ${chalk.underline(moduleName)} - expected version range: ${chalk.underline(
+          expectedRange
+        )} - actual version installed: ${chalk.underline(actualRange)}`
+      );
+    });
+    Log.warn(
+      'Your project may not work correctly until you install the correct versions of the packages.\n' +
+        `To install the correct versions of these packages, please run: ${chalk.inverse(
+          'expo install [package-name ...]'
+        )}`
+    );
+  }
+}

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -646,7 +646,10 @@ export async function upgradeAsync(
   try {
     await Project.startReactNativeServerAsync({
       projectRoot,
-      options: { reset: true, nonPersistent: true },
+      options: {
+        reset: true,
+        nonPersistent: true,
+      },
     });
   } catch (e) {
     clearingCacheStep.fail(`Failed to clear packager cache with error: ${e.message}`);

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -9,7 +9,7 @@ import {
   stopReactNativeServerAsync,
 } from './start/startLegacyReactNativeServerAsync';
 
-export { startAsync, stopWebOnlyAsync, stopAsync } from './start/startAsync';
+export { startAsync, stopAsync } from './start/startAsync';
 
 /**
  * @deprecated Use `ProjectSettings.setPackagerInfoAsync`

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -22,7 +22,7 @@ let serverInstance: Server | null = null;
 
 export async function startAsync(
   projectRoot: string,
-  { exp = getConfig(projectRoot).exp, ...options }: StartOptions & { exp?: ExpoConfig } = {},
+  { exp = getConfig(projectRoot).exp, ...options }: StartOptions & { exp?: ExpoConfig },
   verbose: boolean = true
 ): Promise<ExpoConfig> {
   assertValidProjectRoot(projectRoot);
@@ -55,11 +55,6 @@ export async function startAsync(
     }
   }
   return exp;
-}
-
-export async function stopWebOnlyAsync(projectRoot: string): Promise<void> {
-  DevSession.stopSession();
-  await Webpack.stopAsync(projectRoot);
 }
 
 async function stopInternalAsync(projectRoot: string): Promise<void> {

--- a/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
+++ b/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
@@ -123,7 +123,7 @@ export async function startReactNativeServerAsync({
   verbose = true,
 }: {
   projectRoot: string;
-  options: StartOptions;
+  options: Partial<Pick<StartOptions, 'target' | 'nonPersistent' | 'maxWorkers' | 'reset'>>;
   exp?: ExpoConfig;
   verbose?: boolean;
 }): Promise<void> {


### PR DESCRIPTION
# Why

Start command is really large and confusing for a script that mostly just starts an https server. This PR aims to simplify the args parsing, merge `start` and `start:web`, reuse types, add more strict typing, and add more tests.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- split up the start command file.
- merge `start:web` logic into `start`.
- delete `stopWebOnlyAsync`.
- move args parsing into it's own file and reuse some commander logic to simplify the amount of steps.
- add tests to the remaining ambiguous functionality of start args.
- add more comments.

# Test Plan

- unit tests should cover most functionality changes related to args
- test that start works as expected
- test start:web stops correctly
- test `expo start --lan --localhost --tunnel --host lan` throws an error
