### PR TITLE
[expo-cli] use bundledNativeModules.json from api

### DIFF
--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -1,5 +1,4 @@
 import { getConfig } from '@expo/config';
-import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
 import { Command } from 'commander';
 import npmPackageArg from 'npm-package-arg';
@@ -10,6 +9,7 @@ import CommandError, { SilentError } from '../CommandError';
 import Log from '../log';
 import { findProjectRootAsync } from './utils/ProjectUtils';
 import { autoAddConfigPluginsAsync } from './utils/autoAddConfigPluginsAsync';
+import { getBundledNativeModulesAsync } from './utils/bundledNativeModules';
 
 async function resolveExpoProjectRootAsync() {
   try {
@@ -82,23 +82,7 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
     await packageManager.installAsync();
   }
 
-  const bundledNativeModulesPath = resolveFrom.silent(
-    projectRoot,
-    'expo/bundledNativeModules.json'
-  );
-
-  if (!bundledNativeModulesPath) {
-    Log.addNewLineIfNone();
-    throw new CommandError(
-      `The dependency map ${Log.chalk.bold(
-        `expo/bundledNativeModules.json`
-      )} cannot be found, please ensure you have the package "${Log.chalk
-        .bold`expo`}" installed in your project.\n`
-    );
-  }
-
-  const bundledNativeModules = await JsonFile.readAsync(bundledNativeModulesPath);
-
+  const bundledNativeModules = await getBundledNativeModulesAsync(projectRoot, exp.sdkVersion);
   const nativeModules = [];
   const others = [];
   const versionedPackages = packages.map(arg => {

--- a/packages/expo-cli/src/commands/upgrade.ts
+++ b/packages/expo-cli/src/commands/upgrade.ts
@@ -23,6 +23,7 @@ import Log from '../log';
 import { confirmAsync, selectAsync } from '../prompts';
 import { ora } from '../utils/ora';
 import { findProjectRootAsync } from './utils/ProjectUtils';
+import { getBundledNativeModulesAsync } from './utils/bundledNativeModules';
 import { assertProjectHasExpoExtensionFilesAsync } from './utils/deprecatedExtensionWarnings';
 import maybeBailOnGitStatusAsync from './utils/maybeBailOnGitStatusAsync';
 
@@ -88,9 +89,11 @@ export async function getUpdatedDependenciesAsync(
 ): Promise<{ dependencies: DependencyList; removed: string[] }> {
   // Get the updated version for any bundled modules
   const { exp, pkg } = getConfig(projectRoot);
-  const bundledNativeModules = (await JsonFile.readAsync(
-    resolveFrom(projectRoot, 'expo/bundledNativeModules.json')
-  )) as DependencyList;
+
+  const bundledNativeModules = await getBundledNativeModulesAsync(
+    projectRoot,
+    targetSdkVersionString
+  );
 
   // Smoosh regular and dev dependencies together for now
   const projectDependencies = { ...pkg.dependencies, ...pkg.devDependencies };

--- a/packages/expo-cli/src/commands/utils/__tests__/bundledNativeModules-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/bundledNativeModules-test.ts
@@ -1,0 +1,76 @@
+import { vol } from 'memfs';
+import path from 'path';
+import { ApiV2 } from 'xdl';
+
+import { mockExpoXDL } from '../../../__tests__/mock-utils';
+import { getBundledNativeModulesAsync } from '../bundledNativeModules';
+
+jest.mock('fs');
+mockExpoXDL({
+  ApiV2: {
+    clientForUser: jest.fn(),
+  },
+});
+
+describe(getBundledNativeModulesAsync, () => {
+  const projectRoot = '/test-project';
+
+  beforeEach(() => {
+    (ApiV2.clientForUser as jest.Mock).mockReset();
+    (ApiV2.clientForUser as jest.Mock).mockImplementation(() => {
+      throw new Error('Should not be called');
+    });
+    vol.reset();
+  });
+
+  it('gets the bundled native modules from api', async () => {
+    vol.fromJSON({
+      [path.join(projectRoot, 'node_modules/expo/bundledNativeModules.json')]: JSON.stringify({
+        'expo-abc': '~1.2.3',
+        'expo-def': '~0.1.2',
+      }),
+    });
+    (ApiV2.clientForUser as jest.Mock).mockImplementation(() => ({
+      getAsync: () => [
+        { npmPackage: 'expo-abc', versionRange: '~1.3.3' },
+        { npmPackage: 'expo-def', versionRange: '~0.2.2' },
+      ],
+    }));
+
+    const bundledNativeModules = await getBundledNativeModulesAsync(projectRoot, '66.0.0');
+    expect(bundledNativeModules).toEqual({
+      'expo-abc': '~1.3.3',
+      'expo-def': '~0.2.2',
+    });
+  });
+
+  it('returns the cached bundled native modules if api is down', async () => {
+    vol.fromJSON({
+      [path.join(projectRoot, 'node_modules/expo/bundledNativeModules.json')]: JSON.stringify({
+        'expo-abc': '~1.2.3',
+        'expo-def': '~0.1.2',
+      }),
+    });
+    (ApiV2.clientForUser as jest.Mock).mockImplementation(() => ({
+      getAsync: () => {
+        throw new Error('api is down');
+      },
+    }));
+
+    const bundledNativeModules = await getBundledNativeModulesAsync(projectRoot, '66.0.0');
+    expect(bundledNativeModules).toEqual({
+      'expo-abc': '~1.2.3',
+      'expo-def': '~0.1.2',
+    });
+  });
+
+  it('throws an error if api is down and expo is not installed', async () => {
+    (ApiV2.clientForUser as jest.Mock).mockImplementation(() => ({
+      getAsync: () => {
+        throw new Error('api is down');
+      },
+    }));
+
+    await expect(getBundledNativeModulesAsync(projectRoot, '66.0.0')).rejects.toThrowError();
+  });
+});

--- a/packages/expo-cli/src/commands/utils/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/validateDependenciesVersions-test.ts
@@ -1,0 +1,76 @@
+import { vol } from 'memfs';
+import path from 'path';
+
+import { validateDependenciesVersionsAsync } from '../validateDependenciesVersions';
+
+jest.mock('fs');
+
+jest.mock('../bundledNativeModules', () => ({
+  getBundledNativeModulesAsync: () => ({
+    'expo-splash-screen': '~1.2.3',
+    'expo-updates': '~2.3.4',
+  }),
+}));
+
+describe(validateDependenciesVersionsAsync, () => {
+  const projectRoot = '/test-project';
+
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('resolves to false for SDKs < 33.0.0', async () => {
+    const exp = {
+      sdkVersion: '32.0.0',
+    };
+    const pkg = {
+      dependencies: { 'expo-splash-screen': '~1.2.3', 'expo-updates': '~2.3.4' },
+    };
+
+    await expect(validateDependenciesVersionsAsync(projectRoot, exp as any, pkg)).resolves.toBe(
+      false
+    );
+  });
+
+  it('resolves to true when the installed packages match bundled native modules', async () => {
+    vol.fromJSON({
+      [path.join(projectRoot, 'node_modules/expo-splash-screen/package.json')]: JSON.stringify({
+        version: '1.2.3',
+      }),
+      [path.join(projectRoot, 'node_modules/expo-updates/package.json')]: JSON.stringify({
+        version: '2.3.4',
+      }),
+    });
+    const exp = {
+      sdkVersion: '41.0.0',
+    };
+    const pkg = {
+      dependencies: { 'expo-splash-screen': '~1.2.3', 'expo-updates': '~2.3.4' },
+    };
+
+    await expect(validateDependenciesVersionsAsync(projectRoot, exp as any, pkg)).resolves.toBe(
+      true
+    );
+  });
+
+  it('resolves to false when the installed packages do not match bundled native modules', async () => {
+    vol.fromJSON({
+      [path.join(projectRoot, 'node_modules/expo-splash-screen/package.json')]: JSON.stringify({
+        version: '0.2.3',
+      }),
+      [path.join(projectRoot, 'node_modules/expo-updates/package.json')]: JSON.stringify({
+        version: '1.3.4',
+      }),
+    });
+    const exp = {
+      sdkVersion: '41.0.0',
+    };
+    const pkg = {
+      dependencies: { 'expo-splash-screen': '~0.2.3', 'expo-updates': '~1.3.4' },
+    };
+
+    await expect(validateDependenciesVersionsAsync(projectRoot, exp as any, pkg)).resolves.toBe(
+      false
+    );
+  });
+});

--- a/packages/expo-cli/src/commands/utils/bundledNativeModules.ts
+++ b/packages/expo-cli/src/commands/utils/bundledNativeModules.ts
@@ -12,19 +12,30 @@ interface NativeModule {
 type BundledNativeModuleList = NativeModule[];
 export type BundledNativeModules = Record<string, string>;
 
+/**
+ * Gets the bundledNativeModules.json for a given SDK version:
+ * - Tries to fetch the data from the /sdks/:sdkVersion/native-modules API endpoint.
+ * - If the data is missing on the server (it can happen for SDKs that are yet fully released)
+ *    or there's a downtime, reads the local .json file from the "expo" package.
+ * - For UNVERSIONED, returns the local .json file contents.
+ */
 export async function getBundledNativeModulesAsync(
   projectRoot: string,
   sdkVersion: string
 ): Promise<BundledNativeModules> {
-  try {
-    return await getBundledNativeModulesFromApiAsync(sdkVersion);
-  } catch {
-    Log.warn(
-      `There seem to be a transient problem with Expo servers, using the cached dependency map (${Log.chalk.bold(
-        'bundledNativeModules.json'
-      )}) from the package "${Log.chalk.bold`expo`}" installed in your project.`
-    );
+  if (sdkVersion === 'UNVERSIONED') {
     return await getBundledNativeModulesFromExpoPackageAsync(projectRoot);
+  } else {
+    try {
+      return await getBundledNativeModulesFromApiAsync(sdkVersion);
+    } catch {
+      Log.warn(
+        `There seem to be a transient problem with Expo servers, using the cached dependency map (${Log.chalk.bold(
+          'bundledNativeModules.json'
+        )}) from the package "${Log.chalk.bold`expo`}" installed in your project.`
+      );
+      return await getBundledNativeModulesFromExpoPackageAsync(projectRoot);
+    }
   }
 }
 
@@ -32,6 +43,25 @@ async function getBundledNativeModulesFromApiAsync(
   sdkVersion: string
 ): Promise<BundledNativeModules> {
   const client = ApiV2.clientForUser();
+  /**
+   * The endpoint returns the list of bundled native modules for a given SDK version.
+   * The data is populated by the `et sync-bundled-native-modules` script from expo/expo repo.
+   * See the code for more details:
+   * https://github.com/expo/expo/blob/master/tools/src/commands/SyncBundledNativeModules.ts
+   *
+   * Example result:
+   * [
+   *   {
+   *     id: "79285187-e5c4-47f7-b6a9-664f5d16f0db",
+   *     sdkVersion: "41.0.0",
+   *     npmPackage: "expo-analytics-amplitude",
+   *     versionRange: "~10.1.0",
+   *     createdAt: "2021-04-29T09:34:32.825Z",
+   *     updatedAt: "2021-04-29T09:34:32.825Z"
+   *   },
+   *   ...
+   * ]
+   */
   const list = await client.getAsync(`sdks/${sdkVersion}/native-modules`);
   if (list.length === 0) {
     throw new Error('The bundled native module list from www is empty');
@@ -39,6 +69,10 @@ async function getBundledNativeModulesFromApiAsync(
   return fromBundledNativeModuleList(list);
 }
 
+/**
+ * Get the legacy static `bundledNativeModules.json` file
+ * that's shipped with the version of `expo` that the project has installed.
+ */
 async function getBundledNativeModulesFromExpoPackageAsync(
   projectRoot: string
 ): Promise<BundledNativeModules> {

--- a/packages/expo-cli/src/commands/utils/bundledNativeModules.ts
+++ b/packages/expo-cli/src/commands/utils/bundledNativeModules.ts
@@ -10,7 +10,7 @@ interface NativeModule {
   versionRange: string;
 }
 type BundledNativeModuleList = NativeModule[];
-type BundledNativeModules = Record<string, string>;
+export type BundledNativeModules = Record<string, string>;
 
 export async function getBundledNativeModulesAsync(
   projectRoot: string,

--- a/packages/expo-cli/src/commands/utils/bundledNativeModules.ts
+++ b/packages/expo-cli/src/commands/utils/bundledNativeModules.ts
@@ -1,0 +1,66 @@
+import JsonFile from '@expo/json-file';
+import resolveFrom from 'resolve-from';
+import { ApiV2 } from 'xdl';
+
+import CommandError from '../../CommandError';
+import Log from '../../log';
+
+interface NativeModule {
+  npmPackage: string;
+  versionRange: string;
+}
+type BundledNativeModuleList = NativeModule[];
+type BundledNativeModules = Record<string, string>;
+
+export async function getBundledNativeModulesAsync(
+  projectRoot: string,
+  sdkVersion: string
+): Promise<BundledNativeModules> {
+  try {
+    return await getBundledNativeModulesFromApiAsync(sdkVersion);
+  } catch {
+    Log.warn(
+      `There seem to be a transient problem with Expo servers, using the cached dependency map (${Log.chalk.bold(
+        'bundledNativeModules.json'
+      )}) from the package "${Log.chalk.bold`expo`}" installed in your project.`
+    );
+    return await getBundledNativeModulesFromExpoPackageAsync(projectRoot);
+  }
+}
+
+async function getBundledNativeModulesFromApiAsync(
+  sdkVersion: string
+): Promise<BundledNativeModules> {
+  const client = ApiV2.clientForUser();
+  const list = await client.getAsync(`sdks/${sdkVersion}/native-modules`);
+  if (list.length === 0) {
+    throw new Error('The bundled native module list from www is empty');
+  }
+  return fromBundledNativeModuleList(list);
+}
+
+async function getBundledNativeModulesFromExpoPackageAsync(
+  projectRoot: string
+): Promise<BundledNativeModules> {
+  const bundledNativeModulesPath = resolveFrom.silent(
+    projectRoot,
+    'expo/bundledNativeModules.json'
+  );
+  if (!bundledNativeModulesPath) {
+    Log.addNewLineIfNone();
+    throw new CommandError(
+      `The dependency map ${Log.chalk.bold(
+        `expo/bundledNativeModules.json`
+      )} cannot be found, please ensure you have the package "${Log.chalk
+        .bold`expo`}" installed in your project.\n`
+    );
+  }
+  return await JsonFile.readAsync<BundledNativeModules>(bundledNativeModulesPath);
+}
+
+function fromBundledNativeModuleList(list: BundledNativeModuleList): BundledNativeModules {
+  return list.reduce((acc, i) => {
+    acc[i.npmPackage] = i.versionRange;
+    return acc;
+  }, {} as BundledNativeModules);
+}

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -2,11 +2,14 @@ import { ExpoConfig, PackageJSONConfig } from '@expo/config';
 import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
 import intersection from 'lodash/intersection';
+import nullthrows from 'nullthrows';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 import { Versions } from 'xdl';
 
+import CommandError from '../../CommandError';
 import Log from '../../log';
+import { BundledNativeModules, getBundledNativeModulesAsync } from './bundledNativeModules';
 
 export async function validateDependenciesVersionsAsync(
   projectRoot: string,
@@ -17,8 +20,14 @@ export async function validateDependenciesVersionsAsync(
     return false;
   }
 
-  const bundleNativeModulesPath = resolveFrom.silent(projectRoot, 'expo/bundledNativeModules.json');
-  if (!bundleNativeModulesPath) {
+  let bundledNativeModules: BundledNativeModules | null = null;
+  try {
+    bundledNativeModules = await getBundledNativeModulesAsync(
+      projectRoot,
+      // sdkVersion is defined here because we ran the >= 33.0.0 check before
+      nullthrows(exp.sdkVersion)
+    );
+  } catch {
     Log.warn(
       `Your project is in SDK version >= 33.0.0, but the ${chalk.underline(
         'expo'
@@ -27,34 +36,45 @@ export async function validateDependenciesVersionsAsync(
     return false;
   }
 
-  const bundledNativeModules = await JsonFile.readAsync(bundleNativeModulesPath);
   const bundledNativeModulesNames = Object.keys(bundledNativeModules);
   const projectDependencies = Object.keys(pkg.dependencies || []);
 
-  const modulesToCheck = intersection(bundledNativeModulesNames, projectDependencies);
-  const incorrectDeps = [];
-  for (const moduleName of modulesToCheck) {
-    const expectedRange = bundledNativeModules[moduleName];
-    const actualRange = pkg.dependencies[moduleName];
+  const packagesToCheck = intersection(bundledNativeModulesNames, projectDependencies);
+  const incorrectDeps: {
+    packageName: string;
+    expectedVersionOrRange: string;
+    actualVersion: string;
+  }[] = [];
+
+  const packageVersionsFromPackageJSON = await Promise.all(
+    packagesToCheck.map(packageName => getPackageVersionAsync(projectRoot, packageName))
+  );
+  const packageVersions = packagesToCheck.reduce((acc, packageName, idx) => {
+    acc[packageName] = packageVersionsFromPackageJSON[idx];
+    return acc;
+  }, {} as Record<string, string>);
+
+  for (const packageName of packagesToCheck) {
+    const expectedVersionOrRange = bundledNativeModules[packageName];
+    const actualVersion = packageVersions[packageName];
     if (
-      (semver.valid(actualRange) || semver.validRange(actualRange)) &&
-      typeof expectedRange === 'string' &&
-      !semver.intersects(expectedRange, actualRange)
+      typeof expectedVersionOrRange === 'string' &&
+      !semver.intersects(expectedVersionOrRange, actualVersion)
     ) {
       incorrectDeps.push({
-        moduleName,
-        expectedRange,
-        actualRange,
+        packageName,
+        expectedVersionOrRange,
+        actualVersion,
       });
     }
   }
   if (incorrectDeps.length > 0) {
     Log.warn('Some dependencies are incompatible with the installed expo package version:');
-    incorrectDeps.forEach(({ moduleName, expectedRange, actualRange }) => {
+    incorrectDeps.forEach(({ packageName, expectedVersionOrRange, actualVersion }) => {
       Log.warn(
-        ` - ${chalk.underline(moduleName)} - expected version range: ${chalk.underline(
-          expectedRange
-        )} - actual version installed: ${chalk.underline(actualRange)}`
+        ` - ${chalk.underline(packageName)} - expected version: ${chalk.underline(
+          expectedVersionOrRange
+        )} - actual version installed: ${chalk.underline(actualVersion)}`
       );
     });
     Log.warn(
@@ -66,4 +86,15 @@ export async function validateDependenciesVersionsAsync(
     return false;
   }
   return true;
+}
+
+async function getPackageVersionAsync(projectRoot: string, packageName: string): Promise<string> {
+  const packageJsonPath = resolveFrom.silent(projectRoot, `${packageName}/package.json`);
+  if (!packageJsonPath) {
+    throw new CommandError(
+      `"${packageName}" is added as a dependency in your project's package.json but it doesn't seem to be installed. Please run "yarn" or "npm install" to fix this issue.`
+    );
+  }
+  const packageJson = await JsonFile.readAsync<BundledNativeModules>(packageJsonPath);
+  return packageJson.version;
 }


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-806/turn-bundlednativemodulesjson-into-an-api-endpoint

https://www.notion.so/expo/SDK-42-Plan-5bde287ed44349ad8740998123223ed0

> Make bundledNativeModules easier to update by moving it to an API endpoint rather than json file embedded in expo package

- https://github.com/expo/universe/pull/7426 added API endpoint that serves the bundledNativeModules.json from the db (and also another endpoint for syncing the json file with www)
- https://github.com/expo/expo/pull/12760 added the script to sync bundledNativeModules.json with www

This PR makes Expo CLI use the versions of bundled native modules from the API.

# How

- https://github.com/expo/expo-cli/pull/3444/commits/7df8c9aea309adc7f5d3882af8c7ef91b9f9f2b6 adds the function `getBundledNativeModulesAsync` that reads the bundledNativeModules.json from API. If the API is down (or throws an error) then it serves bundledNativeModules.json from the `expo` package installed locally. This commit also makes `expo install` use the function instead of reading the json straight from the `expo` package. 
- https://github.com/expo/expo-cli/pull/3444/commits/4aa81d11f456b0e37c3722ebccf21d047bc85056 makes `expo upgrade` use the new function.
- https://github.com/expo/expo-cli/pull/3444/commits/5f95cf6a8a8ee31d720960187ce87a3e1bb252ca makes `expo start` also use the new function. It also improves the `validateDependenciesVersionsAsync` function so it reads the exact versions of dependencies from their package.json files instead of relying on the versions from the project's package.json.

# Test Plan

I added unit tests for the function `getBundledNativeModulesAsync`.

I also inited a test project and ran: 
- `expo upgrade`
- `expo install expo-file-system`
- `expo start`
- 
All those commands worked properly. The cached json hasn't been used as the warning didn't show up. 