### PR TITLE
[eject] preserve expo dev client scripts

### DIFF
--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -193,9 +193,15 @@ function updatePackageJSONScripts({ pkg }: { pkg: PackageJSONConfig }) {
   if (!pkg.scripts) {
     pkg.scripts = {};
   }
-  pkg.scripts.start = 'react-native start';
-  pkg.scripts.ios = 'react-native run-ios';
-  pkg.scripts.android = 'react-native run-android';
+  if (!pkg.scripts.start?.includes('--dev-client')) {
+    pkg.scripts.start = 'react-native start';
+  }
+  if (!pkg.scripts.android?.includes('run')) {
+    pkg.scripts.android = 'react-native run-android';
+  }
+  if (!pkg.scripts.ios?.includes('run')) {
+    pkg.scripts.ios = 'react-native run-ios';
+  }
 }
 
 /**


### PR DESCRIPTION
# Why

If a script is using a dev client script like `expo start --dev-client` then don't replace it on eject.
