### PR TITLE
[install] add config plugins automatically

### DIFF
--- a/packages/config-plugins/src/utils/plugin-resolver.ts
+++ b/packages/config-plugins/src/utils/plugin-resolver.ts
@@ -98,6 +98,12 @@ export function assertInternalProjectRoot(projectRoot?: string): asserts project
 
 // Resolve the module function and assert type
 export function resolveConfigPluginFunction(projectRoot: string, pluginReference: string) {
+  const { plugin } = resolveConfigPluginFunctionWithInfo(projectRoot, pluginReference);
+  return plugin;
+}
+
+// Resolve the module function and assert type
+export function resolveConfigPluginFunctionWithInfo(projectRoot: string, pluginReference: string) {
   const { filePath: pluginFile, isPluginFile } = resolvePluginForModule(
     projectRoot,
     pluginReference
@@ -121,12 +127,13 @@ export function resolveConfigPluginFunction(projectRoot: string, pluginReference
     throw error;
   }
 
-  return resolveConfigPluginExport({
+  const plugin = resolveConfigPluginExport({
     plugin: result,
     pluginFile,
     pluginReference,
     isPluginFile,
   });
+  return { plugin, pluginFile, pluginReference, isPluginFile };
 }
 
 /**

--- a/packages/expo-cli/src/commands/build/AndroidBuilder.ts
+++ b/packages/expo-cli/src/commands/build/AndroidBuilder.ts
@@ -8,7 +8,7 @@ import {
   useKeystore,
 } from '../../credentials/views/AndroidKeystore';
 import { SetupAndroidKeystore } from '../../credentials/views/SetupAndroidKeystore';
-import { getOrPromptForPackage } from '../eject/ConfigValidation';
+import { getOrPromptForPackage } from '../utils/getOrPromptApplicationId';
 import BaseBuilder from './BaseBuilder';
 import BuildError from './BuildError';
 import { Platform, PLATFORMS } from './constants';

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -29,8 +29,8 @@ import { SetupIosProvisioningProfile } from '../../../credentials/views/SetupIos
 import { SetupIosPush } from '../../../credentials/views/SetupIosPush';
 import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
-import { getOrPromptForBundleIdentifier } from '../../eject/ConfigValidation';
 import * as TerminalLink from '../../utils/TerminalLink';
+import { getOrPromptForBundleIdentifier } from '../../utils/getOrPromptApplicationId';
 import BaseBuilder from '../BaseBuilder';
 import { PLATFORMS } from '../constants';
 import * as utils from '../utils';

--- a/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
@@ -13,7 +13,10 @@ import util from 'util';
 import { UserManager } from 'xdl';
 
 import Log from '../../log';
-import { getOrPromptForBundleIdentifier, getOrPromptForPackage } from './ConfigValidation';
+import {
+  getOrPromptForBundleIdentifier,
+  getOrPromptForPackage,
+} from '../utils/getOrPromptApplicationId';
 
 // Expo managed packages that require extra update.
 // These get applied automatically to create parity with expo build in eas build.

--- a/packages/expo-cli/src/commands/eject/ensureConfigAsync.ts
+++ b/packages/expo-cli/src/commands/eject/ensureConfigAsync.ts
@@ -5,7 +5,10 @@ import path from 'path';
 
 import CommandError from '../../CommandError';
 import Log from '../../log';
-import { getOrPromptForBundleIdentifier, getOrPromptForPackage } from './ConfigValidation';
+import {
+  getOrPromptForBundleIdentifier,
+  getOrPromptForPackage,
+} from '../utils/getOrPromptApplicationId';
 
 /**
  * If an Expo config file does not exist, write a new one using the in-memory config.

--- a/packages/expo-cli/src/commands/fetch/ios.ts
+++ b/packages/expo-cli/src/commands/fetch/ios.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import CommandError from '../../CommandError';
 import { Context } from '../../credentials/context';
 import Log from '../../log';
-import { getOrPromptForBundleIdentifier } from '../eject/ConfigValidation';
+import { getOrPromptForBundleIdentifier } from '../utils/getOrPromptApplicationId';
 
 async function fetchIosCertsAsync(projectRoot: string): Promise<void> {
   const inProjectDir = (filename: string): string => path.resolve(projectRoot, filename);

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -1,8 +1,4 @@
-import { ExpoConfig, getConfig } from '@expo/config';
-import {
-  normalizeStaticPlugin,
-  resolveConfigPluginFunction,
-} from '@expo/config-plugins/build/utils/plugin-resolver';
+import { getConfig } from '@expo/config';
 import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
 import { Command } from 'commander';
@@ -12,57 +8,8 @@ import { Versions } from 'xdl';
 
 import CommandError, { SilentError } from '../CommandError';
 import Log from '../log';
-import { attemptAddingPluginsAsync } from './eject/ConfigValidation';
 import { findProjectRootAsync } from './utils/ProjectUtils';
-
-function packageHasConfigPlugin(projectRoot: string, packageName: string) {
-  try {
-    return !!resolveConfigPluginFunction(projectRoot, packageName);
-  } catch {
-    return false;
-  }
-}
-
-function getNamedPlugins(plugins: NonNullable<ExpoConfig['plugins']>): string[] {
-  const namedPlugins = [];
-  for (const plugin of plugins) {
-    try {
-      // @ts-ignore
-      const [normal] = normalizeStaticPlugin(plugin);
-      if (typeof normal === 'string') {
-        namedPlugins.push(normal);
-      }
-    } catch {
-      // ignore assertions
-    }
-  }
-  return namedPlugins;
-}
-
-async function maybePromptToAddPackagePluginsAsync(
-  projectRoot: string,
-  exp: Pick<ExpoConfig, 'plugins'>,
-  packages: string[]
-) {
-  Log.debug('Checking config plugins...');
-  const currentPlugins = exp.plugins || [];
-  const normalized = getNamedPlugins(currentPlugins);
-
-  Log.debug(`Existing plugins: ${normalized.join(', ')}`);
-
-  const plugins = packages.filter(pkg => {
-    if (normalized.includes(pkg)) {
-      // already included in plugins array
-      return false;
-    }
-    // Check if the package has a valid plugin. Must be a well-made plugin for it to work with this.
-    const hasPlugin = packageHasConfigPlugin(projectRoot, pkg);
-    Log.debug(`Package "${pkg}" has plugin: ${hasPlugin}`);
-    return hasPlugin;
-  });
-
-  await attemptAddingPluginsAsync(projectRoot, exp, plugins);
-}
+import { autoAddConfigPluginsAsync } from './utils/autoAddConfigPluginsAsync';
 
 async function resolveExpoProjectRootAsync() {
   try {
@@ -183,7 +130,7 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   Log.log(`Installing ${messages.join(' and ')} using ${packageManager.name}.`);
   await packageManager.addAsync(...versionedPackages);
 
-  await maybePromptToAddPackagePluginsAsync(
+  await autoAddConfigPluginsAsync(
     projectRoot,
     exp,
     versionedPackages.map(pkg => pkg.split('@')[0]).filter(Boolean)

--- a/packages/expo-cli/src/commands/utils/__tests__/autoAddConfigPluginsAsync-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/autoAddConfigPluginsAsync-test.ts
@@ -1,0 +1,22 @@
+import { getNamedPlugins } from '../autoAddConfigPluginsAsync';
+
+describe(getNamedPlugins, () => {
+  it('gets named plugins', () => {
+    expect(
+      getNamedPlugins([
+        'bacon',
+        '@evan/bacon',
+        '@evan/bacon/foobar.js',
+        ['./avocado.js', null],
+        // @ts-ignore
+        ['invalid', null, null],
+        // @ts-ignore
+        c => c,
+        // @ts-ignore
+        false,
+        // @ts-ignore
+        [c => c, null],
+      ])
+    ).toStrictEqual(['bacon', '@evan/bacon', '@evan/bacon/foobar.js', './avocado.js']);
+  });
+});

--- a/packages/expo-cli/src/commands/utils/__tests__/validateApplicationId-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/validateApplicationId-test.ts
@@ -1,4 +1,4 @@
-import { validateBundleId } from '../ConfigValidation';
+import { validateBundleId } from '../validateApplicationId';
 
 describe(validateBundleId, () => {
   it(`validates`, () => {

--- a/packages/expo-cli/src/commands/utils/autoAddConfigPluginsAsync.ts
+++ b/packages/expo-cli/src/commands/utils/autoAddConfigPluginsAsync.ts
@@ -1,0 +1,58 @@
+import { ExpoConfig } from '@expo/config';
+import {
+  normalizeStaticPlugin,
+  resolveConfigPluginFunction,
+} from '@expo/config-plugins/build/utils/plugin-resolver';
+
+import Log from '../../log';
+import { attemptAddingPluginsAsync } from '../eject/ConfigValidation';
+
+function packageHasConfigPlugin(projectRoot: string, packageName: string) {
+  try {
+    return !!resolveConfigPluginFunction(projectRoot, packageName);
+  } catch {
+    return false;
+  }
+}
+
+function getNamedPlugins(plugins: NonNullable<ExpoConfig['plugins']>): string[] {
+  const namedPlugins = [];
+  for (const plugin of plugins) {
+    try {
+      // @ts-ignore
+      const [normal] = normalizeStaticPlugin(plugin);
+      if (typeof normal === 'string') {
+        namedPlugins.push(normal);
+      }
+    } catch {
+      // ignore assertions
+    }
+  }
+  return namedPlugins;
+}
+
+export async function autoAddConfigPluginsAsync(
+  projectRoot: string,
+  exp: Pick<ExpoConfig, 'plugins'>,
+  packages: string[]
+) {
+  Log.debug('Checking config plugins...');
+
+  const currentPlugins = exp.plugins || [];
+  const normalized = getNamedPlugins(currentPlugins);
+
+  Log.debug(`Existing plugins: ${normalized.join(', ')}`);
+
+  const plugins = packages.filter(pkg => {
+    if (normalized.includes(pkg)) {
+      // already included in plugins array
+      return false;
+    }
+    // Check if the package has a valid plugin. Must be a well-made plugin for it to work with this.
+    const hasPlugin = packageHasConfigPlugin(projectRoot, pkg);
+    Log.debug(`Package "${pkg}" has plugin: ${hasPlugin}`);
+    return hasPlugin;
+  });
+
+  await attemptAddingPluginsAsync(projectRoot, exp, plugins);
+}

--- a/packages/expo-cli/src/commands/utils/autoAddConfigPluginsAsync.ts
+++ b/packages/expo-cli/src/commands/utils/autoAddConfigPluginsAsync.ts
@@ -5,7 +5,7 @@ import {
 } from '@expo/config-plugins/build/utils/plugin-resolver';
 
 import Log from '../../log';
-import { attemptAddingPluginsAsync } from '../eject/ConfigValidation';
+import { attemptAddingPluginsAsync } from './modifyConfigAsync';
 
 /**
  * Resolve if a package has a config plugin.

--- a/packages/expo-cli/src/commands/utils/modifyConfigAsync.ts
+++ b/packages/expo-cli/src/commands/utils/modifyConfigAsync.ts
@@ -1,0 +1,71 @@
+import { ExpoConfig, modifyConfigAsync } from '@expo/config';
+
+import { SilentError } from '../../CommandError';
+import Log from '../../log';
+
+export async function attemptModification(
+  projectRoot: string,
+  edits: Partial<ExpoConfig>,
+  exactEdits: Partial<ExpoConfig>
+): Promise<void> {
+  const modification = await modifyConfigAsync(projectRoot, edits, {
+    skipSDKVersionRequirement: true,
+  });
+  if (modification.type === 'success') {
+    Log.addNewLineIfNone();
+  } else {
+    warnAboutConfigAndThrow(modification.type, modification.message!, exactEdits);
+  }
+}
+
+function logNoConfig() {
+  Log.log(
+    Log.chalk.yellow(
+      `No Expo config was found. Please create an Expo config (${Log.chalk.bold`app.json`} or ${Log
+        .chalk.bold`app.config.js`}) in your project root.`
+    )
+  );
+}
+
+export async function attemptAddingPluginsAsync(
+  projectRoot: string,
+  exp: Pick<ExpoConfig, 'plugins'>,
+  plugins: string[]
+): Promise<void> {
+  if (!plugins.length) return;
+
+  const edits = {
+    plugins: (exp.plugins || []).concat(plugins),
+  };
+  const modification = await modifyConfigAsync(projectRoot, edits, {
+    skipSDKVersionRequirement: true,
+  });
+  if (modification.type === 'success') {
+    Log.log(`\u203A Added config plugins: ${plugins.join(', ')}`);
+  } else {
+    const exactEdits = {
+      plugins,
+    };
+    warnAboutConfigAndThrow(modification.type, modification.message!, exactEdits);
+  }
+}
+
+export function warnAboutConfigAndThrow(type: string, message: string, edits: Partial<ExpoConfig>) {
+  Log.addNewLineIfNone();
+  if (type === 'warn') {
+    // The project is using a dynamic config, give the user a helpful log and bail out.
+    Log.log(Log.chalk.yellow(message));
+  } else {
+    logNoConfig();
+  }
+
+  notifyAboutManualConfigEdits(edits);
+  throw new SilentError();
+}
+
+function notifyAboutManualConfigEdits(edits: Partial<ExpoConfig>) {
+  Log.log(Log.chalk.cyan(`Please add the following to your Expo config`));
+  Log.newLine();
+  Log.log(JSON.stringify(edits, null, 2));
+  Log.newLine();
+}

--- a/packages/expo-cli/src/commands/utils/validateApplicationId.ts
+++ b/packages/expo-cli/src/commands/utils/validateApplicationId.ts
@@ -1,0 +1,84 @@
+import got from 'got';
+
+import Log from '../../log';
+import { learnMore } from './TerminalLink';
+import { isUrlAvailableAsync } from './url';
+
+export function validateBundleId(value: string): boolean {
+  return /^[a-zA-Z0-9-.]+$/.test(value);
+}
+
+export function validatePackage(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(value);
+}
+
+const cachedBundleIdResults: Record<string, string> = {};
+const cachedPackageNameResults: Record<string, string> = {};
+
+/**
+ * A quality of life method that provides a warning when the bundle ID is already in use.
+ *
+ * @param bundleId
+ */
+export async function getBundleIdWarningAsync(bundleId: string): Promise<string | null> {
+  // Prevent fetching for the same ID multiple times.
+  if (cachedBundleIdResults[bundleId]) {
+    return cachedBundleIdResults[bundleId];
+  }
+
+  if (!(await isUrlAvailableAsync('itunes.apple.com'))) {
+    // If no network, simply skip the warnings since they'll just lead to more confusion.
+    return null;
+  }
+
+  const url = `http://itunes.apple.com/lookup?bundleId=${bundleId}`;
+  try {
+    const response = await got(url);
+    const json = JSON.parse(response.body?.trim());
+    if (json.resultCount > 0) {
+      const firstApp = json.results[0];
+      const message = formatInUseWarning(firstApp.trackName, firstApp.sellerName, bundleId);
+      cachedBundleIdResults[bundleId] = message;
+      return message;
+    }
+  } catch {
+    // Error fetching itunes data.
+  }
+  return null;
+}
+
+export async function getPackageNameWarningAsync(packageName: string): Promise<string | null> {
+  // Prevent fetching for the same ID multiple times.
+  if (cachedPackageNameResults[packageName]) {
+    return cachedPackageNameResults[packageName];
+  }
+
+  if (!(await isUrlAvailableAsync('play.google.com'))) {
+    // If no network, simply skip the warnings since they'll just lead to more confusion.
+    return null;
+  }
+
+  const url = `https://play.google.com/store/apps/details?id=${packageName}`;
+  try {
+    const response = await got(url);
+    // If the page exists, then warn the user.
+    if (response.statusCode === 200) {
+      // There is no JSON API for the Play Store so we can't concisely
+      // locate the app name and developer to match the iOS warning.
+      const message = `⚠️  The package ${Log.chalk.bold(
+        packageName
+      )} is already in use. ${Log.chalk.dim(learnMore(url))}`;
+      cachedPackageNameResults[packageName] = message;
+      return message;
+    }
+  } catch {
+    // Error fetching play store data or the page doesn't exist.
+  }
+  return null;
+}
+
+function formatInUseWarning(appName: string, author: string, id: string): string {
+  return `⚠️  The app ${Log.chalk.bold(appName)} by ${Log.chalk.italic(
+    author
+  )} is already using ${Log.chalk.bold(id)}`;
+}


### PR DESCRIPTION
# Why

1. Make setup guides easier
2. Help migrate people away from auto config plugins. Auto config plugins are bad form and shouldn't really exist since they add unexpected functionality to the project, we added them for easier migration from `expo build` to `eas build`. This will enable people to run `expo install expo-camera` and have `expo-camera` be added to their plugins array.
3. Improve migration. Guides can say "run expo install ... with all of your existing packages to add any existing config plugins". This isn't perfect since a package might need a plugin but not have one setup.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

When a user installs packages with `expo install`, the command will check if the newly installed packages have any "valid" config plugins included. 

For sanity purposes we'll only enable this feature with packages that use the app.plugin.js entry point, this will prevent packages like lodash from being confused for config plugins and corrupting the prebuild. 

If the Expo config doesn't exist, the user will be warned with what to add. Similarly if the config is dynamic then we'll warn them and bail out. Otherwise the plugins will be added and a log will be printed showing the results. 

Currently there is no mechanism for detecting if a plugin has required props, so the build could still fail if a plugin is added without those required secondary props.

# Test Plan

- `EXPO_DEBUG=1 expod install lodash` should not add lodash to plugins.
- `EXPO_DEBUG=1 expod install expo-notifications expo-brightness` should add expo-notifications and expo-brightness to plugins. Running this command again shouldn't modify the app.json. This means the plugins won't be overwritten.
- `EXPO_DEBUG=1 expod install expo-sms` should not add plugins.
- In a project with `app.config.js` - `EXPO_DEBUG=1 expod install expo-notifications` should log what to add.
- In a project without an Expo config - `EXPO_DEBUG=1 expod install expo-notifications` should log what to add and that the config needs to be created.
