### PR TITLE
[expo cli] unify terminal stack trace logs

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -39,6 +39,7 @@ import { profileMethod } from './commands/utils/profileMethod';
 import Log from './log';
 import update from './update';
 import urlOpts from './urlOpts';
+import { matchFileNameOrURLFromStackTrace } from './utils/matchFileNameOrURLFromStackTrace';
 
 // We use require() to exclude package.json from TypeScript's analysis since it lives outside the
 // src directory and would change the directory structure of the emitted files under the build
@@ -378,27 +379,6 @@ Command.prototype.asyncAction = function (asyncFn: Action, skipUpdateCheck: bool
     }
   });
 };
-
-/**
- *
- * @param traceLine
- */
-function matchFileNameOrURLFromStackTrace(traceMessage: string): string | null {
-  if (!traceMessage.includes(' in ')) return null;
-  const traceLine = traceMessage.split(' in ')[0]?.trim();
-  // Is URL
-  // "http://127.0.0.1:19000/index.bundle?platform=ios&dev=true&hot=false&minify=false:110910:3 in global code"
-  if (traceLine.match(/https?:\/\//g)) {
-    const [url, params] = traceLine.split('?');
-
-    const paramsWithoutLocation = params.replace(/:(\d+)/g, '').trim();
-    return `${url}?${paramsWithoutLocation}`;
-  }
-
-  // "node_modules/react-native/Libraries/LogBox/LogBox.js:117:10 in registerWarning"
-  // "somn.js:1:0 in <global>"
-  return traceLine.replace(/:(\d+)/g, '').trim();
-}
 
 function getStringBetweenParens(value: string): string {
   const regExp = /\(([^)]+)\)/;

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -551,12 +551,15 @@ Command.prototype.asyncActionProjectDir = function (
           // Use the same regex we use in Metro config to filter out traces:
           isCollapsed = INTERNAL_CALLSITES_REGEX.test(fileNameOrUrl);
 
+          // Unless the user is in debug mode, skip printing the collapsed files.
           if (!Log.isDebug && isCollapsed) {
             continue;
           }
         }
 
+        // If a file is collapsed, print it with dim styling.
         const style = isCollapsed ? chalk.dim : (message: string) => message;
+        // Use the `at` prefix to match Node.js
         nestedLogFn(style('at ' + line));
       }
 

--- a/packages/expo-cli/src/utils/__tests__/matchFileNameOrURLFromStackTrace-test.ts
+++ b/packages/expo-cli/src/utils/__tests__/matchFileNameOrURLFromStackTrace-test.ts
@@ -1,0 +1,31 @@
+import { matchFileNameOrURLFromStackTrace } from '../matchFileNameOrURLFromStackTrace';
+
+describe(matchFileNameOrURLFromStackTrace, () => {
+  it(`matches a Metro URL`, () => {
+    expect(
+      matchFileNameOrURLFromStackTrace(
+        'http://127.0.0.1:19000/index.bundle?platform=ios&dev=true&hot=false&minify=false:110910:3 in global code'
+      )
+    ).toBe('http://127.0.0.1:19000/index.bundle?platform=ios&dev=true&hot=false&minify=false');
+  });
+  it(`matches a Metro file path`, () => {
+    expect(
+      matchFileNameOrURLFromStackTrace(
+        'node_modules/react-native/Libraries/LogBox/LogBox.js:117:10 in registerWarning'
+      )
+    ).toBe('node_modules/react-native/Libraries/LogBox/LogBox.js');
+  });
+  it(`matches a Metro file path (short)`, () => {
+    expect(matchFileNameOrURLFromStackTrace('somn.js:1:0 in <global>')).toBe('somn.js');
+  });
+  it(`returns null for malformed stack lines`, () => {
+    // no ` in `
+    expect(matchFileNameOrURLFromStackTrace('somn.js:1:0')).toBe(null);
+  });
+  it(`splits even when the location is missing the character number`, () => {
+    expect(matchFileNameOrURLFromStackTrace('somn.js:1 in <global>')).toBe('somn.js');
+  });
+  it(`splits without a location`, () => {
+    expect(matchFileNameOrURLFromStackTrace('somn.js in <global>')).toBe('somn.js');
+  });
+});

