### PR TITLE
improve cocoapods manager

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/Podfile.ts
+++ b/packages/expo-cli/src/commands/run/ios/Podfile.ts
@@ -18,7 +18,7 @@ export function getDependenciesFromPodfileLock(podfileLockPath: string) {
     fileContent = fs.readFileSync(podfileLockPath, 'utf8');
   } catch (err) {
     Log.error(
-      `Could not find "Podfile.lock" at ${chalk.dim(podfileLockPath)}. Did you run "${chalk.bold(
+      `Could not find "Podfile.lock" at ${chalk.bold(podfileLockPath)}. Did you run "${chalk.bold(
         'npx pod-install'
       )}"?`
     );

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -170,6 +170,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
     log: Log.log,
+    warn: Log.warn,
     silent: !EXPO_DEBUG,
   });
 

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -179,7 +179,11 @@ export async function installCocoaPodsAsync(projectRoot: string) {
       step.render();
       await PackageManager.CocoaPodsPackageManager.installCLIAsync({
         nonInteractive: true,
-        spawnOptions: packageManager.options,
+        spawnOptions: {
+          ...packageManager.options,
+          // Don't silence this part
+          stdio: ['inherit', 'inherit', 'pipe'],
+        },
       });
       step.succeed('Installed CocoaPods CLI.');
       step = logNewSection('Running `pod install` in the `ios` directory.');

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -169,8 +169,6 @@ export async function installCocoaPodsAsync(projectRoot: string) {
 
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
-    log: Log.log,
-    warn: Log.warn,
     silent: !EXPO_DEBUG,
   });
 
