### PR TITLE
Update xmldom and xcode dependencies

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -44,7 +44,7 @@
     "resolve-from": "^5.0.0",
     "slash": "^3.0.0",
     "slugify": "^1.3.4",
-    "xcode": "^2.1.0",
+    "xcode": "^3.0.1",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {

--- a/packages/plist/package.json
+++ b/packages/plist/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "base64-js": "^1.2.3",
     "xmlbuilder": "^14.0.0",
-    "xmldom": "~0.1.31"
+    "xmldom": "~0.5.0"
   },
   "devDependencies": {
     "@types/base64-js": "^1.2.5",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -95,9 +95,7 @@
     "url-join": "4.0.0",
     "uuid": "3.3.2",
     "webpack": "4.43.0",
-    "webpack-dev-server": "3.11.0",
-    "xcode": "^2.1.0",
-    "xmldom": "0.1.27"
+    "webpack-dev-server": "3.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22531,15 +22531,15 @@ xmldoc@^1.1.2:
   dependencies:
     sax "^1.2.1"
 
-xmldom@0.1.27:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
-  integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
-
-xmldom@0.1.x, xmldom@~0.1.31:
+xmldom@0.1.x:
   version "0.1.31"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
   integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
+
+xmldom@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xpipe@*, xpipe@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
# Why

- `xdl` dependended on `xmldom` and `xcode` but was not using those dependencies anymore
- `@expo/config-plugins` and `@expo/configure-splash-screen` were using different versions of `xcode`
- `xmldom` 0.1.x gets flagged by `npm audit` (https://github.com/expo/expo-cli/issues/3296)

Fixes https://github.com/expo/expo-cli/issues/3296.

# How

Removed unused dependencies from `xdl`. Updated dependencies in `@expo/config-plugins` and `@expo/plist`.

# Test Plan

--