### PR TITLE
[xdl] facebookReactNativeVersionToExpoVersionAsync: only map to released versions

### DIFF
--- a/packages/xdl/src/Versions.ts
+++ b/packages/xdl/src/Versions.ts
@@ -227,7 +227,7 @@ export async function facebookReactNativeVersionToExpoVersionAsync(
     );
   }
 
-  const sdkVersions = await sdkVersionsAsync();
+  const sdkVersions = await releasedSdkVersionsAsync();
   let currentSdkVersion: string | null = null;
 
   for (const [version, { facebookReactNativeVersion }] of Object.entries(sdkVersions)) {


### PR DESCRIPTION
# Why

`facebookReactNativeVersionToExpoVersionAsync` was mapping `react-native` versions to SDK versions that were added to the versions endpoint, but not yet released. This PR makes it only map to released versions.

Fixes #3288.

# How

Used `releasedSdkVersionsAsync` to get applicable versions.

# Test Plan

Tested briefly in the `node` console, following statements both printed '40.0.0' after the fix was done:
```
require('xdl').Versions.facebookReactNativeVersionToExpoVersionAsync('0.63.2').then(console.log)
require('xdl').Versions.facebookReactNativeVersionToExpoVersionAsync('0.63.4').then(console.log)
```