### PR TITLE
Sort code signing identities by last selected

### DIFF
--- a/packages/xdl/src/UserSettings.ts
+++ b/packages/xdl/src/UserSettings.ts
@@ -7,6 +7,7 @@ import * as Env from './Env';
 import { ConnectionType } from './User';
 
 export type UserSettingsData = {
+  developmentCodeSigningId?: string;
   appleId?: string;
   accessToken?: string;
   auth?: UserData | null;
@@ -18,6 +19,7 @@ export type UserSettingsData = {
 };
 
 export type UserData = {
+  developmentCodeSigningId?: string;
   appleId?: string;
   userId?: string;
   username?: string;


### PR DESCRIPTION
# Why

Sort the signing info by “last selected”, not sure if there’s a native way to get the user’s preferred signing identity but this will at least make it so developers who have more than one team (which I think is most devs cuz you'll have a paid team and a personal team) will be able to just mash the enter key to sign the app.

For example, when signing a new app, my list looks like this:

```log
? Development team for signing the app › - Use arrow-keys. Return to submit.
❯   650 Industries, Inc. (XXXXQTF339) - Apple Development: Evan Bacon (XXXXMDXG4H)
    Evan Bacon (XXXXR9NU86) - Apple Development: bacon@expo.io (XXXX2U6XNQ)
    Evan Bacon (XXXXRJ5UTD) - Apple Development: Evan Bacon (XXXXNJ89KU)
    Evan Bacon (XXXX8G34TX) - Apple Development: evanjbacon@gmail.com (XXXX42893T)
```

I almost always select the third one down (XXXXRJ5UTD) and would be upset if I accidentally signed my bundle id to the wrong team. After this PR, the third one down will be cached as my preference, and the next app I sign will show this:
```log
? Development team for signing the app › - Use arrow-keys. Return to submit.
❯   Evan Bacon (XXXXRJ5UTD) - Apple Development: Evan Bacon (XXXXNJ89KU)
    Evan Bacon (XXXX8G34TX) - Apple Development: evanjbacon@gmail.com (XXXX42893T)
    650 Industries, Inc. (XXXXQTF339) - Apple Development: Evan Bacon (XXXXMDXG4H)
    Evan Bacon (XXXXR9NU86) - Apple Development: bacon@expo.io (XXXX2U6XNQ)
```

# Test Plan

1. In a project, delete the `DEVELOPMENT_TEAM = XXXXRJ5UTD;` lines from the `.pbxproj`
2. Run `expo run:ios -d` and select a physically connected device
3. Select to code sign with an option (assuming you have more than two teams to sign with)
4. Repeat step 1. and 2.
5. Notice that the list is sorted by preference, and the preferred value will be bold if you scroll off of it.
