### PR TITLE
[doctor] Re-enable checking reachability of exp.host domain

### DIFF
--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -354,7 +354,6 @@ async function _validateReactNativeVersionAsync(
       return WARNING;
     }
   }
-
   return NO_ISSUES;
 }
 
@@ -432,13 +431,7 @@ async function validateAsync(
 }
 
 export async function validateExpoServersAsync(projectRoot: string): Promise<number> {
-  const domains = [
-    'expo.io',
-    'expo.fyi',
-    'expo.dev',
-    'static.expo.dev',
-    // 'exp.host', - This is causing some intermittent false errors
-  ];
+  const domains = ['expo.io', 'expo.fyi', 'expo.dev', 'static.expo.dev', 'exp.host'];
   const attempts = await Promise.all(
     domains.map(async domain => ({
       domain,


### PR DESCRIPTION
# Why

This may have helped slightly to debug https://github.com/expo/expo/issues/12145

# How

Enable the `exp.host` domain. It was disabled in https://github.com/expo/expo-cli/pull/2474 but now that the check is only run on `expo doctor` and a failure just prints a warning, I think it's fine to leave it enabled even if it is slightly flakey.

# Test Plan

`yarn expo doctor`