### PR TITLE
fix product name getter

### DIFF
--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -296,6 +296,9 @@ export function getProductName(project: XcodeProject): string {
   let productName = '$(TARGET_NAME)';
   try {
     // If the product name is numeric, this will fail (it's a getter).
+    // If the bundle identifier' final component is only numeric values, then the PRODUCT_NAME
+    // will be a numeric value, this results in a bug where the product name isn't useful,
+    // i.e. `com.bacon.001` -> `1` -- in this case, use the first target name.
     productName = project.productName;
   } catch {}
 

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -293,11 +293,15 @@ export function getPbxproj(projectRoot: string): XcodeProject {
  * @param project
  */
 export function getProductName(project: XcodeProject): string {
-  let productName = project.productName;
+  let productName = '$(TARGET_NAME)';
+  try {
+    // If the product name is numeric, this will fail (it's a getter).
+    productName = project.productName;
+  } catch {}
 
   if (productName === '$(TARGET_NAME)') {
     const targetName = project.getFirstTarget()?.firstTarget?.productName;
-    productName = targetName ?? project.productName;
+    productName = targetName ?? productName;
   }
 
   return productName;


### PR DESCRIPTION
# Why

- fix https://github.com/expo/expo-cli/issues/3341

# How

- improve algo for getting the ios product name to name the entitlements file. 

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `expo prebuild` a project with `ios.bundleIdentifier: com.bacon.001` -> name should not be `1` unless the project's name is `1`

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->