### PR TITLE
disable wiping the console in tsc watch mode

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -4,7 +4,7 @@
   "description": "A library for Expo config plugins",
   "main": "build/index.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/config-types/package.json
+++ b/packages/config-types/package.json
@@ -5,7 +5,7 @@
   "types": "build/ExpoConfig.d.ts",
   "main": "build/ExpoConfig.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "generate": "ts-node ./scripts/generate.ts",
     "prepare": "yarn run clean && yarn build",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,7 +4,7 @@
   "description": "A library for interacting with the app.json",
   "main": "build/index.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -4,7 +4,7 @@
   "description": "Development servers for starting React Native projects",
   "main": "build/MetroDevServer.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "yarn run prepare && yarn run watch",
     "build": "tsc --emitDeclarationOnly && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "introspect": "ts-node ./scripts/introspect.ts",
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/expo-codemod/package.json
+++ b/packages/expo-codemod/package.json
@@ -13,7 +13,7 @@
     "expo-codemod": "./bin/expo-codemod.js"
   },
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -4,7 +4,7 @@
   "description": "A package used by Expo CLI for processing images",
   "main": "build/index.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "test": "jest",
     "prepare": "yarn run clean && yarn build",

--- a/packages/json-file/package.json
+++ b/packages/json-file/package.json
@@ -4,7 +4,7 @@
   "description": "A module for reading, writing, and manipulating JSON files",
   "main": "build/JsonFile.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -4,7 +4,7 @@
   "description": "A Metro config for running React Native projects with the Metro bundler",
   "main": "build/ExpoMetroConfig.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/next-adapter/package.json
+++ b/packages/next-adapter/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/osascript/package.json
+++ b/packages/osascript/package.json
@@ -4,7 +4,7 @@
   "description": "Tools for running an osascripts in Node",
   "main": "build/index.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo"

--- a/packages/package-manager/package.json
+++ b/packages/package-manager/package.json
@@ -4,7 +4,7 @@
   "description": "A library for installing and finding packages in a node project",
   "main": "build",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn run clean && yarn build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",

--- a/packages/pkcs12/package.json
+++ b/packages/pkcs12/package.json
@@ -4,7 +4,7 @@
   "description": "PKCS#12 Utilities for Node.js",
   "main": "build/index.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn build",
     "lint": "eslint .",

--- a/packages/plist/package.json
+++ b/packages/plist/package.json
@@ -4,7 +4,7 @@
   "description": "Mac OS X Plist parser/builder for Node.js and browsers",
   "main": "build/index.js",
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn build",
     "test": "jest"

--- a/packages/pod-install/package.json
+++ b/packages/pod-install/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "prepare": "yarn run clean && yarn run build:prod",
     "lint": "eslint .",
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "watch:ncc": "yarn run build -w",
     "build": "ncc build ./src/index.ts -o build/",
     "build:prod": "ncc build ./src/index.ts -o build/ --minify --no-cache --no-source-map-register",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -27,7 +27,7 @@
     "prepare": "yarn run clean && yarn run build",
     "test": "jest",
     "lint": "eslint .",
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "clean": "rimraf build ./tsconfig.tsbuildinfo"
   },

--- a/packages/schemer/package.json
+++ b/packages/schemer/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest --testPathIgnorePatterns network",
     "test-integration": "jest",
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "prepare": "yarn build"
   },

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/webpack-config"
   },
   "scripts": {
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "build": "tsc",
     "lint": "eslint .",
     "clean": "rimraf ./webpack/ ./tsconfig.tsbuildinfo",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn run clean && yarn run build",
     "prepack": "node scripts/updateCaches.js",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "test": "jest",
     "integration-tests": "jest --config jest/integration-test-config.js"
   },

--- a/unlinked-packages/configure-splash-screen/package.json
+++ b/unlinked-packages/configure-splash-screen/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "yarn run prepare",
     "build": "tsc",
-    "watch": "tsc --watch",
+    "watch": "tsc --watch --preserveWatchOutput",
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx,.d.ts src",


### PR DESCRIPTION
# Why

I use `yarn start` in the root directory when working on sth in multiple packages. The output of this command is not really helpful as after each file change the console is wiped. Some type errors can be printed just before the console was wiped.

# How

I passed `--preserveWatchOutput` to every `tsc --watch` command.

# Test Plan

<img width="1487" alt="Screenshot 2021-05-12 at 12 03 24" src="https://user-images.githubusercontent.com/5256730/117958284-28818d80-b31b-11eb-8ac4-97a36490e2ee.png">
