### PR TITLE
[expo-cli] validate project dependencies on `doctor` run

### DIFF
--- a/packages/expo-cli/src/commands/doctor/index.ts
+++ b/packages/expo-cli/src/commands/doctor/index.ts
@@ -1,17 +1,28 @@
+import { getConfig } from '@expo/config';
+import chalk from 'chalk';
 import { Command } from 'commander';
 import { Doctor } from 'xdl';
 
 import Log from '../../log';
+import { profileMethod } from '../utils/profileMethod';
+import { validateDependenciesVersionsAsync } from '../utils/validateDependenciesVersions';
 import { warnUponCmdExe } from './windows';
 
 async function actionAsync(projectRoot: string) {
   await warnUponCmdExe();
 
+  const { exp, pkg } = profileMethod(getConfig)(projectRoot);
+  const areDepsValid = await profileMethod(validateDependenciesVersionsAsync)(
+    projectRoot,
+    exp,
+    pkg
+  );
+
   // note: this currently only warns when something isn't right, it doesn't fail
   await Doctor.validateExpoServersAsync(projectRoot);
 
-  if ((await Doctor.validateWithNetworkAsync(projectRoot)) === Doctor.NO_ISSUES) {
-    Log.log(`Didn't find any issues with the project!`);
+  if ((await Doctor.validateWithNetworkAsync(projectRoot)) === Doctor.NO_ISSUES && areDepsValid) {
+    Log.log(chalk.green(`🎉 Didn't find any issues with the project!`));
   }
 }
 

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -15,10 +15,10 @@ import {
   parseStartOptions,
   RawStartOptions,
 } from './start/parseStartOptions';
-import { validateDependenciesVersionsAsync } from './start/validateDependenciesVersions';
 import { assertProjectHasExpoExtensionFilesAsync } from './utils/deprecatedExtensionWarnings';
 import { profileMethod } from './utils/profileMethod';
 import { ensureTypeScriptSetupAsync } from './utils/typescript/ensureTypeScriptSetup';
+import { validateDependenciesVersionsAsync } from './utils/validateDependenciesVersions';
 
 async function action(projectRoot: string, options: NormalizedOptions): Promise<void> {
   Log.log(chalk.gray(`Starting project at ${projectRoot}`));

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -12,9 +12,9 @@ export async function validateDependenciesVersionsAsync(
   projectRoot: string,
   exp: ExpoConfig,
   pkg: PackageJSONConfig
-): Promise<void> {
+): Promise<boolean> {
   if (!Versions.gteSdkVersion(exp, '33.0.0')) {
-    return;
+    return false;
   }
 
   const bundleNativeModulesPath = resolveFrom.silent(projectRoot, 'expo/bundledNativeModules.json');
@@ -24,7 +24,7 @@ export async function validateDependenciesVersionsAsync(
         'expo'
       )} package version seems to be older.`
     );
-    return;
+    return false;
   }
 
   const bundledNativeModules = await JsonFile.readAsync(bundleNativeModulesPath);
@@ -63,5 +63,7 @@ export async function validateDependenciesVersionsAsync(
           'expo install [package-name ...]'
         )}`
     );
+    return false;
   }
+  return true;
 }


### PR DESCRIPTION
# Why

Fixes #3075

Currently project dependencies were only checked on the `start` run, but `doctor` command should do the same.

# How

This PR moves the `validateDependenciesVersionsAsync` to the `/utils` directory and refactors the return type, so `doctor` command have a clue if there were any warnings, and can skip the success message in such case.

I have also changed the `doctor` success message color to green and I have added the emoji to differentiate a bit the messaged in console.

# Test Plan

Command changes were tested on `localhost` using the local build of `expo-cli` package.

# Preview

<img width="850" alt="Screenshot 2021-04-22 at 17 23 09" src="https://user-images.githubusercontent.com/719641/115741857-692b5e00-a390-11eb-8d89-6bf3db2cdc40.png">

CC: @brentvatne 