### PR TITLE
[codemod] don't throw on node 14

### DIFF
--- a/packages/expo-codemod/bin/expo-codemod.js
+++ b/packages/expo-codemod/bin/expo-codemod.js
@@ -2,7 +2,7 @@
 const semver = require('semver');
 const version = process.versions.node;
 
-if (semver.satisfies(version, '^10.13.0 || ^12.0.0 || ^13.0.0')) {
+if (semver.satisfies(version, '^10.13.0 || ^12.0.0 || ^13.0.0 || ^14.0.0')) {
   require('../build/cli.js')
     .runAsync(process.argv)
     .catch(error => {
@@ -10,5 +10,5 @@ if (semver.satisfies(version, '^10.13.0 || ^12.0.0 || ^13.0.0')) {
       process.exit(1);
     });
 } else {
-  throw new Error('expo-codemod supports Node versions ^10.13.0, ^12.0.0 and ^13.0.0.');
+  throw new Error('expo-codemod supports Node versions ^10.13.0, ^12.0.0, ^13.0.0, and ^14.0.0.');
 }


### PR DESCRIPTION
# Why

`expo-codemod` should support node 14


# Test Plan

seems to work afaict- run `expo-codemod/bin/expo-codemod.js sdk41-async-storage ./` with node 14, result:
```diff
diff --git a/App.js b/App.js
index 56bbe11..cb3ecc6 100644
--- a/App.js
+++ b/App.js
@@ -11,7 +11,7 @@ import {
   NativeModules,
 } from "react-native";
 import * as Linking from "expo-linking";
-import AsyncStorage from "@react-native-community/async-storage";
+import AsyncStorage from '@react-native-async-storage/async-storage';
```