### PR TITLE
[expo-cli] Combine stop methods for web and native

### DIFF
--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -9,11 +9,11 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
-import { installExitHooks } from '../exit';
 import Log from '../log';
 import * as sendTo from '../sendTo';
 import urlOpts, { URLOptions } from '../urlOpts';
 import * as TerminalUI from './start/TerminalUI';
+import { installExitHooks } from './start/installExitHooks';
 import { ensureTypeScriptSetupAsync } from './utils/typescript/ensureTypeScriptSetup';
 
 type NormalizedOptions = URLOptions & {
@@ -281,11 +281,8 @@ async function configureProjectAsync(
   projectDir: string,
   options: NormalizedOptions
 ): Promise<{ rootPath: string; exp: ExpoConfig; pkg: PackageJSONConfig }> {
-  if (options.webOnly) {
-    installExitHooks(projectDir, Project.stopWebOnlyAsync);
-  } else {
-    installExitHooks(projectDir);
-  }
+  installExitHooks(projectDir);
+
   await urlOpts.optsAsync(projectDir, options);
 
   Log.log(chalk.gray(`Starting project at ${projectDir}`));

--- a/packages/expo-cli/src/commands/start/installExitHooks.ts
+++ b/packages/expo-cli/src/commands/start/installExitHooks.ts
@@ -1,18 +1,15 @@
 import { Project } from '@expo/xdl';
 import ora from 'ora';
 
-import Log from './log';
+import Log from '../../log';
 
-export function installExitHooks(
-  projectRoot: string,
-  onStop: (projectRoot: string) => Promise<void> = Project.stopAsync
-): void {
+export function installExitHooks(projectRoot: string): void {
   const killSignals: ['SIGINT', 'SIGTERM'] = ['SIGINT', 'SIGTERM'];
   for (const signal of killSignals) {
     process.on(signal, () => {
       const spinner = ora({ text: 'Stopping server', color: 'white' }).start();
       Log.setSpinner(spinner);
-      onStop(projectRoot)
+      Project.stopAsync(projectRoot)
         .then(() => {
           spinner.stopAndPersist({ text: 'Stopped server', symbol: `\u203A` });
           process.exit();

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -9,7 +9,7 @@ import {
   stopReactNativeServerAsync,
 } from './start/startLegacyReactNativeServerAsync';
 
-export { startAsync, stopWebOnlyAsync, stopAsync } from './start/startAsync';
+export { startAsync, stopAsync } from './start/startAsync';
 
 /**
  * @deprecated Use `ProjectSettings.setPackagerInfoAsync`

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -57,11 +57,6 @@ export async function startAsync(
   return exp;
 }
 
-export async function stopWebOnlyAsync(projectRoot: string): Promise<void> {
-  DevSession.stopSession();
-  await Webpack.stopAsync(projectRoot);
-}
-
 async function stopInternalAsync(projectRoot: string): Promise<void> {
   DevSession.stopSession();
 


### PR DESCRIPTION
# Why

- Delete `Project.stopWebOnly`.
- Move exit.ts to the start folder.
- moved from https://github.com/expo/expo-cli/pull/3230
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- `expod start:web` then stopping should be slower and log correctly.
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->