### PR TITLE
Activate android emulator window

### DIFF
--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig, getConfig, readExpRcAsync } from '@expo/config';
 import { AndroidConfig } from '@expo/config-plugins';
+import * as osascript from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import child_process, { execFileSync } from 'child_process';
@@ -551,6 +552,43 @@ async function _openUrlAsync({
   return openProject;
 }
 
+function getUnixPID(port: number | string) {
+  return execFileSync('lsof', [`-i:${port}`, '-P', '-t', '-sTCP:LISTEN'], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+  })
+    .split('\n')[0]
+    .trim();
+}
+
+export async function activateEmulatorWindowAsync(device: Device) {
+  if (
+    // only mac is supported for now.
+    process.platform !== 'darwin' ||
+    // can only focus emulators
+    device.type !== 'emulator'
+  ) {
+    return;
+  }
+
+  // Google Emulator ID: `emulator-5554` -> `5554`
+  const androidPid = device.pid!.match(/-(\d+)/)?.[1];
+  if (!androidPid) {
+    return;
+  }
+  // Unix PID
+  const pid = getUnixPID(androidPid);
+
+  try {
+    await osascript.execAsync(`
+  tell application "System Events"
+    set frontmost of the first process whose unix id is ${pid} to true
+  end tell`);
+  } catch {
+    // noop -- this feature is very specific and subject to failure.
+  }
+}
+
 export async function openAppAsync(
   device: Pick<Device, 'pid'>,
   {
@@ -635,6 +673,9 @@ async function openUrlAsync({
     if (!bootedDevice) {
       return;
     }
+
+    await activateEmulatorWindowAsync(bootedDevice);
+
     device = bootedDevice;
 
     let installedExpo = false;

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -561,7 +561,7 @@ function getUnixPID(port: number | string) {
     .trim();
 }
 
-export async function activateEmulatorWindowAsync(device: Device) {
+export async function activateEmulatorWindowAsync(device: Pick<Device, 'type' | 'pid'>) {
   if (
     // only mac is supported for now.
     process.platform !== 'darwin' ||
@@ -590,7 +590,7 @@ export async function activateEmulatorWindowAsync(device: Device) {
 }
 
 export async function openAppAsync(
-  device: Pick<Device, 'pid'>,
+  device: Pick<Device, 'pid' | 'type'>,
   {
     packageName,
     mainActivity,
@@ -620,6 +620,8 @@ export async function openAppAsync(
   if (openProject.includes(CANT_START_ACTIVITY_ERROR)) {
     throw new Error(openProject.substring(openProject.indexOf('Error: ')));
   }
+
+  await activateEmulatorWindowAsync(device);
 
   return openProject;
 }


### PR DESCRIPTION
# Why

Emulate iOS functionality of bringing the window to the front when activated.


# Test Plan

- `expo start --android` -- activates window
- `shift+a` -- select new device, that window should be activated instead of the other window.