### PR TITLE
Improve bplist parsing

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
+++ b/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
@@ -67,28 +67,41 @@ export async function getProjectBuildSettings(
 export function getAppBinaryPath(buildOutput: string) {
   // Matches what's used in "Bundle React Native code and images" script.
   // Requires that `-hideShellScriptEnvironment` is not included in the build command (extra logs).
+
+  // Like `\=/Users/evanbacon/Library/Developer/Xcode/DerivedData/Exponent-anpuosnglkxokahjhfszejloqfvo/Build/Products/Debug-iphonesimulator`
   const CONFIGURATION_BUILD_DIR = extractEnvVariableFromBuild(
     buildOutput,
     'CONFIGURATION_BUILD_DIR'
+  ).sort(
+    // Longer name means more suffixes, we want the shortest possible one to be first.
+    // Massive projects (like Expo Go) can sometimes print multiple different sets of environment variables.
+    // This can become an issue with some
+    (a, b) => a.length - b.length
   );
+  // Like `Exponent.app`
   const UNLOCALIZED_RESOURCES_FOLDER_PATH = extractEnvVariableFromBuild(
     buildOutput,
     'UNLOCALIZED_RESOURCES_FOLDER_PATH'
   );
-  return path.join(CONFIGURATION_BUILD_DIR, UNLOCALIZED_RESOURCES_FOLDER_PATH);
+  return path.join(
+    // Use the shortest defined env variable (usually there's just one).
+    CONFIGURATION_BUILD_DIR[0],
+    // Use the last defined env variable.
+    UNLOCALIZED_RESOURCES_FOLDER_PATH[UNLOCALIZED_RESOURCES_FOLDER_PATH.length - 1]
+  );
 }
 
 function extractEnvVariableFromBuild(buildOutput: string, variableName: string) {
   // Xcode can sometimes escape `=` with a backslash or put the value in quotes
-  const reg = new RegExp(`export ${variableName}\\\\?=(.*)$`, 'm');
-  const matched = reg.exec(buildOutput);
+  const reg = new RegExp(`export ${variableName}\\\\?=(.*)$`, 'mg');
+  const matched = [...buildOutput.matchAll(reg)];
 
   if (!matched || !matched.length) {
     throw new CommandError(
       `Malformed xcodebuild results: "${variableName}" variable was not generated in build output. Please report this issue and run your project with Xcode instead.`
     );
   }
-  return matched[1];
+  return matched.map(value => value[1]).filter(Boolean) as string[];
 }
 
 function getProcessOptions({

--- a/packages/expo-cli/src/commands/run/utils/binaryPlist.ts
+++ b/packages/expo-cli/src/commands/run/utils/binaryPlist.ts
@@ -1,18 +1,27 @@
 import plist from '@expo/plist';
 // @ts-ignore
-import bplist from 'bplist-parser';
+import binaryPlist from 'bplist-parser';
 import fs from 'fs-extra';
 
+const CHAR_CHEVRON_OPEN = 60;
+const CHAR_B_LOWER = 98;
+// .mobileprovision
+// const CHAR_ZERO = 30;
+
 export async function parseBinaryPlistAsync(plistPath: string) {
-  try {
-    const data = await bplist.parseFile(plistPath);
-    return data[0];
-  } catch (error) {
-    // Parse the plist as txt
-    const data = plist.parse(await fs.readFile(plistPath, 'utf8'));
-    if (data) {
-      return data;
-    }
-    throw error;
+  return parsePlistBuffer(await fs.readFile(plistPath));
+}
+
+export function parsePlistBuffer(contents: Buffer) {
+  if (contents[0] === CHAR_CHEVRON_OPEN) {
+    const info = plist.parse(contents.toString());
+    if (Array.isArray(info)) return info[0];
+    return info;
+  } else if (contents[0] === CHAR_B_LOWER) {
+    const info = binaryPlist.parseBuffer(contents);
+    if (Array.isArray(info)) return info[0];
+    return info;
+  } else {
+    throw new Error(`Cannot parse plist of type byte (0x${contents[0].toString(16)})`);
   }
 }

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/files.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/files.ts
@@ -64,8 +64,8 @@ async function downloadAppArchiveAsync(url: string): Promise<string> {
   // Special use-case for downloading an EAS tar.gz file and unpackaging it.
   if (pathIsTar(url)) {
     await pipeline(downloadStream, tar.extract({ cwd: destinationFolder }, []));
-    // Move the folder contents matching .ipa, .apk, or .aab
-    return await moveFileOfTypeAsync(destinationFolder, '{ipa,apk,aab}', destinationPath);
+    // Move the folder contents matching .ipa, .app, .apk, or .aab
+    return await moveFileOfTypeAsync(destinationFolder, '{ipa,app,apk,aab}', destinationPath);
   } else {
     await pipeline(downloadStream, fs.createWriteStream(destinationPath));
   }


### PR DESCRIPTION
# Why

Improve cryptic error message

```
/Users/evanbacon/Documents/GitHub/cli/node_modules/bplist-parser/bplistParser.js:44
        return callback(err);
               ^

TypeError: callback is not a function
    at ReadFileContext.callback (/Users/evanbacon/Documents/GitHub/cli/node_modules/bplist-parser/bplistParser.js:44:16)
    at FSReqCallback.readFileAfterOpen [as oncomplete] (fs.js:273:13)
```

# How

applied myself more...

# Test Plan

- clean expo go from source and rebuild it (☹️), the error should go away at the end 