### PR TITLE
[expo-cli] refactor and test start command

### DIFF
--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -12,8 +12,8 @@ import { tryOpeningDevToolsAsync } from './start/openDevTools';
 import {
   NormalizedOptions,
   normalizeOptionsAsync,
-  Options,
   parseStartOptions,
+  RawStartOptions,
 } from './start/parseStartOptions';
 import { validateDependenciesVersionsAsync } from './start/validateDependenciesVersions';
 import { assertProjectHasExpoExtensionFilesAsync } from './utils/deprecatedExtensionWarnings';
@@ -115,7 +115,7 @@ export default (program: any) => {
     .urlOpts()
     .allowOffline()
     .asyncActionProjectDir(
-      async (projectRoot: string, options: Options): Promise<void> => {
+      async (projectRoot: string, options: RawStartOptions): Promise<void> => {
         const normalizedOptions = await normalizeOptionsAsync(projectRoot, options);
         return await action(projectRoot, normalizedOptions);
       }
@@ -136,7 +136,7 @@ export default (program: any) => {
     .urlOpts()
     .allowOffline()
     .asyncActionProjectDir(
-      async (projectRoot: string, options: Options): Promise<void> => {
+      async (projectRoot: string, options: RawStartOptions): Promise<void> => {
         const normalizedOptions = await normalizeOptionsAsync(projectRoot, {
           ...options,
           webOnly: true,

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -1,167 +1,40 @@
-import { ExpoConfig, getConfig, isLegacyImportsEnabled } from '@expo/config';
-import { Project, ProjectSettings, UrlUtils, Versions } from '@expo/xdl';
+import { getConfig, isLegacyImportsEnabled } from '@expo/config';
+import { Project, UrlUtils, Versions } from '@expo/xdl';
 import chalk from 'chalk';
 import path from 'path';
 
 import Log from '../log';
 import * as sendTo from '../sendTo';
-import urlOpts, { URLOptions } from '../urlOpts';
+import urlOpts from '../urlOpts';
 import * as TerminalUI from './start/TerminalUI';
 import { installExitHooks } from './start/installExitHooks';
 import { tryOpeningDevToolsAsync } from './start/openDevTools';
+import {
+  NormalizedOptions,
+  normalizeOptionsAsync,
+  Options,
+  parseStartOptions,
+} from './start/parseStartOptions';
 import { validateDependenciesVersionsAsync } from './start/validateDependenciesVersions';
 import { assertProjectHasExpoExtensionFilesAsync } from './utils/deprecatedExtensionWarnings';
 import { ensureTypeScriptSetupAsync } from './utils/typescript/ensureTypeScriptSetup';
 
-type NormalizedOptions = URLOptions & {
-  webOnly?: boolean;
-  dev?: boolean;
-  minify?: boolean;
-  https?: boolean;
-  nonInteractive?: boolean;
-  clear?: boolean;
-  maxWorkers?: number;
-  sendTo?: string;
-  host?: string;
-  lan?: boolean;
-  localhost?: boolean;
-  tunnel?: boolean;
-};
-
-type Options = NormalizedOptions & {
-  parent?: { nonInteractive: boolean; rawArgs: string[] };
-};
-
-function hasBooleanArg(rawArgs: string[], argName: string): boolean {
-  return rawArgs.includes('--' + argName) || rawArgs.includes('--no-' + argName);
-}
-
-function getBooleanArg(rawArgs: string[], argName: string): boolean {
-  if (rawArgs.includes('--' + argName)) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-// The main purpose of this function is to take existing options object and
-// support boolean args with as defined in the hasBooleanArg and getBooleanArg
-// functions.
-async function normalizeOptionsAsync(
-  projectDir: string,
-  options: Options
-): Promise<NormalizedOptions> {
-  const opts: NormalizedOptions = {
-    ...options, // This is necessary to ensure we don't drop any options
-    webOnly: !!options.webOnly, // This is only ever true in the start:web command
-    nonInteractive: options.parent?.nonInteractive,
-  };
-
-  const rawArgs = options.parent?.rawArgs || [];
-
-  if (hasBooleanArg(rawArgs, 'dev')) {
-    opts.dev = getBooleanArg(rawArgs, 'dev');
-  } else {
-    opts.dev = true;
-  }
-  if (hasBooleanArg(rawArgs, 'minify')) {
-    opts.minify = getBooleanArg(rawArgs, 'minify');
-  } else {
-    opts.minify = false;
-  }
-  if (hasBooleanArg(rawArgs, 'https')) {
-    opts.https = getBooleanArg(rawArgs, 'https');
-  } else {
-    opts.https = false;
-  }
-
-  if (hasBooleanArg(rawArgs, 'android')) {
-    opts.android = getBooleanArg(rawArgs, 'android');
-  }
-
-  if (hasBooleanArg(rawArgs, 'ios')) {
-    opts.ios = getBooleanArg(rawArgs, 'ios');
-  }
-
-  if (hasBooleanArg(rawArgs, 'web')) {
-    opts.web = getBooleanArg(rawArgs, 'web');
-  }
-
-  if (hasBooleanArg(rawArgs, 'localhost')) {
-    opts.localhost = getBooleanArg(rawArgs, 'localhost');
-  }
-
-  if (hasBooleanArg(rawArgs, 'lan')) {
-    opts.lan = getBooleanArg(rawArgs, 'lan');
-  }
-
-  if (hasBooleanArg(rawArgs, 'tunnel')) {
-    opts.tunnel = getBooleanArg(rawArgs, 'tunnel');
-  }
-
-  await cacheOptionsAsync(projectDir, opts);
-  return opts;
-}
-
-async function cacheOptionsAsync(projectDir: string, options: NormalizedOptions): Promise<void> {
-  await ProjectSettings.setAsync(projectDir, {
-    devClient: options.devClient,
-    scheme: options.scheme,
-    dev: options.dev,
-    minify: options.minify,
-    https: options.https,
-  });
-}
-
-function parseStartOptions(options: NormalizedOptions, exp: ExpoConfig): Project.StartOptions {
-  const startOpts: Project.StartOptions = {};
-
-  if (options.clear) {
-    startOpts.reset = true;
-  }
-
-  if (options.nonInteractive) {
-    startOpts.nonInteractive = true;
-  }
-
-  if (options.webOnly) {
-    startOpts.webOnly = true;
-  }
-
-  if (options.maxWorkers) {
-    startOpts.maxWorkers = options.maxWorkers;
-  }
-
-  if (options.devClient) {
-    startOpts.devClient = true;
-  }
-
-  if (isLegacyImportsEnabled(exp)) {
-    // For `expo start`, the default target is 'managed', for both managed *and* bare apps.
-    // See: https://docs.expo.io/bare/using-expo-client
-    startOpts.target = options.devClient ? 'bare' : 'managed';
-    Log.debug('Using target: ', startOpts.target);
-  }
-
-  return startOpts;
-}
-
-async function action(projectDir: string, options: NormalizedOptions): Promise<void> {
-  Log.log(chalk.gray(`Starting project at ${projectDir}`));
+async function action(projectRoot: string, options: NormalizedOptions): Promise<void> {
+  Log.log(chalk.gray(`Starting project at ${projectRoot}`));
 
   // Add clean up hooks
-  installExitHooks(projectDir);
+  installExitHooks(projectRoot);
 
-  const { exp, pkg } = getConfig(projectDir, {
+  const { exp, pkg } = getConfig(projectRoot, {
     skipSDKVersionRequirement: options.webOnly,
   });
 
   // Assert various random things
   // TODO: split up this method
-  await urlOpts.optsAsync(projectDir, options);
+  await urlOpts.optsAsync(projectRoot, options);
 
   // TODO: This is useless on mac, check if useless on win32
-  const rootPath = path.resolve(projectDir);
+  const rootPath = path.resolve(projectRoot);
 
   // Optionally open the developer tools UI.
   await tryOpeningDevToolsAsync(rootPath, {
@@ -170,17 +43,17 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
   });
 
   if (Versions.gteSdkVersion(exp, '34.0.0')) {
-    await ensureTypeScriptSetupAsync(projectDir);
+    await ensureTypeScriptSetupAsync(projectRoot);
   }
 
   if (!options.webOnly) {
     // TODO: only validate dependencies if starting in managed workflow
-    await validateDependenciesVersionsAsync(projectDir, exp, pkg);
+    await validateDependenciesVersionsAsync(projectRoot, exp, pkg);
     // Warn about expo extensions.
     if (!isLegacyImportsEnabled(exp)) {
       // Adds a few seconds in basic projects so we should
       // drop this in favor of the upgrade version as soon as possible.
-      await assertProjectHasExpoExtensionFilesAsync(projectDir);
+      await assertProjectHasExpoExtensionFilesAsync(projectRoot);
     }
   }
 
@@ -189,20 +62,20 @@ async function action(projectDir: string, options: NormalizedOptions): Promise<v
   await Project.startAsync(rootPath, { ...startOptions, exp });
 
   // Send to option...
-  const url = await UrlUtils.constructDeepLinkAsync(projectDir);
+  const url = await UrlUtils.constructDeepLinkAsync(projectRoot);
   const recipient = await sendTo.getRecipient(options.sendTo);
   if (recipient) {
     await sendTo.sendUrlAsync(url, recipient);
   }
 
   // Open project on devices.
-  await urlOpts.handleMobileOptsAsync(projectDir, options);
+  await urlOpts.handleMobileOptsAsync(projectRoot, options);
 
   // Present the Terminal UI.
   const isTerminalUIEnabled = !options.nonInteractive && !exp.isDetached;
 
   if (isTerminalUIEnabled) {
-    await TerminalUI.startAsync(projectDir, startOptions);
+    await TerminalUI.startAsync(projectRoot, startOptions);
   } else {
     if (!exp.isDetached) {
       Log.newLine();

--- a/packages/expo-cli/src/commands/start/__tests__/parseStartOptions-test.ts
+++ b/packages/expo-cli/src/commands/start/__tests__/parseStartOptions-test.ts
@@ -1,0 +1,35 @@
+import { parseRawArguments, setBooleanArg } from '../parseStartOptions';
+
+describe(setBooleanArg, () => {
+  it(`uses fallback`, () => {
+    expect(setBooleanArg('dev', [], true)).toBe(true);
+  });
+  it(`uses true value first`, () => {
+    expect(setBooleanArg('dev', ['--no-dev', '--dev'])).toBe(true);
+  });
+  it(`uses false value`, () => {
+    expect(setBooleanArg('dev', ['--no-dev'])).toBe(false);
+  });
+});
+
+describe(parseRawArguments, () => {
+  it(`args overwrite incoming options`, () => {
+    expect(
+      parseRawArguments(
+        {
+          dev: true,
+        },
+        ['--no-dev']
+      ).dev
+    ).toBe(false);
+
+    expect(
+      parseRawArguments(
+        {
+          dev: false,
+        },
+        []
+      ).dev
+    ).toBe(true);
+  });
+});

--- a/packages/expo-cli/src/commands/start/openDevTools.ts
+++ b/packages/expo-cli/src/commands/start/openDevTools.ts
@@ -1,0 +1,28 @@
+import { ExpoConfig } from '@expo/config';
+// @ts-ignore: not typed
+import { DevToolsServer } from '@expo/dev-tools';
+import { UserSettings } from '@expo/xdl';
+import chalk from 'chalk';
+
+import Log from '../../log';
+import * as TerminalUI from './TerminalUI';
+
+export async function tryOpeningDevToolsAsync(
+  projectRoot: string,
+  {
+    exp,
+    options,
+  }: {
+    exp: Pick<ExpoConfig, 'isDetached'>;
+    options: { nonInteractive?: boolean };
+  }
+): Promise<void> {
+  const devToolsUrl = await DevToolsServer.startAsync(projectRoot);
+  Log.log(`Developer tools running on ${chalk.underline(devToolsUrl)}`);
+
+  if (!options.nonInteractive && !exp.isDetached) {
+    if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
+      TerminalUI.openDeveloperTools(devToolsUrl);
+    }
+  }
+}

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -1,0 +1,141 @@
+import { ExpoConfig, isLegacyImportsEnabled } from '@expo/config';
+import { Project, ProjectSettings } from '@expo/xdl';
+
+import Log from '../../log';
+import { URLOptions } from '../../urlOpts';
+
+export type NormalizedOptions = URLOptions & {
+  webOnly?: boolean;
+  dev?: boolean;
+  minify?: boolean;
+  https?: boolean;
+  nonInteractive?: boolean;
+  clear?: boolean;
+  maxWorkers?: number;
+  sendTo?: string;
+  host?: string;
+  lan?: boolean;
+  localhost?: boolean;
+  tunnel?: boolean;
+};
+
+export type Options = NormalizedOptions & {
+  parent?: { nonInteractive: boolean; rawArgs: string[] };
+};
+
+function hasBooleanArg(rawArgs: string[], argName: string): boolean {
+  return rawArgs.includes('--' + argName) || rawArgs.includes('--no-' + argName);
+}
+
+function getBooleanArg(rawArgs: string[], argName: string): boolean {
+  if (rawArgs.includes('--' + argName)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// The main purpose of this function is to take existing options object and
+// support boolean args with as defined in the hasBooleanArg and getBooleanArg
+// functions.
+export async function normalizeOptionsAsync(
+  projectDir: string,
+  options: Options
+): Promise<NormalizedOptions> {
+  const opts: NormalizedOptions = {
+    ...options, // This is necessary to ensure we don't drop any options
+    webOnly: !!options.webOnly, // This is only ever true in the start:web command
+    nonInteractive: options.parent?.nonInteractive,
+  };
+
+  const rawArgs = options.parent?.rawArgs || [];
+
+  if (hasBooleanArg(rawArgs, 'dev')) {
+    opts.dev = getBooleanArg(rawArgs, 'dev');
+  } else {
+    opts.dev = true;
+  }
+  if (hasBooleanArg(rawArgs, 'minify')) {
+    opts.minify = getBooleanArg(rawArgs, 'minify');
+  } else {
+    opts.minify = false;
+  }
+  if (hasBooleanArg(rawArgs, 'https')) {
+    opts.https = getBooleanArg(rawArgs, 'https');
+  } else {
+    opts.https = false;
+  }
+
+  if (hasBooleanArg(rawArgs, 'android')) {
+    opts.android = getBooleanArg(rawArgs, 'android');
+  }
+
+  if (hasBooleanArg(rawArgs, 'ios')) {
+    opts.ios = getBooleanArg(rawArgs, 'ios');
+  }
+
+  if (hasBooleanArg(rawArgs, 'web')) {
+    opts.web = getBooleanArg(rawArgs, 'web');
+  }
+
+  if (hasBooleanArg(rawArgs, 'localhost')) {
+    opts.localhost = getBooleanArg(rawArgs, 'localhost');
+  }
+
+  if (hasBooleanArg(rawArgs, 'lan')) {
+    opts.lan = getBooleanArg(rawArgs, 'lan');
+  }
+
+  if (hasBooleanArg(rawArgs, 'tunnel')) {
+    opts.tunnel = getBooleanArg(rawArgs, 'tunnel');
+  }
+
+  await cacheOptionsAsync(projectDir, opts);
+  return opts;
+}
+
+async function cacheOptionsAsync(projectDir: string, options: NormalizedOptions): Promise<void> {
+  await ProjectSettings.setAsync(projectDir, {
+    devClient: options.devClient,
+    scheme: options.scheme,
+    dev: options.dev,
+    minify: options.minify,
+    https: options.https,
+  });
+}
+
+export function parseStartOptions(
+  options: NormalizedOptions,
+  exp: ExpoConfig
+): Project.StartOptions {
+  const startOpts: Project.StartOptions = {};
+
+  if (options.clear) {
+    startOpts.reset = true;
+  }
+
+  if (options.nonInteractive) {
+    startOpts.nonInteractive = true;
+  }
+
+  if (options.webOnly) {
+    startOpts.webOnly = true;
+  }
+
+  if (options.maxWorkers) {
+    startOpts.maxWorkers = options.maxWorkers;
+  }
+
+  if (options.devClient) {
+    startOpts.devClient = true;
+  }
+
+  if (isLegacyImportsEnabled(exp)) {
+    // For `expo start`, the default target is 'managed', for both managed *and* bare apps.
+    // See: https://docs.expo.io/bare/using-expo-client
+    startOpts.target = options.devClient ? 'bare' : 'managed';
+    Log.debug('Using target: ', startOpts.target);
+  }
+
+  return startOpts;
+}

--- a/packages/expo-cli/src/commands/start/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/start/validateDependenciesVersions.ts
@@ -1,0 +1,67 @@
+import { ExpoConfig, PackageJSONConfig } from '@expo/config';
+import JsonFile from '@expo/json-file';
+import { Versions } from '@expo/xdl';
+import chalk from 'chalk';
+import intersection from 'lodash/intersection';
+import resolveFrom from 'resolve-from';
+import semver from 'semver';
+
+import Log from '../../log';
+
+export async function validateDependenciesVersionsAsync(
+  projectRoot: string,
+  exp: ExpoConfig,
+  pkg: PackageJSONConfig
+): Promise<void> {
+  if (!Versions.gteSdkVersion(exp, '33.0.0')) {
+    return;
+  }
+
+  const bundleNativeModulesPath = resolveFrom.silent(projectRoot, 'expo/bundledNativeModules.json');
+  if (!bundleNativeModulesPath) {
+    Log.warn(
+      `Your project is in SDK version >= 33.0.0, but the ${chalk.underline(
+        'expo'
+      )} package version seems to be older.`
+    );
+    return;
+  }
+
+  const bundledNativeModules = await JsonFile.readAsync(bundleNativeModulesPath);
+  const bundledNativeModulesNames = Object.keys(bundledNativeModules);
+  const projectDependencies = Object.keys(pkg.dependencies || []);
+
+  const modulesToCheck = intersection(bundledNativeModulesNames, projectDependencies);
+  const incorrectDeps = [];
+  for (const moduleName of modulesToCheck) {
+    const expectedRange = bundledNativeModules[moduleName];
+    const actualRange = pkg.dependencies[moduleName];
+    if (
+      (semver.valid(actualRange) || semver.validRange(actualRange)) &&
+      typeof expectedRange === 'string' &&
+      !semver.intersects(expectedRange, actualRange)
+    ) {
+      incorrectDeps.push({
+        moduleName,
+        expectedRange,
+        actualRange,
+      });
+    }
+  }
+  if (incorrectDeps.length > 0) {
+    Log.warn('Some dependencies are incompatible with the installed expo package version:');
+    incorrectDeps.forEach(({ moduleName, expectedRange, actualRange }) => {
+      Log.warn(
+        ` - ${chalk.underline(moduleName)} - expected version range: ${chalk.underline(
+          expectedRange
+        )} - actual version installed: ${chalk.underline(actualRange)}`
+      );
+    });
+    Log.warn(
+      'Your project may not work correctly until you install the correct versions of the packages.\n' +
+        `To install the correct versions of these packages, please run: ${chalk.inverse(
+          'expo install [package-name ...]'
+        )}`
+    );
+  }
+}


### PR DESCRIPTION
# Why

Start command is really large and confusing for a script that mostly just starts an https server. This PR aims to simplify the args parsing, merge `start` and `start:web`, reuse types, add more strict typing, and add more tests.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- split up the start command file.
- merge `start:web` logic into `start`.
- move args parsing into it's own file and reuse some commander logic to simplify the amount of steps.
- add tests to the remaining ambiguous functionality of start args.
- add more comments.

# Test Plan

- unit tests should cover most functionality changes related to args
- test that start works as expected
- test start:web stops correctly
- test `expo start --lan --localhost --tunnel --host lan` throws an error
