### PR TITLE
[expo-cli] Pause interactions after stopping

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -299,6 +299,10 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
       case CTRL_D: {
         // @ts-ignore: Argument of type '"SIGINT"' is not assignable to parameter of type '"disconnect"'.
         process.emit('SIGINT');
+        // Prevent terminal UI from accepting commands while the process is closing.
+        // Without this, fast typers will close the server then start typing their
+        // next command and have a bunch of unrelated things pop up.
+        Prompts.pauseInteractions();
         break;
       }
       case CTRL_L: {


### PR DESCRIPTION
# Why

```
// Prevent terminal UI from accepting commands while the process is closing.
// Without this, fast typers will close the server then start typing their
// next command and have a bunch of unrelated things pop up.
```

# Test Plan


- `expo start --ios` (wait until a device connects otherwise the server closes instantly)
- `ctrl+c`, then spam the `d` key, the dev menu should not open, when the server closes the history should now be in the output i.e. `$ dddd`