### PR TITLE
Simplify Config module

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -715,8 +715,6 @@ function runAsync(programName: string) {
       }
     }
 
-    Config.developerTool = packageJSON.name;
-
     // Setup our commander instance
     program.name(programName);
     program

--- a/packages/xdl/src/Config.ts
+++ b/packages/xdl/src/Config.ts
@@ -8,17 +8,13 @@ interface ApiConfig {
   port: number | null;
 }
 interface XDLConfig {
-  turtleApi: ApiConfig;
   api: ApiConfig;
   ngrok: {
     authToken: string;
     authTokenPublicId: string;
     domain: string;
   };
-  developerTool: string | null;
-  validation: {
-    reactNativeVersionWarnings: boolean;
-  };
+  developerTool: string;
   offline: boolean;
 }
 
@@ -42,46 +38,23 @@ const apiConfig: { [env in Environment]: ApiConfig } = {
   },
 };
 
-const turtleApiConfig: { [env in Environment]: ApiConfig } = {
-  local: {
-    scheme: 'http',
-    host: 'localhost',
-    port: 3006,
-  },
-  staging: {
-    scheme: 'https',
-    host: 'staging.turtle.expo.io',
-    port: 443,
-  },
-  production: {
-    scheme: 'https',
-    host: 'turtle.expo.io',
-    port: 443,
-  },
-};
-
-let api: ApiConfig = apiConfig.production;
-let turtleApi: ApiConfig = turtleApiConfig.production;
+let api: ApiConfig;
 if (Env.isLocal()) {
   api = apiConfig.local;
-  turtleApi = turtleApiConfig.local;
 } else if (Env.isStaging()) {
   api = apiConfig.staging;
-  turtleApi = turtleApiConfig.staging;
+} else {
+  api = apiConfig.production;
 }
 
 const config: XDLConfig = {
   api,
-  turtleApi,
   ngrok: {
     authToken: '5W1bR67GNbWcXqmxZzBG1_56GezNeaX6sSRvn8npeQ8',
     authTokenPublicId: '5W1bR67GNbWcXqmxZzBG1',
     domain: 'exp.direct',
   },
-  developerTool: null,
-  validation: {
-    reactNativeVersionWarnings: true,
-  },
+  developerTool: 'expo-cli',
   offline: false,
 };
 

--- a/packages/xdl/src/Config.ts
+++ b/packages/xdl/src/Config.ts
@@ -9,11 +9,6 @@ interface ApiConfig {
 }
 interface XDLConfig {
   api: ApiConfig;
-  ngrok: {
-    authToken: string;
-    authTokenPublicId: string;
-    domain: string;
-  };
   developerTool: string;
   offline: boolean;
 }
