### PR TITLE
Use relative asset registry path

### DIFF
--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -144,8 +144,7 @@ export function getDefaultConfig(
     transformer: {
       allowOptionalDependencies: true,
       babelTransformerPath: require.resolve('metro-react-native-babel-transformer'),
-      // TODO: Bacon: Add path for web platform
-      assetRegistryPath: path.join(reactNativePath, 'Libraries/Image/AssetRegistry'),
+      assetRegistryPath: 'react-native/Libraries/Image/AssetRegistry',
       assetPlugins: hashAssetFilesPath ? [hashAssetFilesPath] : undefined,
     },
   });


### PR DESCRIPTION
# Why

- minimize the differences between a JS bundle generated with expo-cli and one [generated with RN CLI](https://github.com/react-native-community/cli/blob/760708fc3216aee565f59877a103a7e35df2d77d/packages/cli/src/tools/loadMetroConfig.ts#L119).

