### PR TITLE
Added spinner for device searching

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
@@ -1,9 +1,11 @@
 import chalk from 'chalk';
+import ora from 'ora';
 import { SimControl, Simulator } from 'xdl';
 
 import CommandError from '../../../CommandError';
 import Log from '../../../log';
 import prompt from '../../../prompts';
+import { profileMethod } from '../../utils/profileMethod';
 
 async function getSimulatorsAsync(): Promise<SimControl.SimulatorDevice[]> {
   const simulatorDeviceInfo = await SimControl.listAsync('devices');
@@ -13,11 +15,15 @@ async function getSimulatorsAsync(): Promise<SimControl.SimulatorDevice[]> {
 }
 
 async function getBuildDestinationsAsync() {
-  const devices = (await SimControl.listDevicesAsync()).filter(device => {
+  const devices = (
+    await profileMethod(SimControl.listDevicesAsync, 'SimControl.listDevicesAsync')()
+  ).filter(device => {
     return device.deviceType === 'device';
   });
 
-  const simulators = await Simulator.sortDefaultDeviceToBeginningAsync(await getSimulatorsAsync());
+  const simulators = await Simulator.sortDefaultDeviceToBeginningAsync(
+    await profileMethod(getSimulatorsAsync)()
+  );
 
   return [...devices, ...simulators];
 }
@@ -26,10 +32,17 @@ export async function resolveDeviceAsync(
   device: string | boolean | undefined
 ): Promise<SimControl.SimulatorDevice | SimControl.XCTraceDevice> {
   if (!device) {
-    return await Simulator.ensureSimulatorOpenAsync();
+    return await profileMethod(
+      Simulator.ensureSimulatorOpenAsync,
+      'Simulator.ensureSimulatorOpenAsync'
+    )();
   }
 
-  const devices = await getBuildDestinationsAsync();
+  const spinner = ora(
+    `🔍 Finding ${device === true ? 'devices' : `device ${chalk.cyan(device)}`}`
+  ).start();
+  const devices = await getBuildDestinationsAsync().catch(() => []);
+  spinner.stop();
 
   if (device === true) {
     // --device with no props after

--- a/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
@@ -41,7 +41,10 @@ export async function resolveDeviceAsync(
   const spinner = ora(
     `🔍 Finding ${device === true ? 'devices' : `device ${chalk.cyan(device)}`}`
   ).start();
-  const devices = await getBuildDestinationsAsync().catch(() => []);
+  const devices: (
+    | SimControl.SimulatorDevice
+    | SimControl.XCTraceDevice
+  )[] = await getBuildDestinationsAsync().catch(() => []);
   spinner.stop();
 
   if (device === true) {


### PR DESCRIPTION
# Why

- Apple's `xctrace` is ridiculously slow (1.7s on my machine). To add more transparency to why the CLI is slow to build, I added a temporary loader which hides after it completes.

# Test Plan


- `expo run:ios --device`
- `expo run:ios --device foobar`