### PR TITLE
Added withGradleProperties mod

### DIFF
--- a/packages/config-plugins/README.md
+++ b/packages/config-plugins/README.md
@@ -258,6 +258,8 @@ The following default mods are provided by the mod compiler for common file mani
 - `mods.android.mainActivity` -- Modify the `android/app/src/main/<package>/MainActivity.java` as a string.
 - `mods.android.appBuildGradle` -- Modify the `android/app/build.gradle` as a string.
 - `mods.android.projectBuildGradle` -- Modify the `android/build.gradle` as a string.
+- `mods.android.settingsGradle` -- Modify the `android/settings.gradle` as a string.
+- `mods.android.gradleProperties` -- Modify the `android/gradle.properties` as a `Properties.PropertiesItem[]`.
 
 After the mods are resolved, the contents of each mod will be written to disk. Custom default mods can be added to support new native files.
 For example, you can create a mod to support the `GoogleServices-Info.plist`, and pass it to other mods.
@@ -282,6 +284,7 @@ Instead you should use the helper mods provided by `@expo/config-plugins`:
   - `withProjectBuildGradle`
   - `withAppBuildGradle`
   - `withSettingsGradle`
+  - `withGradleProperties`
 
 A mod plugin gets passed a `config` object with additional properties `modResults` and `modRequest` added to it.
 

--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -2,6 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 import { JSONObject } from '@expo/json-file';
 import { XcodeProject } from 'xcode';
 
+import { Properties } from './android';
 import { AndroidManifest } from './android/Manifest';
 import * as AndroidPaths from './android/Paths';
 import { ResourceXML } from './android/Resources';
