### PR TITLE
[config-plugins] Created unversioned react-native-maps plugin

### DIFF
--- a/packages/config-plugins/src/ios/Google.ts
+++ b/packages/config-plugins/src/ios/Google.ts
@@ -22,32 +22,12 @@ export const withGoogleServicesFile: ConfigPlugin = config => {
   });
 };
 
-export function getGoogleMapsApiKey(config: Pick<ExpoConfig, 'ios'>) {
-  return config.ios?.config?.googleMapsApiKey ?? null;
-}
-
 export function getGoogleSignInReservedClientId(config: Pick<ExpoConfig, 'ios'>) {
   return config.ios?.config?.googleSignIn?.reservedClientId ?? null;
 }
 
 export function getGoogleServicesFile(config: Pick<ExpoConfig, 'ios'>) {
   return config.ios?.googleServicesFile ?? null;
-}
-
-export function setGoogleMapsApiKey(
-  config: Pick<ExpoConfig, 'ios'>,
-  { GMSApiKey, ...infoPlist }: InfoPlist
-): InfoPlist {
-  const apiKey = getGoogleMapsApiKey(config);
-
-  if (apiKey === null) {
-    return infoPlist;
-  }
-
-  return {
-    ...infoPlist,
-    GMSApiKey: apiKey,
-  };
 }
 
 export function setGoogleSignInReservedClientId(
@@ -64,7 +44,6 @@ export function setGoogleSignInReservedClientId(
 }
 
 export function setGoogleConfig(config: Pick<ExpoConfig, 'ios'>, infoPlist: InfoPlist): InfoPlist {
-  infoPlist = setGoogleMapsApiKey(config, infoPlist);
   infoPlist = setGoogleSignInReservedClientId(config, infoPlist);
   return infoPlist;
 }

--- a/packages/config-plugins/src/ios/Maps.ts
+++ b/packages/config-plugins/src/ios/Maps.ts
@@ -2,17 +2,25 @@ import { ExpoConfig } from '@expo/config-types';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { WarningAggregator } from '..';
 import { ConfigPlugin, InfoPlist } from '../Plugin.types';
 import { withDangerousMod } from '../plugins/core-plugins';
-import { createInfoPlistPlugin } from '../plugins/ios-plugins';
-import { mergeContents, MergeResults } from '../utils/generateCode';
+import { createInfoPlistPlugin, withAppDelegate } from '../plugins/ios-plugins';
+import { mergeContents, MergeResults, removeContents } from '../utils/generateCode';
+import { resolvePackageRootFolder } from '../utils/resolvePackageRootFolder';
+
+export const MATCH_INIT = /(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[\[RCTBridge alloc\])/g;
 
 const withGoogleMapsKey = createInfoPlistPlugin(setGoogleMapsApiKey, 'withGoogleMapsKey');
 
 export const withMaps: ConfigPlugin = config => {
   config = withGoogleMapsKey(config);
+
+  const apiKey = getGoogleMapsApiKey(config);
   // Technically adds react-native-maps (Apple maps) and google maps.
-  config = withMapsCocoaPods(config, { useGoogleMaps: !!getGoogleMapsApiKey(config) });
+  config = withMapsCocoaPods(config, { useGoogleMaps: !!apiKey });
+  // Adds/Removes AppDelegate setup for Google Maps API on iOS
+  config = withGoogleMapsAppDelegate(config, { apiKey });
 
   return config;
 };
@@ -37,30 +45,110 @@ export function setGoogleMapsApiKey(
   };
 }
 
-export function addMapsCocoaPods(contents: string, useGoogleMaps: boolean): MergeResults {
-  return mergeContents(
-    contents,
-    [
-      useGoogleMaps && `  pod 'GoogleMaps'`,
-      useGoogleMaps && `  pod 'Google-Maps-iOS-Utils'`,
-      `  post_install do |installer|`,
-      `    installer.pods_project.targets.each do |target|`,
-      `      next unless target.name == 'react-native-google-maps'`,
-      ``,
-      `      target.build_configurations.each do |config|`,
-      `        config.build_settings['CLANG_ENABLE_MODULES'] = 'No'`,
-      `      end`,
-      `    end`,
-      `  end`,
-    ]
-      .filter(Boolean)
-      .join('\n'),
-    'react-native-maps',
-    // Anchor:
-    'use_react_native',
-    0,
-    '#'
+export function addGoogleMapsAppDelegateImport(src: string): MergeResults {
+  const newSrc = [];
+  newSrc.push(
+    '#if __has_include(<GoogleMaps/GoogleMaps.h>)',
+    '#import <GoogleMaps/GoogleMaps.h>',
+    '#endif'
   );
+
+  return mergeContents({
+    tag: 'react-native-maps-import',
+    src,
+    newSrc: newSrc.join('\n'),
+    anchor: /#import "AppDelegate\.h"/,
+    offset: 1,
+    comment: '//',
+  });
+}
+
+export function removeGoogleMapsAppDelegateImport(src: string): MergeResults {
+  return removeContents({
+    tag: 'react-native-maps-import',
+    src,
+  });
+}
+
+export function addGoogleMapsAppDelegateInit(src: string, apiKey: string): MergeResults {
+  const newSrc = [];
+  newSrc.push(
+    '#if __has_include(<GoogleMaps/GoogleMaps.h>)',
+    `  [GMSServices provideAPIKey:@"${apiKey}"];`,
+    '#endif'
+  );
+
+  return mergeContents({
+    tag: 'react-native-maps-init',
+    src,
+    newSrc: newSrc.join('\n'),
+    anchor: MATCH_INIT,
+    offset: 0,
+    comment: '//',
+  });
+}
+
+export function removeGoogleMapsAppDelegateInit(src: string): MergeResults {
+  return removeContents({
+    tag: 'react-native-maps-init',
+    src,
+  });
+}
+
+/**
+ * @param src
+ * @param useGoogleMaps
+ * @param googleMapsPath '../node_modules/react-native-maps'
+ * @returns
+ */
+export function addMapsCocoaPods(
+  src: string,
+  useGoogleMaps: boolean,
+  googleMapsPath: string | null
+): MergeResults {
+  const newSrc = [];
+  if (useGoogleMaps) {
+    if (googleMapsPath) {
+      newSrc.push(`  pod 'react-native-google-maps', path: '${googleMapsPath}'`);
+    } else {
+      // Not sure when this could ever happen.
+      WarningAggregator.addWarningIOS(
+        'react-native-maps',
+        'Failed to resolve react-native-maps module for project. Ensure react-native-maps is installed, or disable Google Maps for iOS by removing the `ios.config.googleMapsApiKey` value from your Expo config.'
+      );
+    }
+  }
+  newSrc.push(
+    `  post_install do |installer|`,
+    `    installer.pods_project.targets.each do |target|`,
+    `      next unless target.name == 'react-native-google-maps'`,
+    ` `,
+    `      target.build_configurations.each do |config|`,
+    `        config.build_settings['CLANG_ENABLE_MODULES'] = 'No'`,
+    `      end`,
+    `    end`,
+    `  end`
+  );
+
+  return mergeContents({
+    tag: 'react-native-maps',
+    src,
+    newSrc: newSrc.join('\n'),
+    anchor: /use_react_native/,
+    offset: 1,
+    comment: '#',
+  });
+}
+
+function removeMapsCocoaPods(src: string): MergeResults {
+  return removeContents({
+    tag: 'react-native-maps',
+    src,
+  });
+}
+
+function isReactNativeMapsInstalled(projectRoot: string): string | null {
+  return resolvePackageRootFolder(projectRoot, 'react-native-maps');
 }
 
 const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { useGoogleMaps }) => {
@@ -69,12 +157,68 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
     async config => {
       const filePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
       const contents = await fs.readFile(filePath, 'utf-8');
-      const results = addMapsCocoaPods(contents, useGoogleMaps);
+      let results: MergeResults;
+      // Only add the block if react-native-maps is installed in the project (best effort).
+      // Generally prebuild runs after a yarn install so this should always work as expected.
+      const googleMapsPath = isReactNativeMapsInstalled(config.modRequest.projectRoot);
+      if (googleMapsPath) {
+        // Make the pod path relative to the ios folder.
+        const googleMapsPodPath = googleMapsPath
+          ? path.relative(config.modRequest.platformProjectRoot, googleMapsPath)
+          : null;
+        try {
+          results = addMapsCocoaPods(contents, useGoogleMaps, googleMapsPodPath);
+        } catch (error) {
+          if (error.code === 'ERR_NO_MATCH') {
+            throw new Error(
+              `Cannot add react-native-maps to the project's ios/Podfile because it's malformed. Please report this with a copy of your project Podfile.`
+            );
+          }
+          throw error;
+        }
+      } else {
+        // If the package is no longer installed, then remove the block.
+        results = removeMapsCocoaPods(contents);
+      }
       if (results.didMerge) {
         await fs.writeFile(filePath, results.contents);
       }
-
       return config;
     },
   ]);
+};
+
+const withGoogleMapsAppDelegate: ConfigPlugin<{ apiKey: string | null }> = (config, { apiKey }) => {
+  return withAppDelegate(config, config => {
+    if (config.modResults.language === 'objc') {
+      if (apiKey && isReactNativeMapsInstalled(config.modRequest.projectRoot)) {
+        try {
+          config.modResults.contents = addGoogleMapsAppDelegateImport(
+            config.modResults.contents
+          ).contents;
+          config.modResults.contents = addGoogleMapsAppDelegateInit(
+            config.modResults.contents,
+            apiKey
+          ).contents;
+        } catch (error) {
+          if (error.code === 'ERR_NO_MATCH') {
+            throw new Error(
+              `Cannot add Google Maps to the project's AppDelegate because it's malformed. Please report this with a copy of your project AppDelegate.`
+            );
+          }
+          throw error;
+        }
+      } else {
+        config.modResults.contents = removeGoogleMapsAppDelegateImport(
+          config.modResults.contents
+        ).contents;
+        config.modResults.contents = removeGoogleMapsAppDelegateInit(
+          config.modResults.contents
+        ).contents;
+      }
+    } else {
+      throw new Error('Cannot setup Google Maps because the AppDelegate is not Objective C');
+    }
+    return config;
+  });
 };

