### PR TITLE
[expo-cli] remove dead code

### DIFF
--- a/packages/expo-cli/src/commands/export.ts
+++ b/packages/expo-cli/src/commands/export.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { UrlUtils } from 'xdl';
 
-import CommandError, { SilentError } from '../CommandError';
+import CommandError from '../CommandError';
 import Log from '../log';
 import prompt from '../prompts';
 import { exportAppAsync } from './export/exportAppAsync';
@@ -171,24 +171,12 @@ export async function action(projectRoot: string, options: Options) {
   const outputPath = path.resolve(projectRoot, options.outputDir);
   await fs.ensureDir(outputPath);
 
-  // Assert if the folder has contents
-  if (
-    !(await CreateApp.assertFolderEmptyAsync({
-      projectRoot: outputPath,
-      folderName: options.outputDir,
-      // Always overwrite files, this is inline with most bundler tooling.
-      overwrite: true,
-      // overwrite: options.force,
-    }))
-  ) {
-    const message = `Try using a new directory name with ${Log.chalk.bold(
-      '--output-dir'
-    )}, moving these files, or using ${Log.chalk.bold('--force')} to overwrite them.`;
-    Log.newLine();
-    Log.nested(message);
-    Log.newLine();
-    throw new SilentError(message);
-  }
+  await CreateApp.assertFolderEmptyAsync({
+    projectRoot: outputPath,
+    folderName: options.outputDir,
+    // Always overwrite files, this is inline with most bundler tooling.
+    overwrite: true,
+  });
 
   // Wrap the XDL method for exporting assets
   await exportFilesAsync(projectRoot, options);


### PR DESCRIPTION
# Why
Follow up for https://github.com/expo/expo-cli/pull/3395/files

This will never return false if `overwrite = true`: https://github.com/expo/expo-cli/blob/a2542a74972ec47815f555e974e45943af888f16/packages/expo-cli/src/commands/utils/CreateApp.ts#L53

# How

removed if statement
