### PR TITLE
[config-plugins] eas build:configure fixes for windows

### DIFF
--- a/packages/config-plugins/src/android/EasBuild.ts
+++ b/packages/config-plugins/src/android/EasBuild.ts
@@ -9,6 +9,7 @@ const APPLY_EAS_GRADLE = 'apply from: "./eas-build.gradle"';
 function hasApplyLine(content: string, applyLine: string): boolean {
   return (
     content
+      .replace(/\r\n/g, '\n')
       .split('\n')
       // Check for both single and double quotes
       .some(line => line === applyLine || line === applyLine.replace(/"/g, "'"))

--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -167,9 +167,13 @@ export function formatApplyLineForBuildGradle(projectRoot: string): string {
     );
   }
 
-  return `apply from: ${JSON.stringify(
-    path.relative(path.join(projectRoot, 'android', 'app'), updatesGradleScriptPath)
-  )}`;
+  const relativePath = path.relative(
+    path.join(projectRoot, 'android', 'app'),
+    updatesGradleScriptPath
+  );
+  const posixPath = process.platform === 'win32' ? relativePath.replace(/\\/g, '/') : relativePath;
+
+  return `apply from: "${posixPath}"`;
 }
 
 export function isBuildGradleConfigured(projectRoot: string, buildGradleContents: string): boolean {
@@ -177,6 +181,7 @@ export function isBuildGradleConfigured(projectRoot: string, buildGradleContents
 
   return (
     buildGradleContents
+      .replace(/\r\n/g, '\n')
       .split('\n')
       // Check for both single and double quotes
       .some(line => line === androidBuildScript || line === androidBuildScript.replace(/"/g, "'"))

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -123,7 +123,8 @@ function formatConfigurationScriptPath(projectRoot: string): string {
     );
   }
 
-  return path.relative(path.join(projectRoot, 'ios'), buildScriptPath);
+  const relativePath = path.relative(path.join(projectRoot, 'ios'), buildScriptPath);
+  return process.platform === 'win32' ? relativePath.replace(/\\/g, '/') : relativePath;
 }
 
 interface ShellScriptBuildPhase {


### PR DESCRIPTION
# Why

incorrect behavior on windows when configuring project for eas

https://forums.expo.io/t/eas-build-configure-on-windows-minor-problems/49015/3

# How

- handle CRLF line ending with `.replace(/\r\n/g, '\n')`
- use posix separator on windows `.replace(/\\/g, '/')` 
- remove JSON.stringify (it converted path `a\b\c` into `"a\\b\\c\\"`)

# Test Plan

Tested only on linux, implemented based on a diff from a post on the forum linked above