### PR TITLE
Refactor projectDir -> projectRoot

### DIFF
--- a/packages/config-plugins/src/android/Package.ts
+++ b/packages/config-plugins/src/android/Package.ts
@@ -147,8 +147,8 @@ export function setPackageInAndroidManifest(
   return androidManifest;
 }
 
-export async function getApplicationIdAsync(projectDir: string): Promise<string | null> {
-  const buildGradlePath = getAppBuildGradle(projectDir);
+export async function getApplicationIdAsync(projectRoot: string): Promise<string | null> {
+  const buildGradlePath = getAppBuildGradle(projectRoot);
   if (!(await fs.pathExists(buildGradlePath))) {
     return null;
   }

--- a/packages/dev-tools/server/DevToolsServer.ts
+++ b/packages/dev-tools/server/DevToolsServer.ts
@@ -49,7 +49,7 @@ export async function createAuthenticationContextAsync({ port }: { port: number 
   };
 }
 
-export async function startAsync(projectDir: string): Promise<string> {
+export async function startAsync(projectRoot: string): Promise<string> {
   const port = await freeportAsync(19002, { hostnames: [null, 'localhost'] });
   const server = express();
 
@@ -73,19 +73,19 @@ export async function startAsync(projectDir: string): Promise<string> {
     httpServer.once('listening', resolve);
     httpServer.listen(port, listenHostname);
   });
-  startGraphQLServer(projectDir, httpServer, authenticationContext);
-  await ProjectSettings.setPackagerInfoAsync(projectDir, { devToolsPort: port });
+  startGraphQLServer(projectRoot, httpServer, authenticationContext);
+  await ProjectSettings.setPackagerInfoAsync(projectRoot, { devToolsPort: port });
   return `http://${listenHostname}:${port}`;
 }
 
 export function startGraphQLServer(
-  projectDir: string,
+  projectRoot: string,
   httpServer: http.Server,
   authenticationContext: any
 ) {
   const layout = createLayout();
   const issues = new Issues();
-  const messageBuffer = createMessageBuffer(projectDir, issues);
+  const messageBuffer = createMessageBuffer(projectRoot, issues);
   SubscriptionServer.create(
     {
       schema: GraphQLSchema,
@@ -94,7 +94,7 @@ export function startGraphQLServer(
       onOperation: (operation, params) => ({
         ...params,
         context: createContext({
-          projectDir,
+          projectDir: projectRoot,
           messageBuffer,
           layout,
           issues,

--- a/packages/expo-cli/e2e/__tests__/start-test.ts
+++ b/packages/expo-cli/e2e/__tests__/start-test.ts
@@ -6,7 +6,7 @@ import { ProjectSettings } from 'xdl';
 import { EXPO_CLI } from '../TestUtils';
 
 const tempDir = temporary.directory();
-const projectDir = path.join(tempDir, 'my-app');
+const projectRoot = path.join(tempDir, 'my-app');
 
 beforeAll(async () => {
   // jest.setTimeout(60000);
@@ -16,7 +16,7 @@ beforeAll(async () => {
 });
 
 xtest('start --offline', async () => {
-  const promise = spawnAsync(EXPO_CLI, ['start', '--offline'], { cwd: projectDir });
+  const promise = spawnAsync(EXPO_CLI, ['start', '--offline'], { cwd: projectRoot });
   const cli = promise.child;
 
   cli.stderr.pipe(process.stderr);
@@ -39,7 +39,7 @@ xtest('start --offline with existing packager info', async () => {
     packagerPid: 1337,
   });
 
-  const promise = spawnAsync(EXPO_CLI, ['start', '--offline'], { cwd: projectDir });
+  const promise = spawnAsync(EXPO_CLI, ['start', '--offline'], { cwd: projectRoot });
   const cli = promise.child;
 
   cli.stderr.pipe(process.stderr);

--- a/packages/expo-cli/src/commands/bundle-assets.ts
+++ b/packages/expo-cli/src/commands/bundle-assets.ts
@@ -11,9 +11,9 @@ type Options = {
   platform?: string;
 };
 
-async function action(projectDir: string, options: Options) {
+async function action(projectRoot: string, options: Options) {
   try {
-    await Detach.bundleAssetsAsync(projectDir, options);
+    await Detach.bundleAssetsAsync(projectRoot, options);
   } catch (e) {
     Log.error(e);
     Log.error(

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -25,6 +25,237 @@ import * as ClientUpgradeUtils from '../utils/ClientUpgradeUtils';
 import { createClientBuildRequest, getExperienceName, isAllowedToBuild } from './clientBuildApi';
 import generateBundleIdentifier from './generateBundleIdentifier';
 
+async function actionAsync(
+  projectRoot: string,
+  options: {
+    appleId?: string;
+    config?: string;
+    parent?: {
+      nonInteractive: boolean;
+    };
+  }
+) {
+  const disabledServices: { [key: string]: { name: string; reason: string } } = {
+    pushNotifications: {
+      name: 'Push Notifications',
+      reason: 'not yet available until API tokens are supported for the Push Notification system',
+    },
+  };
+
+  // get custom project manifest if it exists
+  // Note: this is the current developer's project, NOT Expo Go's manifest
+  const spinner = ora(`Finding custom configuration for Expo Go...`).start();
+  if (options.config) {
+    setCustomConfigPath(projectRoot, options.config);
+  }
+  const { exp } = getConfig(projectRoot, {
+    skipSDKVersionRequirement: true,
+  });
+
+  if (exp) {
+    spinner.succeed(`Found custom configuration for Expo Go`);
+  } else {
+    spinner.warn(`Unable to find custom configuration for Expo Go`);
+  }
+  if (!exp.ios) exp.ios = {};
+
+  if (!exp.facebookAppId || !exp.facebookScheme) {
+    const disabledReason = exp
+      ? `facebookAppId or facebookScheme are missing from app configuration. `
+      : 'No custom configuration file could be found. You will need to provide a json file with valid facebookAppId and facebookScheme fields.';
+    disabledServices.facebookLogin = { name: 'Facebook Login', reason: disabledReason };
+  }
+  if (!exp.ios.config?.googleMapsApiKey) {
+    const disabledReason = exp
+      ? `ios.config.googleMapsApiKey does not exist in the app configuration.`
+      : 'No custom configuration file could be found. You will need to provide a json file with a valid ios.config.googleMapsApiKey field.';
+    disabledServices.googleMaps = { name: 'Google Maps', reason: disabledReason };
+  }
+  if (exp.ios.googleServicesFile) {
+    const contents = await fs.readFile(
+      path.resolve(projectRoot, exp.ios.googleServicesFile!),
+      'base64'
+    );
+    exp.ios.googleServicesFile = contents;
+  }
+
+  const user = await UserManager.getCurrentUserAsync();
+  const context = new Context();
+  await context.init(projectRoot, {
+    ...options,
+    allowAnonymous: true,
+    nonInteractive: options.parent?.nonInteractive,
+  });
+  await context.ensureAppleCtx();
+  const appleContext = context.appleCtx;
+  if (user) {
+    await context.ios.getAllCredentials(context.projectOwner); // initialize credentials
+  }
+
+  // check if any builds are in flight
+  const { isAllowed, errorMessage } = await isAllowedToBuild({
+    user,
+    appleTeamId: appleContext.team.id,
+  });
+
+  if (!isAllowed) {
+    throw new CommandError(
+      'CLIENT_BUILD_REQUEST_NOT_ALLOWED',
+      `New Expo Go build request disallowed. Reason: ${errorMessage}`
+    );
+  }
+
+  const bundleIdentifier = generateBundleIdentifier(appleContext.team.id);
+  const experienceName = await getExperienceName({ user, appleTeamId: appleContext.team.id });
+  const appLookupParams = getAppLookupParams(experienceName, bundleIdentifier);
+
+  await appleApi.ensureBundleIdExistsAsync(appleContext, appLookupParams, {
+    enablePushNotifications: true,
+  });
+
+  const requestContext = getRequestContext(appleContext);
+  const devices = await Device.getAllIOSProfileDevicesAsync(requestContext);
+  const udids = devices.map(device => device.attributes.udid);
+
+  let distributionCert;
+  if (user) {
+    await runCredentialsManager(context, new SetupIosDist(appLookupParams));
+    distributionCert = await context.ios.getDistCert(appLookupParams);
+  } else {
+    distributionCert = await new CreateIosDist(appLookupParams.accountName).provideOrGenerate(
+      context
+    );
+  }
+  if (!distributionCert) {
+    throw new CommandError(
+      'INSUFFICIENT_CREDENTIALS',
+      `This build request requires a valid distribution certificate.`
+    );
+  }
+
+  let pushKey;
+  if (user) {
+    await runCredentialsManager(context, new SetupIosPush(appLookupParams));
+    pushKey = await context.ios.getPushKey(appLookupParams);
+  }
+
+  let provisioningProfile;
+  const createOrReuseProfile = new CreateOrReuseProvisioningProfileAdhoc(appLookupParams, {
+    distCertSerialNumber: distributionCert.distCertSerialNumber!,
+    udids,
+  });
+  if (user) {
+    await runCredentialsManager(context, createOrReuseProfile);
+    provisioningProfile = await context.ios.getProvisioningProfile(appLookupParams);
+  } else {
+    provisioningProfile = await createOrReuseProfile.createOrReuse(context);
+  }
+  if (!provisioningProfile) {
+    throw new CommandError(
+      'INSUFFICIENT_CREDENTIALS',
+      `This build request requires a valid provisioning profile.`
+    );
+  }
+
+  // push notifications won't work if we dont have any push creds
+  // we also dont store anonymous creds, so user needs to be logged in
+  if (pushKey === null || !user) {
+    const disabledReason =
+      pushKey === null
+        ? 'you did not upload your push credentials'
+        : 'we require you to be logged in to store push credentials';
+    // TODO(quin): remove this when we fix push notifications
+    // keep the default push notification reason if we haven't implemented API tokens
+    disabledServices.pushNotifications.reason =
+      disabledServices.pushNotifications.reason || disabledReason;
+  }
+
+  if (Object.keys(disabledServices).length > 0) {
+    Log.newLine();
+    Log.warn('These services will be disabled in your custom Expo Go app:');
+    const table = new CliTable({ head: ['Service', 'Reason'], style: { head: ['cyan'] } });
+    table.push(
+      ...Object.keys(disabledServices).map(serviceKey => {
+        const service = disabledServices[serviceKey];
+        return [service.name, service.reason];
+      })
+    );
+    Log.log(table.toString());
+    Log.log(
+      'See https://docs.expo.io/guides/adhoc-builds/#optional-additional-configuration-steps for more details.'
+    );
+  }
+
+  let email;
+  if (user && user.kind === 'user') {
+    email = user.email;
+  } else {
+    email = await promptEmailAsync({
+      message: 'Please enter an email address to notify, when the build is completed:',
+      initial: (context?.user as User)?.email,
+    });
+  }
+  Log.newLine();
+
+  let addUdid;
+  if (udids.length === 0) {
+    Log.log(
+      'There are no devices registered to your Apple Developer account. Please follow the instructions below to register an iOS device.'
+    );
+    addUdid = true;
+  } else {
+    Log.log(
+      'Custom builds of Expo Go can only be installed on devices which have been registered with Apple at build-time.'
+    );
+    Log.log('These devices are currently registered on your Apple Developer account:');
+    const table = new CliTable({ head: ['Name', 'Identifier'], style: { head: ['cyan'] } });
+    table.push(...devices.map(device => [device.attributes.name, device.attributes.udid]));
+    Log.log(table.toString());
+
+    const udidPrompt = await confirmAsync({
+      message: 'Would you like to register a new device to use Expo Go with?',
+    });
+    addUdid = udidPrompt;
+  }
+
+  const result = await createClientBuildRequest({
+    user,
+    appleContext,
+    distributionCert,
+    provisioningProfile,
+    pushKey,
+    udids,
+    addUdid,
+    email,
+    bundleIdentifier,
+    customAppConfig: exp,
+  });
+
+  Log.newLine();
+  if (addUdid) {
+    urlOpts.printQRCode(result.registrationUrl);
+    Log.log(
+      'Open the following link on your iOS device (or scan the QR code) and follow the instructions to install the development profile:'
+    );
+    Log.newLine();
+    Log.log(chalk.green(`${result.registrationUrl}`));
+    Log.newLine();
+    Log.log('Please note that you can only register one iOS device per request.');
+    Log.log(
+      "After you register your device, we'll start building your client, and you'll receive an email when it's ready to install."
+    );
+  } else {
+    urlOpts.printQRCode(result.statusUrl);
+    Log.log('Your custom Expo Go app is being built! 🛠');
+    Log.log(
+      'Open this link on your iOS device (or scan the QR code) to view build logs and install the client:'
+    );
+    Log.newLine();
+    Log.log(chalk.green(`${result.statusUrl}`));
+  }
+  Log.newLine();
+}
+
 export default function (program: Command) {
   program
     .command('client:ios [path]')
@@ -39,239 +270,7 @@ export default function (program: Command) {
       '--apple-id <login>',
       'Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable).'
     )
-    .asyncActionProjectDir(
-      async (
-        projectDir: string,
-        options: {
-          appleId?: string;
-          config?: string;
-          parent?: {
-            nonInteractive: boolean;
-          };
-        }
-      ) => {
-        const disabledServices: { [key: string]: { name: string; reason: string } } = {
-          pushNotifications: {
-            name: 'Push Notifications',
-            reason:
-              'not yet available until API tokens are supported for the Push Notification system',
-          },
-        };
-
-        // get custom project manifest if it exists
-        // Note: this is the current developer's project, NOT Expo Go's manifest
-        const spinner = ora(`Finding custom configuration for Expo Go...`).start();
-        if (options.config) {
-          setCustomConfigPath(projectDir, options.config);
-        }
-        const { exp } = getConfig(projectDir, {
-          skipSDKVersionRequirement: true,
-        });
-
-        if (exp) {
-          spinner.succeed(`Found custom configuration for Expo Go`);
-        } else {
-          spinner.warn(`Unable to find custom configuration for Expo Go`);
-        }
-        if (!exp.ios) exp.ios = {};
-
-        if (!exp.facebookAppId || !exp.facebookScheme) {
-          const disabledReason = exp
-            ? `facebookAppId or facebookScheme are missing from app configuration. `
-            : 'No custom configuration file could be found. You will need to provide a json file with valid facebookAppId and facebookScheme fields.';
-          disabledServices.facebookLogin = { name: 'Facebook Login', reason: disabledReason };
-        }
-        if (!exp.ios.config?.googleMapsApiKey) {
-          const disabledReason = exp
-            ? `ios.config.googleMapsApiKey does not exist in the app configuration.`
-            : 'No custom configuration file could be found. You will need to provide a json file with a valid ios.config.googleMapsApiKey field.';
-          disabledServices.googleMaps = { name: 'Google Maps', reason: disabledReason };
-        }
-        if (exp.ios.googleServicesFile) {
-          const contents = await fs.readFile(
-            path.resolve(projectDir, exp.ios.googleServicesFile!),
-            'base64'
-          );
-          exp.ios.googleServicesFile = contents;
-        }
-
-        const user = await UserManager.getCurrentUserAsync();
-        const context = new Context();
-        await context.init(projectDir, {
-          ...options,
-          allowAnonymous: true,
-          nonInteractive: options.parent?.nonInteractive,
-        });
-        await context.ensureAppleCtx();
-        const appleContext = context.appleCtx;
-        if (user) {
-          await context.ios.getAllCredentials(context.projectOwner); // initialize credentials
-        }
-
-        // check if any builds are in flight
-        const { isAllowed, errorMessage } = await isAllowedToBuild({
-          user,
-          appleTeamId: appleContext.team.id,
-        });
-
-        if (!isAllowed) {
-          throw new CommandError(
-            'CLIENT_BUILD_REQUEST_NOT_ALLOWED',
-            `New Expo Go build request disallowed. Reason: ${errorMessage}`
-          );
-        }
-
-        const bundleIdentifier = generateBundleIdentifier(appleContext.team.id);
-        const experienceName = await getExperienceName({ user, appleTeamId: appleContext.team.id });
-        const appLookupParams = getAppLookupParams(experienceName, bundleIdentifier);
-
-        await appleApi.ensureBundleIdExistsAsync(appleContext, appLookupParams, {
-          enablePushNotifications: true,
-        });
-
-        const requestContext = getRequestContext(appleContext);
-        const devices = await Device.getAllIOSProfileDevicesAsync(requestContext);
-        const udids = devices.map(device => device.attributes.udid);
-
-        let distributionCert;
-        if (user) {
-          await runCredentialsManager(context, new SetupIosDist(appLookupParams));
-          distributionCert = await context.ios.getDistCert(appLookupParams);
-        } else {
-          distributionCert = await new CreateIosDist(appLookupParams.accountName).provideOrGenerate(
-            context
-          );
-        }
-        if (!distributionCert) {
-          throw new CommandError(
-            'INSUFFICIENT_CREDENTIALS',
-            `This build request requires a valid distribution certificate.`
-          );
-        }
-
-        let pushKey;
-        if (user) {
-          await runCredentialsManager(context, new SetupIosPush(appLookupParams));
-          pushKey = await context.ios.getPushKey(appLookupParams);
-        }
-
-        let provisioningProfile;
-        const createOrReuseProfile = new CreateOrReuseProvisioningProfileAdhoc(appLookupParams, {
-          distCertSerialNumber: distributionCert.distCertSerialNumber!,
-          udids,
-        });
-        if (user) {
-          await runCredentialsManager(context, createOrReuseProfile);
-          provisioningProfile = await context.ios.getProvisioningProfile(appLookupParams);
-        } else {
-          provisioningProfile = await createOrReuseProfile.createOrReuse(context);
-        }
-        if (!provisioningProfile) {
-          throw new CommandError(
-            'INSUFFICIENT_CREDENTIALS',
-            `This build request requires a valid provisioning profile.`
-          );
-        }
-
-        // push notifications won't work if we dont have any push creds
-        // we also dont store anonymous creds, so user needs to be logged in
-        if (pushKey === null || !user) {
-          const disabledReason =
-            pushKey === null
-              ? 'you did not upload your push credentials'
-              : 'we require you to be logged in to store push credentials';
-          // TODO(quin): remove this when we fix push notifications
-          // keep the default push notification reason if we haven't implemented API tokens
-          disabledServices.pushNotifications.reason =
-            disabledServices.pushNotifications.reason || disabledReason;
-        }
-
-        if (Object.keys(disabledServices).length > 0) {
-          Log.newLine();
-          Log.warn('These services will be disabled in your custom Expo Go app:');
-          const table = new CliTable({ head: ['Service', 'Reason'], style: { head: ['cyan'] } });
-          table.push(
-            ...Object.keys(disabledServices).map(serviceKey => {
-              const service = disabledServices[serviceKey];
-              return [service.name, service.reason];
-            })
-          );
-          Log.log(table.toString());
-          Log.log(
-            'See https://docs.expo.io/guides/adhoc-builds/#optional-additional-configuration-steps for more details.'
-          );
-        }
-
-        let email;
-        if (user && user.kind === 'user') {
-          email = user.email;
-        } else {
-          email = await promptEmailAsync({
-            message: 'Please enter an email address to notify, when the build is completed:',
-            initial: (context?.user as User)?.email,
-          });
-        }
-        Log.newLine();
-
-        let addUdid;
-        if (udids.length === 0) {
-          Log.log(
-            'There are no devices registered to your Apple Developer account. Please follow the instructions below to register an iOS device.'
-          );
-          addUdid = true;
-        } else {
-          Log.log(
-            'Custom builds of Expo Go can only be installed on devices which have been registered with Apple at build-time.'
-          );
-          Log.log('These devices are currently registered on your Apple Developer account:');
-          const table = new CliTable({ head: ['Name', 'Identifier'], style: { head: ['cyan'] } });
-          table.push(...devices.map(device => [device.attributes.name, device.attributes.udid]));
-          Log.log(table.toString());
-
-          const udidPrompt = await confirmAsync({
-            message: 'Would you like to register a new device to use Expo Go with?',
-          });
-          addUdid = udidPrompt;
-        }
-
-        const result = await createClientBuildRequest({
-          user,
-          appleContext,
-          distributionCert,
-          provisioningProfile,
-          pushKey,
-          udids,
-          addUdid,
-          email,
-          bundleIdentifier,
-          customAppConfig: exp,
-        });
-
-        Log.newLine();
-        if (addUdid) {
-          urlOpts.printQRCode(result.registrationUrl);
-          Log.log(
-            'Open the following link on your iOS device (or scan the QR code) and follow the instructions to install the development profile:'
-          );
-          Log.newLine();
-          Log.log(chalk.green(`${result.registrationUrl}`));
-          Log.newLine();
-          Log.log('Please note that you can only register one iOS device per request.');
-          Log.log(
-            "After you register your device, we'll start building your client, and you'll receive an email when it's ready to install."
-          );
-        } else {
-          urlOpts.printQRCode(result.statusUrl);
-          Log.log('Your custom Expo Go app is being built! 🛠');
-          Log.log(
-            'Open this link on your iOS device (or scan the QR code) to view build logs and install the client:'
-          );
-          Log.newLine();
-          Log.log(chalk.green(`${result.statusUrl}`));
-        }
-        Log.newLine();
-      }
-    );
+    .asyncActionProjectDir(actionAsync);
 
   program
     .command('client:install:ios')

--- a/packages/expo-cli/src/commands/credentials.ts
+++ b/packages/expo-cli/src/commands/credentials.ts
@@ -21,9 +21,9 @@ export default function (program: CommanderStatic) {
     .helpGroup('credentials')
     .option('-p --platform <platform>', 'Platform: [android|ios]', /^(android|ios)$/i)
     .asyncActionProjectDir(
-      async (projectDir: string, options: Options) => {
+      async (projectRoot: string, options: Options) => {
         const context = new Context();
-        await context.init(projectDir, {
+        await context.init(projectRoot, {
           nonInteractive: options.parent?.nonInteractive,
         });
         let mainpage;

--- a/packages/expo-cli/src/commands/customize.ts
+++ b/packages/expo-cli/src/commands/customize.ts
@@ -36,13 +36,13 @@ const dependencyMap: { [key: string]: string[] } = {
 };
 
 async function generateFilesAsync({
-  projectDir,
+  projectRoot,
   staticPath,
   options,
   answer,
   templateFolder,
 }: {
-  projectDir: string;
+  projectRoot: string;
   staticPath: string;
   options: Options;
   answer: string[];
@@ -52,7 +52,7 @@ async function generateFilesAsync({
 
   for (const file of answer) {
     if (Object.keys(dependencyMap).includes(file)) {
-      const projectFilePath = path.resolve(projectDir, file);
+      const projectFilePath = path.resolve(projectRoot, file);
       // copy the file from template
       promises.push(
         fs.copy(
@@ -63,7 +63,7 @@ async function generateFilesAsync({
       );
 
       if (file in dependencyMap) {
-        const packageManager = PackageManager.createForProject(projectDir, { log: Log.log });
+        const packageManager = PackageManager.createForProject(projectRoot, { log: Log.log });
         for (const dependency of dependencyMap[file]) {
           promises.push(packageManager.addDevAsync(dependency));
         }
@@ -71,7 +71,7 @@ async function generateFilesAsync({
     } else {
       const fileName = path.basename(file);
       const src = path.resolve(templateFolder, fileName);
-      const dest = path.resolve(projectDir, staticPath, fileName);
+      const dest = path.resolve(projectRoot, staticPath, fileName);
       if (await fs.pathExists(src)) {
         promises.push(fs.copy(src, dest, { overwrite: true, recursive: true }));
       } else {
@@ -82,10 +82,10 @@ async function generateFilesAsync({
   await Promise.all(promises);
 }
 
-export async function action(projectDir: string = './', options: Options = { force: false }) {
+export async function action(projectRoot: string = './', options: Options = { force: false }) {
   // Get the static path (defaults to 'web/')
   // Doesn't matter if expo is installed or which mode is used.
-  const { exp } = getConfig(projectDir, {
+  const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
 
@@ -103,7 +103,7 @@ export async function action(projectDir: string = './', options: Options = { for
   const values = [];
 
   for (const file of allFiles) {
-    const localProjectFile = path.resolve(projectDir, file);
+    const localProjectFile = path.resolve(projectRoot, file);
     const exists = fs.existsSync(localProjectFile);
 
     values.push({
@@ -125,7 +125,7 @@ export async function action(projectDir: string = './', options: Options = { for
     return;
   }
 
-  await maybeWarnToCommitAsync(projectDir);
+  await maybeWarnToCommitAsync(projectRoot);
 
   const { answer } = await prompts({
     type: 'multiselect',
@@ -142,7 +142,13 @@ export async function action(projectDir: string = './', options: Options = { for
     Log.log('\n\u203A Exiting with no change...\n');
     return;
   }
-  await generateFilesAsync({ projectDir, staticPath, options, answer, templateFolder });
+  await generateFilesAsync({
+    projectRoot,
+    staticPath,
+    options,
+    answer,
+    templateFolder,
+  });
 }
 
 export default function (program: Command) {

--- a/packages/expo-cli/src/commands/doctor/index.ts
+++ b/packages/expo-cli/src/commands/doctor/index.ts
@@ -4,13 +4,13 @@ import { Doctor } from 'xdl';
 import Log from '../../log';
 import { warnUponCmdExe } from './windows';
 
-async function action(projectDir: string) {
+async function actionAsync(projectRoot: string) {
   await warnUponCmdExe();
 
   // note: this currently only warns when something isn't right, it doesn't fail
-  await Doctor.validateExpoServersAsync(projectDir);
+  await Doctor.validateExpoServersAsync(projectRoot);
 
-  if ((await Doctor.validateWithNetworkAsync(projectDir)) === Doctor.NO_ISSUES) {
+  if ((await Doctor.validateWithNetworkAsync(projectRoot)) === Doctor.NO_ISSUES) {
     Log.log(`Didn't find any issues with the project!`);
   }
 }
@@ -20,5 +20,5 @@ export default function (program: Command) {
     .command('doctor [path]')
     .description('Diagnose issues with the project')
     .helpGroup('info')
-    .asyncActionProjectDir(action);
+    .asyncActionProjectDir(actionAsync);
 }

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -20,7 +20,7 @@ async function userWantsToEjectWithoutUpgradingAsync() {
 }
 
 export async function actionAsync(
-  projectDir: string,
+  projectRoot: string,
   {
     platform,
     ...options
@@ -29,7 +29,7 @@ export async function actionAsync(
     platform?: string;
   }
 ) {
-  const { exp } = getConfig(projectDir);
+  const { exp } = getConfig(projectRoot);
 
   if (options.npm) {
     options.packageManager = 'npm';
@@ -44,7 +44,7 @@ export async function actionAsync(
     }
   } else {
     Log.debug('Eject Mode: Latest');
-    await ejectAsync(projectDir, {
+    await ejectAsync(projectRoot, {
       ...options,
       platforms: platformsFromPlatform(platform),
     } as EjectAsyncOptions);

--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -100,7 +100,7 @@ async function exportFilesAsync(
 }
 
 async function mergeSourceDirectoriesAsync(
-  projectDir: string,
+  projectRoot: string,
   mergeSrcDirs: string[],
   options: Pick<Options, 'mergeSrcUrl' | 'mergeSrcDir' | 'outputDir'>
 ): Promise<void> {
@@ -112,7 +112,7 @@ async function mergeSourceDirectoriesAsync(
 
   // Merge app distributions
   await Project.mergeAppDistributions(
-    projectDir,
+    projectRoot,
     [...mergeSrcDirs, options.outputDir], // merge stuff in srcDirs and outputDir together
     options.outputDir
   );
@@ -122,7 +122,7 @@ async function mergeSourceDirectoriesAsync(
 }
 
 export async function collectMergeSourceUrlsAsync(
-  projectDir: string,
+  projectRoot: string,
   mergeSrcUrl: string[]
 ): Promise<string[]> {
   // Merge src dirs/urls into a multimanifest if specified
@@ -131,7 +131,7 @@ export async function collectMergeSourceUrlsAsync(
   // src urls were specified to merge in, so download and decompress them
   if (mergeSrcUrl.length > 0) {
     // delete .tmp if it exists and recreate it anew
-    const tmpFolder = path.resolve(projectDir, '.tmp');
+    const tmpFolder = path.resolve(projectRoot, '.tmp');
     await fs.remove(tmpFolder);
     await fs.ensureDir(tmpFolder);
 

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -159,18 +159,18 @@ function padEnd(str: string, width: number): string {
   return str + Array(len + 1).join(' ');
 }
 
-async function action(projectDir: string, command: Command) {
+async function action(incomingProjectRoot: string, command: Command) {
   const options = parseOptions(command);
 
   // Resolve the name, and projectRoot
   let projectRoot: string;
-  if (!projectDir && options.yes) {
+  if (!incomingProjectRoot && options.yes) {
     projectRoot = path.resolve(process.cwd());
     const folderName = path.basename(projectRoot);
     assertValidName(folderName);
     await assertFolderEmptyAsync(projectRoot, folderName);
   } else {
-    projectRoot = await resolveProjectRootAsync(projectDir || options.name);
+    projectRoot = await resolveProjectRootAsync(incomingProjectRoot || options.name);
   }
 
   let resolvedTemplate: string | null = options.template ?? null;

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -7,7 +7,7 @@ import { EjectAsyncOptions, prebuildAsync } from './eject/prebuildAsync';
 import { learnMore } from './utils/TerminalLink';
 
 export async function actionAsync(
-  projectDir: string,
+  projectRoot: string,
   {
     platform,
     skipDependencyUpdate,
@@ -25,9 +25,9 @@ export async function actionAsync(
   const platforms = platformsFromPlatform(platform);
 
   // Clear the native folders before syncing
-  await clearNativeFolder(projectDir, platforms);
+  await clearNativeFolder(projectRoot, platforms);
 
-  await prebuildAsync(projectDir, {
+  await prebuildAsync(projectRoot, {
     ...options,
     skipDependencyUpdate: skipDependencyUpdate ? skipDependencyUpdate.split(',') : [],
     platforms,

--- a/packages/expo-cli/src/commands/prepare-detached-build.ts
+++ b/packages/expo-cli/src/commands/prepare-detached-build.ts
@@ -6,8 +6,8 @@ type Options = {
   skipXcodeConfig: boolean;
 };
 
-async function action(projectDir: string, options: Options) {
-  await Detach.prepareDetachedBuildAsync(projectDir, options);
+async function action(projectRoot: string, options: Options) {
+  await Detach.prepareDetachedBuildAsync(projectRoot, options);
 }
 
 export default function (program: Command) {

--- a/packages/expo-cli/src/commands/publish-info.ts
+++ b/packages/expo-cli/src/commands/publish-info.ts
@@ -32,8 +32,8 @@ export default (program: any) => {
     .option('-s, --sdk-version <version>', 'Filter by SDK version e.g. 35.0.0')
     .option('-r, --raw', 'Produce some raw output.')
     .asyncActionProjectDir(
-      async (projectDir: string, options: HistoryOptions) => {
-        const result = await getPublishHistoryAsync(projectDir, options);
+      async (projectRoot: string, options: HistoryOptions) => {
+        const result = await getPublishHistoryAsync(projectRoot, options);
 
         if (options.raw) {
           Log.log(JSON.stringify(result));
@@ -91,12 +91,12 @@ export default (program: any) => {
     .option('--publish-id <publish-id>', 'Publication id. (Required)')
     .option('-r, --raw', 'Produce some raw output.')
     .asyncActionProjectDir(
-      async (projectDir: string, options: DetailOptions) => {
+      async (projectRoot: string, options: DetailOptions) => {
         if (!options.publishId) {
           throw new Error('--publish-id must be specified.');
         }
 
-        const detail = await getPublicationDetailAsync(projectDir, options);
+        const detail = await getPublicationDetailAsync(projectRoot, options);
         await printPublicationDetailAsync(detail, options);
       },
       { checkConfig: true }

--- a/packages/expo-cli/src/commands/publish-modify.ts
+++ b/packages/expo-cli/src/commands/publish-modify.ts
@@ -28,7 +28,7 @@ export default function (program: Command) {
     )
     .asyncActionProjectDir(
       async (
-        projectDir: string,
+        projectRoot: string,
         options: { releaseChannel?: string; publishId?: string }
       ): Promise<void> => {
         if (!options.releaseChannel) {
@@ -39,7 +39,7 @@ export default function (program: Command) {
         }
         try {
           const result = await setPublishToChannelAsync(
-            projectDir,
+            projectRoot,
             options as { releaseChannel: string; publishId: string }
           );
           const tableString = table.printTableJson(
@@ -65,7 +65,7 @@ export default function (program: Command) {
     .option('-p, --platform <ios|android>', 'The platform to rollback.')
     .asyncActionProjectDir(
       async (
-        projectDir: string,
+        projectRoot: string,
         options: {
           releaseChannel?: string;
           sdkVersion?: string;
@@ -79,7 +79,7 @@ export default function (program: Command) {
           );
         }
         if (!options.releaseChannel || !options.sdkVersion) {
-          const usage = await getUsageAsync(projectDir);
+          const usage = await getUsageAsync(projectRoot);
           throw new Error(usage);
         }
         if (options.platform) {
@@ -89,14 +89,14 @@ export default function (program: Command) {
             );
           }
         }
-        await rollbackPublicationFromChannelAsync(projectDir, options as RollbackOptions);
+        await rollbackPublicationFromChannelAsync(projectRoot, options as RollbackOptions);
       },
       { checkConfig: true }
     );
 }
-async function getUsageAsync(projectDir: string): Promise<string> {
+async function getUsageAsync(projectRoot: string): Promise<string> {
   try {
-    return await _getUsageAsync(projectDir);
+    return await _getUsageAsync(projectRoot);
   } catch (e) {
     Log.warn(e);
     // couldn't print out warning for some reason
@@ -104,9 +104,9 @@ async function getUsageAsync(projectDir: string): Promise<string> {
   }
 }
 
-async function _getUsageAsync(projectDir: string): Promise<string> {
+async function _getUsageAsync(projectRoot: string): Promise<string> {
   const allPlatforms = ['ios', 'android'];
-  const publishesResult = await getPublishHistoryAsync(projectDir, {
+  const publishesResult = await getPublishHistoryAsync(projectRoot, {
     releaseChannel: 'default', // not specifying a channel will return most recent publishes but this is not neccesarily the most recent entry in a channel (user could have set an older publish to top of the channel)
     count: allPlatforms.length,
   });
@@ -124,7 +124,7 @@ async function _getUsageAsync(projectDir: string): Promise<string> {
       const detailOptions = {
         publishId: publication.publicationId,
       };
-      return await getPublicationDetailAsync(projectDir, detailOptions);
+      return await getPublicationDetailAsync(projectRoot, detailOptions);
     })
   );
 

--- a/packages/expo-cli/src/commands/push-creds.ts
+++ b/packages/expo-cli/src/commands/push-creds.ts
@@ -10,13 +10,13 @@ export default function (program: Command) {
     .description('Upload an FCM key for Android push notifications')
     .helpGroup('notifications')
     .option('--api-key [api-key]', 'Server API key for FCM.')
-    .asyncActionProjectDir(async (projectDir: string, options: { apiKey?: string }) => {
+    .asyncActionProjectDir(async (projectRoot: string, options: { apiKey?: string }) => {
       if (!options.apiKey || options.apiKey.length === 0) {
         throw new Error('Must specify an API key to upload with --api-key.');
       }
 
       const ctx = new Context();
-      await ctx.init(projectDir);
+      await ctx.init(projectRoot);
       const experienceName = `@${ctx.projectOwner}/${ctx.manifest.slug}`;
 
       await ctx.android.updateFcmKey(experienceName, options.apiKey);
@@ -27,9 +27,9 @@ export default function (program: Command) {
     .command('push:android:show [path]')
     .description('Log the value currently in use for FCM notifications for this project')
     .helpGroup('notifications')
-    .asyncActionProjectDir(async (projectDir: string) => {
+    .asyncActionProjectDir(async (projectRoot: string) => {
       const ctx = new Context();
-      await ctx.init(projectDir);
+      await ctx.init(projectRoot);
       const experienceName = `@${ctx.projectOwner}/${ctx.manifest.slug}`;
 
       const fcmCredentials = await ctx.android.fetchFcmKey(experienceName);
@@ -44,9 +44,9 @@ export default function (program: Command) {
     .command('push:android:clear [path]')
     .description('Delete a previously uploaded FCM credential')
     .helpGroup('notifications')
-    .asyncActionProjectDir(async (projectDir: string) => {
+    .asyncActionProjectDir(async (projectRoot: string) => {
       const ctx = new Context();
-      await ctx.init(projectDir);
+      await ctx.init(projectRoot);
       const experienceName = `@${ctx.projectOwner}/${ctx.manifest.slug}`;
 
       await ctx.android.removeFcmKey(experienceName);

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -108,8 +108,8 @@ export function parseRawArguments(options: RawStartOptions, rawArgs: string[]): 
   return opts;
 }
 
-async function cacheOptionsAsync(projectDir: string, options: NormalizedOptions): Promise<void> {
-  await ProjectSettings.setAsync(projectDir, {
+async function cacheOptionsAsync(projectRoot: string, options: NormalizedOptions): Promise<void> {
+  await ProjectSettings.setAsync(projectRoot, {
     devClient: options.devClient,
     scheme: options.scheme,
     dev: options.dev,

--- a/packages/expo-cli/src/commands/upload.ts
+++ b/packages/expo-cli/src/commands/upload.ts
@@ -40,13 +40,13 @@ export default function (program: Command) {
     )
     .option('--verbose', 'Always print logs from Submission Service')
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
-    .asyncActionProjectDir(async (projectDir: string, options: AndroidSubmitCommandOptions) => {
+    .asyncActionProjectDir(async (projectRoot: string, options: AndroidSubmitCommandOptions) => {
       if (options.useSubmissionService) {
         Log.warn(
           '\n`--use-submission-service is now the default and the flag will be deprecated in the future.`'
         );
       }
-      const ctx = AndroidSubmitCommand.createContext(projectDir, options);
+      const ctx = AndroidSubmitCommand.createContext(projectRoot, options);
       const command = new AndroidSubmitCommand(ctx);
       await command.runAsync();
     });
@@ -99,7 +99,7 @@ export default function (program: Command) {
     )
     .option('--public-url <url>', 'The URL of an externally hosted manifest (for self-hosted apps)')
     // TODO: make this work outside the project directory (if someone passes all necessary options for upload)
-    .asyncActionProjectDir(async (projectDir: string, options: any) => {
+    .asyncActionProjectDir(async () => {
       const logItem = (name: string, link: string) => {
         Log.log(`\u203A ${TerminalLink.linkedText(name, link)}`);
       };

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/config.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/config.ts
@@ -17,9 +17,9 @@ function getAppConfig(projecDir: string): AppConfig {
 }
 
 let exp: ExpoConfig;
-function getExpoConfig(projectDir: string): ExpoConfig {
+function getExpoConfig(projectRoot: string): ExpoConfig {
   if (!exp) {
-    const { exp: _exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
+    const { exp: _exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
     exp = _exp;
   }
   return exp;

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -105,13 +105,13 @@ export async function setPublishToChannelAsync(
 }
 
 async function _rollbackPublicationFromChannelForPlatformAsync(
-  projectDir: string,
+  projectRoot: string,
   platform: 'android' | 'ios',
   options: Omit<RollbackOptions, 'platform'>
 ) {
   const { releaseChannel, sdkVersion } = options;
   // get the 2 most recent things in the channel history
-  const historyQueryResult = await getPublishHistoryAsync(projectDir, {
+  const historyQueryResult = await getPublishHistoryAsync(projectRoot, {
     releaseChannel,
     platform,
     sdkVersion,
@@ -135,7 +135,7 @@ async function _rollbackPublicationFromChannelForPlatformAsync(
   const nonInteractiveOptions = options.parent ? { parent: options.parent } : {};
   // confirm that users will be receiving the secondMostRecent item in the Publish history
   await _printAndConfirm(
-    projectDir,
+    projectRoot,
     secondMostRecent.publicationId,
     releaseChannel,
     platform,
@@ -146,7 +146,7 @@ async function _rollbackPublicationFromChannelForPlatformAsync(
   const revertProgress = ora(
     `${platform}: Applying a revert publication to channel ${releaseChannel}`
   ).start();
-  await setPublishToChannelAsync(projectDir, {
+  await setPublishToChannelAsync(projectRoot, {
     releaseChannel,
     publishId: secondMostRecent.publicationId,
   });
@@ -156,14 +156,14 @@ async function _rollbackPublicationFromChannelForPlatformAsync(
 }
 
 export async function rollbackPublicationFromChannelAsync(
-  projectDir: string,
+  projectRoot: string,
   options: RollbackOptions
 ) {
   const { platform, ...restOfTheOptions } = options;
 
   if (platform) {
     return await _rollbackPublicationFromChannelForPlatformAsync(
-      projectDir,
+      projectRoot,
       platform,
       restOfTheOptions
     );
@@ -173,7 +173,11 @@ export async function rollbackPublicationFromChannelAsync(
   const completedPlatforms = [] as ('android' | 'ios')[];
   try {
     for (const platform of platforms) {
-      await _rollbackPublicationFromChannelForPlatformAsync(projectDir, platform, restOfTheOptions);
+      await _rollbackPublicationFromChannelForPlatformAsync(
+        projectRoot,
+        platform,
+        restOfTheOptions
+      );
       completedPlatforms.push(platform);
     }
   } catch (e) {
@@ -189,7 +193,7 @@ export async function rollbackPublicationFromChannelAsync(
 }
 
 async function _printAndConfirm(
-  projectDir: string,
+  projectRoot: string,
   publicationId: string,
   channel: string,
   platform: string,
@@ -198,7 +202,7 @@ async function _printAndConfirm(
   const detailOptions = {
     publishId: publicationId,
   };
-  const detail = await getPublicationDetailAsync(projectDir, detailOptions);
+  const detail = await getPublicationDetailAsync(projectRoot, detailOptions);
   await printPublicationDetailAsync(detail, detailOptions);
 
   if (partialOptions.parent && partialOptions.parent.nonInteractive) {

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -452,13 +452,13 @@ Command.prototype.asyncActionProjectDir = function (
   options: { checkConfig?: boolean; skipSDKVersionRequirement?: boolean } = {}
 ) {
   this.option('--config [file]', 'Specify a path to app.json or app.config.js');
-  return this.asyncAction(async (projectDir: string, ...args: any[]) => {
+  return this.asyncAction(async (projectRoot: string, ...args: any[]) => {
     const opts = args[0];
 
-    if (!projectDir) {
-      projectDir = process.cwd();
+    if (!projectRoot) {
+      projectRoot = process.cwd();
     } else {
-      projectDir = path.resolve(process.cwd(), projectDir);
+      projectRoot = path.resolve(process.cwd(), projectRoot);
     }
 
     if (opts.config) {
@@ -489,7 +489,7 @@ Command.prototype.asyncActionProjectDir = function (
         process.exit(1);
         // throw new Error(`File at provided config path does not exist: ${pathToConfig}`);
       }
-      setCustomConfigPath(projectDir, pathToConfig);
+      setCustomConfigPath(projectRoot, pathToConfig);
     }
 
     const logLines = (msg: any, logFn: (...args: any[]) => void) => {
@@ -598,7 +598,7 @@ Command.prototype.asyncActionProjectDir = function (
     let bar: ProgressBar | null;
     // eslint-disable-next-line no-new
     new PackagerLogsStream({
-      projectRoot: projectDir,
+      projectRoot,
       onStartBuildBundle: () => {
         bar = new ProgressBar('Building JavaScript bundle [:bar] :percent', {
           width: 64,
@@ -650,7 +650,7 @@ Command.prototype.asyncActionProjectDir = function (
     });
 
     // needed for validation logging to function
-    ProjectUtils.attachLoggerStream(projectDir, {
+    ProjectUtils.attachLoggerStream(projectRoot, {
       stream: {
         write: (chunk: LogRecord) => {
           if (chunk.tag === 'device') {
@@ -670,13 +670,13 @@ Command.prototype.asyncActionProjectDir = function (
     // This is relevant for command such as `send`
     if (
       options.checkConfig &&
-      (await ProjectSettings.getCurrentStatusAsync(projectDir)) !== 'running'
+      (await ProjectSettings.getCurrentStatusAsync(projectRoot)) !== 'running'
     ) {
       const spinner = ora('Making sure project is set up correctly...').start();
       Log.setSpinner(spinner);
       // validate that this is a good projectDir before we try anything else
 
-      const status = await Doctor.validateWithoutNetworkAsync(projectDir, {
+      const status = await Doctor.validateWithoutNetworkAsync(projectRoot, {
         skipSDKVersionRequirement: options.skipSDKVersionRequirement,
       });
       if (status === Doctor.FATAL) {
@@ -689,7 +689,7 @@ Command.prototype.asyncActionProjectDir = function (
     // the existing CLI modules only pass one argument to this function, so skipProjectValidation
     // will be undefined in most cases. we can explicitly pass a truthy value here to avoid validation (eg for init)
 
-    return asyncFn(projectDir, ...args);
+    return asyncFn(projectRoot, ...args);
   });
 };
 

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -43,8 +43,8 @@ function addOptions(program: Command) {
     .option('--localhost', 'Same as --host localhost');
 }
 
-async function optsAsync(projectDir: string, options: any) {
-  const opts = await ProjectSettings.readAsync(projectDir);
+async function optsAsync(projectRoot: string, options: any) {
+  const opts = await ProjectSettings.readAsync(projectRoot);
 
   if ([options.host, options.lan, options.localhost, options.tunnel].filter(i => i).length > 1) {
     throw new CommandError(
@@ -73,7 +73,7 @@ async function optsAsync(projectDir: string, options: any) {
 
   // Prevent using --dev-client in a managed app.
   if (options.devClient) {
-    const defaultTarget = getDefaultTarget(projectDir);
+    const defaultTarget = getDefaultTarget(projectRoot);
     if (defaultTarget !== 'bare') {
       Log.warn(
         `\nOption ${Log.chalk.bold(
@@ -91,13 +91,13 @@ async function optsAsync(projectDir: string, options: any) {
     opts.scheme = options.scheme ?? null;
   } else if (options.devClient) {
     // Attempt to find the scheme or warn the user how to setup a custom scheme
-    opts.scheme = await getDevClientSchemeAsync(projectDir);
+    opts.scheme = await getDevClientSchemeAsync(projectRoot);
   } else {
     // Ensure this is reset when users don't use `--scheme` or `--dev-client`
     opts.scheme = null;
   }
 
-  await ProjectSettings.setAsync(projectDir, opts);
+  await ProjectSettings.setAsync(projectRoot, opts);
 
   return opts;
 }

--- a/packages/expo-optimize/src/update.ts
+++ b/packages/expo-optimize/src/update.ts
@@ -6,7 +6,7 @@ function shouldUseYarn() {
   try {
     execSync('yarnpkg --version', { stdio: 'ignore' });
     return true;
-  } catch (_) {
+  } catch {
     return false;
   }
 }

--- a/packages/image-utils/src/Cache.ts
+++ b/packages/image-utils/src/Cache.ts
@@ -49,7 +49,7 @@ export async function getImageFromCacheAsync(
 ): Promise<null | Buffer> {
   try {
     return await readFile(resolve(cacheKeys[cacheKey], fileName));
-  } catch (_) {
+  } catch {
     return null;
   }
 }

--- a/packages/image-utils/src/sharp.ts
+++ b/packages/image-utils/src/sharp.ts
@@ -39,7 +39,7 @@ export async function isAvailableAsync(): Promise<boolean> {
   }
   try {
     return !!(await findSharpBinAsync());
-  } catch (_) {
+  } catch {
     return false;
   }
 }
@@ -159,7 +159,7 @@ export async function findSharpInstanceAsync(): Promise<any | null> {
     const sharp = require('sharp');
     _sharpInstance = sharp;
     return sharp;
-  } catch (_) {}
+  } catch {}
 
   // Attempt to resolve the sharp instance used by the global CLI
   let sharpCliPath;
@@ -176,7 +176,7 @@ export async function findSharpInstanceAsync(): Promise<any | null> {
     try {
       // attempt to require the global sharp package
       _sharpInstance = require(sharpPath);
-    } catch (_) {}
+    } catch {}
   }
 
   return _sharpInstance;

--- a/packages/next-adapter/src/cli/update.ts
+++ b/packages/next-adapter/src/cli/update.ts
@@ -9,7 +9,7 @@ function shouldUseYarn() {
   try {
     execSync('yarnpkg --version', { stdio: 'ignore' });
     return true;
-  } catch (_) {
+  } catch {
     return false;
   }
 }

--- a/packages/pwa/src/update.ts
+++ b/packages/pwa/src/update.ts
@@ -6,7 +6,7 @@ function shouldUseYarn() {
   try {
     execSync('yarnpkg --version', { stdio: 'ignore' });
     return true;
-  } catch (_) {
+  } catch {
     return false;
   }
 }

--- a/packages/uri-scheme/src/update.ts
+++ b/packages/uri-scheme/src/update.ts
@@ -6,7 +6,7 @@ function shouldUseYarn(): boolean {
   try {
     execSync('yarnpkg --version', { stdio: 'ignore' });
     return true;
-  } catch (_) {
+  } catch {
     return false;
   }
 }

--- a/packages/webpack-config/src/env/paths.ts
+++ b/packages/webpack-config/src/env/paths.ts
@@ -72,7 +72,7 @@ function parsePaths(
       ['./index', './src/index'],
       getPlatformExtensions(env.platform ?? 'web')
     );
-  } catch (_) {
+  } catch {
     // ignore the error
   }
 

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -880,11 +880,11 @@ const splashScreenDPIConstraints: readonly DPIConstraint[] = [
 /**
  * Checks whether `resizeMode` is set to `native` and if `true` analyzes provided images for splashscreen
  * providing `Logger` feedback upon problems.
- * @param projectDir - directory of the expo project
+ * @param projectRoot - directory of the expo project
  * @since SDK33
  */
-export async function checkSplashScreenImages(projectDir: string): Promise<void> {
-  const { exp } = getConfig(projectDir);
+export async function checkSplashScreenImages(projectRoot: string): Promise<void> {
+  const { exp } = getConfig(projectRoot);
 
   // return before SDK33
   if (!Versions.gteSdkVersion(exp, '33.0.0')) {
@@ -907,7 +907,7 @@ export async function checkSplashScreenImages(projectDir: string): Promise<void>
     );
     return;
   }
-  const generalSplashImage = await getImageDimensionsAsync(projectDir, generalSplashImagePath);
+  const generalSplashImage = await getImageDimensionsAsync(projectRoot, generalSplashImagePath);
   if (!generalSplashImage) {
     Logger.global.warn(
       `Couldn't read dimensions of provided splash image '${chalk.italic(
@@ -922,7 +922,7 @@ export async function checkSplashScreenImages(projectDir: string): Promise<void>
   for (const { dpi, sizeMultiplier } of splashScreenDPIConstraints) {
     const imageRelativePath = androidSplash?.[dpi];
     if (imageRelativePath) {
-      const splashImage = await getImageDimensionsAsync(projectDir, imageRelativePath);
+      const splashImage = await getImageDimensionsAsync(projectRoot, imageRelativePath);
       if (!splashImage) {
         Logger.global.warn(
           `Couldn't read dimensions of provided splash image '${chalk.italic(

--- a/packages/xdl/src/BundleIdentifier.ts
+++ b/packages/xdl/src/BundleIdentifier.ts
@@ -107,11 +107,11 @@ function missingBundleIdentifierMessage(configDescription: string): string {
 }
 
 async function updateAppJsonConfigAsync(
-  projectDir: string,
+  projectRoot: string,
   exp: ExpoConfig,
   newBundleIdentifier: string
 ): Promise<void> {
-  const paths = getConfigFilePaths(projectDir);
+  const paths = getConfigFilePaths(projectRoot);
   assert(paths.staticConfigPath, "Can't update dynamic configs");
 
   const rawStaticConfig = (await JsonFile.readAsync(paths.staticConfigPath)) as any;
@@ -129,13 +129,13 @@ async function updateAppJsonConfigAsync(
  * It will return false if the value in static config is different than "ios.bundleIdentifier" in ExpoConfig
  */
 async function hasBundleIdentifierInStaticConfigAsync(
-  projectDir: string,
+  projectRoot: string,
   exp: ExpoConfig
 ): Promise<boolean> {
   if (!exp.ios?.bundleIdentifier) {
     return false;
   }
-  const paths = getConfigFilePaths(projectDir);
+  const paths = getConfigFilePaths(projectRoot);
   if (!paths.staticConfigPath) {
     return false;
   }

--- a/packages/xdl/src/detach/Detach.ts
+++ b/packages/xdl/src/detach/Detach.ts
@@ -50,7 +50,7 @@ async function _getIosExpoKitVersionThrowErrorAsync(iosProjectDirectory: string)
 async function readNullableConfigJsonAsync(projectDir: string) {
   try {
     return getConfig(projectDir);
-  } catch (_) {
+  } catch {
     return null;
   }
 }

--- a/packages/xdl/src/tools/ImageUtils.ts
+++ b/packages/xdl/src/tools/ImageUtils.ts
@@ -16,7 +16,7 @@ async function getImageDimensionsAsync(
 ): Promise<{ width: number; height: number } | null> {
   try {
     return await _getImageDimensionsAsync(projectDirname, basename);
-  } catch (_) {}
+  } catch {}
   return null;
 }
 


### PR DESCRIPTION
# Why

- projectRoot is used more frequently across the repo, this doesn't do all cases but it covers a number of easier ones.
- Remove unused `(_)` in try/catch statements.
