### PR TITLE
output logs and clear on pod folder

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/Podfile.ts
+++ b/packages/expo-cli/src/commands/run/ios/Podfile.ts
@@ -88,6 +88,11 @@ function isLockfileCreated(projectRoot: string): boolean {
   return fs.existsSync(podfileLockPath);
 }
 
+function isPodFolderCreated(projectRoot: string): boolean {
+  const podFolderPath = path.join(projectRoot, 'ios', 'Pods');
+  return fs.existsSync(podFolderPath);
+}
+
 // TODO: Same process but with app.config changes + default plugins.
 // This will ensure the user is prompted for extra setup.
 export default async function maybePromptToSyncPodsAsync(projectRoot: string) {
@@ -95,7 +100,7 @@ export default async function maybePromptToSyncPodsAsync(projectRoot: string) {
     // Project does not use CocoaPods
     return;
   }
-  if (!isLockfileCreated(projectRoot)) {
+  if (!isLockfileCreated(projectRoot) || !isPodFolderCreated(projectRoot)) {
     if (!(await installCocoaPodsAsync(projectRoot))) {
       throw new AbortCommandError();
     }

--- a/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
+++ b/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
@@ -272,15 +272,16 @@ function writeBuildLogs(projectRoot: string, buildOutput: string, errorOutput: s
     '\n```\n\n# Error output\n\n```log\n' +
     errorOutput +
     '\n```\n';
-  const logFilePath = getErrorLogFilePath(projectRoot);
+  const [mdFilePath, logFilePath] = getErrorLogFilePath(projectRoot);
 
-  fs.writeFileSync(logFilePath, output);
-  return logFilePath;
+  fs.writeFileSync(mdFilePath, output);
+  fs.writeFileSync(logFilePath, buildOutput);
+  return mdFilePath;
 }
 
-function getErrorLogFilePath(projectRoot: string): string {
+function getErrorLogFilePath(projectRoot: string): [string, string] {
   const filename = 'xcodebuild.md';
   const folder = path.join(projectRoot, '.expo');
   fs.ensureDirSync(folder);
-  return path.join(folder, filename);
+  return [path.join(folder, filename), path.join(folder, 'xcodebuild-output.log')];
 }


### PR DESCRIPTION
# Why

- Missing pods folder should trigger a rebuild
- Print logs for easier examination
