### PR TITLE
Allow single platform for dev client schemes

### DIFF
--- a/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
+++ b/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
@@ -8,7 +8,7 @@ import Log from '../../log';
 import { confirmAsync } from '../../prompts';
 import * as CreateApp from '../utils/CreateApp';
 
-async function directoryExistsAsync(file: string): Promise<boolean> {
+export async function directoryExistsAsync(file: string): Promise<boolean> {
   return (await fs.stat(file).catch(() => null))?.isDirectory() ?? false;
 }
 


### PR DESCRIPTION
# Why

a user with just ios or just android should still be able to use the dev client bundler.

