### PR TITLE
[cli] Newline after full log output and skip newline before help output

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -37,7 +37,7 @@ type StartOptions = {
 };
 
 const printHelp = (): void => {
-  logCommandsTable([[], ['?', 'show all commands']]);
+  logCommandsTable([['?', 'show all commands']]);
 };
 
 const div = chalk.dim(`│`);
@@ -79,6 +79,7 @@ const printUsageAsync = async (
     ['d', `open developer tools`],
     ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
     !options.webOnly && ['e', `share the app link by email`],
+    [],
   ]);
 };
 
@@ -96,6 +97,7 @@ const printBasicUsageAsync = async (options: Pick<StartOptions, 'webOnly'> = {})
     ['d', `open developer tools`],
     ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
     !options.webOnly && ['e', `share the app link by email`],
+    [],
   ]);
 };
 


### PR DESCRIPTION
# Why

The newline before the help prompt on a clear screen was bothering me a bit. One solution is to remove the newline. Another alternative would be to add a newline after it too. I opted for the former, but could be convinced. Also, added a newline after the full help output because it looked a bit off to me without it.

## Before

(you probably need to click on these to see)

![group2](https://user-images.githubusercontent.com/90494/109080528-97086500-76b5-11eb-9c16-bbd224ded13b.png)
![group](https://user-images.githubusercontent.com/90494/109080531-98399200-76b5-11eb-888e-736454057537.png)

# Test Plan

Run `expo start` and play with terminal UI to re-create the scenarios from screenshots.