### PR TITLE
Improve no xcode warnings

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
@@ -31,6 +31,9 @@ async function getBuildDestinationsAsync() {
 export async function resolveDeviceAsync(
   device: string | boolean | undefined
 ): Promise<SimControl.SimulatorDevice | SimControl.XCTraceDevice> {
+  if (!(await profileMethod(Simulator.ensureXcodeCommandLineToolsInstalledAsync)())) {
+    throw new CommandError('Unable to verify Xcode and Simulator installation.');
+  }
   if (!device) {
     return await profileMethod(
       Simulator.ensureSimulatorOpenAsync,

--- a/packages/xdl/src/SimControl.ts
+++ b/packages/xdl/src/SimControl.ts
@@ -1,10 +1,13 @@
 import * as osascript from '@expo/osascript';
 import spawnAsync, { SpawnOptions, SpawnResult } from '@expo/spawn-async';
 import chalk from 'chalk';
+import { exec, execSync } from 'child_process';
 import path from 'path';
+import { promisify } from 'util';
 
 import { Logger, XDLError } from './internal';
 
+const execAsync = promisify(exec);
 type DeviceState = 'Shutdown' | 'Booted';
 
 export type SimulatorDevice = {
@@ -370,12 +373,12 @@ export async function isSimulatorAppRunningAsync(): Promise<boolean> {
 }
 
 export async function openSimulatorAppAsync({ udid }: { udid?: string }) {
-  const args = ['-a', 'Simulator'];
+  const args = ['open', '-a', 'Simulator'];
   if (udid) {
     // This has no effect if the app is already running.
     args.push('--args', '-CurrentDeviceUDID', udid);
   }
-  return await spawnAsync('open', args);
+  await execAsync(args.join(' '));
 }
 
 export async function killAllAsync() {
@@ -393,9 +396,9 @@ export function isLicenseOutOfDate(text: string) {
 
 export async function isXcrunInstalledAsync() {
   try {
-    await spawnAsync('xcrun', ['--version']);
+    execSync('xcrun --version', { stdio: 'ignore' });
     return true;
-  } catch (error) {
+  } catch {
     return false;
   }
 }

--- a/packages/xdl/src/Xcode.ts
+++ b/packages/xdl/src/Xcode.ts
@@ -1,4 +1,4 @@
-import spawnAsync from '@expo/spawn-async';
+import { execSync } from 'child_process';
 
 import { Logger } from './internal';
 
@@ -6,20 +6,15 @@ import { Logger } from './internal';
 export const minimumVersion = 9.4;
 export const appStoreId = '497799835';
 
-export async function getXcodeVersionAsync(): Promise<string | null> {
+export function getXcodeVersion(): string | null {
   try {
-    const { stdout } = await spawnAsync('xcodebuild', ['-version']);
-
-    const match = stdout.match(/^Xcode (\d+\.\d+)/);
-    if (match?.length) {
-      const last = match.pop();
-      // Convert to a semver string
-      if (last) {
-        return `${last}.0`;
-      }
-      return null;
+    const last = execSync('xcodebuild -version', { stdio: 'pipe' })
+      .toString()
+      .match(/^Xcode (\d+\.\d+)/)?.[1];
+    // Convert to a semver string
+    if (last) {
+      return `${last}.0`;
     }
-
     // not sure what's going on
     Logger.global.error(
       'Unable to check Xcode version. Command ran successfully but no version number was found.'
@@ -35,9 +30,9 @@ export async function getXcodeVersionAsync(): Promise<string | null> {
  *
  * @param appId
  */
-export async function openAppStoreAsync(appId: string): Promise<void> {
+export function openAppStore(appId: string) {
   const link = getAppStoreLink(appId);
-  await spawnAsync('open', [link]);
+  execSync(`open ${link}`, { stdio: 'ignore' });
 }
 
 function getAppStoreLink(appId: string): string {

--- a/packages/xdl/src/utils/profileMethod.ts
+++ b/packages/xdl/src/utils/profileMethod.ts
@@ -1,0 +1,41 @@
+import chalk from 'chalk';
+import { boolish } from 'getenv';
+
+const isProfiling = boolish('EXPO_PROFILE', false);
+
+// eslint-disable-next-line no-console
+const consoleTime: (label?: string) => void = isProfiling ? console.time : () => {};
+// eslint-disable-next-line no-console
+const consoleTimeEnd: (label?: string) => void = isProfiling ? console.timeEnd : () => {};
+
+/**
+ * Wrap a method and profile the time it takes to execute the method using `EXPO_PROFILE`.
+ * Works best with named functions (i.e. not arrow functions).
+ *
+ * @param fn
+ * @param functionName
+ */
+export const profileMethod = <T extends any[], U>(fn: (...args: T) => U, functionName?: string) => {
+  const name = chalk.dim(`⏱  [profile] ${functionName ?? (fn.name || 'unknown')}`);
+  return (...args: T): U => {
+    consoleTime(name);
+    const results = fn(...args);
+    if (results instanceof Promise) {
+      // @ts-ignore
+      return new Promise<U>((resolve, reject) => {
+        results
+          .then(results => {
+            resolve(results);
+            consoleTimeEnd(name);
+          })
+          .catch(error => {
+            reject(error);
+            consoleTimeEnd(name);
+          });
+      });
+    } else {
+      consoleTimeEnd(name);
+    }
+    return results;
+  };
+};


### PR DESCRIPTION
# Why

Checking if xcode was installed took too long so we often skipped it, but this led to cryptic and annoying errors for beginners. This PR changes spawnAsync to execSync which improves the time from `1.705s -> 273.583ms`.  Now we can use perform the xcode check more liberally.

