### PR TITLE
Only auto add plugins if the plugins array is defined or the project is greater than 42

### DIFF
--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -130,11 +130,14 @@ async function installAsync(packages: string[], options: PackageManager.CreateFo
   Log.log(`Installing ${messages.join(' and ')} using ${packageManager.name}.`);
   await packageManager.addAsync(...versionedPackages);
 
-  await autoAddConfigPluginsAsync(
-    projectRoot,
-    exp,
-    versionedPackages.map(pkg => pkg.split('@')[0]).filter(Boolean)
-  );
+  // Only auto add plugins if the plugins array is defined or if the project is using SDK +42.
+  if (Versions.gteSdkVersion(exp, '42.0.0') || Array.isArray(exp.plugins)) {
+    await autoAddConfigPluginsAsync(
+      projectRoot,
+      exp,
+      versionedPackages.map(pkg => pkg.split('@')[0]).filter(Boolean)
+    );
+  }
 }
 
 export default function install(program: Command) {


### PR DESCRIPTION
# Why

Make the transition less confusing for users who aren't using eas build