### PR TITLE
Added unversioned document picker plugin

### DIFF
--- a/packages/config-plugins/src/ios/Entitlements.ts
+++ b/packages/config-plugins/src/ios/Entitlements.ts
@@ -3,9 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import slash from 'slash';
 
-import { ConfigPlugin } from '../Plugin.types';
-import { createEntitlementsPlugin, withEntitlementsPlist } from '../plugins/ios-plugins';
-import * as WarningAggregator from '../utils/warnings';
+import { createEntitlementsPlugin } from '../plugins/ios-plugins';
 import { InfoPlist } from './IosConfig.types';
 import * as Paths from './Paths';
 import {
@@ -34,16 +32,6 @@ export const withAppleSignInEntitlement = createEntitlementsPlugin(
   'withAppleSignInEntitlement'
 );
 
-export const withICloudEntitlement: ConfigPlugin<{ appleTeamId: string }> = (
-  config,
-  { appleTeamId }
-) => {
-  return withEntitlementsPlist(config, config => {
-    config.modResults = setICloudEntitlement(config, config.modResults, appleTeamId);
-    return config;
-  });
-};
-
 // TODO: should it be possible to turn off these entitlements by setting false in app.json and running apply
 
 export function getConfigEntitlements(config: ExpoConfig) {
@@ -57,23 +45,6 @@ export function setCustomEntitlementsEntries(config: ExpoConfig, entitlements: I
     ...entitlements,
     ...entries,
   };
-}
-
-export function setICloudEntitlement(
-  config: ExpoConfig,
-  entitlementsPlist: Plist,
-  appleTeamId: string
-): Plist {
-  if (config.ios?.usesIcloudStorage) {
-    // TODO: need access to the appleTeamId for this one!
-    WarningAggregator.addWarningIOS(
-      'ios.usesIcloudStorage',
-      'Enable the iCloud Storage Entitlement from the Capabilities tab in your Xcode project.'
-      // TODO: add a link to a docs page with more information on how to do this
-    );
-  }
-
-  return entitlementsPlist;
 }
 
 export function setAppleSignInEntitlement(

--- a/packages/config-plugins/src/plugins/__tests__/__snapshots__/expo-plugins-test.ts.snap
+++ b/packages/config-plugins/src/plugins/__tests__/__snapshots__/expo-plugins-test.ts.snap
@@ -12,6 +12,10 @@ Object {
         "name": "expo-branch",
         "version": "UNVERSIONED",
       },
+      "expo-document-picker": Object {
+        "name": "expo-document-picker",
+        "version": "UNVERSIONED",
+      },
       "expo-facebook": Object {
         "name": "expo-facebook",
         "version": "UNVERSIONED",

--- a/packages/config-plugins/src/plugins/expo-plugins.ts
+++ b/packages/config-plugins/src/plugins/expo-plugins.ts
@@ -7,6 +7,7 @@ import * as IOSConfig from '../ios';
 import { withPlugins } from './core-plugins';
 import withAdMob from './unversioned/expo-ads-admob';
 import withBranch from './unversioned/expo-branch';
+import withDocumentPicker from './unversioned/expo-document-picker';
 import withFacebook from './unversioned/expo-facebook';
 import withNotifications from './unversioned/expo-notifications';
 import withSplashScreen from './unversioned/expo-splash-screen';
@@ -39,8 +40,6 @@ export const withExpoIOSPlugins: ConfigPlugin<{
     // Entitlements
     IOSConfig.Entitlements.withAppleSignInEntitlement,
     IOSConfig.Entitlements.withAccessesContactNotes,
-    // TODO: We don't have a mechanism for getting the apple team id here yet
-    [IOSConfig.Entitlements.withICloudEntitlement, { appleTeamId: 'TODO-GET-APPLE-TEAM-ID' }],
     IOSConfig.Entitlements.withAssociatedDomains,
     // XcodeProject
     IOSConfig.DeviceFamily.withDeviceFamily,
@@ -114,6 +113,7 @@ export const withExpoVersionedSDKPlugins: ConfigPlugin<{ expoUsername: string | 
     withNotifications,
     [withUpdates, { expoUsername }],
     withBranch,
+    withDocumentPicker,
     withFacebook,
     withSplashScreen,
   ]);

--- a/packages/config-plugins/src/plugins/unversioned/expo-document-picker.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-document-picker.ts
@@ -1,0 +1,50 @@
+import { ExpoConfig } from '@expo/config-types';
+import { JSONObject } from '@expo/json-file';
+
+import { ConfigPlugin } from '../../Plugin.types';
+import * as WarningAggregator from '../../utils/warnings';
+import { createRunOncePlugin } from '../core-plugins';
+import { withEntitlementsPlist } from '../ios-plugins';
+import { withStaticPlugin } from '../static-plugins';
+
+const packageName = 'expo-document-picker';
+
+const withICloudEntitlement: ConfigPlugin<{ appleTeamId: string }> = (config, { appleTeamId }) => {
+  return withEntitlementsPlist(config, config => {
+    config.modResults = setICloudEntitlement(config, config.modResults, appleTeamId);
+    return config;
+  });
+};
+
+function setICloudEntitlement(
+  config: ExpoConfig,
+  entitlementsPlist: JSONObject,
+  appleTeamId: string
+): JSONObject {
+  if (config.ios?.usesIcloudStorage) {
+    // TODO: need access to the appleTeamId for this one!
+    WarningAggregator.addWarningIOS(
+      'ios.usesIcloudStorage',
+      'Enable the iCloud Storage Entitlement from the Capabilities tab in your Xcode project.'
+      // TODO: add a link to a docs page with more information on how to do this
+    );
+  }
+
+  return entitlementsPlist;
+}
+
+const withUnversionedDocumentPicker: ConfigPlugin = createRunOncePlugin(config => {
+  // No mechanism to get Apple Team ID.
+  config = withICloudEntitlement(config, { appleTeamId: 'TODO-GET-APPLE-TEAM-ID' });
+  return config;
+}, packageName);
+
+const withDocumentPicker: ConfigPlugin = config => {
+  return withStaticPlugin(config, {
+    plugin: packageName,
+    // If the static plugin isn't found, use the unversioned one.
+    fallback: withUnversionedDocumentPicker,
+  });
+};
+
+export default withDocumentPicker;


### PR DESCRIPTION
# Why

- https://github.com/expo/expo/pull/11977
- this will get disabled when someone uses the versioned copy
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
