### PR TITLE
[config-plugins][config-types] set default url returned by getUpdateU…

### DIFF
--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -1,9 +1,9 @@
-import { ExpoConfig } from '@expo/config-types';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidManifest } from '../plugins/android-plugins';
+import { ExpoConfigUpdates, getUpdateUrl } from '../utils/Updates';
 import {
   addMetaDataItemToMainApplication,
   AndroidManifest,
@@ -13,11 +13,6 @@ import {
 } from './Manifest';
 
 const CREATE_MANIFEST_ANDROID_PATH = 'expo-updates/scripts/create-manifest-android.gradle';
-
-type ExpoConfigUpdates = Pick<
-  ExpoConfig,
-  'sdkVersion' | 'owner' | 'runtimeVersion' | 'updates' | 'slug'
->;
 
 export enum Config {
   ENABLED = 'expo.modules.updates.ENABLED',
@@ -39,17 +34,6 @@ export const withUpdates: ConfigPlugin<{ expoUsername: string | null }> = (
     return config;
   });
 };
-
-export function getUpdateUrl(
-  config: Pick<ExpoConfigUpdates, 'owner' | 'slug'>,
-  username: string | null
-): string | null {
-  const user = typeof config.owner === 'string' ? config.owner : username;
-  if (!user) {
-    return null;
-  }
-  return `https://exp.host/@${user}/${config.slug}`;
-}
 
 export function getRuntimeVersion(
   config: Pick<ExpoConfigUpdates, 'runtimeVersion'>
@@ -104,11 +88,13 @@ export function setUpdatesConfig(
   );
 
   const updateUrl = getUpdateUrl(config, username);
+  console.log({ updateUrl });
   if (updateUrl) {
     addMetaDataItemToMainApplication(mainApplication, Config.UPDATE_URL, updateUrl);
   } else {
     removeMetaDataItemFromMainApplication(mainApplication, Config.UPDATE_URL);
   }
+  console.log({ mainApplication });
 
   return setVersionsConfig(config, androidManifest);
 }

--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -88,13 +88,11 @@ export function setUpdatesConfig(
   );
 
   const updateUrl = getUpdateUrl(config, username);
-  console.log({ updateUrl });
   if (updateUrl) {
     addMetaDataItemToMainApplication(mainApplication, Config.UPDATE_URL, updateUrl);
   } else {
     removeMetaDataItemFromMainApplication(mainApplication, Config.UPDATE_URL);
   }
-  console.log({ mainApplication });
 
   return setVersionsConfig(config, androidManifest);
 }

