### PR TITLE
Improve errors when a package doesn't have a valid plugin

### DIFF
--- a/packages/config-plugins/src/plugins/__tests__/static-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/static-plugins-test.ts
@@ -15,6 +15,8 @@ function withInternalRemoved(config: ExpoConfig) {
   return config;
 }
 
+jest.unmock('resolve-from');
+
 const projectRoot = join(__dirname, 'fixtures/project-files');
 
 // Not using in-memory fs because the node resolution isn't mocked out.
@@ -66,15 +68,15 @@ describe(withStaticPlugin, () => {
     );
   });
   it(`uses internal projectRoot`, () => {
-    let config: ExpoConfig = {
-      name: 'foo',
-      slug: 'foo',
-      _internal: { projectRoot: '.' },
-    };
+    let config: ExpoConfig = withInternal(
+      {
+        name: 'foo',
+        slug: 'foo',
+      },
+      projectRoot
+    );
 
     config = withPlugins(config, [
-      // @ts-ignore -- invalid type
-      c => withInternal(c, projectRoot),
       // @ts-ignore -- invalid type
       c =>
         withStaticPlugin(c, {
@@ -94,11 +96,13 @@ describe(withStaticPlugin, () => {
   });
 
   it(`passes props to plugin`, () => {
-    let config: ExpoConfig = {
-      name: 'foo',
-      slug: 'foo',
-      _internal: { projectRoot: '.' },
-    };
+    let config: ExpoConfig = withInternal(
+      {
+        name: 'foo',
+        slug: 'foo',
+      },
+      '.'
+    );
 
     config = withPlugins(config, [
       // @ts-ignore -- invalid type
@@ -141,6 +145,6 @@ describe(withStaticPlugin, () => {
         plugin: ['./not-existing.js', { foobar: true }],
         projectRoot,
       })
-    ).toThrow(/Cannot find module '.\/not-existing.js'/);
+    ).toThrow(/Failed to resolve plugin for module ".\/not-existing.js"/);
   });
 });

--- a/packages/config-plugins/src/plugins/static-plugins.ts
+++ b/packages/config-plugins/src/plugins/static-plugins.ts
@@ -14,14 +14,15 @@ const EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS = boolish('EXPO_CONFIG_PLUGIN_VERBOSE_ER
 
 function isModuleMissingError(name: string, error: Error): boolean {
   // @ts-ignore
-  if (error.code === 'MODULE_NOT_FOUND') {
+  if (['MODULE_NOT_FOUND', 'PLUGIN_NOT_FOUND'].includes(error.code)) {
     return true;
   }
   return error.message.includes(`Cannot find module '${name}'`);
 }
 
 function isUnexpectedTokenError(error: Error): boolean {
-  if (error instanceof SyntaxError) {
+  // @ts-expect-error
+  if (error instanceof SyntaxError || error.code === 'INVALID_PLUGIN_IMPORT') {
     return (
       // These are the most common errors that'll be thrown when a package isn't transpiled correctly.
       !!error.message.match(/Unexpected token/) ||

--- a/packages/config-plugins/src/plugins/static-plugins.ts
+++ b/packages/config-plugins/src/plugins/static-plugins.ts
@@ -21,8 +21,10 @@ function isModuleMissingError(name: string, error: Error): boolean {
 }
 
 function isUnexpectedTokenError(error: Error): boolean {
-  // @ts-expect-error
-  if (error instanceof SyntaxError || error.code === 'INVALID_PLUGIN_IMPORT') {
+  if (
+    error instanceof SyntaxError ||
+    (error instanceof PluginError && error.code === 'INVALID_PLUGIN_IMPORT')
+  ) {
     return (
       // These are the most common errors that'll be thrown when a package isn't transpiled correctly.
       !!error.message.match(/Unexpected token/) ||

--- a/packages/config-plugins/src/utils/errors.ts
+++ b/packages/config-plugins/src/utils/errors.ts
@@ -6,7 +6,7 @@ export class UnexpectedError extends Error {
   }
 }
 
-export type PluginErrorCode = 'INVALID_PLUGIN_TYPE';
+export type PluginErrorCode = 'INVALID_PLUGIN_TYPE' | 'INVALID_PLUGIN_IMPORT' | 'PLUGIN_NOT_FOUND';
 
 /**
  * Based on `JsonFileError` from `@expo/json-file`

--- a/packages/config-plugins/src/utils/plugin-resolver.ts
+++ b/packages/config-plugins/src/utils/plugin-resolver.ts
@@ -159,7 +159,7 @@ export function resolveConfigPluginExport({
     // If the plugin reference is a node module, and that node module does not export a function then it probably doesn't have a config plugin.
     if (!isPluginFile && !moduleNameIsDirectFileReference(pluginReference)) {
       throw new PluginError(
-        `Package "${pluginReference}" does not contain a valid config plugin. Module must export a function from file: ${pluginFile}.\n${learnMoreLink}`,
+        `Package "${pluginReference}" does not contain a valid config plugin. Module must export a function from file: ${pluginFile}\n${learnMoreLink}`,
         'INVALID_PLUGIN_TYPE'
       );
     }

--- a/packages/config/src/__tests__/getConfig-e2e-test.ts
+++ b/packages/config/src/__tests__/getConfig-e2e-test.ts
@@ -6,6 +6,8 @@ import { getDynamicConfig } from '../getConfig';
 
 const mockConfigContext = {} as any;
 
+jest.unmock('resolve-from');
+
 describe(getDynamicConfig, () => {
   describe('process.cwd in a child process', () => {
     const originalCwd = process.cwd();


### PR DESCRIPTION
# Why

Make it clearer when an invalid plugin is used that the package may not have an config plugin.

Before/After
<img width="1410" alt="Screen Shot 2021-04-22 at 4 58 15 PM" src="https://user-images.githubusercontent.com/9664363/115795599-0c767600-a385-11eb-8e04-a9c524e40e02.png">

Also new

## Before

<img width="1340" alt="Screen Shot 2021-04-22 at 5 11 23 PM" src="https://user-images.githubusercontent.com/9664363/115795811-7c84fc00-a385-11eb-9107-9f8629abda42.png">

## After

<img width="1340" alt="Screen Shot 2021-04-22 at 5 10 56 PM" src="https://user-images.githubusercontent.com/9664363/115795823-80b11980-a385-11eb-8380-4d3325a15e64.png">

