### PR TITLE
Remove default metro logger from default metro config

### DIFF
--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -61,7 +61,12 @@ export function getDefaultConfig(
       ? getBareExtensions([], sourceExtsConfig)
       : getManagedExtensions([], sourceExtsConfig);
 
-  const metroDefaultValues = MetroConfig.getDefaultConfig.getDefaultValues(projectRoot);
+  const {
+    // Remove the default reporter which metro always resolves to be the react-native-community/cli reporter.
+    // This prints a giant React logo which is less accessible to users on smaller terminals.
+    reporter,
+    ...metroDefaultValues
+  } = MetroConfig.getDefaultConfig.getDefaultValues(projectRoot);
   // Merge in the default config from Metro here, even though loadConfig uses it as defaults.
   // This is a convenience for getDefaultConfig use in metro.config.js, e.g. to modify assetExts.
   return MetroConfig.mergeConfig(metroDefaultValues, {


### PR DESCRIPTION
# Why

If a project uses the default expo/metro-config in their metro.config.js, a giant React logo is shown when running `expo start`. 

# Test Plan

- use a `metro.config.js` in a project, run `expo start` no React logo should show.
- run `npx react-native start` the React logo should still show.
