### PR TITLE
Remove deprecated property "xde" from the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Remove deprecated property `xde` from the manifest ([#3366](https://github.com/expo/expo-cli/pull/3366))
+
 ### 🎉 New features
 
 ### 🧹 Chores
@@ -288,7 +290,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 📦 Packages updated
 
-  - @expo/config-plugins@1.0.18
+- @expo/config-plugins@1.0.18
 - @expo/config@3.3.28
 - @expo/dev-server@0.1.54
 - @expo/dev-tools@0.13.82

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -63,7 +63,6 @@ export type ExpoAppManifest = ExpoConfig & {
   sdkVersion: string;
   bundledAssets?: string[];
   isKernel?: boolean;
-  xde?: boolean;
   kernel?: { androidManifestPath?: string; iosManifestPath?: string };
   assetUrlOverride?: string;
   publishedTime?: string;

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -321,7 +321,6 @@ export default async function (
   // TODO(Bacon): Move to expo/config - manifest code from XDL Project
   const publicConfig = {
     ...config,
-    xde: true,
     developer: {
       tool: 'expo-cli',
       projectRoot: env.projectRoot,

--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -200,7 +200,6 @@ export async function getManifestResponseAsync({
   const hostInfo = await createHostInfoAsync();
   const [projectSettings, bundleUrlPackagerOpts] = await getPackagerOptionsAsync(projectRoot);
   // Mutate the manifest
-  manifest.xde = true; // deprecated
   manifest.developer = {
     tool: Config.developerTool,
     projectRoot,


### PR DESCRIPTION
# Why

This property has been deprecated since 2018 and its use in the SDK was removed here:
https://github.com/expo/expo/commit/2807b0994b0139ecf9e7b3ff7c73de9a15535dce

# How

Searched for all references to `xde` in this repo to verify it's not relied on here either.

# Test Plan

Verified that editing an app (refresh) and starting the debugger works both on iOS and Android, with Expo Go 2.18.7.