### PR TITLE
Support building apps with escaped names

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
+++ b/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
@@ -84,11 +84,28 @@ export function getAppBinaryPath(buildOutput: string) {
     buildOutput,
     'UNLOCALIZED_RESOURCES_FOLDER_PATH'
   );
-  return path.join(
+
+  const binaryPath = path.join(
     // Use the shortest defined env variable (usually there's just one).
     CONFIGURATION_BUILD_DIR[0],
     // Use the last defined env variable.
     UNLOCALIZED_RESOURCES_FOLDER_PATH[UNLOCALIZED_RESOURCES_FOLDER_PATH.length - 1]
+  );
+
+  // If the app has a space in the name it'll fail because it isn't escaped properly by Xcode.
+  return getEscapedPath(binaryPath);
+}
+
+export function getEscapedPath(filePath: string): string {
+  if (fs.existsSync(filePath)) {
+    return filePath;
+  }
+  const unescapedPath = filePath.split(/\\ /).join(' ');
+  if (fs.existsSync(unescapedPath)) {
+    return unescapedPath;
+  }
+  throw new Error(
+    `Unexpected: Generated app at path "${filePath}" cannot be read, the app cannot be installed. Please report this and build onto a simulator.`
   );
 }
 

--- a/packages/expo-cli/src/commands/run/utils/binaryPlist.ts
+++ b/packages/expo-cli/src/commands/run/utils/binaryPlist.ts
@@ -3,12 +3,16 @@ import plist from '@expo/plist';
 import binaryPlist from 'bplist-parser';
 import fs from 'fs-extra';
 
+import Log from '../../../log';
+
 const CHAR_CHEVRON_OPEN = 60;
 const CHAR_B_LOWER = 98;
 // .mobileprovision
 // const CHAR_ZERO = 30;
 
 export async function parseBinaryPlistAsync(plistPath: string) {
+  Log.debug(`Parse plist: ${plistPath}`);
+
   return parsePlistBuffer(await fs.readFile(plistPath));
 }
 


### PR DESCRIPTION
# Why

Building bare expo failed without this. 