### PR TITLE
[xdl] Fix missing/extraneous dependencies

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@expo/bunyan": "4.0.0",
     "@expo/config": "3.3.34",
+    "@expo/config-plugins": "1.0.24",
     "@expo/dev-server": "0.1.60",
     "@expo/devcert": "^1.0.0",
     "@expo/json-file": "8.2.28",
@@ -56,7 +57,6 @@
     "getenv": "^1.0.0",
     "glob": "7.1.6",
     "hasbin": "1.2.3",
-    "indent-string": "3.2.0",
     "internal-ip": "4.3.0",
     "is-reachable": "^4.0.0",
     "is-root": "^2.1.0",
@@ -71,19 +71,17 @@
     "p-retry": "4.1.0",
     "p-timeout": "3.1.0",
     "package-json": "6.4.0",
-    "pascal-case": "2.0.1",
     "pretty-bytes": "^5.3.0",
     "probe-image-size": "~6.0.0",
     "progress": "2.0.3",
     "prompts": "^2.3.2",
     "raven": "2.6.3",
     "react-dev-utils": "~11.0.1",
-    "replace-string": "1.1.0",
+    "resolve-from": "^5.0.0",
     "requireg": "^0.2.2",
     "semver": "7.3.2",
     "serialize-error": "6.0.0",
     "slugid": "1.1.0",
-    "slugify": "^1.3.6",
     "source-map-support": "0.4.18",
     "split": "1.0.1",
     "strip-ansi": "^6.0.0",
@@ -94,7 +92,8 @@
     "url-join": "4.0.0",
     "uuid": "3.3.2",
     "webpack": "4.43.0",
-    "webpack-dev-server": "3.11.0"
+    "webpack-dev-server": "3.11.0",
+    "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -106,6 +105,7 @@
     "@types/fs-extra": "^9.0.1",
     "@types/getenv": "^0.7.0",
     "@types/hapi__joi": "^17.1.2",
+    "@types/hashids": "^1.0.30",
     "@types/node-forge": "^0.9.7",
     "@types/text-table": "^0.2.1",
     "@types/raven": "^2.5.3",
@@ -119,8 +119,11 @@
     "@types/uuid": "^3.4.4",
     "@types/webpack": "4.41.18",
     "@types/webpack-dev-server": "3.11.0",
+    "@types/wrap-ansi": "^3.0.0",
+    "hashids": "1.1.4",
     "memfs": "^3.2.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "tempy": "^0.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6666,7 +6666,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camel-case@3.0.x, camel-case@^3.0.0:
+camel-case@3.0.x:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
   integrity sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
@@ -11353,11 +11353,6 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
-indent-string@3.2.0, indent-string@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
-  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
-
 indent-string@4.0.0, indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
@@ -11369,6 +11364,11 @@ indent-string@^2.1.0:
   integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
   dependencies:
     repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -16031,14 +16031,6 @@ parseurl@~1.3.2, parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-pascal-case@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-2.0.1.tgz#2d578d3455f660da65eca18ef95b4e0de912761e"
-  integrity sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=
-  dependencies:
-    camel-case "^3.0.0"
-    upper-case-first "^1.1.0"
-
 pascal-case@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.1.tgz#5ac1975133ed619281e88920973d2cd1f279de5f"
@@ -17758,11 +17750,6 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-replace-string@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/replace-string/-/replace-string-1.1.0.tgz#87062117f823fe5800c306bacb2cfa359b935fea"
-  integrity sha1-hwYhF/gj/lgAwwa6yyz6NZuTX+o=
-
 request-promise-core@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.3.tgz#e9a3c081b51380dfea677336061fea879a829ee9"
@@ -18551,7 +18538,7 @@ slugid@1.1.0:
   dependencies:
     uuid "^2.0.1"
 
-slugify@^1.0.2, slugify@^1.3.4, slugify@^1.3.6:
+slugify@^1.0.2, slugify@^1.3.4:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.6.tgz#ba5fd6159b570fe4811d02ea9b1f4906677638c3"
   integrity sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ==
@@ -20184,13 +20171,6 @@ update-check@1.5.3, update-check@^1.5.3:
   dependencies:
     registry-auth-token "3.3.2"
     registry-url "3.1.0"
-
-upper-case-first@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-1.1.2.tgz#5d79bedcff14419518fd2edb0a0507c9b6859115"
-  integrity sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=
-  dependencies:
-    upper-case "^1.1.1"
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
# Why

XDL had a few dev dependencies missing from `package.json` that happened to work because they were dependencies in other Expo CLI packages. Additionally there were a few dependencies that were no longer used.

# How

Ran `npx depcheck` to find these and double checked with search to find out how the dependencies were used.

# Test Plan

N/A