### PR TITLE
[prebuild] Added template prop 

### DIFF
--- a/packages/expo-cli/src/commands/eject/Github.ts
+++ b/packages/expo-cli/src/commands/eject/Github.ts
@@ -90,7 +90,7 @@ export async function resolveTemplateArgAsync(
     if (!repoUrl) {
       const templatePath = path.resolve(template);
       if (!fs.existsSync(templatePath)) {
-        throw new CommandError('template file does not exist: ' + templatePath);
+        throw new CommandError(`template file does not exist: ${templatePath}`);
       }
 
       return await extractTemplateAppFolderAsync(templatePath, tempDir, { name: appName });

--- a/packages/expo-cli/src/commands/eject/Github.ts
+++ b/packages/expo-cli/src/commands/eject/Github.ts
@@ -1,0 +1,159 @@
+import chalk from 'chalk';
+import * as fs from 'fs-extra';
+import got from 'got';
+import { Ora } from 'ora';
+import path from 'path';
+import { Stream } from 'stream';
+import tar from 'tar';
+import { promisify } from 'util';
+
+import CommandError, { AbortCommandError } from '../../CommandError';
+import {
+  createEntryResolver,
+  createFileTransform,
+  extractTemplateAppFolderAsync,
+} from '../../utils/extractTemplateAppAsync';
+
+// @ts-ignore
+const pipeline = promisify(Stream.pipeline);
+
+type RepoInfo = {
+  username: string;
+  name: string;
+  branch: string;
+  filePath: string;
+};
+
+async function isUrlOk(url: string): Promise<boolean> {
+  const res = await got(url).catch(e => e);
+  return res.statusCode === 200;
+}
+
+async function getRepoInfo(url: any, examplePath?: string): Promise<RepoInfo | undefined> {
+  const [, username, name, t, _branch, ...file] = url.pathname.split('/');
+  const filePath = examplePath ? examplePath.replace(/^\//, '') : file.join('/');
+
+  // Support repos whose entire purpose is to be an example, e.g.
+  // https://github.com/:username/:my-cool-example-repo-name.
+  if (t === undefined) {
+    const infoResponse = await got(`https://api.github.com/repos/${username}/${name}`).catch(
+      e => e
+    );
+    if (infoResponse.statusCode !== 200) {
+      return;
+    }
+    const info = JSON.parse(infoResponse.body);
+    return { username, name, branch: info['default_branch'], filePath };
+  }
+
+  // If examplePath is available, the branch name takes the entire path
+  const branch = examplePath
+    ? `${_branch}/${file.join('/')}`.replace(new RegExp(`/${filePath}|/$`), '')
+    : _branch;
+
+  if (username && name && branch && t === 'tree') {
+    return { username, name, branch, filePath };
+  }
+  return undefined;
+}
+
+function hasRepo({ username, name, branch, filePath }: RepoInfo) {
+  const contentsUrl = `https://api.github.com/repos/${username}/${name}/contents`;
+  const packagePath = `${filePath ? `/${filePath}` : ''}/package.json`;
+
+  return isUrlOk(contentsUrl + packagePath + `?ref=${branch}`);
+}
+
+export async function resolveTemplateArgAsync(
+  tempDir: string,
+  oraInstance: Ora,
+  appName: string,
+  template: string,
+  templatePath?: string
+) {
+  let repoInfo: RepoInfo | undefined;
+
+  if (template) {
+    // @ts-ignore
+    let repoUrl: URL | undefined;
+
+    try {
+      // @ts-ignore
+      repoUrl = new URL(template);
+    } catch (error) {
+      if (error.code !== 'ERR_INVALID_URL') {
+        oraInstance.fail(error);
+        throw error;
+      }
+    }
+
+    if (!repoUrl) {
+      const templatePath = path.resolve(template);
+      if (!fs.existsSync(templatePath)) {
+        throw new CommandError('template file does not exist: ' + templatePath);
+      }
+
+      return await extractTemplateAppFolderAsync(templatePath, tempDir, { name: appName });
+    }
+
+    if (repoUrl.origin !== 'https://github.com') {
+      oraInstance.fail(
+        `Invalid URL: ${chalk.red(
+          `"${template}"`
+        )}. Only GitHub repositories are supported. Please use a GitHub URL and try again.`
+      );
+      throw new AbortCommandError();
+    }
+
+    repoInfo = await getRepoInfo(repoUrl, templatePath);
+
+    if (!repoInfo) {
+      oraInstance.fail(
+        `Found invalid GitHub URL: ${chalk.red(`"${template}"`)}. Please fix the URL and try again.`
+      );
+      throw new AbortCommandError();
+    }
+
+    const found = await hasRepo(repoInfo);
+
+    if (!found) {
+      oraInstance.fail(
+        `Could not locate the repository for ${chalk.red(
+          `"${template}"`
+        )}. Please check that the repository exists and try again.`
+      );
+      throw new AbortCommandError();
+    }
+  }
+
+  if (repoInfo) {
+    oraInstance.text = chalk.bold(
+      `Downloading files from repo ${chalk.cyan(template)}. This might take a moment.`
+    );
+
+    await downloadAndExtractRepoAsync(tempDir, repoInfo);
+  }
+
+  return true;
+}
+
+function downloadAndExtractRepoAsync(
+  root: string,
+  { username, name, branch, filePath }: RepoInfo
+): Promise<void> {
+  const projectName = path.basename(root);
+
+  const strip = filePath ? filePath.split('/').length + 1 : 1;
+  return pipeline(
+    got.stream(`https://codeload.github.com/${username}/${name}/tar.gz/${branch}`),
+    tar.extract(
+      {
+        cwd: root,
+        transform: createFileTransform({ name: projectName }),
+        onentry: createEntryResolver(projectName),
+        strip,
+      },
+      [`${name}-${branch}${filePath ? `/${filePath}` : ''}`]
+    )
+  );
+}

--- a/packages/expo-cli/src/commands/eject/createNativeProjectsFromTemplateAsync.ts
+++ b/packages/expo-cli/src/commands/eject/createNativeProjectsFromTemplateAsync.ts
@@ -10,10 +10,7 @@ import semver from 'semver';
 
 import { AbortCommandError, SilentError } from '../../CommandError';
 import Log from '../../log';
-import {
-  extractTemplateAppAsync,
-  extractTemplateAppFolderAsync,
-} from '../../utils/extractTemplateAppAsync';
+import { extractTemplateAppAsync } from '../../utils/extractTemplateAppAsync';
 import * as CreateApp from '../utils/CreateApp';
 import * as GitIgnore from '../utils/GitIgnore';
 import { resolveTemplateArgAsync } from './Github';

--- a/packages/expo-cli/src/commands/eject/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/eject/prebuildAsync.ts
@@ -11,11 +11,13 @@ import { createNativeProjectsFromTemplateAsync } from './createNativeProjectsFro
 import { ensureConfigAsync } from './ensureConfigAsync';
 import { installNodeDependenciesAsync } from './installNodeDependenciesAsync';
 import { assertPlatforms, ensureValidPlatforms } from './platformOptions';
+import { resolveTemplateOption } from './resolveTemplate';
 import { warnIfDependenciesRequireAdditionalSetup } from './setupWarnings';
 
 export type EjectAsyncOptions = {
   verbose?: boolean;
   force?: boolean;
+  template?: string;
   install?: boolean;
   packageManager?: 'npm' | 'yarn';
   platforms: ModPlatform[];
@@ -58,6 +60,7 @@ export async function prebuildAsync(
     projectRoot,
     exp,
     pkg,
+    template: options.template != null ? resolveTemplateOption(options.template) : undefined,
     tempDir,
     platforms,
     skipDependencyUpdate: options.skipDependencyUpdate,

--- a/packages/expo-cli/src/commands/eject/resolveTemplate.ts
+++ b/packages/expo-cli/src/commands/eject/resolveTemplate.ts
@@ -5,13 +5,17 @@ import { isURL } from 'xdl/build/UrlUtils';
 import CommandError from '../../CommandError';
 
 export function resolveTemplateOption(template: string) {
-  // TODO: Resolve earlier
   if (isURL(template, {})) {
-    throw new CommandError('template of type URL is not supported');
+    return template;
   }
   const templatePath = path.resolve(template);
   if (!fs.existsSync(templatePath)) {
     throw new CommandError('template file does not exist: ' + templatePath);
+  }
+  if (!fs.statSync(templatePath).isFile()) {
+    throw new CommandError(
+      'template must be a tar file created by running `npm pack` in a project: ' + templatePath
+    );
   }
   return templatePath;
 }

--- a/packages/expo-cli/src/commands/eject/resolveTemplate.ts
+++ b/packages/expo-cli/src/commands/eject/resolveTemplate.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { isURL } from 'xdl/build/UrlUtils';
+
+import CommandError from '../../CommandError';
+
+export function resolveTemplateOption(template: string) {
+  // TODO: Resolve earlier
+  if (isURL(template, {})) {
+    throw new CommandError('template of type URL is not supported');
+  }
+  const templatePath = path.resolve(template);
+  if (!fs.existsSync(templatePath)) {
+    throw new CommandError('template file does not exist: ' + templatePath);
+  }
+  return templatePath;
+}

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -57,7 +57,7 @@ export default function (program: Command) {
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
     .option(
       '--template <template>',
-      'Project template to clone from. File path pointing to a local tar file'
+      'Project template to clone from. File path pointing to a local tar file or a github repo'
     )
     .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
     .option(

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -55,6 +55,10 @@ export default function (program: Command) {
     .option('--no-install', 'Skip installing npm packages and CocoaPods.')
     .option('--clean', 'Delete the native folders and regenerate them before applying changes')
     .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
+    .option(
+      '--template <template>',
+      'Project template to clone from. File path pointing to a local tar file'
+    )
     .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
     .option(
       '--skip-dependency-update <dependencies>',

--- a/packages/expo-cli/src/utils/extractTemplateAppAsync.ts
+++ b/packages/expo-cli/src/utils/extractTemplateAppAsync.ts
@@ -113,7 +113,7 @@ export async function extractAndPrepareTemplateAppAsync(
 export async function extractTemplateAppAsync(
   templateSpec: PackageSpec,
   targetPath: string,
-  config: { name?: string }
+  config: TemplateConfig
 ) {
   await pacote.tarball.stream(
     templateSpec,
@@ -128,9 +128,19 @@ export async function extractTemplateAppAsync(
   return targetPath;
 }
 
+export async function extractTemplateAppFolderAsync(
+  tarFilePath: string,
+  targetPath: string,
+  config: TemplateConfig
+) {
+  const readStream = fs.createReadStream(tarFilePath);
+  await extractTemplateAppAsyncImpl(targetPath, config, readStream);
+  return targetPath;
+}
+
 async function extractTemplateAppAsyncImpl(
   targetPath: string,
-  config: { name?: string },
+  config: TemplateConfig,
   tarStream: Readable
 ) {
   await fs.mkdirp(targetPath);
@@ -139,7 +149,6 @@ async function extractTemplateAppAsyncImpl(
       cwd: targetPath,
       strip: 1,
       // TODO(ville): pending https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36598
-      // @ts-ignore property missing from the type definition
       transform: createFileTransform(config),
       onentry(entry: ReadEntry) {
         if (config.name) {


### PR DESCRIPTION
# Why

Make it easier to test local template modifications. Also add ability to start testing other languages.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Added `expo prebuild --template [template]` where template can be a local tar file packed with npm pack, or a github URL where the root of the repo is a template (this can be scaled to support subpaths).

# Test Plan

- Run `npm pack` in the `expo/templates/expo-template-bare-minimum/` project. Run `expo prebuild --template ../expo/templates/expo-template-bare-minimum/expo-template-bare-minimum-41.0.5.tgz --clean`
- Run `expo prebuild --template https://github.com/victorkvarghese/react-native-boilerplate`
- Run `expo prebuild --template https://github.com/victorkvarghese/react-native-boilerplatefake` to test the error message with an invalid URL.