### PR TITLE
[dev-client] Allow running projects without app.json

### DIFF
--- a/packages/xdl/src/BundleIdentifier.ts
+++ b/packages/xdl/src/BundleIdentifier.ts
@@ -89,10 +89,8 @@ However, if you choose the one defined in the Xcode project you'll have to updat
   } else if (bundleIdentifierFromPbxproj && !bundleIdentifierFromConfig) {
     if (getConfigFilePaths(projectRoot).staticConfigPath) {
       await updateAppJsonConfigAsync(projectRoot, exp, bundleIdentifierFromPbxproj);
-      return bundleIdentifierFromPbxproj;
-    } else {
-      throw new Error(missingBundleIdentifierMessage(configDescription));
     }
+    return bundleIdentifierFromPbxproj;
   } else if (!bundleIdentifierFromPbxproj && bundleIdentifierFromConfig) {
     IOSConfig.BundleIdentifier.setBundleIdentifierForPbxproj(
       projectRoot,


### PR DESCRIPTION
# Why

We allow bare projects to not have an `app.json` / app config module, but previously trying to run a project without an `app.json` in dev client resulted in an error.
> Please define "ios.bundleIdentifier" in app.json.

# How

This PR changes this so that when `app.json` exists, but we can detect a bundle identifier from the Xcode project, no error is thrown and we simply use the bundle identifier from the native project.

# Test Plan

Created an app using ` npx crna -t with-dev-client`, removed `app.json` and verified that `expod run:ios` works.