### PR TITLE
[uri-scheme] Improve running in a project with single platform

### DIFF
--- a/packages/uri-scheme/src/Ios.ts
+++ b/packages/uri-scheme/src/Ios.ts
@@ -7,7 +7,7 @@ import fs from 'fs';
 import { sync as globSync } from 'glob';
 import * as path from 'path';
 
-import { Options } from './Options';
+import { CommandError, Options } from './Options';
 
 const ignoredPaths = ['**/@(Carthage|Pods|node_modules)/**'];
 
@@ -32,7 +32,6 @@ export async function addAsync({
   dryRun,
 }: Pick<Options, 'uri' | 'infoPath' | 'projectRoot' | 'dryRun'>): Promise<boolean> {
   const infoPlistPath = infoPath ?? getConfigPath(projectRoot);
-
   let config = readConfig(infoPlistPath);
 
   if (Scheme.hasScheme(uri, config)) {
@@ -116,6 +115,9 @@ export function getConfigPath(projectRoot: string): string {
     return rnInfoPlistPaths[0];
   }
   const infoPlistPaths = getInfoPlistsInDirectory(projectRoot);
+  if (!infoPlistPaths.length) {
+    throw new CommandError(`iOS: No Info.plist found for project at root: ${projectRoot}`);
+  }
   return infoPlistPaths[0];
 }
 


### PR DESCRIPTION
# Why

Running `npx uri-scheme add ...` in a project with only android or only ios (without specifying a platform) will throw an error because the CLI defaults to both platforms. This change will disable auto platforms that don't exist.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- `expo prebuild -p android` - creates android only
- `npx uri-scheme add somn` - won't throw an error now, silently just skips ios