### PR TITLE
[config-plugins] feat: enable splash screen plugin for any SDK greater than 38

### DIFF
--- a/packages/config-plugins/src/android/SplashScreen.ts
+++ b/packages/config-plugins/src/android/SplashScreen.ts
@@ -44,7 +44,8 @@ export function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenCo
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
-  const majorVersionString = config.sdkVersion?.split('.').shift();
+  const majorVersionString =
+    config.sdkVersion === 'UNVERSIONED' ? null : config.sdkVersion?.split('.').shift();
   const splashScreenIsSupported =
     (majorVersionString && Number(majorVersionString) >= 39) ||
     /** UNVERSIONED CASE */ !majorVersionString;
@@ -52,7 +53,7 @@ export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: stri
   if (!splashScreenIsSupported) {
     WarningAggregator.addWarningAndroid(
       'splash',
-      'Unable to automatically configure splash screen. Please refer to the expo-splash-screen README for more information: https://github.com/expo/expo/tree/master/packages/expo-splash-screen'
+      `Unable to automatically configure splash screen. Automatic splash screen configuration is available since SDK 39. Please upgrade to the newer SDK version. Please refer to the expo-splash-screen README for more information: https://github.com/expo/expo/tree/master/packages/expo-splash-screen`
     );
 
     return;

--- a/packages/config-plugins/src/android/SplashScreen.ts
+++ b/packages/config-plugins/src/android/SplashScreen.ts
@@ -44,8 +44,11 @@ export function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenCo
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
+  const majorVersionString = config.sdkVersion?.split('.').shift();
   const splashScreenIsSupported =
-    config.sdkVersion === '39.0.0' || config.sdkVersion === '40.0.0' || !config.sdkVersion;
+    (majorVersionString && Number(majorVersionString) >= 39) ||
+    /** UNVERSIONED CASE */ !majorVersionString;
+
   if (!splashScreenIsSupported) {
     WarningAggregator.addWarningAndroid(
       'splash',

--- a/packages/config-plugins/src/ios/SplashScreen.ts
+++ b/packages/config-plugins/src/ios/SplashScreen.ts
@@ -38,8 +38,11 @@ export function getSplashScreen(config: ExpoConfig): IosSplashScreenConfig | und
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
+  const majorVersionString = config.sdkVersion?.split('.').shift();
   const splashScreenIsSupported =
-    config.sdkVersion === '39.0.0' || config.sdkVersion === '40.0.0' || !config.sdkVersion;
+    (majorVersionString && Number(majorVersionString) >= 39) ||
+    /** UNVERSIONED CASE */ !majorVersionString;
+
   if (!splashScreenIsSupported) {
     WarningAggregator.addWarningIOS(
       'splash',

--- a/packages/config-plugins/src/ios/SplashScreen.ts
+++ b/packages/config-plugins/src/ios/SplashScreen.ts
@@ -38,7 +38,8 @@ export function getSplashScreen(config: ExpoConfig): IosSplashScreenConfig | und
 }
 
 export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: string) {
-  const majorVersionString = config.sdkVersion?.split('.').shift();
+  const majorVersionString =
+    config.sdkVersion === 'UNVERSIONED' ? null : config.sdkVersion?.split('.').shift();
   const splashScreenIsSupported =
     (majorVersionString && Number(majorVersionString) >= 39) ||
     /** UNVERSIONED CASE */ !majorVersionString;
@@ -46,7 +47,7 @@ export async function setSplashScreenAsync(config: ExpoConfig, projectRoot: stri
   if (!splashScreenIsSupported) {
     WarningAggregator.addWarningIOS(
       'splash',
-      'Unable to automatically configure splash screen. Please refer to the expo-splash-screen README for more information: https://github.com/expo/expo/tree/master/packages/expo-splash-screen'
+      `Unable to automatically configure splash screen. Automatic splash screen configuration is available since SDK 39. Please upgrade to the newer SDK version. Please refer to the expo-splash-screen README for more information: https://github.com/expo/expo/tree/master/packages/expo-splash-screen`
     );
     return;
   }


### PR DESCRIPTION
# Why

Launching `eas build -p ios` for SDK 41 results in the following warning: 
![image](https://user-images.githubusercontent.com/16623003/114989575-d7a38400-9e97-11eb-8dcf-19f33b88001b.png)

# How

`splash-screen` plugin was enabled only for SDK 39 and 40 (and UNVERSIONED), but not for SDK 41.
I've changed the enabling rules for this plugin to be enabled for any SDK greater than 38 (including UNVERSIONED).

# Test Plan

Locally the problem was reproducible via `expo-cli prebuild`.
Launching this with command with this change results with no warning message anymore.