### PR TITLE
Remove Config.offline

### DIFF
--- a/packages/dev-tools/server/graphql/GraphQLSchema.ts
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.ts
@@ -4,7 +4,7 @@ import { makeExecutableSchema } from 'graphql-tools';
 import { $$asyncIterator } from 'iterall';
 import {
   Android,
-  Config,
+  ConnectionStatus,
   Exp,
   Logger,
   Project,
@@ -458,7 +458,7 @@ const resolvers = {
   },
   ProjectSettings: {
     hostType(projectSettings) {
-      if (Config.offline && projectSettings.hostType === 'tunnel') {
+      if (ConnectionStatus.isOffline() && projectSettings.hostType === 'tunnel') {
         return 'lan';
       } else {
         return projectSettings.hostType;

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -19,6 +19,7 @@ import {
   ApiV2,
   Binaries,
   Config,
+  ConnectionStatus,
   Doctor,
   Logger,
   LogRecord,
@@ -341,7 +342,7 @@ Command.prototype.asyncAction = function (asyncFn: Action) {
     try {
       const options = args[args.length - 1];
       if (options.offline) {
-        Config.offline = true;
+        ConnectionStatus.setIsOffline(true);
       }
 
       await asyncFn(...args);

--- a/packages/xdl/src/Config.ts
+++ b/packages/xdl/src/Config.ts
@@ -19,7 +19,6 @@ interface XDLConfig {
   validation: {
     reactNativeVersionWarnings: boolean;
   };
-  offline: boolean;
 }
 
 type Environment = 'local' | 'staging' | 'production';
@@ -82,7 +81,6 @@ const config: XDLConfig = {
   validation: {
     reactNativeVersionWarnings: true,
   },
-  offline: false,
 };
 
 export default config;

--- a/packages/xdl/src/DevSession.ts
+++ b/packages/xdl/src/DevSession.ts
@@ -1,6 +1,12 @@
 import os from 'os';
 
-import { ApiV2 as ApiV2Client, Config, Logger as logger, UrlUtils, UserManager } from './internal';
+import {
+  ApiV2 as ApiV2Client,
+  ConnectionStatus,
+  Logger as logger,
+  UrlUtils,
+  UserManager,
+} from './internal';
 
 const UPDATE_FREQUENCY_SECS = 20;
 
@@ -17,7 +23,7 @@ export async function startSession(
     keepUpdating = true;
   }
 
-  if (!Config.offline && keepUpdating) {
+  if (!ConnectionStatus.isOffline() && keepUpdating) {
     // TODO(anp) if the user has configured device ids, then notify for those too
     const authSession = await UserManager.getSessionAsync();
 

--- a/packages/xdl/src/Sentry.ts
+++ b/packages/xdl/src/Sentry.ts
@@ -1,6 +1,6 @@
 import Raven from 'raven';
 
-import { Config } from './internal';
+import { Config, ConnectionStatus } from './internal';
 
 const SENTRY_DSN =
   'https://8554f14d112d4ed4b0558154762760ef:bae5673d5e5243abac5563d70861b5d8@sentry.io/194120';
@@ -23,7 +23,7 @@ function getOptions(options: any = {}) {
     tags: {
       ...options.tags,
       developerTool: Config.developerTool,
-      offline: Config.offline,
+      offline: ConnectionStatus.isOffline(),
     },
   };
 }

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -7,7 +7,6 @@ import resolveFrom from 'resolve-from';
 import url from 'url';
 
 import {
-  Config,
   ConnectionStatus,
   ip,
   ProjectSettings,

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -6,7 +6,15 @@ import QueryString from 'querystring';
 import resolveFrom from 'resolve-from';
 import url from 'url';
 
-import { Config, ip, ProjectSettings, ProjectUtils, Versions, XDLError } from './internal';
+import {
+  Config,
+  ConnectionStatus,
+  ip,
+  ProjectSettings,
+  ProjectUtils,
+  Versions,
+  XDLError,
+} from './internal';
 
 interface URLOptions extends Omit<ProjectSettings.ProjectSettings, 'urlRandomness'> {
   urlType: null | 'exp' | 'http' | 'no-protocol' | 'redirect' | 'custom';
@@ -337,7 +345,7 @@ export async function constructUrlAsync(
   } else if (opts.hostType === 'localhost' || requestHostname === 'localhost') {
     hostname = '127.0.0.1';
     port = isPackager ? packagerInfo.packagerPort : packagerInfo.expoServerPort;
-  } else if (opts.hostType === 'lan' || Config.offline) {
+  } else if (opts.hostType === 'lan' || ConnectionStatus.isOffline()) {
     if (process.env.EXPO_PACKAGER_HOSTNAME) {
       hostname = process.env.EXPO_PACKAGER_HOSTNAME.trim();
     } else if (process.env.REACT_NATIVE_PACKAGER_HOSTNAME) {

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -7,6 +7,7 @@ import {
   Analytics,
   ApiV2 as ApiV2Client,
   Config,
+  ConnectionStatus,
   Logger,
   Semaphore,
   UserData,
@@ -177,7 +178,7 @@ export class UserManagerInstance {
    * If there are any issues with the login, this method throws.
    */
   async ensureLoggedInAsync(): Promise<User | RobotUser> {
-    if (Config.offline) {
+    if (ConnectionStatus.isOffline()) {
       throw new XDLError('NETWORK_REQUIRED', "Can't verify user without network access");
     }
 
@@ -227,7 +228,7 @@ export class UserManagerInstance {
         return currentUser;
       }
 
-      if (Config.offline) {
+      if (ConnectionStatus.isOffline()) {
         return null;
       }
 
@@ -308,7 +309,7 @@ export class UserManagerInstance {
       return manifest.owner;
     } else if (process.env.EAS_BUILD_USERNAME) {
       return process.env.EAS_BUILD_USERNAME;
-    } else if (!Config.offline) {
+    } else if (!ConnectionStatus.isOffline()) {
       const username = await this.getCurrentUsernameAsync();
       if (username) {
         return username;

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -6,7 +6,6 @@ import snakeCase from 'lodash/snakeCase';
 import {
   Analytics,
   ApiV2 as ApiV2Client,
-  Config,
   ConnectionStatus,
   Logger,
   Semaphore,

--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -11,6 +11,7 @@ import {
   ANONYMOUS_USERNAME,
   ApiV2,
   Config,
+  ConnectionStatus,
   Doctor,
   learnMore,
   ProjectAssets,
@@ -249,7 +250,7 @@ export async function getManifestResponseAsync({
           `Please request access from an admin of @${manifest.owner} or change the "owner" field to an account you belong to.\n` +
           learnMore('https://docs.expo.io/versions/latest/config/app/#owner')
       );
-      Config.offline = true;
+      ConnectionStatus.setIsOffline(true);
       manifestString = await getManifestStringAsync(manifest, hostInfo.host, acceptSignature);
     } else if (error.code === 'ENOTFOUND') {
       // Got a DNS error, i.e. can't access exp.host, warn and enable offline mode.
@@ -259,7 +260,7 @@ export async function getManifestResponseAsync({
           error.hostname || 'exp.host'
         }.`
       );
-      Config.offline = true;
+      ConnectionStatus.setIsOffline(true);
       manifestString = await getManifestStringAsync(manifest, hostInfo.host, acceptSignature);
     } else {
       throw error;
@@ -303,12 +304,12 @@ async function getManifestStringAsync(
   acceptSignature?: string | string[]
 ): Promise<string> {
   const currentSession = await UserManager.getSessionAsync();
-  if (!currentSession || Config.offline) {
+  if (!currentSession || ConnectionStatus.isOffline()) {
     manifest.id = `@${ANONYMOUS_USERNAME}/${manifest.slug}-${hostUUID}`;
   }
   if (!acceptSignature) {
     return JSON.stringify(manifest);
-  } else if (!currentSession || Config.offline) {
+  } else if (!currentSession || ConnectionStatus.isOffline()) {
     return getUnsignedManifestString(manifest);
   } else {
     return await getSignedManifestStringAsync(manifest, currentSession);

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -6,6 +6,7 @@ import {
   Android,
   assertValidProjectRoot,
   Config,
+  ConnectionStatus,
   DevSession,
   Env,
   ProjectSettings,
@@ -70,7 +71,7 @@ export async function startAsync(
 
   const { hostType } = await ProjectSettings.readAsync(projectRoot);
 
-  if (!Config.offline && hostType === 'tunnel') {
+  if (!ConnectionStatus.isOffline() && hostType === 'tunnel') {
     try {
       await startTunnelsAsync(projectRoot);
     } catch (e) {
@@ -99,7 +100,7 @@ async function stopInternalAsync(projectRoot: string): Promise<void> {
     stopExpoServerAsync(projectRoot),
     stopReactNativeServerAsync(projectRoot),
     async () => {
-      if (!Config.offline) {
+      if (!ConnectionStatus.isOffline()) {
         try {
           await stopTunnelsAsync(projectRoot);
         } catch (e) {


### PR DESCRIPTION
# Why

- Use `ConnectionStatus` instead. Ran `expo start --offline` and observed that the username was always being surfaced as anonymous.