--- a/packages/config-plugins/src/ios/Maps.ts
+++ b/packages/config-plugins/src/ios/Maps.ts
@@ -105,8 +105,8 @@ export function addMapsCocoaPods(src: string, googleMapsPath: string): MergeResu
     tag: 'react-native-maps',
     src,
     newSrc: `  pod 'react-native-google-maps', path: '${googleMapsPath}'`,
-    anchor: /use_react_native/,
-    offset: 1,
+    anchor: /use_native_modules/,
+    offset: 0,
     comment: '#',
   });
 }

--- a/packages/config-plugins/src/ios/Maps.ts
+++ b/packages/config-plugins/src/ios/Maps.ts
@@ -1,0 +1,80 @@
+import { ExpoConfig } from '@expo/config-types';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { ConfigPlugin, InfoPlist } from '../Plugin.types';
+import { withDangerousMod } from '../plugins/core-plugins';
+import { createInfoPlistPlugin } from '../plugins/ios-plugins';
+import { mergeContents, MergeResults } from '../utils/generateCode';
+
+const withGoogleMapsKey = createInfoPlistPlugin(setGoogleMapsApiKey, 'withGoogleMapsKey');
+
+export const withMaps: ConfigPlugin = config => {
+  config = withGoogleMapsKey(config);
+  // Technically adds react-native-maps (Apple maps) and google maps.
+  config = withMapsCocoaPods(config, { useGoogleMaps: !!getGoogleMapsApiKey(config) });
+
+  return config;
+};
+
+export function getGoogleMapsApiKey(config: Pick<ExpoConfig, 'ios'>) {
+  return config.ios?.config?.googleMapsApiKey ?? null;
+}
+
+export function setGoogleMapsApiKey(
+  config: Pick<ExpoConfig, 'ios'>,
+  { GMSApiKey, ...infoPlist }: InfoPlist
+): InfoPlist {
+  const apiKey = getGoogleMapsApiKey(config);
+
+  if (apiKey === null) {
+    return infoPlist;
+  }
+
+  return {
+    ...infoPlist,
+    GMSApiKey: apiKey,
+  };
+}
+
+export function addMapsCocoaPods(contents: string, useGoogleMaps: boolean): MergeResults {
+  return mergeContents(
+    contents,
+    [
+      useGoogleMaps && `  pod 'GoogleMaps'`,
+      useGoogleMaps && `  pod 'Google-Maps-iOS-Utils'`,
+      `  post_install do |installer|`,
+      `    installer.pods_project.targets.each do |target|`,
+      `      next unless target.name == 'react-native-google-maps'`,
+      ``,
+      `      target.build_configurations.each do |config|`,
+      `        config.build_settings['CLANG_ENABLE_MODULES'] = 'No'`,
+      `      end`,
+      `    end`,
+      `  end`,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+    'react-native-maps',
+    // Anchor:
+    'use_react_native',
+    0,
+    '#'
+  );
+}
+
+const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { useGoogleMaps }) => {
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      const filePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+      const contents = await fs.readFile(filePath, 'utf-8');
+      const results = addMapsCocoaPods(contents, useGoogleMaps);
+      if (results.didMerge) {
+        await fs.writeFile(filePath, results.contents);
+      }
+
+      return config;
+    },
+  ]);
+};

--- a/packages/config-plugins/src/ios/__tests__/Google-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Google-test.ts
@@ -1,8 +1,6 @@
 import {
-  getGoogleMapsApiKey,
   getGoogleServicesFile,
   getGoogleSignInReservedClientId,
-  setGoogleMapsApiKey,
   setGoogleSignInReservedClientId,
 } from '../Google';
 import { appendScheme } from '../Scheme';
