### PR TITLE
[expo-cli] skip updating dependencies in package.json in `expo prebuild`

### DIFF
--- a/packages/expo-cli/src/commands/eject/createNativeProjectsFromTemplateAsync.ts
+++ b/packages/expo-cli/src/commands/eject/createNativeProjectsFromTemplateAsync.ts
@@ -44,7 +44,7 @@ export async function createNativeProjectsFromTemplateAsync({
   pkg: PackageJSONConfig;
   tempDir: string;
   platforms: ModPlatform[];
-  skipDependencyUpdate: string[];
+  skipDependencyUpdate?: string[];
 }): Promise<
   { hasNewProjectFiles: boolean; needsPodInstall: boolean } & DependenciesModificationResults
 > {

--- a/packages/expo-cli/src/commands/eject/createNativeProjectsFromTemplateAsync.ts
+++ b/packages/expo-cli/src/commands/eject/createNativeProjectsFromTemplateAsync.ts
@@ -37,12 +37,14 @@ export async function createNativeProjectsFromTemplateAsync({
   pkg,
   tempDir,
   platforms,
+  skipDependencyUpdate,
 }: {
   projectRoot: string;
   exp: ExpoConfig;
   pkg: PackageJSONConfig;
   tempDir: string;
   platforms: ModPlatform[];
+  skipDependencyUpdate: string[];
 }): Promise<
   { hasNewProjectFiles: boolean; needsPodInstall: boolean } & DependenciesModificationResults
 > {
@@ -56,7 +58,12 @@ export async function createNativeProjectsFromTemplateAsync({
 
   writeMetroConfig({ projectRoot, pkg, tempDir });
 
-  const depsResults = await updatePackageJSONAsync({ projectRoot, tempDir, pkg });
+  const depsResults = await updatePackageJSONAsync({
+    projectRoot,
+    tempDir,
+    pkg,
+    skipDependencyUpdate,
+  });
 
   return {
     hasNewProjectFiles: !!copiedPaths.length,

--- a/packages/expo-cli/src/commands/eject/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/eject/prebuildAsync.ts
@@ -19,6 +19,7 @@ export type EjectAsyncOptions = {
   install?: boolean;
   packageManager?: 'npm' | 'yarn';
   platforms: ModPlatform[];
+  skipDependencyUpdate?: string[];
 };
 
 export type PrebuildResults = {
@@ -59,6 +60,7 @@ export async function prebuildAsync(
     pkg,
     tempDir,
     platforms,
+    skipDependencyUpdate: options.skipDependencyUpdate ?? [],
   });
 
   // Install node modules

--- a/packages/expo-cli/src/commands/eject/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/eject/prebuildAsync.ts
@@ -60,7 +60,7 @@ export async function prebuildAsync(
     pkg,
     tempDir,
     platforms,
-    skipDependencyUpdate: options.skipDependencyUpdate ?? [],
+    skipDependencyUpdate: options.skipDependencyUpdate,
   });
 
   // Install node modules

--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -24,7 +24,7 @@ export async function updatePackageJSONAsync({
   projectRoot: string;
   tempDir: string;
   pkg: PackageJSONConfig;
-  skipDependencyUpdate: string[];
+  skipDependencyUpdate?: string[];
 }): Promise<DependenciesModificationResults> {
   // NOTE(brentvatne): Removing spaces between steps for now, add back when
   // there is some additional context for steps
@@ -75,16 +75,16 @@ export async function updatePackageJSONAsync({
  * - The same applies to expo-updates -- since some native project configuration may depend on the
  *   version, we should always use the version of expo-updates in the template.
  */
-function updatePackageJSONDependencies({
+export function updatePackageJSONDependencies({
   projectRoot,
   tempDir,
   pkg,
-  skipDependencyUpdate,
+  skipDependencyUpdate = [],
 }: {
   projectRoot: string;
   tempDir: string;
   pkg: PackageJSONConfig;
-  skipDependencyUpdate: string[];
+  skipDependencyUpdate?: string[];
 }): DependenciesModificationResults {
   if (!pkg.devDependencies) {
     pkg.devDependencies = {};

--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -19,10 +19,12 @@ export async function updatePackageJSONAsync({
   projectRoot,
   tempDir,
   pkg,
+  skipDependencyUpdate,
 }: {
   projectRoot: string;
   tempDir: string;
   pkg: PackageJSONConfig;
+  skipDependencyUpdate: string[];
 }): Promise<DependenciesModificationResults> {
   // NOTE(brentvatne): Removing spaces between steps for now, add back when
   // there is some additional context for steps
@@ -32,7 +34,12 @@ export async function updatePackageJSONAsync({
 
   updatePackageJSONScripts({ pkg });
 
-  const results = updatePackageJSONDependencies({ projectRoot, pkg, tempDir });
+  const results = updatePackageJSONDependencies({
+    projectRoot,
+    pkg,
+    tempDir,
+    skipDependencyUpdate,
+  });
 
   const removedPkgMain = updatePackageJSONEntryPoint({ pkg });
   await fs.writeFile(
@@ -72,10 +79,12 @@ function updatePackageJSONDependencies({
   projectRoot,
   tempDir,
   pkg,
+  skipDependencyUpdate,
 }: {
   projectRoot: string;
   tempDir: string;
   pkg: PackageJSONConfig;
+  skipDependencyUpdate: string[];
 }): DependenciesModificationResults {
   if (!pkg.devDependencies) {
     pkg.devDependencies = {};
@@ -96,13 +105,19 @@ function updatePackageJSONDependencies({
   for (const dependenciesKey of requiredDependencies) {
     if (
       // If the local package.json defined the dependency that we want to overwrite...
-      pkg.dependencies?.[dependenciesKey] &&
-      // Then ensure it isn't symlinked (i.e. the user has a custom version in their yarn workspace).
-      isModuleSymlinked({ projectRoot, moduleId: dependenciesKey, isSilent: true })
+      pkg.dependencies?.[dependenciesKey]
     ) {
-      // If the package is in the project's package.json and it's symlinked, then skip overwriting it.
-      symlinkedPackages.push(dependenciesKey);
-      continue;
+      if (
+        // Then ensure it isn't symlinked (i.e. the user has a custom version in their yarn workspace).
+        isModuleSymlinked({ projectRoot, moduleId: dependenciesKey, isSilent: true })
+      ) {
+        // If the package is in the project's package.json and it's symlinked, then skip overwriting it.
+        symlinkedPackages.push(dependenciesKey);
+        continue;
+      }
+      if (skipDependencyUpdate.includes(dependenciesKey)) {
+        continue;
+      }
     }
     combinedDependencies[dependenciesKey] = defaultDependencies[dependenciesKey];
   }

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -10,10 +10,12 @@ export async function actionAsync(
   projectDir: string,
   {
     platform,
+    skipDependencyUpdate,
     ...options
   }: EjectAsyncOptions & {
     npm?: boolean;
     platform?: string;
+    skipDependencyUpdate?: string;
   }
 ) {
   if (options.npm) {
@@ -27,6 +29,7 @@ export async function actionAsync(
 
   await prebuildAsync(projectDir, {
     ...options,
+    skipDependencyUpdate: skipDependencyUpdate ? skipDependencyUpdate.split(',') : [],
     platforms,
   } as EjectAsyncOptions);
 }
@@ -46,5 +49,9 @@ export default function (program: Command) {
     .option('--no-install', 'Skip installing npm packages and CocoaPods.')
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
+    .option(
+      '--skip-dependency-update [dependencies]',
+      'Preserves versions of listed packages in package.json (comma separated list)'
+    )
     .asyncActionProjectDir(actionAsync);
 }

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -50,7 +50,7 @@ export default function (program: Command) {
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
     .option(
-      '--skip-dependency-update [dependencies]',
+      '--skip-dependency-update <dependencies>',
       'Preserves versions of listed packages in package.json (comma separated list)'
     )
     .asyncActionProjectDir(actionAsync);


### PR DESCRIPTION
# Why

We need a way to preserve react-native version when building on EAS

# How

- add param to `expo prebuild`
- use comma separated list because variadic params are only supported in newer commander and updating commander version would break a lot of hacks we are using in cli

# Test Plan

`expo prebuild`
add tests