### PR TITLE
[configure-splash-screen]: remove core-js dependency

### DIFF
--- a/unlinked-packages/configure-splash-screen/package.json
+++ b/unlinked-packages/configure-splash-screen/package.json
@@ -35,12 +35,11 @@
   "license": "MIT",
   "homepage": "https://github.com/expo/expo-cli/tree/master/unlinked-packages/configure-splash-screen",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "dependencies": {
     "color-string": "^1.5.3",
     "commander": "^5.1.0",
-    "core-js": "^3.6.5",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
     "lodash": "^4.17.15",

--- a/unlinked-packages/configure-splash-screen/src/utils/string-utils.ts
+++ b/unlinked-packages/configure-splash-screen/src/utils/string-utils.ts
@@ -1,6 +1,3 @@
-// runtime polyfills
-import 'core-js/es/string/match-all';
-
 /**
  * @returns [`true`, modifiedContent: string] if replacement is successful, [`false`, originalContent] otherwise.
  */

--- a/unlinked-packages/configure-splash-screen/tsconfig.json
+++ b/unlinked-packages/configure-splash-screen/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../tsconfig.base",
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2019",
     "module": "CommonJS",
-    "lib": ["es2018", "es2020.string"],
+    "lib": ["es2019", "es2020.string"],
     "rootDir": "./src",
     "outDir": "./build",
     "esModuleInterop": true,

--- a/unlinked-packages/configure-splash-screen/yarn.lock
+++ b/unlinked-packages/configure-splash-screen/yarn.lock
@@ -1792,11 +1792,6 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.5"
     semver "7.0.0"
 
-core-js@^3.6.5:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
-
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
# Why

Closes #3185 

# How

Since node 10 will be dropped in expo-cli soon (and already dropped by react-native), i think it's safe to upgrade the `engines` to `>=12` and just removing the `matchAll` polyfill.

# Test Plan

tests passed on local
