### PR TITLE
For  to projects made in (blank) TypeScripte

### DIFF
--- a/packages/expo-cli/README.md
+++ b/packages/expo-cli/README.md
@@ -30,7 +30,19 @@ To view this on your phone, do the following:
 To publish something you've made, just follow these steps:
 
 - Create an Expo account or login to an existing one by running `expo login`.
-- Run an Expo CLI server using `expo start`.
+- Run an Expo CLI server usingTo run your project, navigate to the directory and run one of the following yarn commands.
+
+yarn start # you can open iOS, Android, or web from here, or run them directly with the commands below.
+
+yarn android
+
+yarn ios # requires an iOS device or macOS for access to an iOS simulator
+
+yarn web
+
+yarn web
+yarn run v1.22.10
+$ expo start --web.
 - Check to make sure you can load your app by opening it in the Expo app.
 - Once everything looks good, run `expo publish`. A few seconds later, you should get a clean URL sent to you that points to the exp.host server where your package was published to.
 


### PR DESCRIPTION
 - Run `expo send` to send a link via email. You can also use the `--send-to` option when running `expo start`.

- Check your e-mail and tap the link. The Expo app should open and you should be able to view your experience there!

## Publishing a Project

To publish something you've made, just follow these steps:

- Create an Expo account or login to an existing one by running `expo login`.
- Run an Expo CLI server using `expo start`.
- Check to make sure you can load your app by opening it in the Expo app.
- Once everything looks good, run `expo publish`. A few seconds later, you should get a clean URL sent to you that points to the exp.host server where your package was published to.

Nessessario when adding typing to projects made in (blank) TypeScripte

To run your project, navigate to the directory and run one of the following yarn commands.

yarn start # you can open iOS, Android, or web from here, or run them directly with the commands below.

yarn android

yarn ios # requires an iOS device or macOS for access to an iOS simulator

yarn web

yarn web
yarn run v1.22.10
$ expo start --web

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->