### PR TITLE
[config-plugins] Make user interface style default to light if not specified

### DIFF
--- a/packages/config-plugins/src/android/UserInterfaceStyle.ts
+++ b/packages/config-plugins/src/android/UserInterfaceStyle.ts
@@ -44,8 +44,8 @@ export const withUiModeMainActivity: ConfigPlugin = config => {
 
 export function getUserInterfaceStyle(
   config: Pick<ExpoConfig, 'android' | 'userInterfaceStyle'>
-): string | null {
-  return config.android?.userInterfaceStyle ?? config.userInterfaceStyle ?? null;
+): string {
+  return config.android?.userInterfaceStyle ?? config.userInterfaceStyle ?? 'light';
 }
 
 export function setUiModeAndroidManifest(

--- a/packages/config-plugins/src/android/__tests__/UserInterfaceStyle-test.ts
+++ b/packages/config-plugins/src/android/__tests__/UserInterfaceStyle-test.ts
@@ -42,8 +42,8 @@ public class MainActivity extends ReactActivity {
 `;
 
 describe('User interface style', () => {
-  it(`returns null if no userInterfaceStyle is provided`, () => {
-    expect(getUserInterfaceStyle({})).toBe(null);
+  it(`returns light if no userInterfaceStyle is provided`, () => {
+    expect(getUserInterfaceStyle({})).toBe('light');
   });
 
   it(`returns the userInterfaceStyle if provided`, () => {

--- a/packages/config-plugins/src/ios/UserInterfaceStyle.ts
+++ b/packages/config-plugins/src/ios/UserInterfaceStyle.ts
@@ -10,8 +10,8 @@ export const withUserInterfaceStyle = createInfoPlistPlugin(
 
 export function getUserInterfaceStyle(
   config: Pick<ExpoConfig, 'ios' | 'userInterfaceStyle'>
-): string | null {
-  return config.ios?.userInterfaceStyle ?? config.userInterfaceStyle ?? null;
+): string {
+  return config.ios?.userInterfaceStyle ?? config.userInterfaceStyle ?? 'light';
 }
 
 export function setUserInterfaceStyle(
@@ -31,9 +31,7 @@ export function setUserInterfaceStyle(
   };
 }
 
-function mapUserInterfaceStyleForInfoPlist(
-  userInterfaceStyle: string | null
-): InterfaceStyle | null {
+function mapUserInterfaceStyleForInfoPlist(userInterfaceStyle: string): InterfaceStyle | null {
   switch (userInterfaceStyle) {
     case 'light':
       return 'Light';

--- a/packages/config-plugins/src/ios/__tests__/UserInterfaceStyle-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/UserInterfaceStyle-test.ts
@@ -2,8 +2,8 @@ import { getUserInterfaceStyle, setUserInterfaceStyle } from '../UserInterfaceSt
 
 describe('user interface style', () => {
   // TODO: should we default to 'Light' just as we do in the client if none is specified?
-  it(`returns null if no userInterfaceStyle is provided`, () => {
-    expect(getUserInterfaceStyle({})).toBe(null);
+  it(`returns light if no userInterfaceStyle is provided`, () => {
+    expect(getUserInterfaceStyle({})).toBe('light');
   });
 
   it(`returns the value if provided`, () => {


### PR DESCRIPTION
# Why

This is the default behavior in Expo Go and standalone apps built with expo build.

# How

The most reasonable place to change this seemed to be in `getUserInterfaceStyle`, but really anywhere would do.

# Test Plan

Run tests.