### PR TITLE
[expo cli] Added socket controls

### DIFF
--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -28,11 +28,18 @@ export type BundleOutput = {
   map: string;
   assets: readonly BundleAssetWithFileHashes[];
 };
+export type MessageSocket = {
+  broadcast: (method: string, params?: Record<string, any> | undefined) => void;
+};
 
 export async function runMetroDevServerAsync(
   projectRoot: string,
   options: MetroDevServerOptions
-): Promise<{ server: http.Server; middleware: any }> {
+): Promise<{
+  server: http.Server;
+  middleware: any;
+  messageSocket: MessageSocket;
+}> {
   const Metro = importMetroFromProject(projectRoot);
 
   const reporter = new LogReporter(options.logger);
@@ -57,12 +64,13 @@ export async function runMetroDevServerAsync(
 
   const serverInstance = await Metro.runServer(metroConfig, { hmrEnabled: true });
 
-  const { eventsSocket } = attachToServer(serverInstance);
+  const { messageSocket, eventsSocket } = attachToServer(serverInstance);
   reporter.reportEvent = eventsSocket.reportEvent;
 
   return {
     server: serverInstance,
     middleware,
+    messageSocket,
   };
 }
 

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -70,9 +70,9 @@ const printUsageAsync = async (
     isMac && ['shift+i', `select a simulator`],
     ['w', `open web`],
     [],
-    !!options.isWebSocketsEnabled && ['r', `reload native app`],
-    !!options.isWebSocketsEnabled && ['m', `toggle native menu`],
-    !!options.isWebSocketsEnabled && !options.devClient && ['shift+m', `more tools`],
+    !!options.isWebSocketsEnabled && ['r', `reload app in Expo Go`],
+    !!options.isWebSocketsEnabled && ['m', `toggle menu in Expo Go`],
+    !!options.isWebSocketsEnabled && !options.devClient && ['shift+m', `more Expo Go tools`],
     ['o', `open project code in your editor`],
     ['c', `show project QR`],
     ['p', `toggle build mode`, devMode],
@@ -99,8 +99,8 @@ const printBasicUsageAsync = async (
     isMac && ['i', `open iOS simulator`],
     ['w', `open web`],
     [],
-    !!options.isWebSocketsEnabled && ['r', `reload native app`],
-    !!options.isWebSocketsEnabled && ['m', `toggle native menu`],
+    !!options.isWebSocketsEnabled && ['r', `reload app in Expo Go`],
+    !!options.isWebSocketsEnabled && ['m', `toggle menu in Expo Go`],
     ['d', `show developer tools`],
     ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
     [],
@@ -332,7 +332,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
       }
       case 'm': {
         if (options.isWebSocketsEnabled) {
-          Log.log(`${BLT} Toggling native dev menu`);
+          Log.log(`${BLT} Toggling dev menu in Expo Go`);
           Project.broadcastMessage('devMenu');
         }
         break;
@@ -349,12 +349,12 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
           try {
             const value = await selectAsync({
               // Options match: Chrome > View > Developer
-              message: 'More tools',
+              message: `Expo Go tools ${chalk.dim`(native only)`}`,
               choices: [
                 { title: 'Inspect elements', value: 'toggleElementInspector' },
                 { title: 'Performance monitor', value: 'togglePerformanceMonitor' },
-                { title: 'Native developer menu', value: 'toggleDevMenu' },
-                { title: 'Reload native app', value: 'reload' },
+                { title: 'Developer menu', value: 'toggleDevMenu' },
+                { title: 'Reload app', value: 'reload' },
                 // TODO: Maybe a "View Source" option to open code.
                 // Toggling Remote JS Debugging is pretty rough, so leaving it disabled.
                 // { title: 'Toggle Remote Debugging', value: 'toggleRemoteDebugging' },
@@ -386,7 +386,7 @@ Please reload the project in Expo Go for the change to take effect.`
       }
       case 'r':
         if (options.isWebSocketsEnabled) {
-          Log.log(`${BLT} Reloading connected native apps`);
+          Log.log(`${BLT} Reloading connected apps`);
           Project.broadcastMessage('reload');
         } else {
           // [SDK 40]: Restart bundler

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -52,7 +52,7 @@ export async function shouldOpenDevToolsOnStartupAsync() {
 
 const printUsageAsync = async (
   projectRoot: string,
-  options: Pick<StartOptions, 'webOnly'> = {}
+  options: Pick<StartOptions, 'webOnly' | 'devClient'> = {}
 ) => {
   const { dev } = await ProjectSettings.readAsync(projectRoot);
   const openDevToolsAtStartup = await shouldOpenDevToolsOnStartupAsync();
@@ -71,7 +71,7 @@ const printUsageAsync = async (
     [],
     ['r', `reload app`],
     ['m', `toggle menu`],
-    ['shift+m', `more tools`],
+    !options.devClient && ['shift+m', `more tools`],
     ['o', `open project code in your editor`],
     ['c', `show project QR`],
     ['p', `toggle build mode`, devMode],
@@ -330,6 +330,12 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         break;
       }
       case 'M': {
+        // "More tools" is disabled in dev client for now because standard RN projects don't have hooks for it.
+        // In the future if the dev client package supports `sendDevCommand` then we can enable it.
+        if (options.devClient) {
+          return;
+        }
+
         Prompts.pauseInteractions();
         try {
           const value = await selectAsync({
@@ -341,6 +347,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
               { title: 'Developer Menu', value: 'toggleDevMenu' },
               { title: 'Reload App', value: 'reload' },
               // TODO: Maybe a "View Source" option to open code.
+              // Toggling Remote JS Debugging is pretty rough, so leaving it disabled.
               // { title: 'Toggle Remote Debugging', value: 'toggleRemoteDebugging' },
             ],
           });

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -358,7 +358,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
                 { title: 'Inspect elements', value: 'toggleElementInspector' },
                 { title: 'Performance monitor', value: 'togglePerformanceMonitor' },
                 { title: 'Developer menu', value: 'toggleDevMenu' },
-                { title: 'Reload native app', value: 'reload' },
+                { title: 'Reload app', value: 'reload' },
                 // TODO: Maybe a "View Source" option to open code.
                 // Toggling Remote JS Debugging is pretty rough, so leaving it disabled.
                 // { title: 'Toggle Remote Debugging', value: 'toggleRemoteDebugging' },

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -70,8 +70,8 @@ const printUsageAsync = async (
     isMac && ['shift+i', `select a simulator`],
     ['w', `open web`],
     [],
-    !!options.isWebSocketsEnabled && ['r', `reload app`],
-    !!options.isWebSocketsEnabled && ['m', `toggle menu`],
+    !!options.isWebSocketsEnabled && ['r', `reload native app`],
+    !!options.isWebSocketsEnabled && ['m', `toggle native menu`],
     !!options.isWebSocketsEnabled && !options.devClient && ['shift+m', `more tools`],
     ['o', `open project code in your editor`],
     ['c', `show project QR`],
@@ -99,8 +99,8 @@ const printBasicUsageAsync = async (
     isMac && ['i', `open iOS simulator`],
     ['w', `open web`],
     [],
-    !!options.isWebSocketsEnabled && ['r', `reload app`],
-    !!options.isWebSocketsEnabled && ['m', `toggle menu`],
+    !!options.isWebSocketsEnabled && ['r', `reload native app`],
+    !!options.isWebSocketsEnabled && ['m', `toggle native menu`],
     ['d', `show developer tools`],
     ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
     [],
@@ -332,7 +332,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
       }
       case 'm': {
         if (options.isWebSocketsEnabled) {
-          Log.log(`${BLT} Toggling dev menu`);
+          Log.log(`${BLT} Toggling native dev menu`);
           Project.broadcastMessage('devMenu');
         }
         break;
@@ -349,12 +349,12 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
           try {
             const value = await selectAsync({
               // Options match: Chrome > View > Developer
-              message: 'Developer',
+              message: 'More tools',
               choices: [
-                { title: 'Inspect Elements', value: 'toggleElementInspector' },
-                { title: 'Performance Monitor', value: 'togglePerformanceMonitor' },
-                { title: 'Developer Menu', value: 'toggleDevMenu' },
-                { title: 'Reload App', value: 'reload' },
+                { title: 'Inspect elements', value: 'toggleElementInspector' },
+                { title: 'Performance monitor', value: 'togglePerformanceMonitor' },
+                { title: 'Native developer menu', value: 'toggleDevMenu' },
+                { title: 'Reload native app', value: 'reload' },
                 // TODO: Maybe a "View Source" option to open code.
                 // Toggling Remote JS Debugging is pretty rough, so leaving it disabled.
                 // { title: 'Toggle Remote Debugging', value: 'toggleRemoteDebugging' },
@@ -386,7 +386,7 @@ Please reload the project in Expo Go for the change to take effect.`
       }
       case 'r':
         if (options.isWebSocketsEnabled) {
-          Log.log(`${BLT} Reloading app`);
+          Log.log(`${BLT} Reloading connected native apps`);
           Project.broadcastMessage('reload');
         } else {
           // [SDK 40]: Restart bundler

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -28,6 +28,7 @@ const { bold: b, italic: i, underline: u } = chalk;
 
 type StartOptions = {
   isWebSocketsEnabled?: boolean;
+  isRemoteReloadingEnabled?: boolean;
   devClient?: boolean;
   reset?: boolean;
   nonInteractive?: boolean;
@@ -53,7 +54,10 @@ export async function shouldOpenDevToolsOnStartupAsync() {
 
 const printUsageAsync = async (
   projectRoot: string,
-  options: Pick<StartOptions, 'webOnly' | 'devClient' | 'isWebSocketsEnabled'> = {}
+  options: Pick<
+    StartOptions,
+    'webOnly' | 'devClient' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled'
+  > = {}
 ) => {
   const { dev } = await ProjectSettings.readAsync(projectRoot);
   const openDevToolsAtStartup = await shouldOpenDevToolsOnStartupAsync();
@@ -70,15 +74,15 @@ const printUsageAsync = async (
     isMac && ['shift+i', `select a simulator`],
     ['w', `open web`],
     [],
-    (!!options.isWebSocketsEnabled || !!options.webOnly) && ['r', `reload app`],
+    !!options.isRemoteReloadingEnabled && ['r', `reload app`],
     !!options.isWebSocketsEnabled && ['m', `toggle menu in Expo Go`],
     !!options.isWebSocketsEnabled && !options.devClient && ['shift+m', `more Expo Go tools`],
     ['o', `open project code in your editor`],
     ['c', `show project QR`],
     ['p', `toggle build mode`, devMode],
     // TODO: Drop with SDK 40
-    !options.isWebSocketsEnabled && ['r', `restart bundler`],
-    !options.isWebSocketsEnabled && ['shift+r', `restart and clear cache`],
+    !options.isRemoteReloadingEnabled && ['r', `restart bundler`],
+    !options.isRemoteReloadingEnabled && ['shift+r', `restart and clear cache`],
     [],
     ['d', `show developer tools`],
     ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
@@ -87,7 +91,7 @@ const printUsageAsync = async (
 };
 
 const printBasicUsageAsync = async (
-  options: Pick<StartOptions, 'webOnly' | 'isWebSocketsEnabled'> = {}
+  options: Pick<StartOptions, 'webOnly' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled'> = {}
 ) => {
   const isMac = process.platform === 'darwin';
   const openDevToolsAtStartup = await shouldOpenDevToolsOnStartupAsync();
@@ -99,7 +103,7 @@ const printBasicUsageAsync = async (
     isMac && ['i', `open iOS simulator`],
     ['w', `open web`],
     [],
-    (!!options.isWebSocketsEnabled || !!options.webOnly) && ['r', `reload app`],
+    !!options.isRemoteReloadingEnabled && ['r', `reload app`],
     !!options.isWebSocketsEnabled && ['m', `toggle menu in Expo Go`],
     ['d', `show developer tools`],
     ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
@@ -385,7 +389,7 @@ Please reload the project in Expo Go for the change to take effect.`
         break;
       }
       case 'r':
-        if (options.isWebSocketsEnabled || !!options.webOnly) {
+        if (options.isRemoteReloadingEnabled) {
           Log.log(`${BLT} Reloading apps`);
           // Send reload requests over the metro dev server
           Project.broadcastMessage('reload');
@@ -399,7 +403,7 @@ Please reload the project in Expo Go for the change to take effect.`
         }
         break;
       case 'R':
-        if (!options.isWebSocketsEnabled) {
+        if (!options.isRemoteReloadingEnabled) {
           // [SDK 40]: Restart bundler with cache
           Log.clear();
           Project.startAsync(projectRoot, { ...options, reset: true });

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -356,8 +356,8 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
               message: `Expo Go tools ${chalk.dim`(native only)`}`,
               choices: [
                 { title: 'Inspect elements', value: 'toggleElementInspector' },
-                { title: 'Performance monitor', value: 'togglePerformanceMonitor' },
-                { title: 'Developer menu', value: 'toggleDevMenu' },
+                { title: 'Toggle performance monitor', value: 'togglePerformanceMonitor' },
+                { title: 'Toggle developer menu', value: 'toggleDevMenu' },
                 { title: 'Reload app', value: 'reload' },
                 // TODO: Maybe a "View Source" option to open code.
                 // Toggling Remote JS Debugging is pretty rough, so leaving it disabled.

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -69,14 +69,14 @@ const printUsageAsync = async (
     isMac && ['shift+i', `select a simulator`],
     ['w', `open web`],
     [],
+    ['r', `reload app`],
+    ['m', `toggle menu`],
+    ['shift+m', `more tools`],
     ['o', `open project code in your editor`],
     ['c', `show project QR`],
     ['p', `toggle build mode`, devMode],
-    ['r', `reload app`],
-    ['m', `open dev menu`],
-    ['shift+r', `restart and clear cache`],
     [],
-    ['d', `open developer tools`],
+    ['d', `show developer tools`],
     ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
     [],
   ]);
@@ -93,7 +93,9 @@ const printBasicUsageAsync = async (options: Pick<StartOptions, 'webOnly'> = {})
     isMac && ['i', `open iOS simulator`],
     ['w', `open web`],
     [],
-    ['d', `open developer tools`],
+    ['r', `reload app`],
+    ['m', `toggle menu`],
+    ['d', `show developer tools`],
     ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
     [],
   ]);
@@ -319,27 +321,32 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         await UserSettings.setAsync('openDevToolsAtStartup', enabled);
         const currentToggle = enabled ? 'enabled' : 'disabled';
         Log.log(`Auto opening developer tools on startup: ${chalk.bold(currentToggle)}`);
-        logCommandsTable([['d', `open developer tools now`]]);
+        logCommandsTable([['d', `show developer tools now`]]);
         break;
       }
       case 'm': {
-        Project.broadcastMessage('sendDevCommand', { name: 'devMenu' });
+        Log.log(`${BLT} Toggling dev menu`);
+        Project.broadcastMessage('devMenu');
         break;
       }
       case 'M': {
         Prompts.pauseInteractions();
         try {
           const value = await selectAsync({
-            message: 'Dev menu',
+            // Options match: Chrome > View > Developer
+            message: 'Developer',
             choices: [
+              { title: 'Inspect Elements', value: 'toggleElementInspector' },
+              { title: 'Performance Monitor', value: 'togglePerformanceMonitor' },
+              { title: 'Developer Menu', value: 'toggleDevMenu' },
               { title: 'Reload App', value: 'reload' },
-              { title: 'Toggle Menu', value: 'devMenu' },
-              { title: 'Toggle Inspector', value: 'toggleInspector' },
-              // { title: 'Toggle Performance Monitor', value: 'togglePerformance' },
-              // { title: 'Disable Remote Debugging', value: 'disableRemoteDebugging' },
+              // TODO: Maybe a "View Source" option to open code.
+              // { title: 'Toggle Remote Debugging', value: 'toggleRemoteDebugging' },
             ],
           });
           Project.broadcastMessage('sendDevCommand', { name: value });
+        } catch {
+          // do nothing
         } finally {
           Prompts.resumeInteractions();
           printHelp();
@@ -361,8 +368,8 @@ Please reload the project in Expo Go for the change to take effect.`
         break;
       }
       case 'r':
-        // @ts-ignore
-        Project.broadcastMessage('reload', null);
+        Log.log(`${BLT} Reloading app`);
+        Project.broadcastMessage('reload');
         break;
       case 'o':
         Log.log('Trying to open the project in your editor...');

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -151,7 +151,7 @@ export function parseStartOptions(
     Log.debug('Using target: ', startOpts.target);
   }
 
-  if (Versions.gteSdkVersion(exp, '41.0.0')) {
+  if (!startOpts.webOnly && Versions.gteSdkVersion(exp, '41.0.0')) {
     // The SDK 41 client has web socket support.
     startOpts.isWebSocketsEnabled = true;
   }

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig, isLegacyImportsEnabled } from '@expo/config';
-import { Project, ProjectSettings } from '@expo/xdl';
+import { Project, ProjectSettings, Versions } from '@expo/xdl';
 
 import Log from '../../log';
 import { URLOptions } from '../../urlOpts';
@@ -149,6 +149,11 @@ export function parseStartOptions(
     // See: https://docs.expo.io/bare/using-expo-client
     startOpts.target = options.devClient ? 'bare' : 'managed';
     Log.debug('Using target: ', startOpts.target);
+  }
+
+  if (Versions.gteSdkVersion(exp, '41.0.0')) {
+    // The SDK 41 client has web socket support.
+    startOpts.isWebSocketsEnabled = true;
   }
 
   return startOpts;

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -151,9 +151,12 @@ export function parseStartOptions(
     Log.debug('Using target: ', startOpts.target);
   }
 
-  if (!startOpts.webOnly && Versions.gteSdkVersion(exp, '41.0.0')) {
-    // The SDK 41 client has web socket support.
-    startOpts.isWebSocketsEnabled = true;
+  // The SDK 41 client has web socket support.
+  if (Versions.gteSdkVersion(exp, '41.0.0')) {
+    startOpts.isRemoteReloadingEnabled = true;
+    if (!startOpts.webOnly) {
+      startOpts.isWebSocketsEnabled = true;
+    }
   }
 
   return startOpts;

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -9,7 +9,7 @@ import {
   stopReactNativeServerAsync,
 } from './start/startLegacyReactNativeServerAsync';
 
-export { startAsync, stopAsync } from './start/startAsync';
+export { startAsync, stopAsync, broadcastMessage } from './start/startAsync';
 
 /**
  * @deprecated Use `ProjectSettings.setPackagerInfoAsync`

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -112,6 +112,12 @@ async function clearWebCacheAsync(projectRoot: string, mode: string): Promise<vo
   } catch {}
 }
 
+export async function broadcastMessage(message: 'content-changed' | string, data?: any) {
+  if (webpackDevServerInstance && webpackDevServerInstance instanceof WebpackDevServer) {
+    webpackDevServerInstance.sockWrite(webpackDevServerInstance.sockets, message, data);
+  }
+}
+
 export async function startAsync(
   projectRoot: string,
   options: CLIWebOptions = {},

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -19,6 +19,13 @@ import {
 } from './startLegacyReactNativeServerAsync';
 
 let serverInstance: Server | null = null;
+let messageSocket: any | null = null;
+
+export function broadcastMessage(method: string, params?: Record<string, any> | undefined) {
+  if (messageSocket) {
+    messageSocket.broadcast(method, params);
+  }
+}
 
 export async function startAsync(
   projectRoot: string,
@@ -37,7 +44,7 @@ export async function startAsync(
     DevSession.startSession(projectRoot, exp, 'web');
     return exp;
   } else if (shouldUseDevServer(exp) || options.devClient) {
-    serverInstance = await startDevServerAsync(projectRoot, options);
+    [serverInstance, , messageSocket] = await startDevServerAsync(projectRoot, options);
     DevSession.startSession(projectRoot, exp, 'native');
   } else {
     await startExpoServerAsync(projectRoot);

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -21,7 +21,17 @@ import {
 let serverInstance: Server | null = null;
 let messageSocket: any | null = null;
 
-export function broadcastMessage(method: string, params?: Record<string, any> | undefined) {
+/**
+ * Sends a message over web sockets to any connected device,
+ * does nothing when the dev server is not running.
+ *
+ * @param method name of the command. In RN projects `reload`, and `devMenu` are available. In Expo Go, `sendDevCommand` is available.
+ * @param params
+ */
+export function broadcastMessage(
+  method: 'reload' | 'devMenu' | 'sendDevCommand',
+  params?: Record<string, any> | undefined
+) {
   if (messageSocket) {
     messageSocket.broadcast(method, params);
   }

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -9,6 +9,7 @@ import { getFreePortAsync } from './getFreePortAsync';
 
 export type StartOptions = {
   isWebSocketsEnabled?: boolean;
+  isRemoteReloadingEnabled?: boolean;
   devClient?: boolean;
   reset?: boolean;
   nonInteractive?: boolean;

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -8,6 +8,7 @@ import { getManifestHandler } from './ManifestHandler';
 import { getFreePortAsync } from './getFreePortAsync';
 
 export type StartOptions = {
+  isWebSocketsEnabled?: boolean;
   devClient?: boolean;
   reset?: boolean;
   nonInteractive?: boolean;

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -41,7 +41,7 @@ export async function startDevServerAsync(projectRoot: string, startOptions: Sta
     options.maxWorkers = startOptions.maxWorkers;
   }
 
-  const { server, middleware } = await runMetroDevServerAsync(projectRoot, options);
+  const { server, middleware, messageSocket } = await runMetroDevServerAsync(projectRoot, options);
   middleware.use(getManifestHandler(projectRoot));
-  return server;
+  return [server, middleware, messageSocket];
 }


### PR DESCRIPTION
# Why

- Add the ability to open the dev menu, reload an experience, and toggle element inspector, etc. from the CLI. This feature will only work after the new client is released with https://github.com/expo/expo/pull/12151 https://github.com/expo/expo/pull/12172 merged
- resolves https://github.com/expo/expo-cli/issues/160

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Added Terminal UI commands (version gated to SDK 41):
  - `r` to reload any connected apps
  - `m` to open the dev menu in the client
  - `shift+m` to show a list of extra commands inspect elements, toggle perf monitor, reload, and open menu.
- Removed the ability to restart the bundler ('r', 'shift+r') from Terminal UI.
- "more tools" is disabled in "dev client" because there currently is no way to determine what commands are available on the native device, `reload`, and `devMenu` are baked into react-native core so those should continue to work.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- iOS: Checkout https://github.com/expo/expo/pull/12151 and build client
- Android: Checkout https://github.com/expo/expo/pull/12172 and build client 
- Set project `sdkVersion` to `UNVERSIONED` (features should also be back dated later).
- Run `expo start`: 
  - press 'r' to reload apps
  - press 'm' to open menu
  - press 'm' again to close menu
  - press 'shift+m' to open more items
    - selecting 'Inspect Elements' should toggle element inspector.
    - selecting 'Performance Monitor' should toggle the perf monitor.
    - etc. with reload, and menu.
    - ctrl+c, or escape should cancel out of the select menu without throwing or ending the script process.
  - press 'm' with no devices connected, Metro should log a warning: `warn No apps connected. Sending "devMenu" to all React Native apps failed. Make sure your app is running in the simulator or on a phone connected via USB.`
- Changes should be able to run on physical devices as well (untested on iOS). 
- Run `expo start --dev-client`
  - `shift+m` should do nothing, the key binding shouldn't show up in the info log.