### PR TITLE
Improve bundle identifier regex

### DIFF
--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -12,7 +12,7 @@ const noBundleIdMessage = `Your project must have a \`bundleIdentifier\` set in 
 const noPackageMessage = `Your project must have a \`package\` set in the Expo config (app.json or app.config.js).\nSee https://expo.fyi/android-package`;
 
 export function validateBundleId(value: string): boolean {
-  return /^[a-zA-Z0-9\-.]+$/.test(value);
+  return /^[a-zA-Z0-9-.]+$/.test(value);
 }
 
 function validatePackage(value: string): boolean {

--- a/packages/expo-cli/src/commands/eject/ConfigValidation.ts
+++ b/packages/expo-cli/src/commands/eject/ConfigValidation.ts
@@ -11,8 +11,8 @@ import { isUrlAvailableAsync } from '../utils/url';
 const noBundleIdMessage = `Your project must have a \`bundleIdentifier\` set in the Expo config (app.json or app.config.js).\nSee https://expo.fyi/bundle-identifier`;
 const noPackageMessage = `Your project must have a \`package\` set in the Expo config (app.json or app.config.js).\nSee https://expo.fyi/android-package`;
 
-function validateBundleId(value: string): boolean {
-  return /^[a-zA-Z][a-zA-Z0-9\-.]+$/.test(value);
+export function validateBundleId(value: string): boolean {
+  return /^[a-zA-Z0-9\-.]+$/.test(value);
 }
 
 function validatePackage(value: string): boolean {

--- a/packages/expo-cli/src/commands/eject/__tests__/ConfigValidation-test.ts
+++ b/packages/expo-cli/src/commands/eject/__tests__/ConfigValidation-test.ts
@@ -4,6 +4,7 @@ describe(validateBundleId, () => {
   it(`validates`, () => {
     expect(validateBundleId('bacon')).toBe(true);
     expect(validateBundleId('...b.a.-c.0.n...')).toBe(true);
+    expect(validateBundleId('.')).toBe(true);
     expect(validateBundleId('. ..')).toBe(false);
     expect(validateBundleId('_')).toBe(false);
     expect(validateBundleId(',')).toBe(false);

--- a/packages/expo-cli/src/commands/eject/__tests__/ConfigValidation-test.ts
+++ b/packages/expo-cli/src/commands/eject/__tests__/ConfigValidation-test.ts
@@ -1,0 +1,11 @@
+import { validateBundleId } from '../ConfigValidation';
+
+describe(validateBundleId, () => {
+  it(`validates`, () => {
+    expect(validateBundleId('bacon')).toBe(true);
+    expect(validateBundleId('...b.a.-c.0.n...')).toBe(true);
+    expect(validateBundleId('. ..')).toBe(false);
+    expect(validateBundleId('_')).toBe(false);
+    expect(validateBundleId(',')).toBe(false);
+  });
+});


### PR DESCRIPTION
# Why

- fix https://github.com/expo/expo-cli/issues/3315

# How

- allow `.` and `-` at any position in the bundle id.

# Test Plan

- added unit tests
- tested valid options in xcode