### PR TITLE
[config-types] add top level libraries key

### DIFF
--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -171,6 +171,12 @@ export interface ExpoConfig {
     [k: string]: any;
   };
   /**
+   * Configuration information for external libraries. Be careful not to commit anything private here!
+   */
+  libraries?: {
+    [k: string]: any;
+  };
+  /**
    * @deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.io/guides/customizing-metro/)
    */
   packagerOpts?: {


### PR DESCRIPTION
# Why

we want a top level field to put configuration information for external libraries.

In particular, we are going to store the EAS project ID here:

```
"libraries": {
  "eas":{
    "projectId": "xxxxxxxx"
  }
}
```

This will also be the target of `mods` that set values at build time, e.g. if the config has private information that should not be committed to the git repo.

One alternative: should we enforce explicit public/private subfields?

```
libraries : {
  public: {[key: string]: any},
  private: {[key: string]: any}
}
```