### PR TITLE
Mute regenerator runtime and setimmediate traces

### DIFF
--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -33,6 +33,10 @@ export const INTERNAL_CALLSITES_REGEX = new RegExp(
     '/expo/build/logs/RemoteConsole.js$',
     // Improve errors thrown by invariant (ex: `Invariant Violation: "main" has not been registered`).
     'node_modules/invariant/.+\\.js$',
+    // Remove babel runtime additions
+    'node_modules/regenerator-runtime/.+\\.js$',
+    // Remove react native setImmediate ponyfill
+    'node_modules/promise/setimmediate/.+\\.js$',
   ].join('|')
 );
 


### PR DESCRIPTION
# Why

Improved debugging experience.

## Before

```log
expo-permissions is now deprecated — the functionality has been moved to other expo packages that directly use these permissions (e.g. expo-location, expo-camera). The package will be removed in the upcoming releases.
at node_modules/expo-permissions/build/Permissions.js:48:7 in askAsync
at node_modules/regenerator-runtime/runtime.js:63:36 in tryCatch
at node_modules/regenerator-runtime/runtime.js:293:29 in invoke
at node_modules/regenerator-runtime/runtime.js:63:36 in tryCatch
at node_modules/regenerator-runtime/runtime.js:154:27 in invoke
at node_modules/regenerator-runtime/runtime.js:189:16 in PromiseImpl$argument_0
at node_modules/react-native/node_modules/promise/setimmediate/core.js:45:6 in tryCallTwo
at node_modules/react-native/node_modules/promise/setimmediate/core.js:200:22 in doResolve
at node_modules/react-native/node_modules/promise/setimmediate/core.js:66:11 in Promise
at node_modules/regenerator-runtime/runtime.js:188:15 in callInvokeWithMethodAndArg
at node_modules/regenerator-runtime/runtime.js:211:38 in enqueue
at node_modules/regenerator-runtime/runtime.js:238:8 in exports.async
at http://127.0.0.1:19000/index.bundle?platform=ios&dev=true&hot=false&minify=false:138794:37 in askAsync
at node_modules/expo-permissions/build/PermissionsHooks.js:26:27 in usePermissions
at node_modules/expo-permissions/build/PermissionsHooks.js:29:17 in useEffect$argument_0
at [native code]:null in performSyncWorkOnRoot
at node_modules/react-native/Libraries/ReactNative/renderApplication.js:54:4 in renderApplication
at node_modules/react-native/Libraries/ReactNative/AppRegistry.js:117:25 in runnables.appKey.run
at node_modules/react-native/Libraries/ReactNative/AppRegistry.js:202:4 in runApplication
at [native code]:null in callFunctionReturnFlushedQueue
```

## After

```log
expo-permissions is now deprecated — the functionality has been moved to other expo packages that directly use these permissions (e.g. expo-location, expo-camera). The package will be removed in the upcoming releases.
at node_modules/expo-permissions/build/Permissions.js:48:7 in askAsync
at http://127.0.0.1:19000/index.bundle?platform=ios&dev=true&hot=false&minify=false:138794:37 in askAsync
at node_modules/expo-permissions/build/PermissionsHooks.js:26:27 in usePermissions
at node_modules/expo-permissions/build/PermissionsHooks.js:29:17 in useEffect$argument_0
at [native code]:null in performSyncWorkOnRoot
at node_modules/react-native/Libraries/ReactNative/renderApplication.js:54:4 in renderApplication
at node_modules/react-native/Libraries/ReactNative/AppRegistry.js:117:25 in runnables.appKey.run
at node_modules/react-native/Libraries/ReactNative/AppRegistry.js:202:4 in runApplication
at [native code]:null in callFunctionReturnFlushedQueue
```