### PR TITLE
Enable socket controls in run:ios and run:android

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/startBundlerAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/startBundlerAsync.ts
@@ -20,5 +20,7 @@ export async function startBundlerAsync(projectRoot: string) {
   await Project.startAsync(projectRoot, { devClient });
   await TerminalUI.startAsync(projectRoot, {
     devClient,
+    isWebSocketsEnabled: true,
+    isRemoteReloadingEnabled: true,
   });
 }


### PR DESCRIPTION
# Why

- enable r to reload and m to open the dev menu