### PR TITLE
Handle async storage package rename in upgrade command

### DIFF
--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -85,7 +85,7 @@ export async function getUpdatedDependenciesAsync(
   workflow: ExpoWorkflow,
   targetSdkVersion: TargetSDKVersion | null,
   targetSdkVersionString: string
-): Promise<DependencyList> {
+): Promise<{ dependencies: DependencyList; removed: string[] }> {
   // Get the updated version for any bundled modules
   const { exp, pkg } = getConfig(projectRoot);
   const bundledNativeModules = (await JsonFile.readAsync(
@@ -103,6 +103,8 @@ export async function getUpdatedDependenciesAsync(
     targetSdkVersion,
   });
 
+  const removed: string[] = [];
+
   // Add expo-random as a dependency if using expo-auth-session and upgrading to
   // a version where it has been moved to a peer dependency.
   // We can remove this when we no longer support SDK versions < 40, or have a
@@ -115,7 +117,16 @@ export async function getUpdatedDependenciesAsync(
     dependencies['expo-random'] = bundledNativeModules['expo-random'];
   }
 
-  return dependencies;
+  if (
+    dependencies['@react-native-community/async-storage'] &&
+    semver.gte(targetSdkVersionString, '41.0.0')
+  ) {
+    dependencies['@react-native-async-storage/async-storage'] =
+      bundledNativeModules['@react-native-async-storage/async-storage'];
+    removed.push('@react-native-community/async-storage');
+  }
+
+  return { dependencies, removed };
 }
 
 export type UpgradeDependenciesOptions = {
@@ -601,7 +612,7 @@ export async function upgradeAsync(
   Log.addNewLineIfNone();
 
   // Get all updated packages
-  const updates = await getUpdatedDependenciesAsync(
+  const { dependencies: updates, removed } = await getUpdatedDependenciesAsync(
     projectRoot,
     workflow,
     targetSdkVersion,
@@ -639,6 +650,14 @@ export async function upgradeAsync(
       updatingPackagesStep.fail(
         `Failed to upgrade JavaScript dependencies: ${dependenciesAsStringArray.join(' ')}`
       );
+    }
+  }
+
+  if (removed.length) {
+    try {
+      await packageManager.removeAsync(...removed);
+    } catch (e) {
+      updatingPackagesStep.fail(`Failed to remove JavaScript dependencies: ${removed.join(' ')}`);
     }
   }
 
@@ -682,6 +701,13 @@ export async function upgradeAsync(
   Log.log(chalk.grey.bold([...Object.keys(updates), ...['expo']].join(', ')));
   Log.addNewLineIfNone();
 
+  if (removed.length) {
+    Log.addNewLineIfNone();
+    Log.log(chalk.bold(`🗑️ The following packages were removed:`));
+    Log.log(chalk.grey.bold(removed.join(', ')));
+    Log.addNewLineIfNone();
+  }
+
   // List packages that were not updated
   const allDependencies = { ...pkg.dependencies, ...pkg.devDependencies };
   const untouchedDependencies = difference(Object.keys(allDependencies), [
@@ -695,6 +721,17 @@ export async function upgradeAsync(
         `🚨 The following packages were ${chalk.underline(
           'not'
         )} updated. You should check the READMEs for those repositories to determine what version is compatible with your new set of packages:`
+      )
+    );
+    Log.log(chalk.grey.bold(untouchedDependencies.join(', ')));
+    Log.addNewLineIfNone();
+  }
+
+  if (removed.includes('@react-native-community/async-storage')) {
+    Log.addNewLineIfNone();
+    Log.log(
+      chalk.bold(
+        `🚨 @react-native-community/async-storage has been renamed to @react-native-async-storage/async-storage. Run \`npx expo-codemod sdk41-async-storage './**/*'\` to rename imports`
       )
     );
     Log.log(chalk.grey.bold(untouchedDependencies.join(', ')));

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -731,10 +731,9 @@ export async function upgradeAsync(
     Log.addNewLineIfNone();
     Log.log(
       chalk.bold(
-        `🚨 @react-native-community/async-storage has been renamed to @react-native-async-storage/async-storage. Run \`npx expo-codemod sdk41-async-storage './**/*'\` to rename imports`
+        `🚨 @react-native-community/async-storage has been renamed to @react-native-async-storage/async-storage. The dependency has been updated automatically, you will now need to either update the imports in your source code manually, or run \`npx expo-codemod sdk41-async-storage './**/*'\`.`
       )
     );
-    Log.log(chalk.grey.bold(untouchedDependencies.join(', ')));
     Log.addNewLineIfNone();
   }
 

--- a/packages/package-manager/src/NodePackageManagers.ts
+++ b/packages/package-manager/src/NodePackageManagers.ts
@@ -122,6 +122,10 @@ export class NpmPackageManager implements PackageManager {
     }
   }
 
+  async removeAsync(...names: string[]) {
+    await this._runAsync(['uninstall', ...names]);
+  }
+
   async versionAsync() {
     const { stdout } = await spawnAsync('npm', ['--version'], { stdio: 'pipe' });
     return stdout.trim();
@@ -259,6 +263,10 @@ export class YarnPackageManager implements PackageManager {
     const args = await this.withOfflineSupportAsync('add', '--dev');
     args.push(...names);
     await this._runAsync(args);
+  }
+
+  async removeAsync(...names: string[]) {
+    await this._runAsync(['remove', ...names]);
   }
 
   async versionAsync() {


### PR DESCRIPTION
# Why

`@react-native-community/async-storage` has been renamed to `@react-native-async-storage/async-storage`. The old `@react-native-community/async-storage` package will not work with SDK 41. 

#3342 added a `expo doctor` check for the old package in dependencies and a codemod to migrate imports to use the new package. This PR makes the `expo upgrade` command to automatically update the dependency in `package.json`.

# How

For SDK 41 or newer, if `@react-native-community/async-storage` exists in dependencies, it will be replaced with the appropriate version of `@react-native-async-storage/async-storage`.

# Test Plan

Tested using `EXPO_BETA=1 expod upgrade`:
<img width="810" alt="Screen Shot 2021-04-14 at 15 16 29" src="https://user-images.githubusercontent.com/497214/114709270-07864680-9d35-11eb-97b2-4976160d74fa.png">
Result diff:
<img width="1352" alt="Screen Shot 2021-04-14 at 15 15 48" src="https://user-images.githubusercontent.com/497214/114709293-10771800-9d35-11eb-8dff-e0898ea6d350.png">
