### PR TITLE
add expo-ads-facebook to list of auto plugins

### DIFF
--- a/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
@@ -27,6 +27,7 @@ export const expoManagedPlugins = [
   'expo-contacts',
   'expo-image-picker',
   'expo-file-system',
+  'expo-ads-facebook',
   'expo-location',
   'expo-media-library',
   // 'expo-notifications',


### PR DESCRIPTION
# Why

- https://linear.app/expo/issue/ENG-393/set-skadnetwork-ids-for-expo-facebook-expo-ads-facebook-and-expo-admob