### PR TITLE
[cli] "expo is not installed" error

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -470,16 +470,6 @@ function ensureConfigHasDefaultValues({
 
   const expWithDefaults = { ...exp, name, slug, version, description };
 
-  // Find expo binary in project/workspace node_modules
-  const hasExpoInstalled = resolveFrom.silent(projectRoot, 'expo');
-
-  if (!hasExpoInstalled) {
-    throw new ConfigError(
-      `Unable to find expo in this project - have you run yarn / npm install?`,
-      'MODULE_NOT_FOUND'
-    );
-  }
-
   let sdkVersion;
   try {
     sdkVersion = getExpoSDKVersion(projectRoot, expWithDefaults);

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -470,6 +470,16 @@ function ensureConfigHasDefaultValues({
 
   const expWithDefaults = { ...exp, name, slug, version, description };
 
+  // Find expo binary in project/workspace node_modules
+  const hasExpoInstalled = resolveFrom.silent(projectRoot, 'expo');
+
+  if (!hasExpoInstalled) {
+    throw new ConfigError(
+      `Unable to find expo in this project - have you run yarn / npm install?`,
+      'MODULE_NOT_FOUND'
+    );
+  }
+
   let sdkVersion;
   try {
     sdkVersion = getExpoSDKVersion(projectRoot, expWithDefaults);

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -1,6 +1,7 @@
-import { getConfig, isLegacyImportsEnabled } from '@expo/config';
+import { ConfigError, getConfig, isLegacyImportsEnabled } from '@expo/config';
 import chalk from 'chalk';
 import path from 'path';
+import resolveFrom from 'resolve-from';
 import { Project, UrlUtils, Versions } from 'xdl';
 
 import Log from '../log';
@@ -25,6 +26,16 @@ async function action(projectRoot: string, options: NormalizedOptions): Promise<
 
   // Add clean up hooks
   installExitHooks(projectRoot);
+
+  // Find expo binary in project/workspace node_modules
+  const hasExpoInstalled = resolveFrom.silent(projectRoot, 'expo');
+
+  if (!hasExpoInstalled) {
+    throw new ConfigError(
+      `Unable to find expo in this project - have you run yarn / npm install yet?`,
+      'MODULE_NOT_FOUND'
+    );
+  }
 
   const { exp, pkg } = profileMethod(getConfig)(projectRoot, {
     skipSDKVersionRequirement: options.webOnly,


### PR DESCRIPTION
# Why

It's possible to hit a somewhat misleading error message if a user runs `expo start` before installing node_modules in a project. Instead we can check to see if expo is installed before running any additional logic

# How

Added a fs check to see if expo is installed in the project or workspace, if not throw an error message that indicates they need to run `yarn / npm install` first

I initially included this in the Config module but realized that it broke a ton of tests, so I put it in front of the start command only - wondering if there's a better way to resolve the tests breaking / if this check is in the right place

# Test Plan

- `expo start` in a workspace repo before installing node_modules, note the error message appears, `yarn install` and error should go away
- `expo start` in a project repo before installing node_modules, same deal