### PR TITLE
[config-plugins] extract build scheme functions to separate module

### DIFF
--- a/packages/config-plugins/src/ios/BuildScheme.ts
+++ b/packages/config-plugins/src/ios/BuildScheme.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { readXMLAsync } from '../utils/XML';
-import { findSchemePaths } from './Paths';
+import { findSchemeNames, findSchemePaths } from './Paths';
 
 interface SchemeXML {
   Scheme?: {
@@ -20,6 +20,10 @@ interface BuildActionEntryType {
       BuildableName?: string;
     };
   }[];
+}
+
+export function getSchemesFromXcodeproj(projectRoot: string): string[] {
+  return findSchemeNames(projectRoot);
 }
 
 export async function getApplicationTargetForSchemeAsync(

--- a/packages/config-plugins/src/ios/Scheme.ts
+++ b/packages/config-plugins/src/ios/Scheme.ts
@@ -2,7 +2,6 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { createInfoPlistPlugin } from '../plugins/ios-plugins';
 import { InfoPlist, URLScheme } from './IosConfig.types';
-import { findSchemeNames } from './Paths';
 
 export const withScheme = createInfoPlistPlugin(setScheme, 'withScheme');
 
@@ -102,8 +101,4 @@ export function getSchemesFromPlist(infoPlist: InfoPlist): string[] {
     }, []);
   }
   return [];
-}
-
-export function getSchemesFromXcodeproj(projectRoot: string): string[] {
-  return findSchemeNames(projectRoot);
 }

--- a/packages/config-plugins/src/ios/__tests__/BuildScheme-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/BuildScheme-test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { vol } from 'memfs';
 import path from 'path';
 
-import { getApplicationTargetForSchemeAsync } from '../Target';
+import { getApplicationTargetForSchemeAsync } from '../BuildScheme';
 
 const fsReal = jest.requireActual('fs') as typeof fs;
 

--- a/packages/config-plugins/src/ios/index.ts
+++ b/packages/config-plugins/src/ios/index.ts
@@ -1,5 +1,6 @@
 import * as AdMob from './AdMob';
 import * as Branch from './Branch';
+import * as BuildScheme from './BuildScheme';
 import * as BundleIdentifier from './BundleIdentifier';
 import * as CustomInfoPlistEntries from './CustomInfoPlistEntries';
 import * as DeviceFamily from './DeviceFamily';
@@ -17,7 +18,6 @@ import * as ProvisioningProfile from './ProvisioningProfile';
 import * as RequiresFullScreen from './RequiresFullScreen';
 import * as Scheme from './Scheme';
 import * as SplashScreen from './SplashScreen';
-import * as Target from './Target';
 import * as Updates from './Updates';
 import * as UserInterfaceStyle from './UserInterfaceStyle';
 import * as UsesNonExemptEncryption from './UsesNonExemptEncryption';
@@ -30,6 +30,7 @@ import * as XcodeUtils from './utils/Xcodeproj';
 export {
   AdMob,
   Branch,
+  BuildScheme,
   BundleIdentifier,
   CustomInfoPlistEntries,
   DeviceFamily,
@@ -48,7 +49,6 @@ export {
   Permissions,
   RequiresFullScreen,
   Scheme,
-  Target,
   Updates,
   UserInterfaceStyle,
   UsesNonExemptEncryption,


### PR DESCRIPTION
# Why

Derived from https://github.com/expo/expo-cli/pull/3222.

# How

- I renamed `Target` to `BuildScheme`.
- I moved `getSchemesFromXcodeproj` from `Scheme` to `BuildScheme`.

# Test Plan

Let's see if CI passes.

# Follow-up Action

Bump `@expo/config-plugins` in EAS CLI and refactor update calls.