@@ -11,14 +9,11 @@ jest.mock('../Scheme');
 
 describe('ios google config', () => {
   it(`returns null from all getters if no value provided`, () => {
-    expect(getGoogleMapsApiKey({})).toBe(null);
     expect(getGoogleSignInReservedClientId({})).toBe(null);
     expect(getGoogleServicesFile({})).toBe(null);
   });
 
   it(`returns the correct values from all getters if a value is provided`, () => {
-    expect(getGoogleMapsApiKey({ ios: { config: { googleMapsApiKey: '123' } } })).toBe('123');
-
     expect(
       getGoogleSignInReservedClientId({
         ios: { config: { googleSignIn: { reservedClientId: '000' } } },
@@ -27,16 +22,6 @@ describe('ios google config', () => {
     expect(
       getGoogleServicesFile({ ios: { googleServicesFile: './path/to/GoogleService-Info.plist' } })
     ).toBe('./path/to/GoogleService-Info.plist');
-  });
-
-  it(`sets the google maps api key if provided or returns plist`, () => {
-    expect(setGoogleMapsApiKey({ ios: { config: { googleMapsApiKey: '123' } } }, {})).toMatchObject(
-      {
-        GMSApiKey: '123',
-      }
-    );
-
-    expect(setGoogleMapsApiKey({}, {})).toMatchObject({});
   });
 
   it(`adds the reserved client id to scheme if provided`, () => {

--- a/packages/config-plugins/src/ios/__tests__/Maps-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Maps-test.ts
@@ -1,5 +1,37 @@
-import { addMapsCocoaPods, getGoogleMapsApiKey, setGoogleMapsApiKey } from '../Maps';
+import rnFixture from '../../plugins/__tests__/fixtures/react-native-project';
+import {
+  addGoogleMapsAppDelegateImport,
+  addGoogleMapsAppDelegateInit,
+  addMapsCocoaPods,
+  getGoogleMapsApiKey,
+  MATCH_INIT,
+  removeGoogleMapsAppDelegateImport,
+  removeGoogleMapsAppDelegateInit,
+  setGoogleMapsApiKey,
+} from '../Maps';
+import { UnimodulesAppDelegate } from './fixtures/AppDelegate';
 import { PodfileBasic } from './fixtures/Podfile';
+
+describe('MATCH_INIT', () => {
+  it(`matches unimodules projects`, () => {
+    expect(
+      `self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[UMModuleRegistryProvider alloc] init]];`
+    ).toMatch(MATCH_INIT);
+    // wrapped
+    expect(`self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc]`).toMatch(MATCH_INIT);
+    // short hand
+    expect(`_moduleRegistryAdapter=[[UMModuleRegistryAdapter alloc]`).toMatch(MATCH_INIT);
+    // any name
+    expect(`_mo=[[UMModuleRegistryAdapter alloc]`).toMatch(MATCH_INIT);
+  });
+  it(`matches RN projects`, () => {
+    expect(
+      `RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];`
+    ).toMatch(MATCH_INIT);
+    // wrapped
+    expect(`RCTBridge*bri=[[RCTBridge alloc]`).toMatch(MATCH_INIT);
+  });
+});
 
 describe(getGoogleMapsApiKey, () => {
   it(`returns null from all getters if no value provided`, () => {
@@ -24,7 +56,7 @@ describe(getGoogleMapsApiKey, () => {
 
 describe(addMapsCocoaPods, () => {
   it(`adds maps pods to Podfile`, () => {
-    const results = addMapsCocoaPods(PodfileBasic, true);
+    const results = addMapsCocoaPods(PodfileBasic, true, '../node_modules/react-native-maps');
     // matches a static snapshot
     expect(results.contents).toMatchSnapshot();
     // did add new content
@@ -32,21 +64,102 @@ describe(addMapsCocoaPods, () => {
     // didn't remove old content
     expect(results.didClear).toBe(false);
 
-    const modded = addMapsCocoaPods(results.contents, false);
+    const modded = addMapsCocoaPods(results.contents, false, null);
+    expect(modded.contents).toMatchSnapshot();
     // doesn't have the old hash
     expect(modded.contents).not.toMatch(/5c87ad4d9ddfb7bd69df4fc0cf28e520c23ac94b/);
     // does have the new hash
-    expect(modded.contents).toMatch(/68a7fa3da70aeb22eb1be85cf1a635c7a6c53b86/);
+    expect(modded.contents).toMatch(/68b8e46c277237ec1f5e03fce7ee7c85e20995e8/);
     // added new content
     expect(modded.didMerge).toBe(true);
     // removed old content
     expect(modded.didClear).toBe(true);
 
-    const modded2 = addMapsCocoaPods(modded.contents, false);
-    expect(modded2.contents).toMatch(/68a7fa3da70aeb22eb1be85cf1a635c7a6c53b86/);
+    const modded2 = addMapsCocoaPods(modded.contents, false, null);
+    expect(modded2.contents).toMatch(/68b8e46c277237ec1f5e03fce7ee7c85e20995e8/);
     // didn't add new content
     expect(modded2.didMerge).toBe(false);
     // didn't remove old content
     expect(modded2.didClear).toBe(false);
+  });
+});
+
+describe(addGoogleMapsAppDelegateImport, () => {
+  it(`adds maps import to AppDelegate`, () => {
+    const results = addGoogleMapsAppDelegateImport(
+      rnFixture['ios/ReactNativeProject/AppDelegate.m']
+    );
+    // matches a static snapshot
+    expect(results.contents).toMatchSnapshot();
+    expect(results.contents).toMatch(/f2f83125c99c0d74b42a2612947510c4e08c423a/);
+    // did add new content
+    expect(results.didMerge).toBe(true);
+    // didn't remove old content
+    expect(results.didClear).toBe(false);
+
+    const modded = addGoogleMapsAppDelegateImport(results.contents);
+    // nothing changed
+    expect(modded.didMerge).toBe(false);
+    expect(modded.didClear).toBe(false);
+
+    const modded2 = removeGoogleMapsAppDelegateImport(modded.contents);
+    expect(modded2.contents).toBe(rnFixture['ios/ReactNativeProject/AppDelegate.m']);
+    // didn't add new content
+    expect(modded2.didMerge).toBe(false);
+    // did remove the generated content
+    expect(modded2.didClear).toBe(true);
+  });
+  it(`fails to add to a malformed podfile`, () => {
+    expect(() => addGoogleMapsAppDelegateImport(`foobar`)).toThrow(/foobar/);
+  });
+});
+
+describe(addGoogleMapsAppDelegateInit, () => {
+  it(`adds maps import to AppDelegate`, () => {
+    const results = addGoogleMapsAppDelegateInit(
+      rnFixture['ios/ReactNativeProject/AppDelegate.m'],
+      'mykey'
+    );
+    // matches a static snapshot
+    expect(results.contents).toMatchSnapshot();
+    expect(results.contents).toMatch(/97501819d6911e5f50d66c63d369b0cec62853c2/);
+    // did add new content
+    expect(results.didMerge).toBe(true);
+    // didn't remove old content
+    expect(results.didClear).toBe(false);
+
+    const modded = addGoogleMapsAppDelegateInit(results.contents, 'mykey');
+    // nothing changed
+    expect(modded.didMerge).toBe(false);
+    expect(modded.didClear).toBe(false);
+
+    // Test that the block is updated when the API key changes
+    const modded2 = addGoogleMapsAppDelegateInit(results.contents, 'mykey-2');
+    expect(modded2.contents).not.toMatch(/97501819d6911e5f50d66c63d369b0cec62853c2/);
+    expect(modded2.contents).toMatch(/a5c6f82bb5656264220096dea4cfdaa4383d60ab/);
+    // nothing changed
+    expect(modded2.didMerge).toBe(true);
+    expect(modded2.didClear).toBe(true);
+
+    const modded3 = removeGoogleMapsAppDelegateInit(modded.contents);
+    expect(modded3.contents).toBe(rnFixture['ios/ReactNativeProject/AppDelegate.m']);
+    // didn't add new content
+    expect(modded3.didMerge).toBe(false);
+    // did remove the generated content
+    expect(modded3.didClear).toBe(true);
+  });
+  it(`adds maps import to Unimodules AppDelegate`, () => {
+    const results = addGoogleMapsAppDelegateInit(UnimodulesAppDelegate, 'mykey');
+    // matches a static snapshot
+    expect(results.contents).toMatchSnapshot();
+    expect(results.contents).toMatch(/97501819d6911e5f50d66c63d369b0cec62853c2/);
+    // did add new content
+    expect(results.didMerge).toBe(true);
+    // didn't remove old content
+    expect(results.didClear).toBe(false);
+  });
+
+  it(`fails to add to a malformed app delegate`, () => {
+    expect(() => addGoogleMapsAppDelegateInit(`foobar`, 'mykey')).toThrow(/foobar/);
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/Maps-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Maps-test.ts
@@ -1,0 +1,52 @@
+import { addMapsCocoaPods, getGoogleMapsApiKey, setGoogleMapsApiKey } from '../Maps';
+import { PodfileBasic } from './fixtures/Podfile';
+
+describe(getGoogleMapsApiKey, () => {
+  it(`returns null from all getters if no value provided`, () => {
+    expect(getGoogleMapsApiKey({})).toBe(null);
+  });
+
+  it(`returns the correct values from all getters if a value is provided`, () => {
+    expect(getGoogleMapsApiKey({ ios: { config: { googleMapsApiKey: '123' } } })).toBe('123');
+  });
+});
+describe(getGoogleMapsApiKey, () => {
+  it(`sets the google maps api key if provided or returns plist`, () => {
+    expect(setGoogleMapsApiKey({ ios: { config: { googleMapsApiKey: '123' } } }, {})).toMatchObject(
+      {
+        GMSApiKey: '123',
+      }
+    );
+
+    expect(setGoogleMapsApiKey({}, {})).toMatchObject({});
+  });
+});
+
+describe(addMapsCocoaPods, () => {
+  it(`adds maps pods to Podfile`, () => {
+    const results = addMapsCocoaPods(PodfileBasic, true);
+    // matches a static snapshot
+    expect(results.contents).toMatchSnapshot();
+    // did add new content
+    expect(results.didMerge).toBe(true);
+    // didn't remove old content
+    expect(results.didClear).toBe(false);
+
+    const modded = addMapsCocoaPods(results.contents, false);
+    // doesn't have the old hash
+    expect(modded.contents).not.toMatch(/5c87ad4d9ddfb7bd69df4fc0cf28e520c23ac94b/);
+    // does have the new hash
+    expect(modded.contents).toMatch(/68a7fa3da70aeb22eb1be85cf1a635c7a6c53b86/);
+    // added new content
+    expect(modded.didMerge).toBe(true);
+    // removed old content
+    expect(modded.didClear).toBe(true);
+
+    const modded2 = addMapsCocoaPods(modded.contents, false);
+    expect(modded2.contents).toMatch(/68a7fa3da70aeb22eb1be85cf1a635c7a6c53b86/);
+    // didn't add new content
+    expect(modded2.didMerge).toBe(false);
+    // didn't remove old content
+    expect(modded2.didClear).toBe(false);
+  });
+});

--- a/packages/config-plugins/src/ios/__tests__/Maps-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Maps-test.ts
@@ -7,6 +7,7 @@ import {
   MATCH_INIT,
   removeGoogleMapsAppDelegateImport,
   removeGoogleMapsAppDelegateInit,
+  removeMapsCocoaPods,
   setGoogleMapsApiKey,
 } from '../Maps';
 import { UnimodulesAppDelegate } from './fixtures/AppDelegate';
@@ -56,31 +57,26 @@ describe(getGoogleMapsApiKey, () => {
 
 describe(addMapsCocoaPods, () => {
   it(`adds maps pods to Podfile`, () => {
-    const results = addMapsCocoaPods(PodfileBasic, true, '../node_modules/react-native-maps');
+    const results = addMapsCocoaPods(PodfileBasic, '../node_modules/react-native-maps');
     // matches a static snapshot
     expect(results.contents).toMatchSnapshot();
+    expect(results.contents).toMatch(/2f0a6817224f18601deb2879c9e783ba07387bc9/);
     // did add new content
     expect(results.didMerge).toBe(true);
     // didn't remove old content
     expect(results.didClear).toBe(false);
 
-    const modded = addMapsCocoaPods(results.contents, false, null);
-    expect(modded.contents).toMatchSnapshot();
-    // doesn't have the old hash
-    expect(modded.contents).not.toMatch(/5c87ad4d9ddfb7bd69df4fc0cf28e520c23ac94b/);
-    // does have the new hash
-    expect(modded.contents).toMatch(/68b8e46c277237ec1f5e03fce7ee7c85e20995e8/);
-    // added new content
-    expect(modded.didMerge).toBe(true);
-    // removed old content
-    expect(modded.didClear).toBe(true);
+    const modded = addMapsCocoaPods(results.contents, '../node_modules/react-native-maps');
+    // nothing changed
+    expect(modded.didMerge).toBe(false);
+    expect(modded.didClear).toBe(false);
 
-    const modded2 = addMapsCocoaPods(modded.contents, false, null);
-    expect(modded2.contents).toMatch(/68b8e46c277237ec1f5e03fce7ee7c85e20995e8/);
+    const modded2 = removeMapsCocoaPods(modded.contents);
+    expect(modded2.contents).toBe(PodfileBasic);
     // didn't add new content
     expect(modded2.didMerge).toBe(false);
-    // didn't remove old content
-    expect(modded2.didClear).toBe(false);
+    // did remove the generated content
+    expect(modded2.didClear).toBe(true);
   });
 });
 

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -256,57 +256,8 @@ target 'myapp' do
   config = use_native_modules!
 
   use_react_native!(:path => config[\\"reactNativePath\\"])
-# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-85f8575c50e7893d1bd8555bd92e1d2923f04aeb
+# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-2f0a6817224f18601deb2879c9e783ba07387bc9
   pod 'react-native-google-maps', path: '../node_modules/react-native-maps'
-  post_install do |installer|
-    installer.pods_project.targets.each do |target|
-      next unless target.name == 'react-native-google-maps'
- 
-      target.build_configurations.each do |config|
-        config.build_settings['CLANG_ENABLE_MODULES'] = 'No'
-      end
-    end
-  end
-# @generated end react-native-maps
-
-  # Uncomment the code below to enable Flipper.
-  #
-  # You should not install Flipper in CI environments when creating release
-  # builds, this will lead to significantly slower build times.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work.
-  #
-  #  use_flipper!
-  #  post_install do |installer|
-  #    flipper_post_install(installer)
-  #  end
-end
-"
-`;
-
-exports[`addMapsCocoaPods adds maps pods to Podfile 2`] = `
-"
-require_relative '../node_modules/react-native/scripts/react_native_pods'
-require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
-require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
-
-platform :ios, '11.0'
-
-target 'myapp' do
-  use_unimodules!
-  config = use_native_modules!
-
-  use_react_native!(:path => config[\\"reactNativePath\\"])
-# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-68b8e46c277237ec1f5e03fce7ee7c85e20995e8
-  post_install do |installer|
-    installer.pods_project.targets.each do |target|
-      next unless target.name == 'react-native-google-maps'
- 
-      target.build_configurations.each do |config|
-        config.build_settings['CLANG_ENABLE_MODULES'] = 'No'
-      end
-    end
-  end
 # @generated end react-native-maps
 
   # Uncomment the code below to enable Flipper.

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`addMapsCocoaPods adds maps pods to Podfile 1`] = `
+"
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'myapp' do
+  use_unimodules!
+  config = use_native_modules!
+
+# @generated begin react-native-maps (DO NOT MODIFY) sync-5c87ad4d9ddfb7bd69df4fc0cf28e520c23ac94b
+  pod 'GoogleMaps'
+  pod 'Google-Maps-iOS-Utils'
+    installer.pods_project.targets.each do |target|
+      next unless target.name == 'react-native-google-maps'
+      target.build_configurations.each do |config|
+        config.build_settings['CLANG_ENABLE_MODULES'] = 'No'
+      end
+    end
+# @generated end react-native-maps
+  use_react_native!(:path => config[\\"reactNativePath\\"])
+
+  # Uncomment the code below to enable Flipper.
+  #
+  # You should not install Flipper in CI environments when creating release
+  # builds, this will lead to significantly slower build times.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work.
+  #
+  #  use_flipper!
+  #  post_install do |installer|
+  #    flipper_post_install(installer)
+  #  end
+end
+"
+`;

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -253,12 +253,12 @@ platform :ios, '11.0'
 
 target 'myapp' do
   use_unimodules!
-  config = use_native_modules!
-
-  use_react_native!(:path => config[\\"reactNativePath\\"])
 # @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-2f0a6817224f18601deb2879c9e783ba07387bc9
   pod 'react-native-google-maps', path: '../node_modules/react-native-maps'
 # @generated end react-native-maps
+  config = use_native_modules!
+
+  use_react_native!(:path => config[\\"reactNativePath\\"])
 
   # Uncomment the code below to enable Flipper.
   #

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -1,5 +1,248 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`addGoogleMapsAppDelegateImport adds maps import to AppDelegate 1`] = `
+"#import \\"AppDelegate.h\\"
+// @generated begin react-native-maps-import - expo prebuild (DO NOT MODIFY) sync-f2f83125c99c0d74b42a2612947510c4e08c423a
+#if __has_include(<GoogleMaps/GoogleMaps.h>)
+#import <GoogleMaps/GoogleMaps.h>
+#endif
+// @generated end react-native-maps-import
+  
+  #import <React/RCTBridge.h>
+  #import <React/RCTBundleURLProvider.h>
+  #import <React/RCTRootView.h>
+  
+  #if DEBUG
+  #import <FlipperKit/FlipperClient.h>
+  #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+  #import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+  #import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+  #import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+  #import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+  
+  static void InitializeFlipper(UIApplication *application) {
+    FlipperClient *client = [FlipperClient sharedClient];
+    SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+    [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+    [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+    [client addPlugin:[FlipperKitReactPlugin new]];
+    [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+    [client start];
+  }
+  #endif
+  
+  @implementation AppDelegate
+  
+  - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+  {
+  #if DEBUG
+    InitializeFlipper(application);
+  #endif
+  
+    RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+    RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+                                                      moduleName:@\\"ReactNativeProject\\"
+                                              initialProperties:nil];
+  
+    rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  
+    self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    UIViewController *rootViewController = [UIViewController new];
+    rootViewController.view = rootView;
+    self.window.rootViewController = rootViewController;
+    [self.window makeKeyAndVisible];
+    return YES;
+  }
+  
+  - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+  {
+  #if DEBUG
+    return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@\\"index\\" fallbackResource:nil];
+  #else
+    return [[NSBundle mainBundle] URLForResource:@\\"main\\" withExtension:@\\"jsbundle\\"];
+  #endif
+  }
+  
+  @end
+  "
+`;
+
+exports[`addGoogleMapsAppDelegateInit adds maps import to AppDelegate 1`] = `
+"#import \\"AppDelegate.h\\"
+  
+  #import <React/RCTBridge.h>
+  #import <React/RCTBundleURLProvider.h>
+  #import <React/RCTRootView.h>
+  
+  #if DEBUG
+  #import <FlipperKit/FlipperClient.h>
+  #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+  #import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+  #import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+  #import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+  #import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+  
+  static void InitializeFlipper(UIApplication *application) {
+    FlipperClient *client = [FlipperClient sharedClient];
+    SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+    [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+    [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+    [client addPlugin:[FlipperKitReactPlugin new]];
+    [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+    [client start];
+  }
+  #endif
+  
+  @implementation AppDelegate
+  
+  - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+  {
+  #if DEBUG
+    InitializeFlipper(application);
+  #endif
+  
+// @generated begin react-native-maps-init - expo prebuild (DO NOT MODIFY) sync-97501819d6911e5f50d66c63d369b0cec62853c2
+#if __has_include(<GoogleMaps/GoogleMaps.h>)
+  [GMSServices provideAPIKey:@\\"mykey\\"];
+#endif
+// @generated end react-native-maps-init
+    RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+    RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+                                                      moduleName:@\\"ReactNativeProject\\"
+                                              initialProperties:nil];
+  
+    rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  
+    self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    UIViewController *rootViewController = [UIViewController new];
+    rootViewController.view = rootView;
+    self.window.rootViewController = rootViewController;
+    [self.window makeKeyAndVisible];
+    return YES;
+  }
+  
+  - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+  {
+  #if DEBUG
+    return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@\\"index\\" fallbackResource:nil];
+  #else
+    return [[NSBundle mainBundle] URLForResource:@\\"main\\" withExtension:@\\"jsbundle\\"];
+  #endif
+  }
+  
+  @end
+  "
+`;
+
+exports[`addGoogleMapsAppDelegateInit adds maps import to Unimodules AppDelegate 1`] = `
+"
+#import \\"AppDelegate.h\\"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+
+#import <UMCore/UMModuleRegistry.h>
+#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
+#import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
+#import <EXSplashScreen/EXSplashScreenService.h>
+#import <UMCore/UMModuleRegistryProvider.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@interface AppDelegate () <RCTBridgeDelegate>
+
+@property (nonatomic, strong) UMModuleRegistryAdapter *moduleRegistryAdapter;
+@property (nonatomic, strong) NSDictionary *launchOptions;
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+// @generated begin react-native-maps-init - expo prebuild (DO NOT MODIFY) sync-97501819d6911e5f50d66c63d369b0cec62853c2
+#if __has_include(<GoogleMaps/GoogleMaps.h>)
+  [GMSServices provideAPIKey:@\\"mykey\\"];
+#endif
+// @generated end react-native-maps-init
+  self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[UMModuleRegistryProvider alloc] init]];
+  self.launchOptions = launchOptions;
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  #ifdef DEBUG
+    [self initializeReactNativeApp];
+  #else
+    EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
+    controller.delegate = self;
+    [controller startAndShowLaunchScreen:self.window];
+  #endif
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+}
+
+- (RCTBridge *)initializeReactNativeApp
+{
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@\\"main\\" initialProperties:nil];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  return bridge;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
+  // If you'd like to export some custom RCTBridgeModules that are not Expo modules, add them here!
+  return extraModules;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@\\"index\\" fallbackResource:nil];
+ #else
+  return [[EXUpdatesAppController sharedInstance] launchAssetUrl];
+ #endif
+}
+
+- (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success {
+  appController.bridge = [self initializeReactNativeApp];
+  EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
+  [splashScreenService showSplashScreenFor:self.window.rootViewController];
+}
+
+@end
+"
+`;
+
 exports[`addMapsCocoaPods adds maps pods to Podfile 1`] = `
 "
 require_relative '../node_modules/react-native/scripts/react_native_pods'
@@ -12,17 +255,59 @@ target 'myapp' do
   use_unimodules!
   config = use_native_modules!
 
-# @generated begin react-native-maps (DO NOT MODIFY) sync-5c87ad4d9ddfb7bd69df4fc0cf28e520c23ac94b
-  pod 'GoogleMaps'
-  pod 'Google-Maps-iOS-Utils'
+  use_react_native!(:path => config[\\"reactNativePath\\"])
+# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-85f8575c50e7893d1bd8555bd92e1d2923f04aeb
+  pod 'react-native-google-maps', path: '../node_modules/react-native-maps'
+  post_install do |installer|
     installer.pods_project.targets.each do |target|
       next unless target.name == 'react-native-google-maps'
+ 
       target.build_configurations.each do |config|
         config.build_settings['CLANG_ENABLE_MODULES'] = 'No'
       end
     end
+  end
 # @generated end react-native-maps
+
+  # Uncomment the code below to enable Flipper.
+  #
+  # You should not install Flipper in CI environments when creating release
+  # builds, this will lead to significantly slower build times.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work.
+  #
+  #  use_flipper!
+  #  post_install do |installer|
+  #    flipper_post_install(installer)
+  #  end
+end
+"
+`;
+
+exports[`addMapsCocoaPods adds maps pods to Podfile 2`] = `
+"
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'myapp' do
+  use_unimodules!
+  config = use_native_modules!
+
   use_react_native!(:path => config[\\"reactNativePath\\"])
+# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-68b8e46c277237ec1f5e03fce7ee7c85e20995e8
+  post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      next unless target.name == 'react-native-google-maps'
+ 
+      target.build_configurations.each do |config|
+        config.build_settings['CLANG_ENABLE_MODULES'] = 'No'
+      end
+    end
+  end
+# @generated end react-native-maps
 
   # Uncomment the code below to enable Flipper.
   #

--- a/packages/config-plugins/src/ios/__tests__/fixtures/AppDelegate.ts
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/AppDelegate.ts
@@ -1,0 +1,101 @@
+export const UnimodulesAppDelegate = `
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+
+#import <UMCore/UMModuleRegistry.h>
+#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
+#import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
+#import <EXSplashScreen/EXSplashScreenService.h>
+#import <UMCore/UMModuleRegistryProvider.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@interface AppDelegate () <RCTBridgeDelegate>
+
+@property (nonatomic, strong) UMModuleRegistryAdapter *moduleRegistryAdapter;
+@property (nonatomic, strong) NSDictionary *launchOptions;
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[UMModuleRegistryProvider alloc] init]];
+  self.launchOptions = launchOptions;
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  #ifdef DEBUG
+    [self initializeReactNativeApp];
+  #else
+    EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
+    controller.delegate = self;
+    [controller startAndShowLaunchScreen:self.window];
+  #endif
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+}
+
+- (RCTBridge *)initializeReactNativeApp
+{
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  return bridge;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
+  // If you'd like to export some custom RCTBridgeModules that are not Expo modules, add them here!
+  return extraModules;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+ #else
+  return [[EXUpdatesAppController sharedInstance] launchAssetUrl];
+ #endif
+}
+
+- (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success {
+  appController.bridge = [self initializeReactNativeApp];
+  EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
+  [splashScreenService showSplashScreenFor:self.window.rootViewController];
+}
+
+@end
+`;

--- a/packages/config-plugins/src/ios/__tests__/fixtures/Podfile.ts
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/Podfile.ts
@@ -1,0 +1,26 @@
+export const PodfileBasic = `
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'myapp' do
+  use_unimodules!
+  config = use_native_modules!
+
+  use_react_native!(:path => config["reactNativePath"])
+
+  # Uncomment the code below to enable Flipper.
+  #
+  # You should not install Flipper in CI environments when creating release
+  # builds, this will lead to significantly slower build times.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work.
+  #
+  #  use_flipper!
+  #  post_install do |installer|
+  #    flipper_post_install(installer)
+  #  end
+end
+`;

--- a/packages/config-plugins/src/ios/index.ts
+++ b/packages/config-plugins/src/ios/index.ts
@@ -10,6 +10,7 @@ import * as Google from './Google';
 import * as Icons from './Icons';
 import { ExpoPlist, InfoPlist } from './IosConfig.types';
 import * as Locales from './Locales';
+import * as Maps from './Maps';
 import * as Name from './Name';
 import * as Orientation from './Orientation';
 import * as Paths from './Paths';
@@ -39,6 +40,7 @@ export {
   Entitlements,
   Facebook,
   Google,
+  Maps,
   Icons,
   Locales,
   SplashScreen,

--- a/packages/config-plugins/src/plugins/__tests__/__snapshots__/expo-plugins-test.ts.snap
+++ b/packages/config-plugins/src/plugins/__tests__/__snapshots__/expo-plugins-test.ts.snap
@@ -79,8 +79,6 @@ Object {
     "permissions": Array [
       "CAMERA",
       "com.sec.android.provider.badge.permission.WRITE",
-      "android.permission.ACCESS_COARSE_LOCATION",
-      "android.permission.ACCESS_FINE_LOCATION",
     ],
     "softwareKeyboardLayoutMode": "pan",
     "userInterfaceStyle": "light",
@@ -195,7 +193,7 @@ Object {
           },
         },
       },
-      "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
+      "NSLocationWhenInUseUsageDescription": "",
       "UILaunchStoryboardName": "LaunchScreen",
       "UIRequiredDeviceCapabilities": Array [
         "armv7",

--- a/packages/config-plugins/src/plugins/__tests__/__snapshots__/expo-plugins-test.ts.snap
+++ b/packages/config-plugins/src/plugins/__tests__/__snapshots__/expo-plugins-test.ts.snap
@@ -36,6 +36,10 @@ Object {
         "name": "expo-updates",
         "version": "UNVERSIONED",
       },
+      "react-native-maps": Object {
+        "name": "react-native-maps",
+        "version": "UNVERSIONED",
+      },
     },
     "projectRoot": "/app",
   },
@@ -75,6 +79,8 @@ Object {
     "permissions": Array [
       "CAMERA",
       "com.sec.android.provider.badge.permission.WRITE",
+      "android.permission.ACCESS_COARSE_LOCATION",
+      "android.permission.ACCESS_FINE_LOCATION",
     ],
     "softwareKeyboardLayoutMode": "pan",
     "userInterfaceStyle": "light",
@@ -189,7 +195,7 @@ Object {
           },
         },
       },
-      "NSLocationWhenInUseUsageDescription": "",
+      "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
       "UILaunchStoryboardName": "LaunchScreen",
       "UIRequiredDeviceCapabilities": Array [
         "armv7",

--- a/packages/config-plugins/src/plugins/__tests__/expo-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/expo-plugins-test.ts
@@ -6,6 +6,7 @@ import xcode from 'xcode';
 
 import { ExportedConfig } from '../../Plugin.types';
 import { withBranch } from '../../ios/Branch';
+import { PodfileBasic } from '../../ios/__tests__/fixtures/Podfile';
 import { getDirFromFS } from '../../ios/__tests__/utils/getDirFromFS';
 import { readXMLAsync } from '../../utils/XML';
 import {
@@ -55,6 +56,7 @@ describe('built-in plugins', () => {
     vol.fromJSON(
       {
         ...rnFixture,
+        'ios/Podfile': PodfileBasic,
         'config/GoogleService-Info.plist': 'noop',
         'config/google-services.json': '{}',
         './icons/foreground.png': icon,
@@ -294,6 +296,7 @@ describe('built-in plugins', () => {
       'ios/ReactNativeProject/ReactNativeProject-Bridging-Header.h',
       'ios/ReactNativeProject/ReactNativeProject.entitlements',
       'ios/ReactNativeProject.xcodeproj/project.pbxproj',
+      'ios/Podfile',
       'android/app/src/main/java/com/bacon/todo/MainActivity.java',
       'android/app/src/main/java/com/bacon/todo/MainApplication.java',
       'android/app/src/main/AndroidManifest.xml',

--- a/packages/config-plugins/src/plugins/expo-plugins.ts
+++ b/packages/config-plugins/src/plugins/expo-plugins.ts
@@ -29,6 +29,7 @@ export const withExpoIOSPlugins: ConfigPlugin<{
     [IOSConfig.BundleIdentifier.withBundleIdentifier, { bundleIdentifier }],
     IOSConfig.SwiftBridgingHeader.withSwiftBridgingHeader,
     IOSConfig.Google.withGoogle,
+    IOSConfig.Maps.withMaps,
     IOSConfig.Name.withDisplayName,
     // IOSConfig.Name.withName,
     IOSConfig.Orientation.withOrientation,

--- a/packages/config-plugins/src/plugins/expo-plugins.ts
+++ b/packages/config-plugins/src/plugins/expo-plugins.ts
@@ -13,6 +13,7 @@ import withFacebook from './unversioned/expo-facebook';
 import withNotifications from './unversioned/expo-notifications';
 import withSplashScreen from './unversioned/expo-splash-screen';
 import withUpdates from './unversioned/expo-updates';
+import withMaps from './unversioned/react-native-maps';
 
 /**
  * Config plugin to apply all of the custom Expo iOS config plugins we support by default.
@@ -29,9 +30,7 @@ export const withExpoIOSPlugins: ConfigPlugin<{
     [IOSConfig.BundleIdentifier.withBundleIdentifier, { bundleIdentifier }],
     IOSConfig.SwiftBridgingHeader.withSwiftBridgingHeader,
     IOSConfig.Google.withGoogle,
-    IOSConfig.Maps.withMaps,
     IOSConfig.Name.withDisplayName,
-    // IOSConfig.Name.withName,
     IOSConfig.Orientation.withOrientation,
     IOSConfig.RequiresFullScreen.withRequiresFullScreen,
     IOSConfig.Scheme.withScheme,
@@ -84,7 +83,6 @@ export const withExpoAndroidPlugins: ConfigPlugin<{
     AndroidConfig.Orientation.withOrientation,
     AndroidConfig.Permissions.withPermissions,
     AndroidConfig.UserInterfaceStyle.withUiModeManifest,
-    AndroidConfig.GoogleMapsApiKey.withGoogleMapsApiKey,
 
     // MainActivity.*
     AndroidConfig.UserInterfaceStyle.withUiModeMainActivity,
@@ -113,6 +111,7 @@ export const withExpoVersionedSDKPlugins: ConfigPlugin<{ expoUsername: string | 
   { expoUsername }
 ) => {
   return withPlugins(config, [
+    withMaps,
     withAdMob,
     withAppleAuthentication,
     withNotifications,

--- a/packages/config-plugins/src/plugins/unversioned/react-native-maps.ts
+++ b/packages/config-plugins/src/plugins/unversioned/react-native-maps.ts
@@ -1,0 +1,41 @@
+import { ConfigPlugin } from '../../Plugin.types';
+import { withGoogleMapsApiKey } from '../../android/GoogleMapsApiKey';
+import { withPermissions } from '../../android/Permissions';
+import { withMaps as withMapsIOS } from '../../ios/Maps';
+import { createRunOncePlugin } from '../core-plugins';
+import { withStaticPlugin } from '../static-plugins';
+
+const packageName = 'react-native-maps';
+const LOCATION_USAGE = 'Allow $(PRODUCT_NAME) to access your location';
+
+// Copied from expo-location package, this gets used when the
+// user has react-native-maps installed but not expo-location.
+const withDefaultLocationPermissions: ConfigPlugin = config => {
+  if (!config.ios) config.ios = {};
+  if (!config.ios.infoPlist) config.ios.infoPlist = {};
+  config.ios.infoPlist.NSLocationWhenInUseUsageDescription =
+    config.ios.infoPlist.NSLocationWhenInUseUsageDescription || LOCATION_USAGE;
+
+  return withPermissions(config, [
+    'android.permission.ACCESS_COARSE_LOCATION',
+    'android.permission.ACCESS_FINE_LOCATION',
+  ]);
+};
+
+export const withMaps: ConfigPlugin = config => {
+  return withStaticPlugin(config, {
+    _isLegacyPlugin: true,
+    plugin: packageName,
+    // If the static plugin isn't found, use the unversioned one.
+    fallback: withUnversionedMaps,
+  });
+};
+
+const withUnversionedMaps: ConfigPlugin = createRunOncePlugin(config => {
+  config = withGoogleMapsApiKey(config);
+  config = withMapsIOS(config);
+  config = withDefaultLocationPermissions(config);
+  return config;
+}, packageName);
+
+export default withMaps;

--- a/packages/config-plugins/src/plugins/unversioned/react-native-maps.ts
+++ b/packages/config-plugins/src/plugins/unversioned/react-native-maps.ts
@@ -1,3 +1,5 @@
+import resolveFrom from 'resolve-from';
+
 import { ConfigPlugin } from '../../Plugin.types';
 import { withGoogleMapsApiKey } from '../../android/GoogleMapsApiKey';
 import { withPermissions } from '../../android/Permissions';
@@ -34,7 +36,13 @@ export const withMaps: ConfigPlugin = config => {
 const withUnversionedMaps: ConfigPlugin = createRunOncePlugin(config => {
   config = withGoogleMapsApiKey(config);
   config = withMapsIOS(config);
-  config = withDefaultLocationPermissions(config);
+  // Only add location permissions if react-native-maps is installed.
+  if (
+    config._internal?.projectRoot &&
+    resolveFrom.silent(config._internal?.projectRoot!, 'react-native-maps')
+  ) {
+    config = withDefaultLocationPermissions(config);
+  }
   return config;
 }, packageName);
 

--- a/packages/config-plugins/src/utils/generateCode.ts
+++ b/packages/config-plugins/src/utils/generateCode.ts
@@ -1,0 +1,102 @@
+/**
+ * Get line indexes for the generated section of a file.
+ *
+ * @param src
+ */
+import crypto from 'crypto';
+
+function getGeneratedSectionIndexes(
+  src: string,
+  tag: string
+): { contents: string[]; start: number; end: number } {
+  const contents = src.split('\n');
+  const start = contents.findIndex(line => line.includes(`@generated begin ${tag}`));
+  const end = contents.findIndex(line => line.includes(`@generated end ${tag}`));
+
+  return { contents, start, end };
+}
+
+export type MergeResults = {
+  contents: string;
+  didClear: boolean;
+  didMerge: boolean;
+};
+
+/**
+ * Merge the contents of two files together and add a generated header.
+ *
+ * @param targetContents contents of the existing file
+ * @param sourceContents contents of the extra file
+ */
+export function mergeContents(
+  targetContents: string,
+  sourceContents: string,
+  tag: string,
+  anchor: string | RegExp,
+  offset: number,
+  comment: string
+): MergeResults {
+  const header = createGeneratedHeaderComment(sourceContents, tag, comment);
+  if (!targetContents.includes(header)) {
+    // Ensure the old generated contents are removed.
+    const sanitizedTarget = removeGeneratedContents(targetContents, tag);
+    return {
+      contents: addLines(sanitizedTarget ?? targetContents, anchor, offset, [
+        header,
+        ...sourceContents.split('\n'),
+        `${comment} @generated end ${tag}`,
+      ]),
+      didMerge: true,
+      didClear: !!sanitizedTarget,
+    };
+  }
+  return { contents: targetContents, didClear: false, didMerge: false };
+}
+
+function addLines(content: string, find: string | RegExp, offset: number, toAdd: string[]) {
+  const lines = content.split('\n');
+
+  let lineIndex = lines.findIndex(line => line.match(find));
+
+  for (const newLine of toAdd) {
+    if (!content.includes(newLine)) {
+      lines.splice(lineIndex + offset, 0, newLine);
+      lineIndex++;
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Removes the generated section from a file, returns null when nothing can be removed.
+ * This sways heavily towards not removing lines unless it's certain that modifications were not made to the gitignore manually.
+ *
+ * @param src
+ */
+export function removeGeneratedContents(src: string, tag: string): string | null {
+  const { contents, start, end } = getGeneratedSectionIndexes(src, tag);
+  if (start > -1 && end > -1 && start < end) {
+    contents.splice(start, end - start + 1);
+    // TODO: We could in theory check that the contents we're removing match the hash used in the header,
+    // this would ensure that we don't accidentally remove lines that someone added or removed from the generated section.
+    return contents.join('\n');
+  }
+  return null;
+}
+
+export function createGeneratedHeaderComment(
+  contents: string,
+  tag: string,
+  comment: string
+): string {
+  const hashKey = createHash(contents);
+
+  return `${comment} @generated begin ${tag} (DO NOT MODIFY) ${hashKey}`;
+}
+
+export function createHash(gitIgnore: string): string {
+  // this doesn't need to be secure, the shorter the better.
+  const hash = crypto.createHash('sha1').update(gitIgnore).digest('hex');
+  return `sync-${hash}`;
+}

--- a/packages/config-plugins/src/utils/generateCode.ts
+++ b/packages/config-plugins/src/utils/generateCode.ts
@@ -90,7 +90,7 @@ function addLines(content: string, find: string | RegExp, offset: number, toAdd:
 
 /**
  * Removes the generated section from a file, returns null when nothing can be removed.
- * This sways heavily towards not removing lines unless it's certain that modifications were not made to the gitignore manually.
+ * This sways heavily towards not removing lines unless it's certain that modifications were not made manually.
  *
  * @param src
  */

--- a/packages/config-plugins/src/utils/generateCode.ts
+++ b/packages/config-plugins/src/utils/generateCode.ts
@@ -25,8 +25,12 @@ export type MergeResults = {
 /**
  * Merge the contents of two files together and add a generated header.
  *
- * @param src contents of the existing file
- * @param sourceContents contents of the extra file
+ * @param src contents of the original file
+ * @param newSrc new contents to merge into the original file
+ * @param identifier used to update and remove merges
+ * @param anchor regex to where the merge should begin
+ * @param offset line offset to start merging at (<1 for behind the anchor)
+ * @param comment comment style `//` or `#`
  */
 export function mergeContents({
   src,
@@ -116,8 +120,8 @@ export function createGeneratedHeaderComment(
   return `${comment} @generated begin ${tag} - expo prebuild (DO NOT MODIFY) ${hashKey}`;
 }
 
-export function createHash(gitIgnore: string): string {
+export function createHash(src: string): string {
   // this doesn't need to be secure, the shorter the better.
-  const hash = crypto.createHash('sha1').update(gitIgnore).digest('hex');
+  const hash = crypto.createHash('sha1').update(src).digest('hex');
   return `sync-${hash}`;
 }

--- a/packages/config-plugins/src/utils/resolvePackageRootFolder.ts
+++ b/packages/config-plugins/src/utils/resolvePackageRootFolder.ts
@@ -1,0 +1,13 @@
+import findUp from 'find-up';
+import * as path from 'path';
+import resolveFrom from 'resolve-from';
+
+export function resolvePackageRootFolder(fromDirectory: string, moduleId: string): string | null {
+  const resolved = resolveFrom.silent(fromDirectory, moduleId);
+  if (!resolved) return null;
+  // Get the closest package.json to the node module
+  const packageJson = findUp.sync('package.json', { cwd: resolved });
+  if (!packageJson) return null;
+  // resolve the root folder for the node module
+  return path.dirname(packageJson);
+}


### PR DESCRIPTION
# Why

- auto configure react-native-maps upon ejecting.

# How

- created an unversioned plugin for `react-native-maps` namespace which:
  - adds `pod 'react-native-google-maps', path: '../node_modules/react-native-maps'` to the podfile if `ios.config.googleMapsApiKey` is defined.
  - adds the following blocks to the AppDelegate.m when Google Maps is enabled:
```objc
// @generated begin react-native-maps-import - expo prebuild (DO NOT MODIFY) sync-f2f83125c99c0d74b42a2612947510c4e08c423a
#if __has_include(<GoogleMaps/GoogleMaps.h>)
#import <GoogleMaps/GoogleMaps.h>
#endif
// @generated end react-native-maps-import

...

- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
{

// @generated begin react-native-maps-init - expo prebuild (DO NOT MODIFY) sync-153e3eb24b7da99b846df4d93dd1d33da90e7c22
#if __has_include(<GoogleMaps/GoogleMaps.h>)
  [GMSServices provideAPIKey:@"API_KEY"];
#endif
// @generated end react-native-maps-init
```
These blocks are special because they can be removed or updated between prebuilds (plugin anti pattern). The `react-native-maps-init` block is matched against RN and Unimodules projects using the following (tested) regex `/(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[\[RCTBridge alloc\])/g`

- The Android permissions `android.permission.ACCESS_COARSE_LOCATION` and `android.permission.ACCESS_FINE_LOCATION` are added
- The iOS permission `NSLocationWhenInUseUsageDescription` is added (no customization options)
- The AndroidManifest tags `com.google.android.geo.API_KEY` and `org.apache.http.legacy` are added, this was previously done directly but the plugin has now been moved into the unversioned `react-native-maps` plugin (meaning it can be disabled by a future plugin in the `react-native-maps` package).
- Finally, `GMSApiKey` is added to the Info.plist (not sure why though).

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Extensive regex testing is done in the unit tests
- In a new project
- Install `yarn add react-native-maps`
- Sync `expod prebuild`
- Build `expod run:ios --bundler` -- this works as expected for Apple maps
- Define a value in `ios.config.googleMapsApiKey` 
- Sync `expod prebuild`
- Install `npx pod-install`
- Build `expod run:ios --bundler` -- this enables Google Maps on iOS
- `yarn remove react-native-maps`
- Sync `expod prebuild` -- this removes the related CocoaPods and AppDelegate code safely.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->