### PR TITLE
[config-plugins] support PKCS keystores for android builds

### DIFF
--- a/packages/config-plugins/src/android/EasBuildGradleScript.ts
+++ b/packages/config-plugins/src/android/EasBuildGradleScript.ts
@@ -50,7 +50,13 @@ tasks.whenTaskAdded {
           storeFile storeFilePath.toFile()
           storePassword credentials.android.keystore.keystorePassword
           keyAlias credentials.android.keystore.keyAlias
-          keyPassword credentials.android.keystore.keyPassword
+          if (credentials.android.keystore.containsKey("keyPassword")) {
+            keyPassword credentials.android.keystore.keyPassword
+          } else {
+            // key password is required by Gradle, but PKCS keystores don't have one
+            // using the keystore password seems to satisfy the requirement
+            keyPassword credentials.android.keystore.keystorePassword
+          }
         } catch (Exception e) {
           println("An error occurred while parsing 'credentials.json': " + e.message)
         }


### PR DESCRIPTION
# Why

PKCS do not have keyPassword, but gradle requires that field. It seems to work when kesytorePassword is passed as both values in that case.

# How

if keyPassword is not specified pass kesytorePassword

# Test Plan

run build locally with modified eas-build.gradle