### PR TITLE
Delete `publishSourceMapPath`

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -80,8 +80,6 @@ export type ExpoAppManifest = ExpoConfig & {
     tool: string | null;
     projectRoot?: string;
   };
-  ios?: { publishSourceMapPath?: string } & ExpoConfig['ios'];
-  android?: { publishSourceMapPath?: string } & ExpoConfig['android'];
 };
 
 export type Hook = {

--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -317,11 +317,9 @@ export async function exportAppAsync(
       iosManifestUrl: urljoin(publicUrl, 'ios-index.json'),
       iosManifest,
       iosBundle,
-      iosSourceMap,
       androidManifestUrl: urljoin(publicUrl, 'android-index.json'),
       androidManifest,
       androidBundle,
-      androidSourceMap,
       target,
     });
   }

--- a/packages/xdl/src/EmbeddedAssets.ts
+++ b/packages/xdl/src/EmbeddedAssets.ts
@@ -20,11 +20,9 @@ export type EmbeddedAssetsConfiguration = {
   iosManifestUrl: string;
   iosManifest: any;
   iosBundle: string;
-  iosSourceMap: string | null;
   androidManifestUrl: string;
   androidManifest: any;
   androidBundle: string;
-  androidSourceMap: string | null;
   target: ProjectTarget;
 };
 
@@ -121,19 +119,15 @@ async function _maybeWriteArtifactsToDiskAsync(config: EmbeddedAssetsConfigurati
     exp,
     iosManifest,
     iosBundle,
-    iosSourceMap,
     androidManifest,
     androidBundle,
-    androidSourceMap,
     target,
   } = config;
 
   let androidBundlePath;
   let androidManifestPath;
-  let androidSourceMapPath;
   let iosBundlePath;
   let iosManifestPath;
-  let iosSourceMapPath;
 
   if (shouldEmbedAssetsForExpoUpdates(projectRoot, exp, pkg, target)) {
     const defaultAndroidDir = _getDefaultEmbeddedAssetDir('android', projectRoot, exp);
@@ -161,17 +155,11 @@ async function _maybeWriteArtifactsToDiskAsync(config: EmbeddedAssetsConfigurati
   if (exp.android?.publishManifestPath) {
     androidManifestPath = exp.android.publishManifestPath;
   }
-  if (exp.android?.publishSourceMapPath) {
-    androidSourceMapPath = exp.android.publishSourceMapPath;
-  }
   if (exp.ios?.publishBundlePath) {
     iosBundlePath = exp.ios.publishBundlePath;
   }
   if (exp.ios?.publishManifestPath) {
     iosManifestPath = exp.ios.publishManifestPath;
-  }
-  if (exp.ios?.publishSourceMapPath) {
-    iosSourceMapPath = exp.ios.publishSourceMapPath;
   }
 
   if (androidBundlePath) {
@@ -192,15 +180,6 @@ async function _maybeWriteArtifactsToDiskAsync(config: EmbeddedAssetsConfigurati
     );
   }
 
-  if (androidSourceMapPath && androidSourceMap) {
-    await writeArtifactSafelyAsync(
-      projectRoot,
-      'android.publishSourceMapPath',
-      androidSourceMapPath,
-      androidSourceMap
-    );
-  }
-
   if (iosBundlePath) {
     await writeArtifactSafelyAsync(projectRoot, 'ios.publishBundlePath', iosBundlePath, iosBundle);
   }
@@ -211,15 +190,6 @@ async function _maybeWriteArtifactsToDiskAsync(config: EmbeddedAssetsConfigurati
       'ios.publishManifestPath',
       iosManifestPath,
       JSON.stringify(iosManifest)
-    );
-  }
-
-  if (iosSourceMapPath && iosSourceMap) {
-    await writeArtifactSafelyAsync(
-      projectRoot,
-      'ios.publishSourceMapPath',
-      iosSourceMapPath,
-      iosSourceMap
     );
   }
 }

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -102,10 +102,8 @@ export async function publishAsync(
 
   const hasHooks = validPostPublishHooks.length > 0;
 
-  const shouldPublishAndroidMaps = !!exp.android?.publishSourceMapPath;
-  const shouldPublishIosMaps = !!exp.ios?.publishSourceMapPath;
-  const androidSourceMap = hasHooks || shouldPublishAndroidMaps ? bundles.android.map : null;
-  const iosSourceMap = hasHooks || shouldPublishIosMaps ? bundles.ios.map : null;
+  const androidSourceMap = hasHooks ? bundles.android.map : null;
+  const iosSourceMap = hasHooks ? bundles.ios.map : null;
 
   let response;
   try {
@@ -184,11 +182,9 @@ export async function publishAsync(
     iosManifestUrl: fullManifestUrl,
     iosManifest,
     iosBundle,
-    iosSourceMap,
     androidManifestUrl: fullManifestUrl,
     androidManifest,
     androidBundle,
-    androidSourceMap,
     target,
   });
 


### PR DESCRIPTION
# Why

This is not on the schema and therefore not useable in `expo publish` (dead code).
