### PR TITLE
[run] add --no-bundler option

### DIFF
--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -142,11 +142,7 @@ export async function runAndroidActionAsync(projectRoot: string, options: Option
 
   if (props.bundler) {
     // TODO: unify logs
-    Log.nested(
-      `\nLogs for your project will appear in the browser console. ${chalk.dim(
-        `Press Ctrl+C to exit.`
-      )}`
-    );
+    Log.nested(`\nLogs for your project will appear below. ${chalk.dim(`Press Ctrl+C to exit.`)}`);
   }
 }
 

--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -67,7 +67,7 @@ async function resolveOptionsAsync(
     throw new CommandError(`Could not find package name in AndroidManifest.xml at "${filePath}"`);
   }
 
-  let port = await resolvePortAsync(projectRoot, options.port);
+  let port = options.bundler ? await resolvePortAsync(projectRoot, options.port) : null;
   options.bundler = !!port;
   if (!port) {
     // Skip bundling if the port is null

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -6,8 +6,9 @@ import { runIosActionAsync } from './ios/runIos';
 export default function (program: Command) {
   program
     .command('run:android [path]')
-    .helpGroup('internal')
     .description('Run the Android app binary locally')
+    .helpGroup('internal')
+    .option('--no-bundler', 'Skip starting the Metro bundler')
     .option('-d, --device [device]', 'Device name to build the app on')
     .option('-p, --port <port>', 'Port to start the Metro bundler on. Default: 8081')
     .option('--variant [name]', '(Android) build variant', 'debug')
@@ -16,6 +17,7 @@ export default function (program: Command) {
     .command('run:ios [path]')
     .description('Run the iOS app binary locally')
     .helpGroup('internal')
+    .option('--no-bundler', 'Skip starting the Metro bundler')
     .option('-d, --device [device]', 'Device name or UDID to build the app on')
     .option('-p, --port <port>', 'Port to start the Metro bundler on. Default: 8081')
     .option('--scheme <scheme>', 'Scheme to build')

--- a/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
@@ -77,7 +77,7 @@ export async function resolveOptionsAsync(
 
   const isSimulator = !('deviceType' in device);
 
-  let port = await resolvePortAsync(projectRoot, options.port);
+  let port = options.bundler ? await resolvePortAsync(projectRoot, options.port) : null;
   // Skip bundling if the port is null
   options.bundler = !!port;
   if (!port) {

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -79,11 +79,7 @@ export async function runIosActionAsync(projectRoot: string, options: Options) {
   }
 
   if (props.shouldStartBundler) {
-    Log.nested(
-      `\nLogs for your project will appear in the browser console. ${chalk.dim(
-        `Press Ctrl+C to exit.`
-      )}`
-    );
+    Log.nested(`\nLogs for your project will appear below. ${chalk.dim(`Press Ctrl+C to exit.`)}`);
   }
 }
 
@@ -134,6 +130,8 @@ async function openInSimulatorAsync({
       udid: device.udid,
       devClient: true,
       scheme,
+      // We always setup native logs before launching to ensure we catch any fatal errors.
+      skipNativeLogs: true,
     });
     if (!result.success) {
       // TODO: Maybe fallback on using the bundle identifier.

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -580,6 +580,7 @@ async function openUrlInSimulatorSafeAsync({
   devClient = false,
   projectRoot,
   exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
+  skipNativeLogs = false,
 }: {
   url: string;
   udid?: string;
@@ -588,6 +589,7 @@ async function openUrlInSimulatorSafeAsync({
   devClient?: boolean;
   exp?: ExpoConfig;
   projectRoot: string;
+  skipNativeLogs?: boolean;
 }): Promise<
   | { success: true; device: SimControl.SimulatorDevice; bundleIdentifier: string }
   | { success: false; msg: string }
@@ -611,8 +613,10 @@ async function openUrlInSimulatorSafeAsync({
         exp
       );
       await profileMethod(assertDevClientInstalledAsync)(simulator, bundleIdentifier);
-      // stream logs before opening the client.
-      await streamLogsAsync({ udid: simulator.udid, bundleIdentifier });
+      if (!skipNativeLogs) {
+        // stream logs before opening the client.
+        await streamLogsAsync({ udid: simulator.udid, bundleIdentifier });
+      }
     } else if (!isDetached) {
       await ensureExpoClientInstalledAsync(simulator, sdkVersion);
       _lastUrl = url;
@@ -742,12 +746,14 @@ export async function openProjectAsync({
   devClient,
   udid,
   scheme,
+  skipNativeLogs,
 }: {
   projectRoot: string;
   shouldPrompt?: boolean;
   devClient?: boolean;
   scheme?: string;
   udid?: string;
+  skipNativeLogs?: boolean;
 }): Promise<
   | { success: true; url: string; udid: string; bundleIdentifier: string }
   | { success: false; error: string }
@@ -787,6 +793,7 @@ export async function openProjectAsync({
     devClient,
     exp,
     projectRoot,
+    skipNativeLogs,
   });
 
   if (result.success) {


### PR DESCRIPTION
# Why

Allow skipping the bundler and native syslogs in run commands when the user passes `--no-bundler` (maybe `--no-serve` is better?). We skip the syslogs to provide the users with a way to run the command and have it end (no long running tasks).