@@ -202,7 +200,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
   }
 
   try {
-    await packageManager.installAsync();
+    await packageManager.installAsync({ spinner: step });
     // Create cached list for later
     await hasPackageJsonDependencyListChangedAsync(projectRoot).catch(() => null);
     step.succeed('Installed pods and initialized Xcode workspace.');

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -176,7 +176,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
     try {
       // prompt user -- do you want to install cocoapods right now?
       step.text = 'CocoaPods CLI not found in your PATH, installing it now.';
-      step.render();
+      step.stopAndPersist();
       await PackageManager.CocoaPodsPackageManager.installCLIAsync({
         nonInteractive: true,
         spawnOptions: {

--- a/packages/package-manager/src/CocoaPodsPackageManager.ts
+++ b/packages/package-manager/src/CocoaPodsPackageManager.ts
@@ -12,13 +12,25 @@ export class CocoaPodsError extends Error {
   readonly isPackageManagerError = true;
 
   constructor(message: string, public code: CocoaPodsErrorCode, public cause?: Error) {
-    super(cause ? `${message}\n└─ Cause: ${cause.name}: ${cause.message}` : message);
+    super(cause ? `${message}\n└─ Cause: ${cause.message}` : message);
   }
+}
+
+export function extractMissingDependencyError(error: string): [string, string] | null {
+  // [!] Unable to find a specification for `expo-dev-menu-interface` depended upon by `expo-dev-launcher`
+  const results = error.match(
+    /Unable to find a specification for ['"`]([\w-_\d\s]+)['"`] depended upon by ['"`]([\w-_\d\s]+)['"`]/g
+  );
+  if (results) {
+    return [results[1], results[2]];
+  }
+  return null;
 }
 
 export class CocoaPodsPackageManager implements PackageManager {
   options: SpawnOptions;
   private log: Logger;
+  private warn: Logger;
   private silent: boolean;
 
   static getPodProjectRoot(projectRoot: string): string | null {
@@ -69,9 +81,13 @@ export class CocoaPodsPackageManager implements PackageManager {
   static async installCLIAsync({
     nonInteractive = false,
     spawnOptions = { stdio: 'inherit' },
+    log = console.log,
+    warn = console.warn,
   }: {
     nonInteractive?: boolean;
     spawnOptions?: SpawnOptions;
+    log?: Logger;
+    warn?: Logger;
   }): Promise<boolean> {
     if (!spawnOptions) {
       spawnOptions = { stdio: 'inherit' };
@@ -79,15 +95,15 @@ export class CocoaPodsPackageManager implements PackageManager {
     const silent = !!spawnOptions.ignoreStdio;
 
     try {
-      !silent && console.log(`\u203A Attempting to install CocoaPods CLI with Gem`);
+      !silent && log(`\u203A Attempting to install CocoaPods CLI with Gem`);
       await CocoaPodsPackageManager.gemInstallCLIAsync(nonInteractive, spawnOptions);
-      !silent && console.log(`\u203A Successfully installed CocoaPods CLI with Gem`);
+      !silent && log(`\u203A Successfully installed CocoaPods CLI with Gem`);
       return true;
     } catch (error) {
       if (!silent) {
-        console.log(chalk.yellow(`\u203A Failed to install CocoaPods CLI with Gem`));
-        console.log(chalk.red(error.stderr ?? error.message));
-        console.log(`\u203A Attempting to install CocoaPods CLI with Homebrew`);
+        log(chalk.yellow(`\u203A Failed to install CocoaPods CLI with Gem`));
+        log(chalk.red(error.stderr ?? error.message));
+        log(`\u203A Attempting to install CocoaPods CLI with Homebrew`);
       }
       try {
         await CocoaPodsPackageManager.brewInstallCLIAsync(spawnOptions);
@@ -111,11 +127,11 @@ export class CocoaPodsPackageManager implements PackageManager {
           }
         }
 
-        !silent && console.log(`\u203A Successfully installed CocoaPods CLI with Homebrew`);
+        !silent && log(`\u203A Successfully installed CocoaPods CLI with Homebrew`);
         return true;
       } catch (error) {
         !silent &&
-          console.log(
+          warn(
             chalk.yellow(
               `\u203A Failed to install CocoaPods with Homebrew. Please install CocoaPods CLI manually and try again.`
             )
@@ -152,13 +168,24 @@ export class CocoaPodsPackageManager implements PackageManager {
     }
   }
 
-  constructor({ cwd, log, silent }: { cwd: string; log?: Logger; silent?: boolean }) {
+  constructor({
+    cwd,
+    log,
+    warn,
+    silent,
+  }: {
+    cwd: string;
+    log?: Logger;
+    warn?: Logger;
+    silent?: boolean;
+  }) {
     this.log = log || console.log;
+    this.warn = warn || console.warn;
     this.silent = !!silent;
     this.options = {
       cwd,
       ...(silent
-        ? { ignoreStdio: true }
+        ? { stdio: 'pipe' }
         : {
             stdio: ['inherit', 'inherit', 'pipe'],
           }),
@@ -181,6 +208,8 @@ export class CocoaPodsPackageManager implements PackageManager {
     return CocoaPodsPackageManager.installCLIAsync({
       nonInteractive: true,
       spawnOptions: this.options,
+      log: this.log,
+      warn: this.warn,
     });
   }
 
@@ -188,22 +217,36 @@ export class CocoaPodsPackageManager implements PackageManager {
     try {
       return await this._runAsync(['install']);
     } catch (error) {
-      const stderr = error.stderr ?? error.stdout;
+      const output = error.output.join('\n').trim();
 
       // When pods are outdated, they'll throw an error informing you to run "pod repo update"
       // Attempt to run that command and try installing again.
-      if (stderr.includes('pod repo update') && shouldUpdate) {
-        !this.silent &&
-          console.log(
-            chalk.yellow(
-              `\u203A Couldn't install Pods. ${chalk.dim(`Updating the repo and trying again.`)}`
-            )
-          );
+      if (output.includes('pod repo update') && shouldUpdate) {
+        const warningInfo = extractMissingDependencyError(output);
+        let message: string;
+        if (warningInfo) {
+          message = `\u203A Couldn't install ${warningInfo[1]} » ${warningInfo[0]}. ${chalk.dim(
+            `Updating the project and trying again.`
+          )}`;
+        } else {
+          message = `\u203A Couldn't install Pods. ${chalk.dim(
+            `Updating the project and trying again.`
+          )}`;
+        }
+        !this.silent && this.warn(chalk.yellow(message));
         await this.podRepoUpdateAsync();
         // Include a boolean to ensure pod repo update isn't invoked in the unlikely case where the pods fail to update.
         return await this._installAsync(false);
       } else {
-        error.message = error.message || stderr;
+        if (error.stdout.match(/No [`'"]Podfile[`'"] found in the project directory/)) {
+          error.message = `No Podfile found in directory: ${this.options
+            .cwd!}. Ensure CocoaPods is setup any try again.`;
+        } else {
+          const stderr = error.stderr.trim();
+          if (error.message && stderr) {
+            error.message += '\n' + stderr;
+          }
+        }
         throw new CocoaPodsError('The command `pod install` failed', 'COMMAND_FAILED', error);
       }
     }


### PR DESCRIPTION
# Why

- Fix regression where pod repo update wasn't being run
- Fix error handling
- Improve logging in Expo CLI
- Pause spinner when installing the cocoapods CLI
- Provide better insight into fixing cocoapods errors


### Before

<img width="920" alt="Screen Shot 2021-04-16 at 4 55 57 PM" src="https://user-images.githubusercontent.com/9664363/115091948-e147de80-9ecd-11eb-9c82-c9c12016b6fb.png">


### After


<img width="946" alt="Screen Shot 2021-04-16 at 4 55 17 PM" src="https://user-images.githubusercontent.com/9664363/115091952-e2790b80-9ecd-11eb-8c3a-e40f22993e5e.png">

