### PR TITLE
Run built APK on device

### DIFF
--- a/packages/expo-cli/src/commands/run/android/Gradle.ts
+++ b/packages/expo-cli/src/commands/run/android/Gradle.ts
@@ -24,8 +24,17 @@ export async function spawnGradleTaskAsync({
 }) {
   const gradlew = resolveGradleWPath(androidProjectPath);
   const task = getGradleTask(buildVariant);
-  Log.debug(`  ${gradlew} ${task}`);
-  await spawnAsync(gradlew, [task], {
+  const args = [
+    task,
+    // ignore linting errors
+    '-x',
+    'lint',
+    // igonore tests
+    '-x',
+    'test',
+  ];
+  Log.debug(`  ${gradlew} ${args.join(' ')}`);
+  await spawnAsync(gradlew, args, {
     cwd: androidProjectPath,
     stdio: 'inherit',
   });

--- a/packages/expo-cli/src/commands/run/android/spawnGradleAsync.ts
+++ b/packages/expo-cli/src/commands/run/android/spawnGradleAsync.ts
@@ -7,23 +7,23 @@ function capitalize(name: string) {
   return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
-function getGradleTask(buildVariant: string): string {
-  return `install${capitalize(buildVariant)}`;
+function getGradleTask(variant: string): string {
+  return `install${capitalize(variant)}`;
 }
 
 function resolveGradleWPath(androidProjectPath: string): string {
   return path.join(androidProjectPath, process.platform === 'win32' ? 'gradlew.bat' : 'gradlew');
 }
 
-export async function spawnGradleTaskAsync({
+export async function spawnGradleAsync({
   androidProjectPath,
-  buildVariant,
+  variant,
 }: {
   androidProjectPath: string;
-  buildVariant: string;
+  variant: string;
 }) {
   const gradlew = resolveGradleWPath(androidProjectPath);
-  const task = getGradleTask(buildVariant);
+  const task = getGradleTask(variant);
   const args = [
     task,
     // ignore linting errors

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -9,7 +9,7 @@ export default function (program: Command) {
     .helpGroup('internal')
     .description('Run the Android app binary locally')
     .option('-d, --device [device]', 'Device name to build the app on')
-    .option('--build-variant [name]', '(Android) build variant', 'release')
+    .option('--variant [name]', '(Android) build variant', 'debug')
     .asyncActionProjectDir(runAndroidActionAsync);
   program
     .command('run:ios [path]')

--- a/packages/xdl/src/utils/downloadApkAsync.ts
+++ b/packages/xdl/src/utils/downloadApkAsync.ts
@@ -1,0 +1,33 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import Api from '../Api';
+import UserSettings from '../UserSettings';
+import * as Versions from '../Versions';
+
+function _apkCacheDirectory() {
+  const dotExpoHomeDirectory = UserSettings.dotExpoHomeDirectory();
+  const dir = path.join(dotExpoHomeDirectory, 'android-apk-cache');
+  fs.mkdirpSync(dir);
+  return dir;
+}
+
+export async function downloadApkAsync(
+  url?: string,
+  downloadProgressCallback?: (roundedProgress: number) => void
+) {
+  if (!url) {
+    const versions = await Versions.versionsAsync();
+    url = versions.androidUrl;
+  }
+
+  const filename = path.parse(url).name;
+  const apkPath = path.join(_apkCacheDirectory(), `${filename}.apk`);
+
+  if (await fs.pathExists(apkPath)) {
+    return apkPath;
+  }
+
+  await Api.downloadAsync(url, apkPath, undefined, downloadProgressCallback);
+  return apkPath;
+}


### PR DESCRIPTION
# Why

- `run:android` currently just opens the Expo Go app after it finishes building (and on an unrelated device no less). This PR adds the ability to install, and open an arbitrary APK, then open it. 
- Also abstracted some functionality out of `Android` since it's getting large. 
- Added a generalized caching system for reading Android device properties.

# Test Plan

- `expo run:android` should work as expected, building an APK then installing _that_ APK and opening it on the selected device.