### PR TITLE
[config-plugins] Support quote marks in target name in pbxproj

### DIFF
--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -250,7 +250,9 @@ export function findNativeTargetByName(
   targetName: string
 ): NativeTargetSectionEntry {
   const nativeTargets = getNativeTargets(project);
-  return nativeTargets.find(([, i]) => i.name === targetName) as NativeTargetSectionEntry;
+  return nativeTargets.find(
+    ([, i]) => i.name === targetName || i.name === `"${targetName}"`
+  ) as NativeTargetSectionEntry;
 }
 
 export function getXCConfigurationListEntries(project: XcodeProject): ConfigurationListEntry[] {


### PR DESCRIPTION
# Why

finding target fails for target myapp-staging in https://github.com/brentvatne/myapp/blob/master/ios/myapp.xcodeproj/project.pbxproj

# How

check case with `""`

# Test Plan

Tested by temporary substituting value in one of the fixtures (I don't think it makes sense to add a separate test for that)