### PR TITLE
[expo-cli][xdl] return correct project page url after expo publish

### DIFF
--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -101,6 +101,7 @@ export async function action(
   });
 
   const url = result.url;
+  const projectPageUrl = result.projectPageUrl;
 
   if (options.quiet) {
     simpleSpinner.stop();
@@ -112,21 +113,18 @@ export async function action(
   logManifestUrl({ url, sdkVersion: exp.sdkVersion });
 
   if (target === 'managed') {
-    // TODO: replace with websiteUrl from server when it is available, if that makes sense.
-    const websiteUrl = url.replace('exp.host', 'expo.io');
-
     // note(brentvatne): disable copy to clipboard functionality for now, need to think more about
     // whether this is desirable.
     //
     // Attempt to copy the URL to the clipboard, if it succeeds then append a notice to the log.
     // const copiedToClipboard = copyToClipboard(websiteUrl);
 
-    logProjectPageUrl({ url: websiteUrl, copiedToClipboard: false });
+    logProjectPageUrl({ url: projectPageUrl, copiedToClipboard: false });
 
     // Only send the link for managed projects.
     const recipient = await sendTo.getRecipient(options.sendTo);
     if (recipient) {
-      await sendTo.sendUrlAsync(websiteUrl, recipient);
+      await sendTo.sendUrlAsync(projectPageUrl, recipient);
     }
   }
 
@@ -164,7 +162,7 @@ function logManifestUrl({ url, sdkVersion }: { url: string; sdkVersion?: string 
 
 /**
  *
- * @example ⚙️   Project page: https://expo.io/@bacon/my-app [copied to clipboard] Learn more: https://expo.fyi/project-page
+ * @example ⚙️   Project page: https://expo.io/@bacon/projects/my-app [copied to clipboard] Learn more: https://expo.fyi/project-page
  * @param options
  */
 function logProjectPageUrl({

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -112,7 +112,7 @@ export async function action(
 
   logManifestUrl({ url, sdkVersion: exp.sdkVersion });
 
-  if (target === 'managed') {
+  if (target === 'managed' && projectPageUrl) {
     // note(brentvatne): disable copy to clipboard functionality for now, need to think more about
     // whether this is desirable.
     //

--- a/packages/xdl/src/__tests__/Project-publishAsync-test.ts
+++ b/packages/xdl/src/__tests__/Project-publishAsync-test.ts
@@ -126,6 +126,7 @@ describe('publishAsync', () => {
     process.env.EXPO_USE_DEV_SERVER = 'true';
     const result = await publishAsync(projectRoot, { resetCache: true });
     expect(result.url).toBe('https://test.exp.host/@testing/publish-test-app');
+    expect(result.projectPageUrl).toBe('https://test.expo.io/@testing/projects/publish-test-app');
 
     process.env.EXPO_USE_DEV_SERVER = 'false';
     const resultOld = await publishAsync(projectRoot, { resetCache: true });

--- a/packages/xdl/src/__tests__/Project-publishAsync-test.ts
+++ b/packages/xdl/src/__tests__/Project-publishAsync-test.ts
@@ -81,6 +81,7 @@ jest.mock('axios', () => ({
         return mockApiV2Response(
           {
             url: 'https://test.exp.host/@testing/publish-test-app',
+            projectPageUrl: 'https://test.expo.io/@testing/projects/publish-test-app',
             ids: ['1', '2'],
           },
           options

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -210,6 +210,10 @@ export interface PublishedProjectResult {
    */
   url: string;
   /**
+   * Project page URL
+   */
+  projectPageUrl: string;
+  /**
    * TODO: What is this?
    */
   ids: string[];
@@ -390,12 +394,22 @@ export async function publishAsync(
     });
   }
 
+  // Create project manifest URL
+  const url =
+    options.releaseChannel && options.releaseChannel !== 'default'
+      ? `${response.url}?release-channel=${options.releaseChannel}`
+      : response.url;
+
+  // Create project page URL
+  const websiteUrl = url.replace('exp.host', 'expo.io');
+  const splitUrl = websiteUrl.split('/');
+  splitUrl.splice(4, 0, 'projects');
+  const projectPageUrl = splitUrl.join('/');
+
   return {
     ...response,
-    url:
-      options.releaseChannel && options.releaseChannel !== 'default'
-        ? `${response.url}?release-channel=${options.releaseChannel}`
-        : response.url,
+    url,
+    projectPageUrl,
   };
 }
 

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -401,10 +401,11 @@ export async function publishAsync(
       : response.url;
 
   // Create project page URL
-  const projectPageUrl =
-    options.releaseChannel && options.releaseChannel !== 'default'
+  const projectPageUrl = response.projectPageUrl
+    ? options.releaseChannel && options.releaseChannel !== 'default'
       ? `${response.projectPageUrl}?release-channel=${options.releaseChannel}`
-      : response.projectPageUrl;
+      : response.projectPageUrl
+    : null;
 
   return {
     ...response,

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -401,10 +401,10 @@ export async function publishAsync(
       : response.url;
 
   // Create project page URL
-  const websiteUrl = url.replace('exp.host', 'expo.io');
-  const splitUrl = websiteUrl.split('/');
-  splitUrl.splice(4, 0, 'projects');
-  const projectPageUrl = splitUrl.join('/');
+  const projectPageUrl =
+    options.releaseChannel && options.releaseChannel !== 'default'
+      ? `${response.projectPageUrl}?release-channel=${options.releaseChannel}`
+      : response.projectPageUrl;
 
   return {
     ...response,


### PR DESCRIPTION
# Why

We are currently returning the website project page URL without the correct path, i.e. `@username/projectname` instead of `@username/projects/projectname` and it can create a "clawback" if the user's project is named `snacks` or `projects`.

More context here: https://github.com/expo/universe/pull/7331#issuecomment-820683580

# How

Created correct project page URL

# Test Plan

Run `expo publish` and check if the URL is correct