### PR TITLE
[eject] fix broken debug spinner

### DIFF
--- a/packages/expo-cli/src/commands/eject/installNodeDependenciesAsync.ts
+++ b/packages/expo-cli/src/commands/eject/installNodeDependenciesAsync.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 
 import { SilentError } from '../../CommandError';
+import Log from '../../log';
 import * as CreateApp from '../utils/CreateApp';
 
 /**
@@ -25,6 +26,11 @@ export async function installNodeDependenciesAsync(
   }
 
   const installJsDepsStep = CreateApp.logNewSection('Installing JavaScript dependencies.');
+
+  // Prevent the spinner from clashing with the node package manager logs
+  if (Log.isDebug) {
+    installJsDepsStep.stop();
+  }
 
   try {
     await CreateApp.installNodeDependenciesAsync(projectRoot, packageManager);

--- a/packages/expo-cli/src/commands/eject/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/eject/prebuildAsync.ts
@@ -93,7 +93,7 @@ export async function prebuildAsync(
   if (WarningAggregator.hasWarningsAndroid() || WarningAggregator.hasWarningsIOS()) {
     configSyncingStep.stopAndPersist({
       symbol: '⚠️ ',
-      text: chalk.red('Config synced with warnings that should be fixed:'),
+      text: chalk.yellow('Config synced with warnings that should be fixed:'),
     });
     logConfigWarningsAndroid();
     logConfigWarningsIOS();

--- a/packages/expo-cli/src/commands/eject/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/eject/prebuildAsync.ts
@@ -81,20 +81,24 @@ export async function prebuildAsync(
   }
 
   // Apply Expo config to native projects
-  const applyingAndroidConfigStep = CreateApp.logNewSection('Config syncing');
+  const configSyncingStep = CreateApp.logNewSection('Config syncing');
+  // Prevent the spinner from clashing with the debug traces
+  if (Log.isDebug) {
+    configSyncingStep.stop();
+  }
   const managedConfig = await configureProjectAsync({
     projectRoot,
     platforms,
   });
   if (WarningAggregator.hasWarningsAndroid() || WarningAggregator.hasWarningsIOS()) {
-    applyingAndroidConfigStep.stopAndPersist({
+    configSyncingStep.stopAndPersist({
       symbol: '⚠️ ',
       text: chalk.red('Config synced with warnings that should be fixed:'),
     });
     logConfigWarningsAndroid();
     logConfigWarningsIOS();
   } else {
-    applyingAndroidConfigStep.succeed('Config synced');
+    configSyncingStep.succeed('Config synced');
   }
 
   // Install CocoaPods

--- a/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
+++ b/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
+import CommandError from '../../CommandError';
 import Log from '../../log';
 import * as CreateApp from '../utils/CreateApp';
 import { learnMore } from '../utils/TerminalLink';
@@ -33,7 +34,7 @@ export function writeMetroConfig({
       const contents = createFileHash(fs.readFileSync(targetConfigPath, 'utf8'));
       const targetContents = createFileHash(fs.readFileSync(sourceConfigPath, 'utf8'));
       if (contents !== targetContents) {
-        throw new Error('Existing Metro configuration found; not overwriting.');
+        throw new CommandError('Existing Metro configuration found; not overwriting.');
       } else {
         // Nothing to change, hide the step and exit.
         updatingMetroConfigStep.stop();
@@ -45,7 +46,7 @@ export function writeMetroConfig({
       pkg.metro ||
       fs.existsSync(path.join(projectRoot, 'rn-cli.config.js'))
     ) {
-      throw new Error('Existing Metro configuration found; not overwriting.');
+      throw new CommandError('Existing Metro configuration found; not overwriting.');
     }
 
     fs.copySync(sourceConfigPath, targetConfigPath);


### PR DESCRIPTION
# Why

- The spinners clash with the debug logs, this PR stops the spinners in EXPO_DEBUG so they don't collide.
- Use CommandError instead of Error to prevent unused stack traces
- Make `Config synced with warnings that should be fixed` yellow instead of red
