### PR TITLE
[xdl] minor improvements to async-storage error message

### DIFF
--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -306,7 +306,7 @@ async function _validateReactNativeVersionAsync(
     ProjectUtils.logWarning(
       projectRoot,
       'expo',
-      `@react-native-community/async-storage has been renamed. To upgrade:\n- remove @react-native-community/async-storage from package.json\n- run "expo install @react-native-async-storage/async-storage"\n- run "npx expo-codemod sdk41-async-storage src" to rename imports`,
+      `\n@react-native-community/async-storage has been renamed. To upgrade:\n- remove @react-native-community/async-storage from package.json\n- run "expo install @react-native-async-storage/async-storage"\n- run "npx expo-codemod sdk41-async-storage path/to/your/app" to rename imports\n`,
       'doctor-legacy-async-storage'
     );
     return WARNING;


### PR DESCRIPTION
# Why

it’s not obvious that `src` is defining the path and might be different for your project, plus the lack of newlines makes it a little harder to read:
<img width="551" alt="Screen Shot 2021-04-14 at 9 55 15 AM" src="https://user-images.githubusercontent.com/35579283/114722436-ce83ad00-9d07-11eb-81b1-b5e3d8cc39ff.png">