--- a/packages/expo-cli/src/utils/matchFileNameOrURLFromStackTrace.ts
+++ b/packages/expo-cli/src/utils/matchFileNameOrURLFromStackTrace.ts
@@ -1,0 +1,23 @@
+/**
+ * Given a line from a metro stack trace, this can attempt to extract
+ * the file name or URL, omitting the code location.
+ * Can be used to filter files from the stacktrace like LogBox.
+ *
+ * @param traceLine
+ */
+export function matchFileNameOrURLFromStackTrace(traceMessage: string): string | null {
+  if (!traceMessage.includes(' in ')) return null;
+  const traceLine = traceMessage.split(' in ')[0]?.trim();
+  // Is URL
+  // "http://127.0.0.1:19000/index.bundle?platform=ios&dev=true&hot=false&minify=false:110910:3 in global code"
+  if (traceLine.match(/https?:\/\//g)) {
+    const [url, params] = traceLine.split('?');
+
+    const paramsWithoutLocation = params.replace(/:(\d+)/g, '').trim();
+    return `${url}?${paramsWithoutLocation}`;
+  }
+
+  // "node_modules/react-native/Libraries/LogBox/LogBox.js:117:10 in registerWarning"
+  // "somn.js:1:0 in <global>"
+  return traceLine.replace(/:(\d+)/g, '').trim();
+}

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -17,13 +17,17 @@ export const INTERNAL_CALLSITES_REGEX = new RegExp(
     '/Libraries/YellowBox/.+\\.js$',
     '/Libraries/LogBox/.+\\.js$',
     '/Libraries/Core/Timers/.+\\.js$',
-    '/node_modules/react-devtools-core/.+\\.js$',
-    '/node_modules/react-refresh/.+\\.js$',
-    '/node_modules/scheduler/.+\\.js$',
+    'node_modules/react-devtools-core/.+\\.js$',
+    'node_modules/react-refresh/.+\\.js$',
+    'node_modules/scheduler/.+\\.js$',
     // Metro replaces `require()` with a different method,
     // we want to omit this method from the stack trace.
     // This is akin to most React tooling.
     '/metro/.*/polyfills/require.js$',
+    // Hide frames related to a fast refresh.
+    '/metro/.*/lib/bundle-modules/.+\\.js$',
+    'node_modules/eventemitter3/index.js',
+    'node_modules/event-target-shim/dist/.+\\.js$',
     // Ignore the log forwarder used in the Expo Go app
     '/expo/build/environment/react-native-logs.fx.js$',
     '/expo/build/logs/RemoteConsole.js$',

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -10,7 +10,7 @@ import resolveFrom from 'resolve-from';
 export const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
 // Import only the types here, the values will be imported from the project, at runtime.
-const INTERNAL_CALLSITES_REGEX = new RegExp(
+export const INTERNAL_CALLSITES_REGEX = new RegExp(
   [
     '/Libraries/Renderer/implementations/.+\\.js$',
     '/Libraries/BatchedBridge/MessageQueue\\.js$',


### PR DESCRIPTION
# Why

- In the client, Metro collapses some irrelevant stack traces in order to make warnings/errors easier to use. 
- When expo-cli prints the stack trace in the terminal, it only skips `/react-native\/.*YellowBox.js/` (with no way to ever see these traces).
- This PR, reuses the regex to filter stack trace files in the client with the terminal so results are much closer and more useable.


<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- export regex list from `@expo/metro-config`.
- extract file names from stack traces and filter them like Metro bundler.
- omit collapsed frames in regular development, and show them with `EXPO_DEBUG=1`.
- updated call sites regex to match against fast refresh changes better.

## Comparison

For reference, this is what the client is showing:

<img width="200" alt="console-warn-after" src="https://user-images.githubusercontent.com/9664363/110405575-a7193080-8035-11eb-92b6-8cd0e636c5ad.png">

## Before

<img width="757" alt="old-terminal-warnings" src="https://user-images.githubusercontent.com/9664363/110405441-79cc8280-8035-11eb-8916-62d67524692c.png">

## After

<img width="760" alt="new-terminal-warnings" src="https://user-images.githubusercontent.com/9664363/110405465-7fc26380-8035-11eb-93cb-9e57a1f065bf.png">

### EXPO_DEBUG

<img width="759" alt="new-terminal-warnings-debug" src="https://user-images.githubusercontent.com/9664363/110405493-8650db00-8035-11eb-9705-66db7ed291f2.png">

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Added unit tests