### PR TITLE
Fix running dev client from terminal UI using wrong bundleIdentifier

### DIFF
--- a/packages/xdl/src/BundleIdentifier.ts
+++ b/packages/xdl/src/BundleIdentifier.ts
@@ -71,7 +71,7 @@ However, if you choose the one defined in the Xcode project you'll have to updat
           },
         ],
       });
-      if (bundleIdentifierSource === BundleIdentiferSource.XcodeProject) {
+      if (bundleIdentifierSource === BundleIdentiferSource.AppJson) {
         IOSConfig.BundleIdentifier.setBundleIdentifierForPbxproj(
           projectRoot,
           bundleIdentifierFromConfig


### PR DESCRIPTION
# Why

Steps to repro:
- Change bundleIdentifier in app.json or Xcode project but not both
- Run a server with expo start --dev-client
- Press i to launch in Simulator.app
- From "Which bundle identifier should we use?" choose the one from Xcode project
- The CLI tries to use the other one
 
<img width="762" alt="Screen Shot 2021-04-21 at 13 59 40" src="https://user-images.githubusercontent.com/497214/115545533-97d00880-a2ac-11eb-985f-b896e348d80b.png">

# How

The if-else condition in `configureBundleIdentifierAsync` was flipped, when you chose "from Xcode project" it actually updated the *Xcode project to use the bundle identifier from `app.json`*. This PR corrects this error.

# Test Plan

Verified the correct bundle identifier is used after this fix:
<img width="970" alt="Screen Shot 2021-04-21 at 14 24 16" src="https://user-images.githubusercontent.com/497214/115546090-470cdf80-a2ad-11eb-8535-2bf0a7b02128.png">
