### PR TITLE
print bundle sizes in export

### DIFF
--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -8,7 +8,15 @@ import readLastLines from 'read-last-lines';
 import semver from 'semver';
 import urljoin from 'url-join';
 import { v1 as uuidv1, v4 as uuidv4 } from 'uuid';
-import { EmbeddedAssets, Env, Project, ProjectAssets, UserManager, XDLError } from 'xdl';
+import {
+  EmbeddedAssets,
+  Env,
+  printBundleSizes,
+  Project,
+  ProjectAssets,
+  UserManager,
+  XDLError,
+} from 'xdl';
 
 import Log from '../../log';
 
@@ -90,6 +98,9 @@ export async function exportAppAsync(
     dev: options.isDev,
     useDevServer: Env.shouldUseDevServer(exp),
   });
+
+  printBundleSizes(bundles);
+
   const iosBundle = bundles.ios.code;
   const androidBundle = bundles.android.code;
 

--- a/packages/xdl/src/index.ts
+++ b/packages/xdl/src/index.ts
@@ -22,6 +22,7 @@ export {
   Logger,
   ModuleVersion,
   NotificationCode,
+  printBundleSizes,
   PackagerLogsStream,
   LogRecord,
   LogUpdater,


### PR DESCRIPTION
# Why

Give more user visibility into bundle sizes in the export command. Reuses the code from expo publish.