### PR TITLE
Add port selection to start --dev-client

### DIFF
--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -99,7 +99,9 @@ export async function runAndroidActionAsync(projectRoot: string, options: Option
   await spawnGradleAsync({ androidProjectPath, variant: options.variant });
 
   if (props.bundler) {
-    await startBundlerAsync(projectRoot);
+    await startBundlerAsync(projectRoot, {
+      metroPort: props.port,
+    });
   }
 
   const apkFile = await getInstallApkNameAsync(props.device, props);

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -51,7 +51,9 @@ export async function runIosActionAsync(projectRoot: string, options: Options) {
   )(buildOutput);
 
   if (props.shouldStartBundler) {
-    await startBundlerAsync(projectRoot);
+    await startBundlerAsync(projectRoot, {
+      metroPort: props.port,
+    });
   }
   const bundleIdentifier = await profileMethod(getBundleIdentifierForBinaryAsync)(binaryPath);
 

--- a/packages/expo-cli/src/commands/run/ios/startBundlerAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/startBundlerAsync.ts
@@ -4,7 +4,10 @@ import { getDevClientSchemeAsync } from '../../../schemes';
 import * as TerminalUI from '../../start/TerminalUI';
 import { installExitHooks } from '../../start/installExitHooks';
 
-export async function startBundlerAsync(projectRoot: string) {
+export async function startBundlerAsync(
+  projectRoot: string,
+  { metroPort }: Pick<Project.StartOptions, 'metroPort'>
+) {
   // Add clean up hooks
   installExitHooks(projectRoot);
   // This basically means don't use the Client app.
@@ -14,9 +17,10 @@ export async function startBundlerAsync(projectRoot: string) {
     devClient,
     scheme,
   });
-  await Project.startAsync(projectRoot, { devClient });
+  await Project.startAsync(projectRoot, { devClient, metroPort });
   await TerminalUI.startAsync(projectRoot, {
     devClient,
+    // Enable controls
     isWebSocketsEnabled: true,
     isRemoteReloadingEnabled: true,
   });

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -10,6 +10,7 @@ import {
 } from '../internal';
 
 export type StartOptions = {
+  metroPort?: number;
   isWebSocketsEnabled?: boolean;
   isRemoteReloadingEnabled?: boolean;
   devClient?: boolean;
@@ -24,9 +25,16 @@ export type StartOptions = {
 export async function startDevServerAsync(projectRoot: string, startOptions: StartOptions) {
   assertValidProjectRoot(projectRoot);
 
-  const port = startOptions.devClient
-    ? Number(process.env.RCT_METRO_PORT) || 8081
-    : await getFreePortAsync(19000);
+  let port: number;
+
+  if (startOptions.metroPort != null) {
+    // If the manually defined port is busy then an error should be thrown
+    port = startOptions.metroPort;
+  } else {
+    port = startOptions.devClient
+      ? Number(process.env.RCT_METRO_PORT) || 8081
+      : await getFreePortAsync(19000);
+  }
   await ProjectSettings.setPackagerInfoAsync(projectRoot, {
     expoServerPort: port,
     packagerPort: port,

--- a/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
+++ b/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
@@ -134,7 +134,7 @@ export async function startReactNativeServerAsync({
   await Watchman.addToPathAsync(); // Attempt to fix watchman if it's hanging
   await Watchman.unblockAndGetVersionAsync(projectRoot);
 
-  let packagerPort = await getFreePortAsync(19001); // Create packager options
+  let packagerPort = options.metroPort ?? (await getFreePortAsync(19001)); // Create packager options
 
   const customLogReporterPath: string = require.resolve(
     path.join(__dirname, '../../build/reporter')


### PR DESCRIPTION
# Why

`expo start --dev-client` throws a large error when 8081 is not available, this is often the behavior you'd want for the built-in RN dev menu, but we want to optimize for `expo-dev-menu` which supports multi-ports. 

### Before

<img width="790" alt="Screen Shot 2021-04-21 at 12 40 00 PM" src="https://user-images.githubusercontent.com/9664363/115604543-5af91700-a296-11eb-818a-1ccc0215e927.png">

### After

<img width="480" alt="Screen Shot 2021-04-21 at 12 39 45 PM" src="https://user-images.githubusercontent.com/9664363/115604553-5cc2da80-a296-11eb-9a12-96327dd8b900.png">
