### PR TITLE
Improve deploy logging

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -78,7 +78,7 @@
     "@expo/results": "^1.0.0",
     "@expo/simple-spinner": "1.0.2",
     "@expo/spawn-async": "1.5.0",
-    "@expo/xcpretty": "^1.0.2",
+    "@expo/xcpretty": "^1.0.3",
     "@hapi/joi": "^17.1.1",
     "babel-runtime": "6.26.0",
     "base32.js": "0.1.0",

--- a/packages/expo-cli/src/commands/run/ios/IOSDeploy.ts
+++ b/packages/expo-cli/src/commands/run/ios/IOSDeploy.ts
@@ -1,7 +1,9 @@
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
-import { spawnSync } from 'child_process';
+import { spawn } from 'child_process';
+import program from 'commander';
 import fs from 'fs-extra';
+import ora, { Ora } from 'ora';
 import os from 'os';
 import path from 'path';
 import wrapAnsi from 'wrap-ansi';
@@ -33,16 +35,14 @@ export async function isInstalledAsync() {
   }
 }
 
-export function installBinaryOnDevice({
-  bundle,
-  appDeltaDirectory,
-  udid,
-}: {
+export async function installOnDeviceAsync(props: {
   bundle: string;
   appDeltaDirectory?: string;
   udid: string;
-}) {
-  const iosDeployInstallArgs = [
+  deviceName: string;
+}): Promise<void> {
+  const { bundle, appDeltaDirectory, udid, deviceName } = props;
+  const args = [
     '--bundle',
     bundle,
     '--id',
@@ -52,19 +52,129 @@ export function installBinaryOnDevice({
     '--no-wifi',
   ];
   if (appDeltaDirectory) {
-    iosDeployInstallArgs.push('--app_deltas', appDeltaDirectory);
+    args.push('--app_deltas', appDeltaDirectory);
   }
   // TODO: Attach LLDB debugger for native logs
   // '--debug'
 
-  Log.debug(`  ios-deploy ${iosDeployInstallArgs.join(' ')}`);
-  const output = spawnSync('ios-deploy', iosDeployInstallArgs, { encoding: 'utf8' });
+  Log.debug(`  ios-deploy ${args.join(' ')}`);
 
-  if (output.error) {
+  let indicator: Ora | undefined;
+  let copyingFileCount = 0;
+  let currentPhase: string | undefined;
+  const output = await spawnIOSDeployAsync(args, message => {
+    const loadingMatch = message.match(/\[(.*?)\] (.*)/m);
+    if (loadingMatch) {
+      const progress = tryParsingNumericValue(loadingMatch[1]);
+      const message = loadingMatch[2];
+      if (indicator) {
+        indicator.text = `${chalk.bold(currentPhase)} ${progress}%`;
+      }
+      if (message.startsWith('Copying ')) {
+        copyingFileCount++;
+      }
+      return;
+    }
+    // Install, Debug, Uninstall
+    const phaseMatch = message.match(/------\s(\w+) phase\s------/m);
+    if (phaseMatch) {
+      let phase = phaseMatch[1]?.trim?.();
+      // Remap name
+      phase = PhaseNameMap[phase] ?? phase;
+
+      if (indicator) {
+        if (currentPhase === 'Installing') {
+          const copiedMessage = chalk.gray`Copied ${copyingFileCount} file(s)`;
+          // Emulate Xcode copy file count, this helps us know if app deltas are working.
+          indicator.succeed(`${chalk.bold('Installed')} ${copiedMessage}`);
+        } else {
+          indicator.succeed();
+        }
+      }
+      indicator = ora(phase).start();
+      currentPhase = phase;
+      return;
+    }
+    Log.debug(message);
+  });
+
+  if (output.code !== 0) {
+    if (indicator) {
+      indicator.fail();
+    }
+    // Allow users to unlock their phone and try the launch over again.
+    if (output.error.includes('The device is locked')) {
+      // Get the app name from the binary path.
+      const appName = path.basename(bundle).split('.')[0] ?? 'app';
+      if (
+        !program.nonInteractive &&
+        (await confirmAsync({
+          message: `Cannot launch ${appName} because the device is locked. Unlock ${deviceName} to continue...`,
+        }))
+      ) {
+        return installOnDeviceAsync(props);
+      } else {
+        throw new CommandError(
+          `Cannot launch ${appName} on ${deviceName} because the device is locked.`
+        );
+      }
+    }
     throw new CommandError(
-      `Failed to install the app on device. Error in "ios-deploy" command: ${output.error.message}`
+      `Failed to install the app on device. Error in "ios-deploy" command: ${output.error}`
     );
+  } else {
+    if (indicator) {
+      if (currentPhase === 'Launching') {
+        indicator.succeed(`${chalk.bold`Launched`} ${chalk.gray(`on ${deviceName}`)}`);
+      } else {
+        indicator.succeed();
+      }
+    }
   }
+}
+
+const PhaseNameMap: Record<string, string> = {
+  Install: 'Installing',
+  Debug: 'Launching',
+  Uninstall: 'Uninstalling',
+};
+
+function tryParsingNumericValue(str?: string): number | null {
+  try {
+    return parseInt(str?.match(/\d+/)?.[0] ?? '-1', 10);
+  } catch {
+    return -1;
+  }
+}
+
+function spawnIOSDeployAsync(args: string[], onStdout: (message: string) => void) {
+  return new Promise<{ output: string; error: string; code: number }>(async (resolve, reject) => {
+    const fork = spawn('ios-deploy', args);
+    let output = '';
+    let errorOutput = '';
+    fork.stdout.on('data', (data: Buffer) => {
+      const stringData = data.toString().split(os.EOL);
+      for (let line of stringData) {
+        line = line.trim();
+        if (!line) continue;
+        if (line.match(/Error: /)) {
+          errorOutput = line;
+        } else {
+          output += line;
+          onStdout(line);
+        }
+      }
+    });
+
+    fork.stderr.on('data', (data: Buffer) => {
+      const stringData = data instanceof Buffer ? data.toString() : data;
+      errorOutput += stringData;
+    });
+
+    fork.on('close', (code: number) => {
+      resolve({ output, error: errorOutput, code });
+    });
+  });
 }
 
 export async function assertInstalledAsync() {

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -50,14 +50,13 @@ export async function runIosActionAsync(projectRoot: string, options: Options) {
     'XcodeBuild.getAppBinaryPath'
   )(buildOutput);
 
-  XcodeBuild.logPrettyItem(`${chalk.bold`Installing`} on ${props.device.name}`);
-
   if (props.shouldStartBundler) {
     await startBundlerAsync(projectRoot);
   }
   const bundleIdentifier = await profileMethod(getBundleIdentifierForBinaryAsync)(binaryPath);
 
   if (props.isSimulator) {
+    XcodeBuild.logPrettyItem(`${chalk.bold`Installing`} on ${props.device.name}`);
     await SimControl.installAsync({ udid: props.device.udid, dir: binaryPath });
 
     await openInSimulatorAsync({
@@ -66,12 +65,12 @@ export async function runIosActionAsync(projectRoot: string, options: Options) {
       shouldStartBundler: props.shouldStartBundler,
     });
   } else {
-    IOSDeploy.installBinaryOnDevice({
+    await IOSDeploy.installOnDeviceAsync({
       bundle: binaryPath,
       appDeltaDirectory: IOSDeploy.getAppDeltaDirectory(bundleIdentifier),
       udid: props.device.udid,
+      deviceName: props.device.name,
     });
-    XcodeBuild.logPrettyItem(`${chalk.bold`Installed`} on ${props.device.name}`);
   }
 
   if (props.shouldStartBundler) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,10 +2201,10 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
-"@expo/xcpretty@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-1.0.2.tgz#5e0c7597709d4d210b32497a73b2d9c1eb8c91bc"
-  integrity sha512-urgOyuVr4jmcUMIUEXHkXbIPSeA/zkudZhpb60t66WZKn2X7JvPYX9rXbIGBa+Aqwa13DfmF98kQKoLmp3zFXw==
+"@expo/xcpretty@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-1.0.3.tgz#49d04b7ffbc0f934abafb85709b130ee9d897881"
+  integrity sha512-DDWOYf4yupkoen6wCeGEJbuLbLW5Gh0tDjcWrhOt9jgpe10w8NUqd7aQlDrKH5LDcs2AE5c55ASAIR/YNp4N9Q==
   dependencies:
     "@babel/code-frame" "7.10.4"
     chalk "^4.1.0"
@@ -22453,7 +22453,7 @@ ws@^7.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.5.tgz#abb1370d4626a5a9cd79d8de404aa18b3465d10d"
   integrity sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==
 
-xcode@^2.0.0, xcode@^2.1.0:
+xcode@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/xcode/-/xcode-2.1.0.tgz#bab64a7e954bb50ca8d19da7e09531c65a43ecfe"
   integrity sha512-uCrmPITrqTEzhn0TtT57fJaNaw8YJs1aCzs+P/QqxsDbvPZSv7XMPPwXrKvHtD6pLjBM/NaVwraWJm8q83Y4iQ==


### PR DESCRIPTION
# Why

- surface the loading progress, copied files info from ios deploy
- allow for retrying the launch if the connected device is locked
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan


- connect ios device (keep locked)
- `expo run:ios -d` select connected
- at end, notice the installing progress and copied files
- without unlocking the phone press y when prompted if you've unlocked the device, this should loop back to the prompt again.
- unlock phone and press y, this should launch the app on the device and end the process.