### PR TITLE
[eject] Added prompt to clear malformed projects

### DIFF
--- a/packages/config-plugins/src/android/Paths.ts
+++ b/packages/config-plugins/src/android/Paths.ts
@@ -105,6 +105,7 @@ export async function getAndroidManifestAsync(projectRoot: string): Promise<stri
   const filePath = path.join(projectPath, 'app/src/main/AndroidManifest.xml');
   return filePath;
 }
+
 export async function getResourceFolderAsync(projectRoot: string): Promise<string> {
   const projectPath = await getProjectPathOrThrowAsync(projectRoot);
   return path.join(projectPath, `app/src/main/res`);

--- a/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
+++ b/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
@@ -1,7 +1,16 @@
-import fs from 'fs-extra';
-import path from 'path';
+import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
+import chalk from 'chalk';
+import program from 'commander';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 
+import Log from '../../log';
+import { confirmAsync } from '../../prompts';
 import * as CreateApp from '../utils/CreateApp';
+
+async function directoryExistsAsync(file: string): Promise<boolean> {
+  return (await fs.stat(file).catch(() => null))?.isDirectory() ?? false;
+}
 
 export async function clearNativeFolder(projectRoot: string, folders: string[]) {
   const step = CreateApp.logNewSection(`Clearing ${folders.join(', ')}`);
@@ -11,5 +20,80 @@ export async function clearNativeFolder(projectRoot: string, folders: string[]) 
   } catch (error) {
     step.fail(`Failed to delete ${folders.join(', ')} code: ${error.message}`);
     throw error;
+  }
+}
+
+async function isAndroidProjectValidAsync(projectRoot: string) {
+  // Only perform the check if the native folder is present.
+  if (!(await directoryExistsAsync(path.join(projectRoot, 'android')))) {
+    return true;
+  }
+  try {
+    await Promise.all([
+      AndroidConfig.Paths.getAppBuildGradleAsync(projectRoot),
+      AndroidConfig.Paths.getProjectBuildGradleAsync(projectRoot),
+      AndroidConfig.Paths.getAndroidManifestAsync(projectRoot),
+      AndroidConfig.Paths.getMainApplicationAsync(projectRoot),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isIOSProjectValidAsync(projectRoot: string) {
+  // Only perform the check if the native folder is present.
+  if (!(await directoryExistsAsync(path.join(projectRoot, 'ios')))) {
+    return true;
+  }
+  try {
+    // If any of the following required files are missing, then the project is malformed.
+    await Promise.all([
+      IOSConfig.Paths.getAppDelegate(projectRoot),
+      IOSConfig.Paths.getAllXcodeProjectPaths(projectRoot),
+      IOSConfig.Paths.getAllInfoPlistPaths(projectRoot),
+      IOSConfig.Paths.getAllPBXProjectPaths(projectRoot),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function promptToClearMalformedNativeProjectsAsync(projectRoot: string) {
+  const [isAndroidValid, isIOSValid] = await Promise.all([
+    isAndroidProjectValidAsync(projectRoot),
+    isIOSProjectValidAsync(projectRoot),
+  ]);
+
+  if (isAndroidValid && isIOSValid) {
+    return;
+  }
+
+  const platforms = [!isAndroidValid && 'android', !isIOSValid && 'ios'].filter(
+    Boolean
+  ) as string[];
+
+  const displayPlatforms = platforms.map(platform => chalk.cyan(platform));
+  // Prompt which platforms to reset.
+  const message =
+    platforms.length > 1
+      ? `The ${displayPlatforms[0]} and ${displayPlatforms[1]} projects are malformed`
+      : `The ${displayPlatforms[0]} project is malformed`;
+
+  if (
+    // If the process is non-interactive, default to clearing the malformed native project.
+    // This would only happen on re-running eject.
+    program.nonInteractive ||
+    // Prompt to clear the native folders.
+    (await confirmAsync({
+      message: `${message}, would you like to clear before prebuilding?`,
+      initial: true,
+    }))
+  ) {
+    await clearNativeFolder(projectRoot, platforms);
+  } else {
+    // Warn the user that the process may fail.
+    Log.warn('Continuing with malformed native projects');
   }
 }

--- a/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
+++ b/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
@@ -87,7 +87,7 @@ export async function promptToClearMalformedNativeProjectsAsync(projectRoot: str
     program.nonInteractive ||
     // Prompt to clear the native folders.
     (await confirmAsync({
-      message: `${message}, would you like to clear before prebuilding?`,
+      message: `${message}, would you like to clear the project files and reinitialize them?`,
       initial: true,
     }))
   ) {

--- a/packages/expo-cli/src/commands/eject/ejectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/ejectAsync.ts
@@ -1,4 +1,5 @@
 import maybeBailOnGitStatusAsync from '../utils/maybeBailOnGitStatusAsync';
+import { promptToClearMalformedNativeProjectsAsync } from './clearNativeFolder';
 import { logNextSteps } from './logNextSteps';
 import { assertPlatforms } from './platformOptions';
 import { EjectAsyncOptions, prebuildAsync } from './prebuildAsync';
@@ -15,7 +16,9 @@ export async function ejectAsync(
   { platforms, ...options }: EjectAsyncOptions
 ): Promise<void> {
   assertPlatforms(platforms);
+
   if (await maybeBailOnGitStatusAsync()) return;
+  await promptToClearMalformedNativeProjectsAsync(projectRoot);
 
   const results = await prebuildAsync(projectRoot, { platforms, ...options });
   logNextSteps(results);


### PR DESCRIPTION
# Why

- help prevent basic errors like this https://github.com/expo/expo-cli/issues/3116
- Sometimes a user will run `expo eject` then git revert the native changes, effectively leaving the native ios, and android folders in place. 


# How

- Check for some core native files in both ios and android on `expo eject`. Prompt to properly clear the malformed projects before prebuilding the project. 
  - This prompt runs after the git prompt.
  - In non interactive mode, the malformed projects are cleared automatically.
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- in a managed project: `expo eject` -- ensure the malformed prompt isn't shown for standard managed projects.
- in a bare project:
  - `rm -rf ios/yourapp/AppDelegate.m`
    - `expo eject` -- should prompt to clear the native ios folder
      - pressing n should proceed then fail.
      - pressing enter or y will clear the ios folder then proceed correctly.
  - `rm -rf ios/yourapp/AppDelegate.m android/build.gradle`
    - `expo eject` -- should prompt to clear both native folders
      - pressing n should proceed then fail.
      - pressing enter or y will clear the ios and android folders then proceed correctly.
