### PR TITLE
[cli] Add deprecation message to --config flag

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -450,7 +450,10 @@ Command.prototype.asyncActionProjectDir = function (
   asyncFn: Action,
   options: { checkConfig?: boolean; skipSDKVersionRequirement?: boolean } = {}
 ) {
-  this.option('--config [file]', 'Specify a path to app.json or app.config.js');
+  this.option(
+    '--config [file]',
+    `${chalk.yellow('Deprecated:')} Use app.config.js to switch config files instead.`
+  );
   return this.asyncAction(async (projectRoot: string, ...args: any[]) => {
     const opts = args[0];
 

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -34,6 +34,7 @@ import {
 import { AbortCommandError, SilentError } from './CommandError';
 import { loginOrRegisterAsync } from './accounts';
 import { registerCommands } from './commands';
+import { learnMore } from './commands/utils/TerminalLink';
 import { profileMethod } from './commands/utils/profileMethod';
 import Log from './log';
 import update from './update';
@@ -464,6 +465,17 @@ Command.prototype.asyncActionProjectDir = function (
     }
 
     if (opts.config) {
+      Log.log(
+        chalk.yellow(
+          `\u203A ${chalk.bold(
+            '--config'
+          )} flag is deprecated. Use app.config.js instead. ${learnMore(
+            'https://expo.fyi/config-flag-migration'
+          )}`
+        )
+      );
+      Log.newLine();
+
       // @ts-ignore: This guards against someone passing --config without a path.
       if (opts.config === true) {
         Log.addNewLineIfNone();


### PR DESCRIPTION
# Why

We don't want to support this in every tool, instead we should consolidate on a single easy-to-understand approach for switching between app configs: `app.config.js`. Developers can use env vars to pick the config to use.

We can keep the behavior of this flag around for a long time so developers can keep using it if it's working well for them, but we won't add support for it to new tools like EAS Build, where developers can use `app.config.js` instead.

So far I only deprecated this in the help description, but we may want to add a warning with a link to a docs page or fyi page with more information about how to use `app.config.js` for this use case.

![Screen Shot 2021-04-12 at 8 54 58 PM](https://user-images.githubusercontent.com/90494/114494498-587d2a00-9bd1-11eb-9369-a546c6051888.png)
