### PR TITLE
[ENG-560][expo-cli] skip update check when EAS_BUILD=1

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -330,9 +330,9 @@ export type Action = (...args: any[]) => void;
 
 // asyncAction is a wrapper for all commands/actions to be executed after commander is done
 // parsing the command input
-Command.prototype.asyncAction = function (asyncFn: Action, skipUpdateCheck: boolean) {
+Command.prototype.asyncAction = function (asyncFn: Action) {
   return this.action(async (...args: any[]) => {
-    if (!skipUpdateCheck) {
+    if (process.env.EAS_BUILD !== '1') {
       try {
         await profileMethod(checkCliVersionAsync)();
       } catch (e) {}


### PR DESCRIPTION
# Why

Fixes https://linear.app/expo/issue/ENG-560/hide-expo-cli-update-message-on-eas-build

# How

- There was already a similar check - the `skipUpdateCheck` variable, but it was never set to true. I verified that by looking for all `asyncAction` occurrences in the code.
- I changed the condition so we check the `EAS_BUILD` env variable now.

# Test Plan

I didn't test it yet. We'll do it when we update expo-cli on EAS Build and release a new expo-cli version.