### PR TITLE
analytics Id from username to userId 

### DIFF
--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -453,7 +453,7 @@ export class UserManagerInstance {
         });
       }
 
-      Analytics.setUserProperties(user.username, {
+      Analytics.setUserProperties(user.userId, {
         userId: user.userId,
         currentConnection: user.currentConnection,
         username: user.username,


### PR DESCRIPTION
# Why

Analytics was using `user.username` (account name) as an ID to track user activity with.  

Users can change their account name, and if they do, we would register them as a new user instead of tracking the change.  Analytics docs recommend using a database id https://segment.com/docs/connections/spec/identify/#user-id 

# How

update the assignment of the ID inside the `User` class to `user.userId` from `user.username`.

# Test Plan

fire some events locally and make sure they are getting the proper ID assigned.