--- a/packages/config-plugins/src/android/__tests__/Updates-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Updates-test.ts
@@ -26,7 +26,6 @@ describe('Android Updates config', () => {
 
   it(`returns correct default values from all getters if no value provided`, () => {
     expect(Updates.getSDKVersion({})).toBe(null);
-    expect(Updates.getUpdateUrl({ slug: 'foo' }, null)).toBe(null);
     expect(Updates.getUpdatesCheckOnLaunch({})).toBe('ALWAYS');
     expect(Updates.getUpdatesEnabled({})).toBe(true);
     expect(Updates.getUpdatesTimeout({})).toBe(0);
@@ -34,10 +33,6 @@ describe('Android Updates config', () => {
 
   it(`returns correct value from all getters if value provided`, () => {
     expect(Updates.getSDKVersion({ sdkVersion: '37.0.0' })).toBe('37.0.0');
-    expect(Updates.getUpdateUrl({ slug: 'my-app' }, 'user')).toBe('https://exp.host/@user/my-app');
-    expect(Updates.getUpdateUrl({ slug: 'my-app', owner: 'owner' }, 'user')).toBe(
-      'https://exp.host/@owner/my-app'
-    );
     expect(
       Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } })
     ).toBe('NEVER');

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -5,6 +5,7 @@ import xcode from 'xcode';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withExpoPlist } from '../plugins/ios-plugins';
+import { getUpdateUrl } from '../utils/Updates';
 import { ExpoPlist } from './IosConfig.types';
 
 const CREATE_MANIFEST_IOS_PATH = 'expo-updates/scripts/create-manifest-ios.sh';
@@ -23,17 +24,6 @@ export enum Config {
   UPDATE_URL = 'EXUpdatesURL',
   RELEASE_CHANNEL = 'EXUpdatesReleaseChannel',
   UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = 'EXUpdatesRequestHeaders',
-}
-
-export function getUpdateUrl(
-  config: Pick<ExpoConfigUpdates, 'owner' | 'slug'>,
-  username: string | null
-): string | null {
-  const user = typeof config.owner === 'string' ? config.owner : username;
-  if (!user) {
-    return null;
-  }
-  return `https://exp.host/@${user}/${config.slug}`;
 }
 
 export function getRuntimeVersion(

--- a/packages/config-plugins/src/ios/__tests__/Updates-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Updates-test.ts
@@ -14,7 +14,6 @@ const { silent } = require('resolve-from');
 describe('iOS Updates config', () => {
   it(`returns correct default values from all getters if no value provided`, () => {
     expect(Updates.getSDKVersion({})).toBe(null);
-    expect(Updates.getUpdateUrl({ slug: 'foo' }, null)).toBe(null);
     expect(Updates.getUpdatesCheckOnLaunch({})).toBe('ALWAYS');
     expect(Updates.getUpdatesEnabled({})).toBe(true);
     expect(Updates.getUpdatesTimeout({})).toBe(0);
@@ -22,10 +21,6 @@ describe('iOS Updates config', () => {
 
   it(`returns correct value from all getters if value provided`, () => {
     expect(Updates.getSDKVersion({ sdkVersion: '37.0.0' })).toBe('37.0.0');
-    expect(Updates.getUpdateUrl({ slug: 'my-app' }, 'user')).toBe('https://exp.host/@user/my-app');
-    expect(Updates.getUpdateUrl({ slug: 'my-app', owner: 'owner' }, 'user')).toBe(
-      'https://exp.host/@owner/my-app'
-    );
     expect(
       Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } })
     ).toBe('NEVER');

--- a/packages/config-plugins/src/utils/Updates.ts
+++ b/packages/config-plugins/src/utils/Updates.ts
@@ -1,0 +1,21 @@
+import { ExpoConfig } from '@expo/config-types';
+
+export type ExpoConfigUpdates = Pick<
+  ExpoConfig,
+  'sdkVersion' | 'owner' | 'runtimeVersion' | 'updates' | 'slug'
+>;
+
+export function getUpdateUrl(
+  config: Pick<ExpoConfigUpdates, 'owner' | 'slug' | 'updates'>,
+  username: string | null
+): string | null {
+  if (config.updates?.url) {
+    return config.updates?.url;
+  }
+
+  const user = typeof config.owner === 'string' ? config.owner : username;
+  if (!user) {
+    return null;
+  }
+  return `https://exp.host/@${user}/${config.slug}`;
+}

--- a/packages/config-plugins/src/utils/__tests__/Updates-test.ts
+++ b/packages/config-plugins/src/utils/__tests__/Updates-test.ts
@@ -1,0 +1,20 @@
+import { getUpdateUrl } from '../Updates';
+
+it(`returns correct default values from all getters if no value provided.`, () => {
+  const url = 'https://u.expo.dev/00000000-0000-0000-0000-000000000000';
+  expect(getUpdateUrl({ updates: { url }, slug: 'foo' }, 'user')).toBe(url);
+});
+
+it(`returns null if neither 'updates.url' or 'user' is supplied.`, () => {
+  expect(getUpdateUrl({ slug: 'foo' }, null)).toBe(null);
+});
+
+it(`returns correct legacy urls if 'updates.url' is not provided, but 'slug' and ('username'|'owner') are provided.`, () => {
+  expect(getUpdateUrl({ slug: 'my-app' }, 'user')).toBe('https://exp.host/@user/my-app');
+  expect(getUpdateUrl({ slug: 'my-app', owner: 'owner' }, 'user')).toBe(
+    'https://exp.host/@owner/my-app'
+  );
+  expect(getUpdateUrl({ slug: 'my-app', owner: 'owner' }, null)).toBe(
+    'https://exp.host/@owner/my-app'
+  );
+});


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Currently we assume that the update URL is `https://expo.dev/@owner/slug`. This is no longer a safe assumption with the coming of EAS Update.

Further this will be nice even for people running self-hosted classic updates.

closes ENG-1489

# How

Add an optional `url` field in the updates config of `app.json`. If nothing is specified, it will fall back to the classic updates URL.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Updated tests.
Ran in a demo repo with the versions `expo-updates` config disabled.
Confirmed custom URL is set.
Confirmed classic URL is set in fallback case.