### PR TITLE
improvement: updated getenv dependencies to 1.0.0

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -39,7 +39,7 @@
     "@expo/plist": "0.0.11",
     "find-up": "~5.0.0",
     "fs-extra": "9.0.0",
-    "getenv": "0.7.0",
+    "getenv": "^1.0.0",
     "glob": "7.1.6",
     "resolve-from": "^5.0.0",
     "slash": "^3.0.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -40,7 +40,7 @@
     "@expo/config-types": "^40.0.0-beta.2",
     "@expo/json-file": "8.2.28-alpha.0",
     "fs-extra": "9.0.0",
-    "getenv": "0.7.0",
+    "getenv": "^1.0.0",
     "glob": "7.1.6",
     "require-from-string": "^2.0.2",
     "resolve-from": "^5.0.0",

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -94,7 +94,7 @@
     "find-yarn-workspace-root": "~2.0.0",
     "form-data": "^2.3.2",
     "fs-extra": "9.0.0",
-    "getenv": "0.7.0",
+    "getenv": "^1.0.0",
     "glob": "7.1.6",
     "got": "^11.1.4",
     "hashids": "1.1.4",

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -30,7 +30,7 @@
     "@expo/spawn-async": "1.5.0",
     "chalk": "^4.0.0",
     "fs-extra": "9.0.0",
-    "getenv": "0.7.0",
+    "getenv": "^1.0.0",
     "jimp": "0.12.1",
     "mime": "^2.4.4",
     "node-fetch": "^2.6.0",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@expo/config": "3.3.31",
     "chalk": "^4.1.0",
-    "getenv": "^0.7.0",
+    "getenv": "^1.0.0",
     "metro-react-native-babel-transformer": "^0.59.0"
   },
   "devDependencies": {

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -52,7 +52,7 @@
     "expo-pwa": "0.0.67",
     "file-loader": "~6.0.0",
     "find-yarn-workspace-root": "~2.0.0",
-    "getenv": "^0.7.0",
+    "getenv": "^1.0.0",
     "html-loader": "~1.1.0",
     "html-webpack-plugin": "~4.3.0",
     "is-wsl": "^2.0.0",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -54,7 +54,7 @@
     "form-data": "^2.3.2",
     "freeport-async": "2.0.0",
     "fs-extra": "9.0.0",
-    "getenv": "0.7.0",
+    "getenv": "^1.0.0",
     "glob": "7.1.6",
     "hasbin": "1.2.3",
     "indent-string": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10739,10 +10739,10 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getenv@0.7.0, getenv@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/getenv/-/getenv-0.7.0.tgz#39b91838707e2086fd1cf6ef8777d1c93e14649e"
-  integrity sha1-ObkYOHB+IIb9HPbvh3fRyT4UZJ4=
+getenv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/getenv/-/getenv-1.0.0.tgz#874f2e7544fbca53c7a4738f37de8605c3fcfc31"
+  integrity sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==
 
 getpass@^0.1.1:
   version "0.1.7"


### PR DESCRIPTION
# Why

Current used version of getenv (0.7.0) in metro-config does not include any type of license. Starting v1.0.0 MIT license is included in the package.

# How

Run `npm install getenv@1.0.0` to update `package.json` files in all packages. Run `yarn` to generate new lockfile and `yarn build` to verify local build.