### PR TITLE
[config-plugins] Throw better error message when target does not exist

### DIFF
--- a/packages/config-plugins/src/ios/ProvisioningProfile.ts
+++ b/packages/config-plugins/src/ios/ProvisioningProfile.ts
@@ -22,9 +22,17 @@ function setProvisioningProfileForPbxproj(
   { targetName, profileName, appleTeamId }: ProvisioningProfileSettings
 ): void {
   const project = getPbxproj(projectRoot);
-  const [nativeTargetId, nativeTarget] = targetName
+  const target = targetName
     ? findNativeTargetByName(project, targetName)
     : findFirstNativeTarget(project);
+
+  if (!target && targetName) {
+    throw new Error(`Unable to find a target named ${targetName}.`);
+  } else if (!target) {
+    throw new Error(`Unable to find any targets in this Xcode project.`);
+  }
+
+  const [nativeTargetId, nativeTarget] = target;
 
   getBuildConfigurationForId(project, nativeTarget.buildConfigurationList)
     .filter(([, item]: ConfigurationSectionEntry) => item.buildSettings.PRODUCT_NAME)

--- a/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
@@ -36,5 +36,15 @@ describe('ProvisioningProfile module', () => {
       const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
       expect(pbxprojContents).toMatchSnapshot();
     });
+    it('throws descriptive error when target name does not exist', async () => {
+      const fn = () => {
+        setProvisioningProfileForPbxproj(projectRoot, {
+          targetName: 'faketargetname',
+          profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+          appleTeamId: 'J5FM626PE2',
+        });
+      };
+      expect(fn).toThrow('Unable to find a target named faketargetname');
+    });
   });
 });


### PR DESCRIPTION
# Why

Current error in that case prints
```
Build failed: (intermediate value)(intermediate value)(intermediate value) is not iterable
```
# How

Send better error message

# Test Plan

add test case