### PR TITLE
Added clean flag to prebuild

### DIFF
--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -11,13 +11,13 @@ export async function actionAsync(
   projectRoot: string,
   {
     platform,
-    reset,
+    clean,
     skipDependencyUpdate,
     ...options
   }: EjectAsyncOptions & {
     npm?: boolean;
     platform?: string;
-    reset?: boolean;
+    clean?: boolean;
     skipDependencyUpdate?: string;
   }
 ) {
@@ -27,7 +27,7 @@ export async function actionAsync(
 
   const platforms = platformsFromPlatform(platform);
 
-  if (reset) {
+  if (clean) {
     if (await maybeBailOnGitStatusAsync()) return;
     // Clear the native folders before syncing
     await clearNativeFolder(projectRoot, platforms);
@@ -53,7 +53,7 @@ export default function (program: Command) {
     )
     .helpGroup('eject')
     .option('--no-install', 'Skip installing npm packages and CocoaPods.')
-    .option('--reset', 'Delete the native folders and regenerate them before applying changes')
+    .option('--clean', 'Delete the native folders and regenerate them before applying changes')
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
     .option(

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -5,6 +5,7 @@ import { clearNativeFolder } from './eject/clearNativeFolder';
 import { platformsFromPlatform } from './eject/platformOptions';
 import { EjectAsyncOptions, prebuildAsync } from './eject/prebuildAsync';
 import { learnMore } from './utils/TerminalLink';
+import maybeBailOnGitStatusAsync from './utils/maybeBailOnGitStatusAsync';
 
 export async function actionAsync(
   projectRoot: string,
@@ -27,6 +28,7 @@ export async function actionAsync(
   const platforms = platformsFromPlatform(platform);
 
   if (reset) {
+    if (await maybeBailOnGitStatusAsync()) return;
     // Clear the native folders before syncing
     await clearNativeFolder(projectRoot, platforms);
   }

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -10,11 +10,13 @@ export async function actionAsync(
   projectRoot: string,
   {
     platform,
+    reset,
     skipDependencyUpdate,
     ...options
   }: EjectAsyncOptions & {
     npm?: boolean;
     platform?: string;
+    reset?: boolean;
     skipDependencyUpdate?: string;
   }
 ) {
@@ -24,8 +26,10 @@ export async function actionAsync(
 
   const platforms = platformsFromPlatform(platform);
 
-  // Clear the native folders before syncing
-  await clearNativeFolder(projectRoot, platforms);
+  if (reset) {
+    // Clear the native folders before syncing
+    await clearNativeFolder(projectRoot, platforms);
+  }
 
   await prebuildAsync(projectRoot, {
     ...options,
@@ -47,6 +51,7 @@ export default function (program: Command) {
     )
     .helpGroup('eject')
     .option('--no-install', 'Skip installing npm packages and CocoaPods.')
+    .option('--reset', 'Delete the native folders and regenerate them before applying changes')
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
     .option(


### PR DESCRIPTION
# Why

If you install an auto plugin like `expo-camera` you should be able to quickly apply the plugin changes without having to fully reset everything. This PR proposes that we add a flag like `--clean`. When `--clean` is provided, the native folders will be cleared, otherwise the config plugin changes will just be applied normally. This could lead to projects getting in weird states because some plugins aren't being cleaned up, but we can solve that by just running `expo prebuild --clean`. 

This optimizes for adding new packages more than adding/removing. With this, we can instruct managed v2 users to install packages like:

# Start Fake Docs


## Installation

```
yarn add expo-camera
```

Expo Go users don't need to do anything else. Users with custom clients should continue.

### Automatic setup

> ⚠️ For users with managed native projects only! Learn more: (doc about new managed workflow)

- Apply the config plugin: `expo prebuild`
  - For custom options see the [expo-camera config plugin docs](#)
- Rebuild: `expo run:ios` or `expo run:android`

### Manual setup

For users with arbitrary changes to their native project (bare workflow). Learn more: (doc about new bare vs new managed workflow).

#### iOS

Add `NSCameraUsageDescription` key to your `Info.plist`:

```xml
<key>NSCameraUsageDescription</key>
<string>Allow $(PRODUCT_NAME) to use the camera</string>
```

Run `npx pod-install` after installing the npm package.

Finally, rebuild the native project with `expo run:ios`.

#### Android

This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` to your `android/**/AndroidManifest.xml`.

```xml
<!-- Added permissions -->
<uses-permission android:name="android.permission.CAMERA" />

<!-- Optional permissions -->
<uses-permission android:name="android.permission.RECORD_AUDIO" />
```

Add the following line to the `android/build.gradle` to add a new `maven` block after all other repositories as described below:

```diff
allprojects {
    repositories {
        // * Your other repositories here *
    }
}

+ allprojects { repositories { maven { url "$rootDir/../node_modules/expo-camera/android/maven" } } }
```

Finally, rebuild the native project with `expo run:android`.

## Uninstallation

```
yarn remove expo-camera
```

Expo Go users don't need to do anything else. Users with custom clients should continue.

### Automatic

> ⚠️ For users with managed native projects only! Learn more: (doc about new managed workflow)

- Reset your generated native folders `expo prebuild --clean` 
  - This will ensure any unused native code, permissions, or assets are removed from your project. Don't do this if you [manually modified](#) your native folders.
- Rebuild: `expo run:ios` or `expo run:android`

### Manual


For users with arbitrary changes to their native project (bare workflow). Learn more: (doc about new bare vs new managed workflow).

#### iOS

Remove `NSCameraUsageDescription` key to your `Info.plist` if you aren't using it for another module:

```diff
- <key>NSCameraUsageDescription</key>
- <string>Allow $(PRODUCT_NAME) to use the camera</string>
```

Run `npx pod-install` to uninstall the CocoaPod.

Finally, rebuild the native project with `expo run:ios`.

#### Android

Remove the `RECORD_AUDIO` and `CAMERA` permissions from your `android/**/AndroidManifest.xml` if you aren't using them for another module.

```diff
- <uses-permission android:name="android.permission.CAMERA" />
- <uses-permission android:name="android.permission.RECORD_AUDIO" />
```

Remove the following line from the `android/build.gradle`:

```diff
allprojects {
    repositories {
        // * Your other repositories here *
    }
}

- allprojects { repositories { maven { url "$rootDir/../node_modules/expo-camera/android/maven" } } }
```

Finally, rebuild the native project with `expo run:android`.

# End Fake Docs
---

# Test Plan

```sh
expo init
# generate native folders
expo prebuild 

yarn add expo-camera
# sync plugin without clearing native code
expo prebuild
# builds as expected
expo run:android

yarn remove expo-camera

# optionally run this again (cannot remove expo-camera changes)
expo prebuild 

# build -- cannot find maven and fails to build
expo run:android

# reset native code and sync changes (removes maven)
expo prebuild --clean
# build as expected
expo run:android
```




