### PR TITLE
[ci] Add permissive windows environment to github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,13 @@ jobs:
           key: v2-${{ github.sha }}-${{ matrix.node }}
   test:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     needs: build
     strategy:
       fail-fast: false
       matrix:
         node: ['10', '12']
-        os: ['ubuntu-latest']
-        experimental: [false]
+        os: ['ubuntu-latest', 'windows-latest']
         package:
           [
             electron-adapter,
@@ -68,30 +67,6 @@ jobs:
             webpack-config,
             xdl,
           ]
-        include:
-          - node: '12'
-            os: windows-latest
-            experimental: true
-            package:
-              - electron-adapter
-              - dev-tools
-              - babel-preset-cli
-              - config
-              - config-plugins
-              - dev-server
-              - expo-cli
-              - expo-codemod
-              - image-utils
-              - json-file
-              - metro-config
-              - package-manager
-              - pkcs12
-              - plist
-              - pwa
-              - schemer
-              - uri-scheme
-              - webpack-config
-              - xdl
     name: Test ${{ matrix.package }} with Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,26 @@ jobs:
           - node: '12'
             os: windows-latest
             experimental: true
+            package:
+              - electron-adapter
+              - dev-tools
+              - babel-preset-cli
+              - config
+              - config-plugins
+              - dev-server
+              - expo-cli
+              - expo-codemod
+              - image-utils
+              - json-file
+              - metro-config
+              - package-manager
+              - pkcs12
+              - plist
+              - pwa
+              - schemer
+              - uri-scheme
+              - webpack-config
+              - xdl
     name: Test ${{ matrix.package }} with Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn lerna run prepare --stream
       - run: yarn lint --max-warnings=0
+        if: ${{ !matrix.experimental }}
       - uses: actions/cache@v2
         if: ${{ !matrix.experimental }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         experimental: [false]
         include:
           - os: windows-latest
+            node: ['10', '12']
             experimental: true
     name: Build with Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
@@ -68,6 +69,7 @@ jobs:
           ]
         include:
           - os: windows-latest
+            node: ['10', '12']
             experimental: true
     name: Test ${{ matrix.package }} with Node ${{ matrix.node }} (${{ matrix.os }})
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - os: windows-latest
             experimental: true
-    name: Build with Node ${{ matrix.node }}
+    name: Build with Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
         with:
@@ -69,7 +69,7 @@ jobs:
         include:
           - os: windows-latest
             experimental: true
-    name: Test ${{ matrix.package }} on Node ${{ matrix.node }}
+    name: Test ${{ matrix.package }} with Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         node: ['10', '12']
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-latest']
         experimental: [false]
         include:
-          - os: windows-latest
-            node: ['10', '12']
+          - node: '12'
+            os: windows-latest
             experimental: true
     name: Build with Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['10', '12']
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-latest']
         experimental: [false]
         package:
           [
@@ -69,8 +69,8 @@ jobs:
             xdl,
           ]
         include:
-          - os: windows-latest
-            node: ['10', '12']
+          - node: '12'
+            os: windows-latest
             experimental: true
     name: Test ${{ matrix.package }} with Node ${{ matrix.node }} (${{ matrix.os }})
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         node: ['10', '12']
+        os: ['ubuntu-latest', 'windows-latest']
+        experimental: [false]
+        include:
+          - os: windows-latest
+            experimental: true
     name: Build with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
@@ -24,16 +30,20 @@ jobs:
       - run: yarn lerna run prepare --stream
       - run: yarn lint --max-warnings=0
       - uses: actions/cache@v2
+        if: ${{ !matrix.experimental }}
         with:
           path: '*'
           key: v2-${{ github.sha }}-${{ matrix.node }}
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     needs: build
     strategy:
       fail-fast: false
       matrix:
         node: ['10', '12']
+        os: ['ubuntu-latest', 'windows-latest']
+        experimental: [false]
         package:
           [
             electron-adapter,
@@ -56,6 +66,9 @@ jobs:
             webpack-config,
             xdl,
           ]
+        include:
+          - os: windows-latest
+            experimental: true
     name: Test ${{ matrix.package }} on Node ${{ matrix.node }}
     steps:
       - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Test ${{ matrix.package }}
-        run: cd packages/${{ matrix.package }} && yarn test
-        # run: cd packages/${{ matrix.package }} && yarn test --coverage
-        env:
-          CI: true
+        working-directory: packages/${{ matrix.package }}
+        run: yarn test
+        # run: yarn test --coverage
       # - name: Get Test Flag Name
       #   id: cov-flag-name
       #   run: echo "::set-output name=flag::$(echo ${{ matrix.package }} | perl -pe 's/[^a-z]+([a-z])/\U\1/gi;s/^([A-Z])/\l\1/')"


### PR DESCRIPTION
# Why

We need a way to test on Windows, this adds a basic allowed-to-fail Windows environment.

# How

- Added `windows-latest` to the matrix, with the `continue-on-error` for Windows.
- It also skips uploading build files on Windows, we also only publish to NPM from macos/linux

# Test Plan

- This thing itself