@@ -49,11 +44,6 @@ if (Env.isLocal()) {
 
 const config: XDLConfig = {
   api,
-  ngrok: {
-    authToken: '5W1bR67GNbWcXqmxZzBG1_56GezNeaX6sSRvn8npeQ8',
-    authTokenPublicId: '5W1bR67GNbWcXqmxZzBG1',
-    domain: 'exp.direct',
-  },
   developerTool: 'expo-cli',
   offline: false,
 };

--- a/packages/xdl/src/Config.ts
+++ b/packages/xdl/src/Config.ts
@@ -7,43 +7,37 @@ interface ApiConfig {
   host: string;
   port: number | null;
 }
+
 interface XDLConfig {
   api: ApiConfig;
   developerTool: string;
   offline: boolean;
 }
 
-type Environment = 'local' | 'staging' | 'production';
-
-const apiConfig: { [env in Environment]: ApiConfig } = {
-  local: {
-    scheme: 'http',
-    host: 'localhost',
-    port: 3000,
-  },
-  staging: {
-    scheme: getenv.string('XDL_SCHEME', 'https'),
-    host: 'staging.exp.host',
-    port: getenv.int('XDL_PORT', 0) || null,
-  },
-  production: {
-    scheme: getenv.string('XDL_SCHEME', 'https'),
-    host: getenv.string('XDL_HOST', 'exp.host'),
-    port: getenv.int('XDL_PORT', 0) || null,
-  },
-};
-
-let api: ApiConfig;
-if (Env.isLocal()) {
-  api = apiConfig.local;
-} else if (Env.isStaging()) {
-  api = apiConfig.staging;
-} else {
-  api = apiConfig.production;
+function getAPI(): ApiConfig {
+  if (Env.isLocal()) {
+    return {
+      scheme: 'http',
+      host: 'localhost',
+      port: 3000,
+    };
+  } else if (Env.isStaging()) {
+    return {
+      scheme: getenv.string('XDL_SCHEME', 'https'),
+      host: 'staging.exp.host',
+      port: getenv.int('XDL_PORT', 0) || null,
+    };
+  } else {
+    return {
+      scheme: getenv.string('XDL_SCHEME', 'https'),
+      host: getenv.string('XDL_HOST', 'exp.host'),
+      port: getenv.int('XDL_PORT', 0) || null,
+    };
+  }
 }
 
 const config: XDLConfig = {
-  api,
+  api: getAPI(),
   developerTool: 'expo-cli',
   offline: false,
 };

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -277,97 +277,96 @@ async function _validateReactNativeVersionAsync(
   sdkVersions: Versions.SDKVersions,
   sdkVersion: string
 ): Promise<number> {
-  if (Config.validation.reactNativeVersionWarnings) {
-    let reactNative = null;
+  let reactNative = null;
 
-    if (pkg.dependencies?.['react-native']) {
-      reactNative = pkg.dependencies['react-native'];
-    } else if (pkg.devDependencies?.['react-native']) {
-      reactNative = pkg.devDependencies['react-native'];
-    } else if (pkg.peerDependencies?.['react-native']) {
-      reactNative = pkg.peerDependencies['react-native'];
-    }
+  if (pkg.dependencies?.['react-native']) {
+    reactNative = pkg.dependencies['react-native'];
+  } else if (pkg.devDependencies?.['react-native']) {
+    reactNative = pkg.devDependencies['react-native'];
+  } else if (pkg.peerDependencies?.['react-native']) {
+    reactNative = pkg.peerDependencies['react-native'];
+  }
 
-    // react-native is required
-    if (!reactNative) {
-      ProjectUtils.logError(
-        projectRoot,
-        'expo',
-        `Error: Can't find react-native in package.json dependencies`,
-        'doctor-no-react-native-in-package-json'
-      );
-      return ERROR;
-    }
-    ProjectUtils.clearNotification(projectRoot, 'doctor-no-react-native-in-package-json');
+  // react-native is required
+  if (!reactNative) {
+    ProjectUtils.logError(
+      projectRoot,
+      'expo',
+      `Error: Can't find react-native in package.json dependencies`,
+      'doctor-no-react-native-in-package-json'
+    );
+    return ERROR;
+  }
+  ProjectUtils.clearNotification(projectRoot, 'doctor-no-react-native-in-package-json');
 
+  if (
+    Versions.gteSdkVersion(exp, '41.0.0') &&
+    pkg.dependencies?.['@react-native-community/async-storage']
+  ) {
+    ProjectUtils.logWarning(
+      projectRoot,
+      'expo',
+      `@react-native-community/async-storage has been renamed. To upgrade:\n- remove @react-native-community/async-storage from package.json\n- run "expo install @react-native-async-storage/async-storage"\n- run "npx expo-codemod sdk41-async-storage src" to rename imports`,
+      'doctor-legacy-async-storage'
+    );
+    return WARNING;
+  } else {
+    ProjectUtils.clearNotification(projectRoot, 'doctor-legacy-async-storage');
+  }
+
+  if (!exp.isDetached) {
+    return NO_ISSUES;
+
+    // (TODO-2017-07-20): Validate the react-native version if it uses
+    // officially published package rather than Expo fork. Expo fork of
+    // react-native was required before CRNA. We now only run the react-native
+    // validation of the version if we are using the fork. We should probably
+    // validate the version here as well such that it matches with the
+    // react-native version compatible with the selected SDK.
+  }
+
+  // Expo fork of react-native is required
+  if (!/expo\/react-native/.test(reactNative)) {
+    ProjectUtils.logWarning(
+      projectRoot,
+      'expo',
+      `Warning: Not using the Expo fork of react-native. ${learnMore('https://docs.expo.io/')}`,
+      'doctor-not-using-expo-fork'
+    );
+    return WARNING;
+  }
+  ProjectUtils.clearNotification(projectRoot, 'doctor-not-using-expo-fork');
+
+  try {
+    const reactNativeTag = reactNative.match(/sdk-\d+\.\d+\.\d+/)[0];
+    const sdkVersionObject = sdkVersions[sdkVersion];
+
+    // TODO: Want to be smarter about this. Maybe warn if there's a newer version.
     if (
-      Versions.gteSdkVersion(exp, '41.0.0') &&
-      pkg.dependencies?.['@react-native-community/async-storage']
+      semver.major(Versions.parseSdkVersionFromTag(reactNativeTag)) !==
+      semver.major(Versions.parseSdkVersionFromTag(sdkVersionObject['expoReactNativeTag']))
     ) {
       ProjectUtils.logWarning(
         projectRoot,
         'expo',
-        `@react-native-community/async-storage has been renamed. To upgrade:\n- remove @react-native-community/async-storage from package.json\n- run "expo install @react-native-async-storage/async-storage"\n- run "npx expo-codemod sdk41-async-storage src" to rename imports`,
-        'doctor-legacy-async-storage'
-      );
-      return WARNING;
-    } else {
-      ProjectUtils.clearNotification(projectRoot, 'doctor-legacy-async-storage');
-    }
-
-    if (!exp.isDetached) {
-      return NO_ISSUES;
-
-      // (TODO-2017-07-20): Validate the react-native version if it uses
-      // officially published package rather than Expo fork. Expo fork of
-      // react-native was required before CRNA. We now only run the react-native
-      // validation of the version if we are using the fork. We should probably
-      // validate the version here as well such that it matches with the
-      // react-native version compatible with the selected SDK.
-    }
-
-    // Expo fork of react-native is required
-    if (!/expo\/react-native/.test(reactNative)) {
-      ProjectUtils.logWarning(
-        projectRoot,
-        'expo',
-        `Warning: Not using the Expo fork of react-native. ${learnMore('https://docs.expo.io/')}`,
-        'doctor-not-using-expo-fork'
+        `Warning: Invalid version of react-native for sdkVersion ${sdkVersion}. Use github:expo/react-native#${sdkVersionObject['expoReactNativeTag']}`,
+        'doctor-invalid-version-of-react-native'
       );
       return WARNING;
     }
-    ProjectUtils.clearNotification(projectRoot, 'doctor-not-using-expo-fork');
+    ProjectUtils.clearNotification(projectRoot, 'doctor-invalid-version-of-react-native');
 
-    try {
-      const reactNativeTag = reactNative.match(/sdk-\d+\.\d+\.\d+/)[0];
-      const sdkVersionObject = sdkVersions[sdkVersion];
-
-      // TODO: Want to be smarter about this. Maybe warn if there's a newer version.
-      if (
-        semver.major(Versions.parseSdkVersionFromTag(reactNativeTag)) !==
-        semver.major(Versions.parseSdkVersionFromTag(sdkVersionObject['expoReactNativeTag']))
-      ) {
-        ProjectUtils.logWarning(
-          projectRoot,
-          'expo',
-          `Warning: Invalid version of react-native for sdkVersion ${sdkVersion}. Use github:expo/react-native#${sdkVersionObject['expoReactNativeTag']}`,
-          'doctor-invalid-version-of-react-native'
-        );
-        return WARNING;
-      }
-      ProjectUtils.clearNotification(projectRoot, 'doctor-invalid-version-of-react-native');
-
-      ProjectUtils.clearNotification(projectRoot, 'doctor-malformed-version-of-react-native');
-    } catch (e) {
-      ProjectUtils.logWarning(
-        projectRoot,
-        'expo',
-        `Warning: ${reactNative} is not a valid version. Version must be in the form of sdk-x.y.z. Please update your package.json file.`,
-        'doctor-malformed-version-of-react-native'
-      );
-      return WARNING;
-    }
+    ProjectUtils.clearNotification(projectRoot, 'doctor-malformed-version-of-react-native');
+  } catch (e) {
+    ProjectUtils.logWarning(
+      projectRoot,
+      'expo',
+      `Warning: ${reactNative} is not a valid version. Version must be in the form of sdk-x.y.z. Please update your package.json file.`,
+      'doctor-malformed-version-of-react-native'
+    );
+    return WARNING;
   }
+
   return NO_ISSUES;
 }
 

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -7,7 +7,7 @@ import isReachable from 'is-reachable';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
-import { Config, ExpSchema, ProjectUtils, Versions, Watchman } from '../internal';
+import { ExpSchema, ProjectUtils, Versions, Watchman } from '../internal';
 import { learnMore } from '../logs/TerminalLink';
 
 export const NO_ISSUES = 0;

--- a/packages/xdl/src/start/ngrok.ts
+++ b/packages/xdl/src/start/ngrok.ts
@@ -6,7 +6,6 @@ import {
   Android,
   ANONYMOUS_USERNAME,
   assertValidProjectRoot,
-  Config,
   delayAsync,
   NgrokOptions,
   ProjectSettings,
@@ -17,6 +16,12 @@ import {
   UserSettings,
   XDLError,
 } from '../internal';
+
+const NGROK_CONFIG = {
+  authToken: '5W1bR67GNbWcXqmxZzBG1_56GezNeaX6sSRvn8npeQ8',
+  authTokenPublicId: '5W1bR67GNbWcXqmxZzBG1',
+  domain: 'exp.direct',
+};
 
 function getNgrokConfigPath() {
   return path.join(UserSettings.dotExpoHomeDirectory(), 'ngrok.yml');
@@ -140,7 +145,7 @@ export async function startTunnelsAsync(
         projectRoot,
         ngrok,
         {
-          authtoken: Config.ngrok.authToken,
+          authtoken: NGROK_CONFIG.authToken,
           port: expoServerPort,
           proto: 'http',
         },
@@ -152,7 +157,7 @@ export async function startTunnelsAsync(
             randomness,
             UrlUtils.domainify(username),
             UrlUtils.domainify(packageShortName),
-            Config.ngrok.domain,
+            NGROK_CONFIG.domain,
           ].join('.');
         },
         packagerInfo.ngrokPid
@@ -161,7 +166,7 @@ export async function startTunnelsAsync(
         projectRoot,
         ngrok,
         {
-          authtoken: Config.ngrok.authToken,
+          authtoken: NGROK_CONFIG.authToken,
           port: packagerInfo.packagerPort,
           proto: 'http',
         },
@@ -174,7 +179,7 @@ export async function startTunnelsAsync(
             randomness,
             UrlUtils.domainify(username),
             UrlUtils.domainify(packageShortName),
-            Config.ngrok.domain,
+            NGROK_CONFIG.domain,
           ].join('.');
         },
         packagerInfo.ngrokPid


### PR DESCRIPTION
# Why

Remove unchanging value and dead code paths

# How

- make `Config.developerTool` static `expo-cli` -- no logic change.
- delete `Config.turtleApi` -- unsure if this breaks anything. Doesn't appear to be in use anywhere.
- delete `Config.validation` -- no logic change.
- move Config.ngrok to the ngrok module -- test: ran expo start --tunnel.
