### PR TITLE
bump minimum Node target to 12

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/expo/expo-cli/tree/master/packages/expo-cli#readme",
   "engines": {
-    "node": ">=6.9.1"
+    "node": ">=12"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/osascript/package.json
+++ b/packages/osascript/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/expo/expo-cli/tree/master/packages/osascript#readme",
   "engines": {
-    "node": "8.x.x || >=10.0.0"
+    "node": ">=12"
   },
   "dependencies": {
     "@expo/spawn-async": "^1.5.0",

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -34,7 +34,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.10"
+    "node": ">=12"
   },
   "bugs": {
     "url": "https://github.com/expo/expo-cli/issues"

--- a/unlinked-packages/configure-splash-screen/package.json
+++ b/unlinked-packages/configure-splash-screen/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "homepage": "https://github.com/expo/expo-cli/tree/master/unlinked-packages/configure-splash-screen",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "dependencies": {
     "color-string": "^1.5.3",


### PR DESCRIPTION
# Why

Refs https://github.com/expo/expo/pull/12743

At the end of April Node 10 will reach it's End-of-life:
* https://nodejs.org/en/about/releases/

# How

Bump `"node"` engines entries in `package.json` to `>=12`.

# Test Plan

`yarn` and `yarn build` executed on the workspace root were successful.