### PR TITLE
Improve cocoapods error messages

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/Podfile.ts
+++ b/packages/expo-cli/src/commands/run/ios/Podfile.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import { safeLoad } from 'js-yaml';
 import * as path from 'path';
 
+import { AbortCommandError } from '../../../CommandError';
 import Log from '../../../log';
 import { hashForDependencyMap } from '../../eject/updatePackageJson';
 import { installCocoaPodsAsync } from '../../utils/CreateApp';
@@ -95,7 +96,9 @@ export default async function maybePromptToSyncPodsAsync(projectRoot: string) {
     return;
   }
   if (!isLockfileCreated(projectRoot)) {
-    await installCocoaPodsAsync(projectRoot);
+    if (!(await installCocoaPodsAsync(projectRoot))) {
+      throw new AbortCommandError();
+    }
     return;
   }
 
@@ -117,7 +120,9 @@ async function promptToInstallPodsAsync(projectRoot: string, missingPods?: strin
   }
 
   try {
-    await installCocoaPodsAsync(projectRoot);
+    if (!(await installCocoaPodsAsync(projectRoot))) {
+      throw new AbortCommandError();
+    }
   } catch (error) {
     fs.removeSync(path.join(getTempPrebuildFolder(projectRoot), 'cached-packages.json'));
     throw error;

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -190,9 +190,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
     } catch (e) {
       step.stopAndPersist({
         symbol: '⚠️ ',
-        text: Log.chalk.red(
-          'Unable to install the CocoaPods CLI. Continuing with project sync, you can install CocoaPods CLI afterwards.'
-        ),
+        text: Log.chalk.red('Unable to install the CocoaPods CLI.'),
       });
       if (e instanceof PackageManager.CocoaPodsError) {
         Log.log(e.message);
@@ -212,9 +210,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
   } catch (e) {
     step.stopAndPersist({
       symbol: '⚠️ ',
-      text: Log.chalk.red(
-        'Something went wrong running `pod install` in the `ios` directory. Continuing with project sync, you can debug this afterwards.'
-      ),
+      text: Log.chalk.red('Something went wrong running `pod install` in the `ios` directory.'),
     });
     if (e instanceof PackageManager.CocoaPodsError) {
       Log.log(e.message);


### PR DESCRIPTION
# Why

- CocoaPods CLI often prints error messages to stdout and add some random nonsense to stderr. This PR attempts to match the useful error message and prune out the less useful content.
- This PR also quits the process in `expo run:ios` when pods fail to install.

### Before

<img width="1614" alt="Screen Shot 2021-04-21 at 4 17 50 PM" src="https://user-images.githubusercontent.com/9664363/115628031-d2d63a00-a2b4-11eb-8f98-274055fd8c5f.png">

### After

<img width="698" alt="Screen Shot 2021-04-21 at 4 17 27 PM" src="https://user-images.githubusercontent.com/9664363/115628021-ce118600-a2b4-11eb-9df7-8446070be75b.png">