@@ -89,6 +90,10 @@ export interface ModConfig {
      * Modify the `android/settings.gradle` as a string.
      */
     settingsGradle?: Mod<AndroidPaths.GradleProjectFile>;
+    /**
+     * Modify the `android/gradle.properties` as a `Properties.PropertiesItem[]`.
+     */
+    gradleProperties?: Mod<Properties.PropertiesItem[]>;
   };
   ios?: {
     /**

--- a/packages/config-plugins/src/android/Properties.ts
+++ b/packages/config-plugins/src/android/Properties.ts
@@ -1,0 +1,51 @@
+export type PropertiesItem =
+  | {
+      type: 'comment';
+      value: string;
+    }
+  | {
+      type: 'empty';
+    }
+  | {
+      type: 'property';
+      key: string;
+      value: string;
+    };
+
+export function parsePropertiesFile(contents: string): PropertiesItem[] {
+  const propertiesList: PropertiesItem[] = [];
+  const lines = contents.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) {
+      propertiesList.push({ type: 'empty' });
+    } else if (line.startsWith('#')) {
+      propertiesList.push({ type: 'comment', value: lines[i].trimStart().substring(1) });
+    } else {
+      const eok = line.indexOf('=');
+      const key = line.slice(0, eok);
+      const value = line.slice(eok + 1, line.length);
+      propertiesList.push({ type: 'property', key, value });
+    }
+  }
+
+  return propertiesList;
+}
+
+export function propertiesListToString(props: PropertiesItem[]): string {
+  let output = '';
+  for (const prop of props) {
+    if (prop.type === 'empty') {
+      output += '';
+    } else if (prop.type === 'comment') {
+      output += '# ' + prop.value;
+    } else if (prop.type === 'property') {
+      output += `${prop.key}=${prop.value}`;
+    } else {
+      // @ts-ignore: assertion
+      throw new Error(`Invalid properties type "${prop.type}"`);
+    }
+    output += '\n';
+  }
+  return output;
+}

--- a/packages/config-plugins/src/android/index.ts
+++ b/packages/config-plugins/src/android/index.ts
@@ -17,6 +17,7 @@ import * as Package from './Package';
 import * as Paths from './Paths';
 import * as Permissions from './Permissions';
 import * as PrimaryColor from './PrimaryColor';
+import * as Properties from './Properties';
 import * as RootViewBackgroundColor from './RootViewBackgroundColor';
 import * as Scheme from './Scheme';
 import * as SplashScreen from './SplashScreen';
@@ -25,6 +26,7 @@ import * as Styles from './Styles';
 import * as Updates from './Updates';
 import * as UserInterfaceStyle from './UserInterfaceStyle';
 import * as Version from './Version';
+
 export {
   AllowBackup,
   EasBuild,
@@ -45,6 +47,7 @@ export {
   Paths,
   Permissions,
   PrimaryColor,
+  Properties,
   RootViewBackgroundColor,
   Scheme,
   SplashScreen,

--- a/packages/config-plugins/src/index.ts
+++ b/packages/config-plugins/src/index.ts
@@ -47,6 +47,7 @@ export {
   withProjectBuildGradle,
   withAppBuildGradle,
   withSettingsGradle,
+  withGradleProperties,
 } from './plugins/android-plugins';
 
 export { withStaticPlugin } from './plugins/static-plugins';

--- a/packages/config-plugins/src/plugins/__tests__/android-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/android-plugins-test.ts
@@ -1,0 +1,50 @@
+import { ExpoConfig } from '@expo/config';
+import fs from 'fs-extra';
+import { vol } from 'memfs';
+import path from 'path';
+
+import { withGradleProperties } from '../android-plugins';
+import { withAndroidGradlePropertiesBaseMod } from '../compiler-plugins';
+import { evalModsAsync } from '../mod-compiler';
+import rnFixture from './fixtures/react-native-project';
+
+jest.mock('fs');
+
+describe(withGradleProperties, () => {
+  const projectRoot = '/app';
+
+  beforeEach(async () => {
+    vol.fromJSON(
+      {
+        ...rnFixture,
+      },
+      projectRoot
+    );
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it(`is passed gradle.properties`, async () => {
+    let config: ExpoConfig = {
+      name: 'foobar',
+      slug: 'foobar',
+    };
+
+    config = withGradleProperties(config, config => {
+      config.modResults.push({ type: 'comment', value: 'expo-test' });
+      config.modResults.push({ type: 'empty' });
+      config.modResults.push({ type: 'property', key: 'foo', value: 'bar' });
+      config.modResults.push({ type: 'empty' });
+      config.modResults.push({ type: 'comment', value: 'end-expo-test' });
+      return config;
+    });
+    config = withAndroidGradlePropertiesBaseMod(config);
+
+    await evalModsAsync(config, { projectRoot, platforms: ['android'] });
+
+    const contents = fs.readFileSync(path.join(projectRoot, 'android/gradle.properties'), 'utf8');
+    expect(contents.endsWith('# expo-test\n\nfoo=bar\n\n# end-expo-test\n')).toBe(true);
+  });
+});

--- a/packages/config-plugins/src/plugins/__tests__/expo-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/expo-plugins-test.ts
@@ -302,6 +302,7 @@ describe('built-in plugins', () => {
       'android/app/src/main/res/values/strings.xml',
       'android/app/build.gradle',
       'android/app/google-services.json',
+      'android/gradle.properties',
       'android/settings.gradle',
       'android/build.gradle',
       'config/GoogleService-Info.plist',

--- a/packages/config-plugins/src/plugins/__tests__/fixtures/react-native-project.ts
+++ b/packages/config-plugins/src/plugins/__tests__/fixtures/react-native-project.ts
@@ -997,6 +997,37 @@ public class MainActivity extends ReactActivity {
   </style>
 </resources>
 `,
+  'android/gradle.properties': `# Project-wide Gradle settings.
+
+  # IDE (e.g. Android Studio) users:
+  # Gradle settings configured through the IDE *will override*
+  # any settings specified in this file.
+  
+  # For more details on how to configure your build environment visit
+  # http://www.gradle.org/docs/current/userguide/build_environment.html
+  
+  # Specifies the JVM arguments used for the daemon process.
+  # The setting is particularly useful for tweaking memory settings.
+  # Default value: -Xmx10248m -XX:MaxPermSize=256m
+  # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+  
+  # When configured, Gradle will run in incubating parallel mode.
+  # This option should only be used with decoupled projects. More details, visit
+  # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+  # org.gradle.parallel=true
+  
+  # AndroidX package structure to make it clearer which packages are bundled with the
+  # Android operating system, and which are packaged with your app's APK
+  # https://developer.android.com/topic/libraries/support-library/androidx-rn
+  android.useAndroidX=true
+  
+  # Automatically convert third-party libraries to use AndroidX
+  android.enableJetifier=true
+  
+  # Version of flipper SDK to use with React Native
+  FLIPPER_VERSION=0.54.0
+  `,
+
   'android/settings.gradle': `rootProject.name = 'HelloWorld'
 
 apply from: '../node_modules/react-native-unimodules/gradle.groovy'

--- a/packages/config-plugins/src/plugins/android-plugins.ts
+++ b/packages/config-plugins/src/plugins/android-plugins.ts
@@ -1,6 +1,7 @@
 import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin, Mod } from '../Plugin.types';
+import { Properties } from '../android';
 import { AndroidManifest } from '../android/Manifest';
 import { ApplicationProjectFile, GradleProjectFile } from '../android/Paths';
 import { ResourceXML } from '../android/Resources';
@@ -129,6 +130,23 @@ export const withSettingsGradle: ConfigPlugin<Mod<GradleProjectFile>> = (config,
   return withExtendedMod(config, {
     platform: 'android',
     mod: 'settingsGradle',
+    action,
+  });
+};
+
+/**
+ * Provides the /gradle.properties for modification.
+ *
+ * @param config
+ * @param action
+ */
+export const withGradleProperties: ConfigPlugin<Mod<Properties.PropertiesItem[]>> = (
+  config,
+  action
+) => {
+  return withExtendedMod(config, {
+    platform: 'android',
+    mod: 'gradleProperties',
     action,
   });
 };


### PR DESCRIPTION
# Why

- We use a custom version in NCL https://github.com/expo/expo/blob/49cdec480538ac229ee91c600c7a2f6312e11176/apps/native-component-list/app.config.js#L22-L27
- It may be useful for other packages like `react-native-webrtc` https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/AndroidInstallation.md#fatal-exception-javalangunsatisfiedlinkerror and detox https://github.com/expo/examples/blob/5e0ac1a28139a347ab6e4bac551981391da6e0b9/with-detox/app.json#L19.

# How

- Created a `.properties` file parser that supports comments. 
- Added a new base mod `mods.android.gradleProperties` and a helper method `withGradleProperties`

# Test Plan

- Created an e2e test for the mod.