### PR TITLE
[prebuild] Skip overwriting modules that are symlinked

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -89,6 +89,7 @@
     "dateformat": "3.0.3",
     "env-editor": "^0.4.1",
     "envinfo": "7.5.0",
+    "find-up": "^5.0.0",
     "find-yarn-workspace-root": "~2.0.0",
     "form-data": "^2.3.2",
     "fs-extra": "9.0.0",

--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -6,6 +6,7 @@ import path from 'path';
 
 import Log from '../../log';
 import * as CreateApp from '../utils/CreateApp';
+import { isModuleSymlinked } from '../utils/isModuleSymlinked';
 
 type DependenciesMap = { [key: string]: string | number };
 
@@ -31,7 +32,7 @@ export async function updatePackageJSONAsync({
 
   updatePackageJSONScripts({ pkg });
 
-  const results = updatePackageJSONDependencies({ pkg, tempDir });
+  const results = updatePackageJSONDependencies({ projectRoot, pkg, tempDir });
 
   const removedPkgMain = updatePackageJSONEntryPoint({ pkg });
   await fs.writeFile(path.resolve(projectRoot, 'package.json'), JSON.stringify(pkg, null, 2));
@@ -63,9 +64,11 @@ export async function updatePackageJSONAsync({
  *   version, we should always use the version of expo-updates in the template.
  */
 function updatePackageJSONDependencies({
+  projectRoot,
   tempDir,
   pkg,
 }: {
+  projectRoot: string;
   tempDir: string;
   pkg: PackageJSONConfig;
 }): DependenciesModificationResults {
@@ -83,16 +86,30 @@ function updatePackageJSONDependencies({
 
   const requiredDependencies = ['react', 'react-native-unimodules', 'react-native', 'expo-updates'];
 
+  const symlinkedPackages: string[] = [];
+
   for (const dependenciesKey of requiredDependencies) {
-    // Only overwrite the react-native version if it's an Expo fork.
-    if (dependenciesKey === 'react-native' && pkg.dependencies?.[dependenciesKey]) {
-      const dependencyVersion = pkg.dependencies[dependenciesKey];
-      if (!dependencyVersion.includes('github.com/expo/react-native')) {
-        continue;
-      }
+    if (
+      // If the local package.json defined the dependency that we want to overwrite...
+      pkg.dependencies?.[dependenciesKey] &&
+      // Then ensure it isn't symlinked (i.e. the user has a custom version in their yarn workspace).
+      isModuleSymlinked({ projectRoot, moduleId: dependenciesKey, isSilent: true })
+    ) {
+      // If the package is in the project's package.json and it's symlinked, then skip overwriting it.
+      symlinkedPackages.push(dependenciesKey);
+      continue;
     }
     combinedDependencies[dependenciesKey] = defaultDependencies[dependenciesKey];
   }
+
+  if (symlinkedPackages.length) {
+    Log.log(
+      `\u203A Using symlinked ${symlinkedPackages
+        .map(pkg => chalk.bold(pkg))
+        .join(', ')} instead of recommended version(s).`
+    );
+  }
+
   const combinedDevDependencies: DependenciesMap = createDependenciesMap({
     ...defaultDevDependencies,
     ...pkg.devDependencies,
@@ -214,7 +231,10 @@ export function hashForDependencyMap(deps: DependenciesMap): string {
 
 export function createFileHash(contents: string): string {
   // this doesn't need to be secure, the shorter the better.
-  return crypto.createHash('sha1').update(contents).digest('hex');
+  return crypto
+    .createHash('sha1')
+    .update(contents)
+    .digest('hex');
 }
 
 export function shouldDeleteMainField(main?: any): boolean {

--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -35,7 +35,12 @@ export async function updatePackageJSONAsync({
   const results = updatePackageJSONDependencies({ projectRoot, pkg, tempDir });
 
   const removedPkgMain = updatePackageJSONEntryPoint({ pkg });
-  await fs.writeFile(path.resolve(projectRoot, 'package.json'), JSON.stringify(pkg, null, 2));
+  await fs.writeFile(
+    path.resolve(projectRoot, 'package.json'),
+    // Add new line to match the format of running yarn.
+    // This prevents the `package.json` from changing when running `prebuild --no-install` multiple times.
+    JSON.stringify(pkg, null, 2) + '\n'
+  );
 
   updatingPackageJsonStep.succeed(
     'Updated package.json and added index.js entry point for iOS and Android.'

--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -236,10 +236,7 @@ export function hashForDependencyMap(deps: DependenciesMap): string {
 
 export function createFileHash(contents: string): string {
   // this doesn't need to be secure, the shorter the better.
-  return crypto
-    .createHash('sha1')
-    .update(contents)
-    .digest('hex');
+  return crypto.createHash('sha1').update(contents).digest('hex');
 }
 
 export function shouldDeleteMainField(main?: any): boolean {

--- a/packages/expo-cli/src/commands/utils/__tests__/isModuleSymlinked-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/isModuleSymlinked-test.ts
@@ -1,0 +1,48 @@
+import { vol } from 'memfs';
+
+import { isModuleSymlinked } from '../isModuleSymlinked';
+
+jest.mock('fs');
+jest.mock('resolve-from', () => {
+  return jest.fn((projectRoot, moduleId) => {
+    return moduleId === 'expo'
+      ? projectRoot + '/node_modules/expo/build/index.js'
+      : projectRoot + '/packages/expo-custom/build/index.js';
+  });
+});
+
+describe(isModuleSymlinked, () => {
+  const projectRoot = '/expo/apps/native-component-list';
+
+  beforeAll(() => {
+    vol.fromJSON({
+      [projectRoot + '/packages/expo-custom/package.json']: '{}',
+      [projectRoot + '/packages/expo-custom/build/index.js']: '',
+      [projectRoot + '/node_modules/expo/package.json']: '{}',
+      [projectRoot + '/node_modules/expo/build/index.js']: '',
+    });
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it(`returns false for a module that is not symlinked`, () => {
+    expect(
+      isModuleSymlinked({
+        projectRoot,
+        moduleId: 'expo',
+        isSilent: false,
+      })
+    ).toBe(false);
+  });
+  it(`returns true for a module that is symlinked`, () => {
+    expect(
+      isModuleSymlinked({
+        projectRoot,
+        moduleId: 'expo-custom',
+        isSilent: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/expo-cli/src/commands/utils/isModuleSymlinked.ts
+++ b/packages/expo-cli/src/commands/utils/isModuleSymlinked.ts
@@ -1,0 +1,83 @@
+import assert from 'assert';
+import findUp from 'find-up';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+/**
+ * Find the closest `package.json`.
+ *
+ * @example findUpPackageJson('./foo/expo/build/index.js') -> './foo/expo/package.json'
+ */
+function findUpPackageJson(root: string): string {
+  const packageJson = findUp.sync('package.json', { cwd: root });
+  assert(packageJson, `No package.json found for module "${root}"`);
+  return packageJson;
+}
+
+/**
+ * Return the root folder for a node module file.
+ *
+ * @example getModuleRootPathForFile('./foo/expo/build/index.js') -> './foo/expo'
+ */
+function getModuleRootPathForFile(moduleFile: string): string {
+  // Get the closest package.json to the node module
+  const packageJson = findUpPackageJson(moduleFile);
+  const moduleRoot = path.dirname(packageJson);
+  return moduleRoot;
+}
+
+/**
+ * Return true if the parent folder for a given file path is named "node_modules".
+ *
+ * @example
+ * isModuleRootPathInNodeModulesFolder('./foo/expo') -> false
+ * isModuleRootPathInNodeModulesFolder('./node_modules/expo') -> true
+ */
+function isModuleRootPathInNodeModulesFolder(moduleRootPath: string): boolean {
+  const parentFolderName = path.basename(path.dirname(moduleRootPath));
+  return parentFolderName === 'node_modules';
+}
+
+/**
+ * Given a node module name, and a project path, this method will:
+ *
+ * 1. Resolve the module path.
+ * 2. Find the module root folder.
+ * 3. Return true if the module root folder is in a folder named `node_modules`
+ *
+ * @param projectRoot
+ * @param moduleId
+ *
+ * @example
+ * isModuleSymlinked({
+ *   projectRoot: './expo/apps/native-component-list',
+ *   moduleId: 'react-native'
+ * })
+ */
+export function isModuleSymlinked({
+  projectRoot,
+  moduleId,
+  isSilent,
+}: {
+  projectRoot: string;
+  moduleId: string;
+  isSilent?: boolean;
+}): boolean {
+  try {
+    const modulePath = resolveFrom(projectRoot, moduleId);
+    if (!modulePath) {
+      // module cannot be resolved (probably not installed), cannot be symlinked.
+      return false;
+    }
+    // resolve the root folder for the node module
+    const moduleRootPath = getModuleRootPathForFile(modulePath);
+    return !isModuleRootPathInNodeModulesFolder(moduleRootPath);
+  } catch (error) {
+    if (!isSilent) {
+      throw error;
+    }
+    // Failed to resolve the package.json relative to the project, not sure what to do here.
+    // This is probably not possible due to node module resolution.
+    return false;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10252,7 +10252,7 @@ find-root@^1.1.0:
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
-find-up@*, find-up@~5.0.0:
+find-up@*, find-up@^5.0.0, find-up@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -11418,10 +11418,10 @@ he@1.2.x, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@0.0.0, hermes-engine@^0.2.1:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
-  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
+hermes-engine@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
+  integrity sha512-eNHUQHuadDMJARpaqvlCZoK/Nitpj6oywq3vQ3wCwEsww5morX34mW5PmKWQTO7aU0ck0hgulxR+EVDlXygGxQ==
 
 hex-color-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
# Why

- Running `expo prebuild` in `expo/apps/native-component-list` doesn't work because it overwrites the `expo-updates` package with a version that isn't symlinked, then it runs the build command which effectively breaks the build. 
- This PR checks to ensure each package that's about to be overwritten is symlinked to ensure custom versions of `'react', 'react-native-unimodules', 'react-native', 'expo-updates'` can still be used.
- Removes the weird logic added to only switch RN versions when the installed version has `expo` in the name. 

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- Added unit tests for the new method.
- Running `expo prebuild` in NCL logs:
  - `› Using symlinked react-native-unimodules, react-native, expo-updates instead of recommended version(s).`
  - The `package.json` also is not modified.
- Running `expo prebuild` in a new `expo init` project logs nothing new, and overwrites all of the recommended packages.
