### PR TITLE
[config-plugins] Pass updates props to plugin

### DIFF
--- a/packages/config-plugins/src/plugins/unversioned/expo-updates.ts
+++ b/packages/config-plugins/src/plugins/unversioned/expo-updates.ts
@@ -10,7 +10,8 @@ const packageName = 'expo-updates';
 
 export const withUpdates: ConfigPlugin<{ expoUsername: string }> = (config, props) => {
   return withStaticPlugin(config, {
-    plugin: packageName,
+    // Pass props to the static plugin if it exists.
+    plugin: [packageName, props],
     // If the static plugin isn't found, use the unversioned one.
     fallback: config => withUnversionedUpdates(config, props),
   });


### PR DESCRIPTION
# Why

- Passes the expo username to the versioned plugin if it exists, this allows for the expo-updates plugin to be agnostic of the Expo user management (expo/xdl).  https://github.com/expo/expo/pull/11981
