### PR TITLE
clean up logging messages

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -218,7 +218,9 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
       switch (key) {
         case 'A':
         case 'a':
-          Log.clear();
+          if (key === 'A') {
+            Log.clear();
+          }
           Log.log(`${BLT} Opening the web project in Chrome on Android...`);
           await Android.openWebProjectAsync({
             projectRoot,
@@ -228,7 +230,9 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
           break;
         case 'i':
         case 'I':
-          Log.clear();
+          if (key === 'I') {
+            Log.clear();
+          }
           Log.log(`${BLT} Opening the web project in Safari on iOS...`);
           await Simulator.openWebProjectAsync({
             projectRoot,
@@ -256,7 +260,6 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
           printHelp();
           break;
         case 'a': {
-          Log.clear();
           Log.log(`${BLT} Opening on Android...`);
           await Android.openProjectAsync({ projectRoot, devClient: options.devClient ?? false });
           printHelp();
@@ -272,8 +275,6 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
           printHelp();
           break;
         case 'i': {
-          Log.clear();
-
           // note(brentvatne): temporarily remove logic for picking the
           // simulator until we have parity for Android. this also ensures that we
           // don't interfere with the default user flow until more users have tested

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -219,7 +219,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         case 'A':
         case 'a':
           Log.clear();
-          Log.log('Opening the web project in Chrome on Android...');
+          Log.log(`${BLT} Opening the web project in Chrome on Android...`);
           await Android.openWebProjectAsync({
             projectRoot,
             shouldPrompt: !options.nonInteractive && key === 'A',
@@ -229,7 +229,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         case 'i':
         case 'I':
           Log.clear();
-          Log.log('Opening the web project in Safari on iOS...');
+          Log.log(`${BLT} Opening the web project in Safari on iOS...`);
           await Simulator.openWebProjectAsync({
             projectRoot,
             shouldPrompt: !options.nonInteractive && key === 'I',
@@ -257,7 +257,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
           break;
         case 'a': {
           Log.clear();
-          Log.log('Opening on Android...');
+          Log.log(`${BLT} Opening on Android...`);
           await Android.openProjectAsync({ projectRoot, devClient: options.devClient ?? false });
           printHelp();
           break;
@@ -283,7 +283,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
           // const shouldPrompt =
           //   !options.nonInteractive && (key === 'I' || !(await Simulator.isSimulatorBootedAsync()));
 
-          Log.log('Opening on iOS...');
+          Log.log(`${BLT} Opening on iOS...`);
           await Simulator.openProjectAsync({
             projectRoot,
             shouldPrompt: false,
@@ -315,7 +315,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         break;
       }
       case 'w': {
-        Log.log('Attempting to open the project in a web browser...');
+        Log.log(`${BLT} Open in the web browser...`);
         await Webpack.openAsync(projectRoot);
         await printServerInfo(projectRoot, options);
         break;
@@ -416,7 +416,7 @@ Please reload the project in Expo Go for the change to take effect.`
         }
         break;
       case 'o':
-        Log.log('Trying to open the project in your editor...');
+        Log.log(`${BLT} Opening the editor...`);
         await openInEditorAsync(projectRoot);
     }
   }

--- a/packages/uri-scheme/src/URIScheme.ts
+++ b/packages/uri-scheme/src/URIScheme.ts
@@ -159,11 +159,11 @@ export async function openAsync(
   options.uri = ensureUriString(options.uri);
 
   if (options.ios) {
-    logPlatformMessage('iOS', `Attempting to open URI "${options.uri}" in simulator`);
+    logPlatformMessage('iOS', `Opening URI "${options.uri}" in simulator`);
     await Ios.openAsync(options);
   }
   if (options.android) {
-    logPlatformMessage('Android', `Attempting to open URI "${options.uri}" in emulator`);
+    logPlatformMessage('Android', `Opening URI "${options.uri}" in emulator`);
     await Android.openAsync(options);
   }
 }

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -139,7 +139,7 @@ async function isBootAnimationCompleteAsync(pid?: string): Promise<boolean> {
 }
 
 async function startEmulatorAsync(device: Pick<Device, 'name'>): Promise<Device> {
-  Logger.global.info(`\u203A Attempting to open emulator: ${device.name}`);
+  Logger.global.info(`\u203A Opening emulator ${chalk.bold(device.name)}`);
 
   // Start a process to open an emulator
   const emulatorProcess = child_process.spawn(


### PR DESCRIPTION
# Why

- only clear logs when selecting a native device and not when simply opening on a device.
- remove "attempting" and "maybe" language from messages.

