### PR TITLE
Updated metro config warning to reflect SDK 41 by default.

### DIFF
--- a/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
+++ b/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
@@ -46,22 +46,22 @@ export function writeMetroConfig({
       pkg.metro ||
       fs.existsSync(path.join(projectRoot, 'rn-cli.config.js'))
     ) {
-      throw new CommandError('Existing Metro configuration found; not overwriting.');
+      throw new CommandError('Existing Metro config found; not overwriting.');
     }
 
     fs.copySync(sourceConfigPath, targetConfigPath);
-    updatingMetroConfigStep.succeed('Added Metro bundler configuration.');
+    updatingMetroConfigStep.succeed('Added Metro config.');
   } catch (e) {
     updatingMetroConfigStep.stopAndPersist({
       symbol: '⚠️ ',
-      text: chalk.yellow('Metro bundler configuration not applied:'),
+      text: chalk.yellow('Metro config not applied:'),
     });
     Log.nested(`\u203A ${e.message}`);
     Log.nested(
-      `\u203A You will need to add the ${chalk.bold(
-        'hashAssetFiles'
-      )} plugin to your Metro configuration.\n  ${Log.chalk.dim(
-        learnMore('https://docs.expo.io/bare/installing-updates/')
+      `\u203A You will need to extend the default ${chalk.bold(
+        '@expo/metro-config'
+      )} in your Metro config.\n  ${Log.chalk.dim(
+        learnMore('https://docs.expo.io/guides/customizing-metro')
       )}`
     );
     Log.newLine();

--- a/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
+++ b/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
@@ -23,7 +23,7 @@ export function writeMetroConfig({
    * hashAssetFiles plugin manually.
    */
 
-  const updatingMetroConfigStep = CreateApp.logNewSection('Adding Metro bundler configuration');
+  const updatingMetroConfigStep = CreateApp.logNewSection('Adding Metro bundler config');
 
   try {
     const sourceConfigPath = path.join(tempDir, 'metro.config.js');
@@ -34,7 +34,7 @@ export function writeMetroConfig({
       const contents = createFileHash(fs.readFileSync(targetConfigPath, 'utf8'));
       const targetContents = createFileHash(fs.readFileSync(sourceConfigPath, 'utf8'));
       if (contents !== targetContents) {
-        throw new CommandError('Existing Metro configuration found; not overwriting.');
+        throw new CommandError('Existing Metro config found; not overwriting.');
       } else {
         // Nothing to change, hide the step and exit.
         updatingMetroConfigStep.stop();

--- a/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
+++ b/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
@@ -54,7 +54,7 @@ export function writeMetroConfig({
   } catch (e) {
     updatingMetroConfigStep.stopAndPersist({
       symbol: '⚠️ ',
-      text: chalk.yellow('Metro config not applied:'),
+      text: chalk.yellow('Skipped Metro config updates:'),
     });
     Log.nested(`\u203A ${e.message}`);
     Log.nested(


### PR DESCRIPTION
# Why

- In SDK 41 the default metro config should be extending `expo/metro-config` (`@expo/metro-config` in older SDK versions).

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Updated the warning when the config is modified to reflect the new default `metro.config.js`:

```log
⚠️  Skipped Metro config updates:
› Existing Metro config found; not overwriting.
› You will need to extend the default @expo/metro-config in your Metro config.
  Learn more: https://docs.expo.io/guides/customizing-metro
```

- Shortened configuration to config to match some other places in the CLI
- Make the warning message a bit more deliberate as this is common behavior.
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `expo prebuild -p android --no-install`
- Modify the `metro.config.js`, repeating step 2 should log the new warning.
- Optionally you can change the project SDK version to 41.0.0