### PR TITLE
[expo-cli] Change template project default branch from master to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
         # run: cd packages/${{ matrix.package }} && yarn test --coverage
         env:
           CI: true
+          EXPO_DEBUG: true
       # - name: Get Test Flag Name
       #   id: cov-flag-name
       #   run: echo "::set-output name=flag::$(echo ${{ matrix.package }} | perl -pe 's/[^a-z]+([a-z])/\U\1/gi;s/^([A-Z])/\l\1/')"

--- a/packages/config/src/__tests__/ConfigParsing-test.ts
+++ b/packages/config/src/__tests__/ConfigParsing-test.ts
@@ -109,7 +109,7 @@ describe(getConfig, () => {
       expect(exp.name).toBe('rewrote+ts-config-test');
       expect(exp._internal).toStrictEqual({
         dynamicConfigPath: 'ts/app.config.ts',
-        isDebug: false,
+        isDebug: true,
         packageJsonPath: 'ts/package.json',
         projectRoot: 'ts',
         staticConfigPath: null,
@@ -132,7 +132,7 @@ describe(getConfig, () => {
       expect(exp.slug).toBe('someslug+config');
       expect(exp._internal).toStrictEqual({
         dynamicConfigPath: 'js/app.config.js',
-        isDebug: false,
+        isDebug: true,
         packageJsonPath: 'js/package.json',
         projectRoot: 'js',
         staticConfigPath: 'js/app.json',
@@ -209,7 +209,7 @@ describe(getConfig, () => {
 
       expect(exp._internal).toStrictEqual({
         dynamicConfigPath: null,
-        isDebug: false,
+        isDebug: true,
         packageJsonPath: 'custom-location-json/package.json',
         projectRoot: 'custom-location-json',
         staticConfigPath: 'custom-location-json/src/app.staging.json',

--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -26,12 +26,12 @@ test('init', async () => {
     { cwd, env: { ...process.env, YARN_CACHE_FOLDER: path.join(cwd, 'yarn-cache') } }
   );
   expect(stdout).toMatch(`Your project is ready!`);
+
   const projectRoot = path.join(cwd, 'hello-world');
   const appJson = await JsonFile.readAsync(path.join(projectRoot, 'app.json'));
   expect(appJson).toHaveProperty(['expo', 'name'], 'hello-world');
   expect(appJson).toHaveProperty(['expo', 'slug'], 'hello-world');
-  const { stdout: gitBranch } = await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-    cwd: projectRoot,
-  });
-  expect(gitBranch.trimEnd()).toBe('main');
+
+  const { stdout: gitBranch } = await spawnAsync('git', ['status'], { cwd: projectRoot });
+  expect(gitBranch).toBe('On branch main\nnothing to commit, working tree clean\n');
 });

--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -1,4 +1,5 @@
 import JsonFile from '@expo/json-file';
+import spawnAsync from '@expo/spawn-async';
 import path from 'path';
 import stripAnsi from 'strip-ansi';
 import temporary from 'tempy';
@@ -17,15 +18,20 @@ test('init (no dir name)', async () => {
   expect(stderr).toMatch(/Pass the project name using the first argument/);
 });
 
-xtest('init', async () => {
+test('init', async () => {
   jest.setTimeout(60000);
   const cwd = temporary.directory();
   const { stdout } = await runAsync(
-    ['init', 'hello-world', '--template', 'blank', '--name', 'hello-&<world/>'],
+    ['init', 'hello-world', '--template', 'blank', '--name', 'hello-world', '--no-install'],
     { cwd, env: { ...process.env, YARN_CACHE_FOLDER: path.join(cwd, 'yarn-cache') } }
   );
   expect(stdout).toMatch(`Your project is ready!`);
-  const appJson = await JsonFile.readAsync(path.join(cwd, 'hello-world/app.json'));
-  expect(appJson).toHaveProperty(['expo', 'name'], 'hello-&<world/>');
+  const projectRoot = path.join(cwd, 'hello-world');
+  const appJson = await JsonFile.readAsync(path.join(projectRoot, 'app.json'));
+  expect(appJson).toHaveProperty(['expo', 'name'], 'hello-world');
   expect(appJson).toHaveProperty(['expo', 'slug'], 'hello-world');
+  const { stdout: gitBranch } = await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: projectRoot,
+  });
+  expect(gitBranch.trimEnd()).toBe('main');
 });

--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -20,6 +20,9 @@ test('init (no dir name)', async () => {
 
 test('init', async () => {
   jest.setTimeout(60000);
+
+  await spawnAsync('git', ['config', '--global', 'user.name', 'Test User']);
+
   const cwd = temporary.directory();
   const { stdout } = await runAsync(
     ['init', 'hello-world', '--template', 'blank', '--name', 'hello-world', '--no-install'],

--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -32,6 +32,9 @@ test('init', async () => {
   expect(appJson).toHaveProperty(['expo', 'name'], 'hello-world');
   expect(appJson).toHaveProperty(['expo', 'slug'], 'hello-world');
 
-  const { stdout: gitBranch } = await spawnAsync('git', ['status'], { cwd: projectRoot });
+  const { stdout: gitBranch } = await spawnAsync('git', ['status'], {
+    cwd: projectRoot,
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
   expect(gitBranch).toBe('On branch main\nnothing to commit, working tree clean\n');
 });

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -385,6 +385,7 @@ export async function initGitRepoAsync(
         cwd: root,
         stdio: 'ignore',
       });
+      await spawnAsync('git', ['branch', '-M', 'main'], { cwd: root, stdio: 'ignore' });
     }
     return true;
   } catch (e) {

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -389,6 +389,7 @@ export async function initGitRepoAsync(
     }
     return true;
   } catch (e) {
+    Log.debug('git error:', e);
     // no-op -- this is just a convenience and we don't care if it fails
     return false;
   }


### PR DESCRIPTION
# Why

[New repositiories on GitHub use `main` as the default branch name](https://github.com/github/renaming#new-repositories-use-main-as-the-default-branch-name)

# How

Added `git branch -M main` after the initial commit in `expo init`.

# Test Plan

Enabled the previously disabled end-to-end test (now with `--no-install` so it won't time out like before, which was the original reason for disabling it, IIRC). Added an assertion that checks that the branch name after running `expo init` is correct.

Additionally, tested running `expo init` manually and checked the branch name using `git status` once finished.