### PR TITLE
Make TSConfig less strict by default

### DIFF
--- a/packages/expo-cli/src/commands/utils/typescript/__tests__/updateTSConfig-test.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/__tests__/updateTSConfig-test.ts
@@ -78,7 +78,7 @@ describe(updateTSConfigAsync, () => {
     });
   });
 
-  it(`forces the base config to be Expo`, async () => {
+  it(`does not force the base config to be Expo`, async () => {
     vol.fromJSON({
       '/tsconfig.json': '{ "extends": "foobar", "compilerOptions": { "strict": true } }',
     });
@@ -91,7 +91,7 @@ describe(updateTSConfigAsync, () => {
     });
 
     expect(JSON.parse(await fs.readFile('/tsconfig.json', 'utf8'))).toStrictEqual({
-      extends: 'expo/tsconfig.base',
+      extends: 'foobar',
       compilerOptions: {
         strict: true,
       },

--- a/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/updateTSConfig.ts
@@ -36,7 +36,9 @@ export async function updateTSConfigAsync({
   // If the default TSConfig template exists (SDK +41), then use it in the project
   const hasTemplateTsconfig = resolveBaseTSConfig(projectRoot);
   if (hasTemplateTsconfig) {
-    if (projectTSConfig.extends !== baseTSConfigName) {
+    // If the extends field isn't defined, set it to the expo default
+    if (!projectTSConfig.extends) {
+      // if (projectTSConfig.extends !== baseTSConfigName) {
       projectTSConfig.extends = baseTSConfigName;
       modifications.push(['extends', baseTSConfigName]);
     }


### PR DESCRIPTION
- resolves https://github.com/expo/expo-cli/issues/3220
- instead of rewriting the extends value, we'll only add it.
