### PR TITLE
Add a command to build and run on Android

### DIFF
--- a/packages/expo-cli/src/commands/index.ts
+++ b/packages/expo-cli/src/commands/index.ts
@@ -22,6 +22,7 @@ const COMMANDS = [
   require('./publish-modify'),
   require('./push-creds'),
   require('./register'),
+  require('./run'),
   require('./send'),
   require('./start'),
   require('./upgrade'),

--- a/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
+++ b/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
@@ -21,6 +21,10 @@ export default async function buildAndroidClientAsync(
   if (!device) {
     return;
   }
+  const bootedDevice = await Android.attemptToStartEmulatorOrAssertAsync(device);
+  if (!bootedDevice) {
+    return;
+  }
 
   const spinner = ora('Building app ').start();
 

--- a/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
+++ b/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
@@ -4,14 +4,20 @@ import { Android } from '@expo/xdl';
 import ora from 'ora';
 import path from 'path';
 
-type Options = object;
+type Options = {
+  buildVariant: string;
+};
+
+function getGradleTask(buildVariant: string): string {
+  return `install${buildVariant.charAt(0).toUpperCase()}${buildVariant.slice(1)}`;
+}
 
 export default async function buildAndroidClientAsync(
   projectRoot: string,
-  _options: Options
+  options: Options
 ): Promise<void> {
   const devices = await Android.getAllAvailableDevicesAsync();
-  const device = await Android.promptForDeviceAsync(devices);
+  const device = devices.length > 1 ? await Android.promptForDeviceAsync(devices) : devices[0];
   if (!device) {
     return;
   }
@@ -24,7 +30,10 @@ export default async function buildAndroidClientAsync(
     process.platform === 'win32' ? 'gradlew.bat' : 'gradlew'
   );
 
-  await spawnAsync(gradlew, ['installRelease'], { cwd: androidProjectPath, stdio: 'inherit' });
+  await spawnAsync(gradlew, [getGradleTask(options.buildVariant)], {
+    cwd: androidProjectPath,
+    stdio: 'inherit',
+  });
 
   spinner.text = 'Starting the development client...';
   await Android.openProjectAsync({

--- a/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
+++ b/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
@@ -1,0 +1,37 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import spawnAsync from '@expo/spawn-async';
+import { Android } from '@expo/xdl';
+import ora from 'ora';
+import path from 'path';
+
+type Options = object;
+
+export default async function buildAndroidClientAsync(
+  projectRoot: string,
+  _options: Options
+): Promise<void> {
+  const devices = await Android.getAllAvailableDevicesAsync();
+  const device = await Android.promptForDeviceAsync(devices);
+  if (!device) {
+    return;
+  }
+
+  const spinner = ora('Building app ').start();
+
+  const androidProjectPath = await AndroidConfig.Paths.getProjectPathOrThrowAsync(projectRoot);
+  const gradlew = path.join(
+    androidProjectPath,
+    process.platform === 'win32' ? 'gradlew.bat' : 'gradlew'
+  );
+
+  await spawnAsync(gradlew, ['installRelease'], { cwd: androidProjectPath, stdio: 'inherit' });
+
+  spinner.text = 'Starting the development client...';
+  await Android.openProjectAsync({
+    projectRoot,
+    shouldPrompt: false,
+    devClient: true,
+  });
+
+  spinner.succeed();
+}

--- a/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
+++ b/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
@@ -10,8 +10,12 @@ type Options = {
   buildVariant: string;
 };
 
+function capitalize(name: string) {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
 function getGradleTask(buildVariant: string): string {
-  return `install${buildVariant.charAt(0).toUpperCase()}${buildVariant.slice(1)}`;
+  return `install${capitalize(buildVariant)}`;
 }
 
 export default async function buildAndroidClientAsync(

--- a/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
+++ b/packages/expo-cli/src/commands/run/buildAndroidClientAsync.ts
@@ -4,6 +4,7 @@ import { Android } from '@expo/xdl';
 import ora from 'ora';
 import path from 'path';
 
+import Log from '../../log';
 import { prebuildAsync } from '../eject/prebuildAsync';
 
 type Options = {
@@ -32,7 +33,7 @@ export default async function buildAndroidClientAsync(
     return;
   }
 
-  const spinner = ora('Building app ').start();
+  Log.log('Building app...');
 
   let androidProjectPath;
   try {
@@ -56,12 +57,17 @@ export default async function buildAndroidClientAsync(
     stdio: 'inherit',
   });
 
-  spinner.text = 'Starting the development client...';
-  await Android.openProjectAsync({
-    projectRoot,
-    shouldPrompt: false,
-    devClient: true,
-  });
+  const spinner = ora('Starting the development client...').start();
+  try {
+    await Android.openProjectAsync({
+      projectRoot,
+      shouldPrompt: false,
+      devClient: true,
+    });
+  } catch (error) {
+    spinner.fail();
+    throw error;
+  }
 
   spinner.succeed();
 }

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -1,0 +1,45 @@
+import { Command } from 'commander';
+
+import prompt from '../../prompts';
+import buildAndroidClientAsync from './buildAndroidClientAsync';
+
+type Options = {
+  platform?: string;
+};
+
+async function runAsync(projectRoot: string, options: Options) {
+  const platform = options.platform?.toLowerCase() ?? (await promptForPlatformAsync());
+  if (platform === 'android') {
+    await buildAndroidClientAsync(projectRoot, {});
+  } else {
+    throw new Error('platform not implemented');
+  }
+}
+
+async function promptForPlatformAsync(): Promise<'android' | 'ios'> {
+  const { platform } = await prompt({
+    type: 'select',
+    message: 'Choose platform',
+    name: 'platform',
+    choices: [
+      {
+        title: 'Android',
+        value: 'android',
+      },
+      {
+        title: 'iOS',
+        value: 'ios',
+      },
+    ],
+  });
+  return platform;
+}
+
+export default function (program: Command) {
+  program
+    .command('run [path]')
+    .helpGroup('experimental')
+    .description('Build a development client and run it in on a device.')
+    .option('-p --platform <platform>', 'Platform: [android|ios]', /^(android|ios)$/i)
+    .asyncActionProjectDir(runAsync);
+}

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -1,16 +1,23 @@
 import { Command } from 'commander';
 
+import CommandError from '../../CommandError';
 import prompt from '../../prompts';
 import buildAndroidClientAsync from './buildAndroidClientAsync';
 
 type Options = {
   platform?: string;
+  buildVariant?: string;
 };
 
 async function runAsync(projectRoot: string, options: Options) {
   const platform = options.platform?.toLowerCase() ?? (await promptForPlatformAsync());
   if (platform === 'android') {
-    await buildAndroidClientAsync(projectRoot, {});
+    if (typeof options.buildVariant !== 'string') {
+      throw new CommandError('--build-variant must be a string');
+    }
+    await buildAndroidClientAsync(projectRoot, {
+      buildVariant: options.buildVariant,
+    });
   } else {
     throw new Error('platform not implemented');
   }
@@ -41,5 +48,6 @@ export default function (program: Command) {
     .helpGroup('experimental')
     .description('Build a development client and run it in on a device.')
     .option('-p --platform <platform>', 'Platform: [android|ios]', /^(android|ios)$/i)
+    .option('--build-variant [name]', '(Android) build variant', 'release')
     .asyncActionProjectDir(runAsync);
 }

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -1,7 +1,6 @@
 import { Command } from 'commander';
 
 import CommandError from '../../CommandError';
-import prompt from '../../prompts';
 import buildAndroidClientAsync from './buildAndroidClientAsync';
 
 type Options = {
@@ -9,37 +8,13 @@ type Options = {
   buildVariant?: string;
 };
 
-async function runAsync(projectRoot: string, options: Options) {
-  const platform = options.platform?.toLowerCase() ?? (await promptForPlatformAsync());
-  if (platform === 'android') {
-    if (typeof options.buildVariant !== 'string') {
-      throw new CommandError('--build-variant must be a string');
-    }
-    await buildAndroidClientAsync(projectRoot, {
-      buildVariant: options.buildVariant,
-    });
-  } else {
-    throw new Error('platform not implemented');
+async function runAndroidAsync(projectRoot: string, options: Options) {
+  if (typeof options.buildVariant !== 'string') {
+    throw new CommandError('--build-variant must be a string');
   }
-}
-
-async function promptForPlatformAsync(): Promise<'android' | 'ios'> {
-  const { platform } = await prompt({
-    type: 'select',
-    message: 'Choose platform',
-    name: 'platform',
-    choices: [
-      {
-        title: 'Android',
-        value: 'android',
-      },
-      {
-        title: 'iOS',
-        value: 'ios',
-      },
-    ],
+  await buildAndroidClientAsync(projectRoot, {
+    buildVariant: options.buildVariant,
   });
-  return platform;
 }
 
 export default function (program: Command) {
@@ -47,7 +22,6 @@ export default function (program: Command) {
     .command('run:android [path]')
     .helpGroup('experimental')
     .description('Build a development client and run it in on a device.')
-    .option('-p --platform <platform>', 'Platform: [android|ios]', /^(android|ios)$/i)
     .option('--build-variant [name]', '(Android) build variant', 'release')
-    .asyncActionProjectDir(runAsync);
+    .asyncActionProjectDir(runAndroidAsync);
 }

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -44,7 +44,7 @@ async function promptForPlatformAsync(): Promise<'android' | 'ios'> {
 
 export default function (program: Command) {
   program
-    .command('run [path]')
+    .command('run:android [path]')
     .helpGroup('experimental')
     .description('Build a development client and run it in on a device.')
     .option('-p --platform <platform>', 'Platform: [android|ios]', /^(android|ios)$/i)

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -548,7 +548,7 @@ async function _openUrlAsync({
   return openProject;
 }
 
-async function attemptToStartEmulatorOrAssertAsync(device: Device): Promise<Device | null> {
+export async function attemptToStartEmulatorOrAssertAsync(device: Device): Promise<Device | null> {
   // TODO: Add a light-weight method for checking since a device could disconnect.
 
   if (!(await isDeviceBootedAsync(device))) {

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -995,7 +995,7 @@ function nameStyleForDevice(device: Device) {
   return (text: string) => chalk.bold(chalk.gray(text));
 }
 
-async function promptForDeviceAsync(devices: Device[]): Promise<Device | null> {
+export async function promptForDeviceAsync(devices: Device[]): Promise<Device | null> {
   // TODO: provide an option to add or download more simulators
 
   // Pause interactions on the TerminalUI


### PR DESCRIPTION
# Why

This is going to be the v1 of the emulator flow for Android dev client. The command allows building, installing and launching the dev client app on Android.
 
# How

Launch with `expod run --platform android`.

TODO:
- [x] Hide the command from `--help`

# Test Plan

- Create an app
    npx crna -t with-development-client my-dev-client-app
    cd my-dev-client-app
- Uncomment this line in `android/gradle.properties`: `# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8`
- Build and run it
    expod run:android
    