### PR TITLE
Added system for hiding legacy plugin errors

### DIFF
--- a/packages/config-plugins/README.md
+++ b/packages/config-plugins/README.md
@@ -462,5 +462,5 @@ Because of this reasoning, the root of a Node module is searched instead of righ
 
 ## Debugging
 
-You can debug config plugins by running `expo prebuild`. If `EXPO_DEBUG` is enabled, the plugin stack logs will be printed, these are useful for viewing which mods ran, and in what order they ran in. To view all static plugin resolution errors, enable `EXPO_CONFIG_PLUGIN_VERBOSE`, this should only be needed for plugin authors.
+You can debug config plugins by running `expo prebuild`. If `EXPO_DEBUG` is enabled, the plugin stack logs will be printed, these are useful for viewing which mods ran, and in what order they ran in. To view all static plugin resolution errors, enable `EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS`, this should only be needed for plugin authors.
 By default some automatic plugin errors are hidden because they're usually related to versioning issues and aren't very helpful (i.e. legacy package doesn't have a config plugin yet).

--- a/packages/config-plugins/README.md
+++ b/packages/config-plugins/README.md
@@ -459,3 +459,8 @@ Because of this reasoning, the root of a Node module is searched instead of righ
 [cli-eject]: https://docs.expo.io/workflow/expo-cli/#eject
 [sandbox]: https://codesandbox.io/s/expo-config-plugins-8qhof?file=/src/project/app.config.js
 [configplugin]: ./src/Plugin.types.ts
+
+## Debugging
+
+You can debug config plugins by running `expo prebuild`. If `EXPO_DEBUG` is enabled, the plugin stack logs will be printed, these are useful for viewing which mods ran, and in what order they ran in. To view all static plugin resolution errors, enable `EXPO_CONFIG_PLUGIN_VERBOSE`, this should only be needed for plugin authors.
+By default some automatic plugin errors are hidden because they're usually related to versioning issues and aren't very helpful (i.e. legacy package doesn't have a config plugin yet).

--- a/packages/config-plugins/src/plugins/static-plugins.ts
+++ b/packages/config-plugins/src/plugins/static-plugins.ts
@@ -9,7 +9,7 @@ import {
 } from '../utils/plugin-resolver';
 
 const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
-const EXPO_CONFIG_PLUGIN_VERBOSE = boolish('EXPO_CONFIG_PLUGIN_VERBOSE', false);
+const EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS = boolish('EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS', false);
 
 function isModuleMissingError(name: string, error: Error): boolean {
   // @ts-ignore
@@ -67,7 +67,7 @@ export const withStaticPlugin: ConfigPlugin<{
       withPlugin = resolveConfigPluginFunction(projectRoot, pluginResolve);
     } catch (error) {
       if (EXPO_DEBUG) {
-        if (EXPO_CONFIG_PLUGIN_VERBOSE) {
+        if (EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS) {
           // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
           console.log(`Error resolving plugin "${pluginResolve}"`);
           console.log(error);

--- a/packages/config-plugins/src/plugins/static-plugins.ts
+++ b/packages/config-plugins/src/plugins/static-plugins.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils/plugin-resolver';
 
 const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
+const EXPO_CONFIG_PLUGIN_VERBOSE = boolish('EXPO_CONFIG_PLUGIN_VERBOSE', false);
 
 function isModuleMissingError(name: string, error: Error): boolean {
   // @ts-ignore
@@ -66,18 +67,25 @@ export const withStaticPlugin: ConfigPlugin<{
       withPlugin = resolveConfigPluginFunction(projectRoot, pluginResolve);
     } catch (error) {
       if (EXPO_DEBUG) {
-        const shouldMuteWarning =
-          props._isLegacyPlugin &&
-          (isModuleMissingError(pluginResolve, error) || isUnexpectedTokenError(error));
-        if (!shouldMuteWarning) {
-          if (isModuleMissingError(pluginResolve, error)) {
-            // Prevent causing log spew for basic resolution errors.
-            console.log(`Could not find plugin "${pluginResolve}"`);
-          } else {
-            // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
-            console.log(`Error resolving plugin "${pluginResolve}"`);
-            console.log(error);
-            console.log();
+        if (EXPO_CONFIG_PLUGIN_VERBOSE) {
+          // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
+          console.log(`Error resolving plugin "${pluginResolve}"`);
+          console.log(error);
+          console.log();
+        } else {
+          const shouldMuteWarning =
+            props._isLegacyPlugin &&
+            (isModuleMissingError(pluginResolve, error) || isUnexpectedTokenError(error));
+          if (!shouldMuteWarning) {
+            if (isModuleMissingError(pluginResolve, error)) {
+              // Prevent causing log spew for basic resolution errors.
+              console.log(`Could not find plugin "${pluginResolve}"`);
+            } else {
+              // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).
+              console.log(`Error resolving plugin "${pluginResolve}"`);
+              console.log(error);
+              console.log();
+            }
           }
         }
       }

--- a/packages/config-plugins/src/plugins/static-plugins.ts
+++ b/packages/config-plugins/src/plugins/static-plugins.ts
@@ -20,7 +20,10 @@ function isModuleMissingError(name: string, error: Error): boolean {
 
 function isUnexpectedTokenError(error: Error): boolean {
   if (error instanceof SyntaxError) {
-    return !!error.message.match(/Unexpected token/);
+    return (
+      !!error.message.match(/Unexpected token/) ||
+      !!error.message.match(/Cannot use import statement/)
+    );
   }
   return false;
 }

--- a/packages/config-plugins/src/plugins/static-plugins.ts
+++ b/packages/config-plugins/src/plugins/static-plugins.ts
@@ -21,6 +21,7 @@ function isModuleMissingError(name: string, error: Error): boolean {
 function isUnexpectedTokenError(error: Error): boolean {
   if (error instanceof SyntaxError) {
     return (
+      // These are the most common errors that'll be thrown when a package isn't transpiled correctly.
       !!error.message.match(/Unexpected token/) ||
       !!error.message.match(/Cannot use import statement/)
     );

--- a/packages/config-plugins/src/plugins/unversioned/expo-ads-admob.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-ads-admob.ts
@@ -8,6 +8,7 @@ const packageName = 'expo-ads-admob';
 
 export const withAdMob: ConfigPlugin = config => {
   return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
     plugin: packageName,
     // If the static plugin isn't found, use the unversioned one.
     fallback: withUnversionedAdMob,

--- a/packages/config-plugins/src/plugins/unversioned/expo-apple-authentication.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-apple-authentication.ts
@@ -29,6 +29,7 @@ function setAppleSignInEntitlement(
 
 export const withAppleAuthentication: ConfigPlugin = config => {
   return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
     plugin: packageName,
     // If the static plugin isn't found, use the unversioned one.
     fallback: withUnversionedAppleAuthentication,

--- a/packages/config-plugins/src/plugins/unversioned/expo-branch.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-branch.ts
@@ -8,6 +8,7 @@ const packageName = 'expo-branch';
 
 export const withBranch: ConfigPlugin = config => {
   return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
     plugin: packageName,
     // If the static plugin isn't found, use the unversioned one.
     fallback: withUnversionedBranch,

--- a/packages/config-plugins/src/plugins/unversioned/expo-document-picker.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-document-picker.ts
@@ -41,6 +41,7 @@ const withUnversionedDocumentPicker: ConfigPlugin = createRunOncePlugin(config =
 
 const withDocumentPicker: ConfigPlugin = config => {
   return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
     plugin: packageName,
     // If the static plugin isn't found, use the unversioned one.
     fallback: withUnversionedDocumentPicker,

--- a/packages/config-plugins/src/plugins/unversioned/expo-facebook.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-facebook.ts
@@ -10,6 +10,7 @@ const packageName = 'expo-facebook';
 
 export const withFacebook: ConfigPlugin = config => {
   return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
     plugin: packageName,
     // If the static plugin isn't found, use the unversioned one.
     fallback: withUnversionedFacebook,

--- a/packages/config-plugins/src/plugins/unversioned/expo-notifications.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-notifications.ts
@@ -12,6 +12,7 @@ const packageName = 'expo-notifications';
 
 export const withNotifications: ConfigPlugin = config => {
   return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
     plugin: packageName,
     // If the static plugin isn't found, use the unversioned one.
     fallback: withUnversionedNotifications,

--- a/packages/config-plugins/src/plugins/unversioned/expo-splash-screen.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-splash-screen.ts
@@ -8,6 +8,7 @@ const packageName = 'expo-splash-screen';
 
 export const withSplashScreen: ConfigPlugin = config => {
   return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
     plugin: packageName,
     // If the static plugin isn't found, use the unversioned one.
     fallback: withUnversionedSplashScreen,

--- a/packages/config-plugins/src/plugins/unversioned/expo-updates.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-updates.ts
@@ -10,6 +10,7 @@ const packageName = 'expo-updates';
 
 export const withUpdates: ConfigPlugin<{ expoUsername: string }> = (config, props) => {
   return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
     plugin: packageName,
     // If the static plugin isn't found, use the unversioned one.
     fallback: config => withUnversionedUpdates(config, props),

--- a/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
@@ -56,6 +56,8 @@ const expoManagedVersionedPlugins = [
 const withOptionalPlugins: ConfigPlugin<(StaticPlugin | string)[]> = (config, plugins) => {
   return plugins.reduce((prev, plugin) => {
     return withStaticPlugin(prev, {
+      // hide errors
+      _isLegacyPlugin: true,
       plugin,
       // If a plugin doesn't exist, do nothing.
       fallback: config => config,


### PR DESCRIPTION
# Why

The error output that is generated in EAS build (EXPO_DEBUG) when running `expo prebuild` is very verbose and concerning. Errors are generated by auto plugins that aren't configured to support config plugins yet (older versions, support not added yet). Since these packages are managed by Expo, it seems safe to assume that they'll be built properly.

Just for the sake of debugging, I've added `EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS` which can be enabled to debug all of the errors. This **should not** be enabled in EAS build.

# Test Plan

- `EXPO_DEBUG=1 expo prebuild --no-install` in NCL should produce no errors.
- `EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS=1 expo prebuild --no-install` in NCL should show all default plugin resolution errors.