### PR TITLE
Pad titles in log formatter and add duration

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -80,7 +80,7 @@
     "@expo/results": "^1.0.0",
     "@expo/simple-spinner": "1.0.2",
     "@expo/spawn-async": "1.5.0",
-    "@expo/xcpretty": "~2.0.0",
+    "@expo/xcpretty": "~2.0.1",
     "@hapi/joi": "^17.1.1",
     "babel-runtime": "6.26.0",
     "base32.js": "0.1.0",

--- a/packages/expo-cli/src/commands/run/ios/ExpoLogFormatter.ts
+++ b/packages/expo-cli/src/commands/run/ios/ExpoLogFormatter.ts
@@ -1,5 +1,4 @@
-import { FileOperation, Formatter, Parser } from '@expo/xcpretty';
-import { switchRegex } from '@expo/xcpretty/build/switchRegex';
+import { FileOperation, Formatter, Parser, switchRegex } from '@expo/xcpretty';
 import chalk from 'chalk';
 import findUp from 'find-up';
 import path from 'path';
@@ -106,6 +105,10 @@ type CustomProps = {
 };
 
 export class ExpoLogFormatter extends Formatter {
+  static logPrettyItem(message: string) {
+    Log.log(`${chalk.whiteBright`\u203A`} ${message}`);
+  }
+
   private nativeProjectRoot: string;
 
   constructor(public props: CustomProps) {
@@ -139,17 +142,17 @@ export class ExpoLogFormatter extends Formatter {
       case 'GenerateDSYMFile':
         return `Generating debug`;
       case 'Ld':
-        return 'Linking';
+        return 'Linking  ';
       case 'Libtool':
-        return 'Building lib';
+        return 'Packaging';
       case 'ProcessPCH':
         return 'Precompiling';
       case 'ProcessInfoPlistFile':
-        return 'Processing';
+        return 'Preparing';
       case 'CodeSign':
-        return 'Signing';
+        return 'Signing  ';
       case 'Touch':
-        return 'Creating';
+        return 'Creating ';
       case 'CompileC':
       case 'CompileSwift':
       case 'CompileXIB':
@@ -176,7 +179,7 @@ export class ExpoLogFormatter extends Formatter {
     const moduleNameTag = this.getPkgName('', target);
 
     return Formatter.format(
-      'Running script',
+      'Executing',
       [moduleNameTag, Formatter.formatBreadCrumb(scriptName, target, project)]
         .filter(Boolean)
         .join(' ')

--- a/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
+++ b/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
@@ -159,10 +159,6 @@ function getProcessOptions({
   };
 }
 
-export function logPrettyItem(message: string) {
-  Log.log(`${chalk.whiteBright`\u203A`} ${message}`);
-}
-
 export async function buildAsync({
   projectRoot,
   xcodeProject,
@@ -196,7 +192,7 @@ export async function buildAsync({
     }
   }
 
-  logPrettyItem(chalk.bold`Planning build`);
+  ExpoLogFormatter.logPrettyItem(chalk.bold`Planning build`);
   Log.debug(`  xcodebuild ${args.join(' ')}`);
   const podfileLock = path.join(projectRoot, 'ios', 'Podfile.lock');
   const appName = xcodeProject.name.match(/.*\/(.*)\.\w+/)?.[1] || '';

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -10,6 +10,7 @@ import { EjectAsyncOptions, prebuildAsync } from '../../eject/prebuildAsync';
 import { profileMethod } from '../../utils/profileMethod';
 import { parseBinaryPlistAsync } from '../utils/binaryPlist';
 import { isDevMenuInstalled } from '../utils/isDevMenuInstalled';
+import { ExpoLogFormatter } from './ExpoLogFormatter';
 import * as IOSDeploy from './IOSDeploy';
 import maybePromptToSyncPodsAsync from './Podfile';
 import * as XcodeBuild from './XcodeBuild';
@@ -60,7 +61,7 @@ export async function runIosActionAsync(projectRoot: string, options: Options) {
   const bundleIdentifier = await profileMethod(getBundleIdentifierForBinaryAsync)(binaryPath);
 
   if (props.isSimulator) {
-    XcodeBuild.logPrettyItem(`${chalk.bold`Installing`} on ${props.device.name}`);
+    ExpoLogFormatter.logPrettyItem(`${chalk.bold`Installing`} on ${props.device.name}`);
     await SimControl.installAsync({ udid: props.device.udid, dir: binaryPath });
 
     await openInSimulatorAsync({
@@ -100,7 +101,7 @@ async function openInSimulatorAsync({
   device: XcodeBuild.BuildProps['device'];
   shouldStartBundler?: boolean;
 }) {
-  XcodeBuild.logPrettyItem(
+  ExpoLogFormatter.logPrettyItem(
     `${chalk.bold`Opening`} on ${device.name} ${chalk.dim(`(${bundleIdentifier})`)}`
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,10 +1600,10 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
-"@expo/xcpretty@~2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-2.0.0.tgz#6613ec19093c90e77e203e92b5f335cc13f55c8e"
-  integrity sha512-bukgcPcsiZq7dYxpSVPQ/qvSDrwpUVSkgEf8NQJS9UcClPakgpM+e5XIzYWe2WXLmHtskVJUPruoEX6zWUm8LA==
+"@expo/xcpretty@~2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-2.0.1.tgz#2c912166ca50a88f710cfe3b6b441144f5df14a2"
+  integrity sha512-fyQbzvZpLiKpx68QDzeLlL1AtFhhEW35dqxIqb4QQ6e3iofu57NdWBQTmIAQzDOPcNNXUR9SFncu3M4iyWwQ7Q==
   dependencies:
     "@babel/code-frame" "7.10.4"
     chalk "^4.1.0"


### PR DESCRIPTION
# Why

Make things more even:
```
› Preparing Pods/expo-dev-menu-EXDevMenu » ResourceBundle-EXDevMenu-expo-dev-menu-Info.plist
› Signing   Pods/expo-dev-menu-EXDevMenu » EXDevMenu.bundle
› Compiling expo-dev-menu Pods/expo-dev-menu » DevMenuREAAllTransitions.m
› Packaging expo-dev-menu Pods/expo-dev-menu » libexpo-dev-menu.a
› Executing expo-dev-menu Pods/expo-dev-menu » Copy generated compatibility header
```

Add build duration
```
› Build Succeeded (22.382 sec)
```

