### PR TITLE
[expo-cli] Remove URL mismatch warning

### DIFF
--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -16,7 +16,6 @@ import CommandError from '../CommandError';
 import Log from '../log';
 import { getProjectOwner } from '../projects';
 import * as sendTo from '../sendTo';
-import { getBuildStatusAsync } from './build/getBuildStatusAsync';
 import * as TerminalLink from './utils/TerminalLink';
 import { formatNamedWarning } from './utils/logConfigWarnings';
 
@@ -40,7 +39,7 @@ export async function action(
   const { exp, pkg } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
-  const { sdkVersion, isDetached } = exp;
+  const { sdkVersion } = exp;
 
   const target = options.target ?? getDefaultTarget(projectRoot);
 

--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -66,15 +66,6 @@ export async function action(
 
   // Log warnings.
 
-  if (!isDetached && !options.duringBuild) {
-    // Check for SDK version and release channel mismatches only after displaying the values.
-    await logSDKMismatchWarningsAsync({
-      projectRoot,
-      releaseChannel: options.releaseChannel,
-      sdkVersion,
-    });
-  }
-
   logExpoUpdatesWarnings(pkg);
 
   logOptimizeWarnings({ projectRoot });
@@ -201,46 +192,6 @@ function getExampleManifestUrl(url: string, sdkVersion: string | undefined): str
   } else {
     return `${url}/index.exp?sdkVersion=${sdkVersion}`;
   }
-}
-
-/**
- * A convenient warning reminding people that they're publishing with an SDK that their published app does not support.
- *
- * @param options
- */
-async function logSDKMismatchWarningsAsync({
-  projectRoot,
-  releaseChannel,
-  sdkVersion,
-}: {
-  projectRoot: string;
-  releaseChannel?: string;
-  sdkVersion?: string;
-}) {
-  if (!sdkVersion) {
-    return;
-  }
-
-  const buildStatus = await getBuildStatusAsync(projectRoot, {
-    platform: 'all',
-    current: true,
-    releaseChannel,
-    sdkVersion,
-  });
-  const hasMismatch =
-    buildStatus.userHasBuiltExperienceBefore && !buildStatus.userHasBuiltAppBefore;
-  if (!hasMismatch) {
-    return;
-  }
-
-  // A convenient warning reminding people that they're publishing with an SDK that their published app does not support.
-  Log.nestedWarn(
-    formatNamedWarning(
-      'URL mismatch',
-      `No standalone app has been built with SDK ${sdkVersion} and release channel "${releaseChannel}" for this project before.\n  OTA updates only work for native projects that have the same SDK version and release channel.`,
-      'https://docs.expo.io/workflow/publishing/#limitations'
-    )
-  );
 }
 
 export function logExpoUpdatesWarnings(pkg: PackageJSONConfig): void {


### PR DESCRIPTION
# Why

It is confusing people: https://github.com/expo/expo/issues/11812

I think there are also too many contexts where this does not actually provide accurate information (eg: publishing to a bare app, or if you built with Turtle CLI, if you are just trying to publish for use in Expo Go, etc), so we should just not show this warning.

# How

Delete the code

# Test Plan

Run publish locally, verify that where I previously saw this warning (eg: on a new blank template) that you do not see this warning.