### PR TITLE
Added a flag to skip git status check

### DIFF
--- a/packages/expo-cli/src/commands/utils/maybeBailOnGitStatusAsync.ts
+++ b/packages/expo-cli/src/commands/utils/maybeBailOnGitStatusAsync.ts
@@ -1,12 +1,20 @@
 import program from 'commander';
+import { boolish } from 'getenv';
 
 import Log from '../../log';
 import { confirmAsync } from '../../prompts';
 import { validateGitStatusAsync } from './ProjectUtils';
 
+const EXPO_NO_GIT_STATUS = boolish('EXPO_NO_GIT_STATUS', false);
+
 export default async function maybeBailOnGitStatusAsync(): Promise<boolean> {
+  if (EXPO_NO_GIT_STATUS) {
+    Log.warn(
+      'Git status is dirty but the command will continue because EXPO_NO_GIT_STATUS is enabled...'
+    );
+    return false;
+  }
   const isGitStatusClean = await validateGitStatusAsync();
-  Log.newLine();
 
   // Give people a chance to bail out if git working tree is dirty
   if (!isGitStatusClean) {
@@ -17,6 +25,7 @@ export default async function maybeBailOnGitStatusAsync(): Promise<boolean> {
       return false;
     }
 
+    Log.addNewLineIfNone();
     const answer = await confirmAsync({
       message: `Would you like to proceed?`,
     });


### PR DESCRIPTION
# Why

- Skip git status checks in upgrade and eject when EXPO_NO_GIT_STATUS is enabled.

