### PR TITLE
Reset Expo.plist every time

### DIFF
--- a/packages/config-plugins/src/plugins/compiler-plugins.ts
+++ b/packages/config-plugins/src/plugins/compiler-plugins.ts
@@ -363,7 +363,7 @@ const withExpoPlistBaseMod: ConfigPlugin = config => {
   return withInterceptedMod<JSONObject>(config, {
     platform: 'ios',
     mod: 'expoPlist',
-    skipEmptyMod: true,
+    skipEmptyMod: false,
     async action({ modRequest: { nextMod, ...modRequest }, ...config }) {
       const supportingDirectory = path.join(
         modRequest.platformProjectRoot,
@@ -377,7 +377,8 @@ const withExpoPlistBaseMod: ConfigPlugin = config => {
       };
       try {
         const filePath = path.resolve(supportingDirectory, 'Expo.plist');
-        let modResults = plist.parse(await readFile(filePath, 'utf8'));
+        // Start from scratch every time.
+        let modResults = {};
 
         // TODO: Fix type
         results = await nextMod!({


### PR DESCRIPTION
# Why

- Keep state predictable.
- Support templates that don't have Expo.plist setup by default.
- [ ] Test that the Expo.plist file is linked to Xcode properly. Pending https://github.com/expo/expo-cli/pull/3439

# How

- Ignore the existing Expo.plist and start from an empty object each time. This decouples the Expo.plist logic from the templates.


