### PR TITLE
[config-plugins] make bundle identifier getter aware of multiple targets

### DIFF
--- a/packages/config-plugins/src/ios/BuildScheme.ts
+++ b/packages/config-plugins/src/ios/BuildScheme.ts
@@ -43,7 +43,7 @@ async function readSchemeAsync(
   }
 }
 
-export async function getApplicationTargetForSchemeAsync(
+export async function getApplicationTargetNameForSchemeAsync(
   projectRoot: string,
   scheme: string
 ): Promise<string> {

--- a/packages/config-plugins/src/ios/BundleIdentifier.ts
+++ b/packages/config-plugins/src/ios/BundleIdentifier.ts
@@ -11,7 +11,7 @@ import { getAllInfoPlistPaths, getAllPBXProjectPaths, getPBXProjectPath } from '
 import {
   ConfigurationSectionEntry,
   findFirstNativeTarget,
-  getBuildConfigurationForId,
+  getBuildConfigurationsForListId,
 } from './utils/Xcodeproj';
 
 export const withBundleIdentifier: ConfigPlugin<{ bundleIdentifier?: string }> = (
@@ -72,7 +72,10 @@ function getBundleIdentifierFromPbxproj(projectRoot: string): string | null {
   project.parseSync();
 
   const [, nativeTarget] = findFirstNativeTarget(project);
-  for (const [, item] of getBuildConfigurationForId(project, nativeTarget.buildConfigurationList)) {
+  for (const [, item] of getBuildConfigurationsForListId(
+    project,
+    nativeTarget.buildConfigurationList
+  )) {
     const bundleIdentifierRaw = item.buildSettings.PRODUCT_BUNDLE_IDENTIFIER;
     if (bundleIdentifierRaw) {
       const bundleIdentifier =
@@ -114,7 +117,7 @@ function updateBundleIdentifierForPbxproj(
 
   const [, nativeTarget] = findFirstNativeTarget(project);
 
-  getBuildConfigurationForId(project, nativeTarget.buildConfigurationList).forEach(
+  getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList).forEach(
     ([, item]: ConfigurationSectionEntry) => {
       if (item.buildSettings.PRODUCT_BUNDLE_IDENTIFIER === bundleIdentifier) {
         return;

--- a/packages/config-plugins/src/ios/BundleIdentifier.ts
+++ b/packages/config-plugins/src/ios/BundleIdentifier.ts
@@ -2,15 +2,16 @@ import { ExpoConfig } from '@expo/config-types';
 import plist, { PlistObject } from '@expo/plist';
 import assert from 'assert';
 import fs from 'fs-extra';
-import xcode from 'xcode';
+import xcode, { XCBuildConfiguration } from 'xcode';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withDangerousMod } from '../plugins/core-plugins';
 import { InfoPlist } from './IosConfig.types';
 import { getAllInfoPlistPaths, getAllPBXProjectPaths, getPBXProjectPath } from './Paths';
+import { findFirstNativeTarget, findNativeTargetByName } from './Target';
 import {
   ConfigurationSectionEntry,
-  findFirstNativeTarget,
+  getBuildConfigurationForListIdAndName,
   getBuildConfigurationsForListId,
 } from './utils/Xcodeproj';
 
@@ -54,14 +55,27 @@ function setBundleIdentifier(config: ExpoConfig, infoPlist: InfoPlist): InfoPlis
 }
 
 /**
- * Gets the bundle identifier of the Xcode project found in the project directory.
- * If either the Xcode project doesn't exist or the project is not configured
- * this function returns null.
+ * Gets the bundle identifier defined in the Xcode project found in the project directory.
+ *
+ * A bundle identifier is stored as a value in XCBuildConfiguration entry.
+ * Those entries exist for every pair (build target, build configuration).
+ * Unless target name is passed, the first target defined in the pbxproj is used
+ * (to keep compatibility with the inaccurate legacy implementation of this function).
+ * The build configuration is usually 'Release' or 'Debug'. However, it could be any arbitrary string.
+ * Defaults to 'Release'.
  *
  * @param {string} projectRoot Path to project root containing the ios directory
+ * @param {string} targetName Target name
+ * @param {string} buildConfiguration Build configuration. Defaults to 'Release'.
  * @returns {string | null} bundle identifier of the Xcode project or null if the project is not configured
  */
-function getBundleIdentifierFromPbxproj(projectRoot: string): string | null {
+function getBundleIdentifierFromPbxproj(
+  projectRoot: string,
+  {
+    targetName,
+    buildConfiguration = 'Release',
+  }: { targetName?: string; buildConfiguration?: string } = {}
+): string | null {
   let pbxprojPath: string;
   try {
     pbxprojPath = getPBXProjectPath(projectRoot);
@@ -71,33 +85,41 @@ function getBundleIdentifierFromPbxproj(projectRoot: string): string | null {
   const project = xcode.project(pbxprojPath);
   project.parseSync();
 
-  const [, nativeTarget] = findFirstNativeTarget(project);
-  for (const [, item] of getBuildConfigurationsForListId(
-    project,
-    nativeTarget.buildConfigurationList
-  )) {
-    const bundleIdentifierRaw = item.buildSettings.PRODUCT_BUNDLE_IDENTIFIER;
-    if (bundleIdentifierRaw) {
-      const bundleIdentifier =
-        bundleIdentifierRaw[0] === '"' ? bundleIdentifierRaw.slice(1, -1) : bundleIdentifierRaw;
-      // it's possible to use interpolation for the bundle identifier
-      // the most common case is when the last part of the id is set to `$(PRODUCT_NAME:rfc1034identifier)`
-      // in this case, PRODUCT_NAME should be replaced with its value
-      // the `rfc1034identifier` modifier replaces all non-alphanumeric characters with dashes
-      const bundleIdentifierParts = bundleIdentifier.split('.');
-      if (
-        bundleIdentifierParts[bundleIdentifierParts.length - 1] ===
-          '$(PRODUCT_NAME:rfc1034identifier)' &&
-        item.buildSettings.PRODUCT_NAME
-      ) {
-        bundleIdentifierParts[
-          bundleIdentifierParts.length - 1
-        ] = item.buildSettings.PRODUCT_NAME.replace(/[^a-zA-Z0-9]/g, '-');
-      }
-      return bundleIdentifierParts.join('.');
+  const [, nativeTarget] = targetName
+    ? findNativeTargetByName(project, targetName)
+    : findFirstNativeTarget(project);
+  const [, xcBuildConfiguration] = getBuildConfigurationForListIdAndName(project, {
+    configurationListId: nativeTarget.buildConfigurationList,
+    buildConfiguration,
+  });
+  return getProductBundleIdentifierFromBuildConfiguration(xcBuildConfiguration);
+}
+
+function getProductBundleIdentifierFromBuildConfiguration(
+  xcBuildConfiguration: XCBuildConfiguration
+): string | null {
+  const bundleIdentifierRaw = xcBuildConfiguration.buildSettings.PRODUCT_BUNDLE_IDENTIFIER;
+  if (bundleIdentifierRaw) {
+    const bundleIdentifier =
+      bundleIdentifierRaw[0] === '"' ? bundleIdentifierRaw.slice(1, -1) : bundleIdentifierRaw;
+    // it's possible to use interpolation for the bundle identifier
+    // the most common case is when the last part of the id is set to `$(PRODUCT_NAME:rfc1034identifier)`
+    // in this case, PRODUCT_NAME should be replaced with its value
+    // the `rfc1034identifier` modifier replaces all non-alphanumeric characters with dashes
+    const bundleIdentifierParts = bundleIdentifier.split('.');
+    if (
+      bundleIdentifierParts[bundleIdentifierParts.length - 1] ===
+        '$(PRODUCT_NAME:rfc1034identifier)' &&
+      xcBuildConfiguration.buildSettings.PRODUCT_NAME
+    ) {
+      bundleIdentifierParts[
+        bundleIdentifierParts.length - 1
+      ] = xcBuildConfiguration.buildSettings.PRODUCT_NAME.replace(/[^a-zA-Z0-9]/g, '-');
     }
+    return bundleIdentifierParts.join('.');
+  } else {
+    return null;
   }
-  return null;
 }
 
 /**

--- a/packages/config-plugins/src/ios/ProvisioningProfile.ts
+++ b/packages/config-plugins/src/ios/ProvisioningProfile.ts
@@ -4,7 +4,7 @@ import {
   ConfigurationSectionEntry,
   findFirstNativeTarget,
   findNativeTargetByName,
-  getBuildConfigurationForId,
+  getBuildConfigurationsForListId,
   getPbxproj,
   getProjectSection,
   isNotComment,
@@ -34,7 +34,7 @@ function setProvisioningProfileForPbxproj(
 
   const [nativeTargetId, nativeTarget] = target;
 
-  getBuildConfigurationForId(project, nativeTarget.buildConfigurationList)
+  getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList)
     .filter(([, item]: ConfigurationSectionEntry) => item.buildSettings.PRODUCT_NAME)
     .forEach(([, item]: ConfigurationSectionEntry) => {
       item.buildSettings.PROVISIONING_PROFILE_SPECIFIER = `"${profileName}"`;

--- a/packages/config-plugins/src/ios/ProvisioningProfile.ts
+++ b/packages/config-plugins/src/ios/ProvisioningProfile.ts
@@ -1,9 +1,8 @@
 import fs from 'fs-extra';
 
+import { findFirstNativeTarget, findNativeTargetByName } from './Target';
 import {
   ConfigurationSectionEntry,
-  findFirstNativeTarget,
-  findNativeTargetByName,
   getBuildConfigurationsForListId,
   getPbxproj,
   getProjectSection,
@@ -15,27 +14,27 @@ type ProvisioningProfileSettings = {
   targetName?: string;
   appleTeamId: string;
   profileName: string;
+  buildConfiguration?: string;
 };
 
-function setProvisioningProfileForPbxproj(
+export function setProvisioningProfileForPbxproj(
   projectRoot: string,
-  { targetName, profileName, appleTeamId }: ProvisioningProfileSettings
+  {
+    targetName,
+    profileName,
+    appleTeamId,
+    buildConfiguration = 'Release',
+  }: ProvisioningProfileSettings
 ): void {
   const project = getPbxproj(projectRoot);
-  const target = targetName
+
+  const nativeTargetEntry = targetName
     ? findNativeTargetByName(project, targetName)
     : findFirstNativeTarget(project);
-
-  if (!target && targetName) {
-    throw new Error(`Unable to find a target named ${targetName}.`);
-  } else if (!target) {
-    throw new Error(`Unable to find any targets in this Xcode project.`);
-  }
-
-  const [nativeTargetId, nativeTarget] = target;
+  const [nativeTargetId, nativeTarget] = nativeTargetEntry;
 
   getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList)
-    .filter(([, item]: ConfigurationSectionEntry) => item.buildSettings.PRODUCT_NAME)
+    .filter(([, item]: ConfigurationSectionEntry) => item.name === buildConfiguration)
     .forEach(([, item]: ConfigurationSectionEntry) => {
       item.buildSettings.PROVISIONING_PROFILE_SPECIFIER = `"${profileName}"`;
       item.buildSettings.DEVELOPMENT_TEAM = appleTeamId;
@@ -52,5 +51,3 @@ function setProvisioningProfileForPbxproj(
 
   fs.writeFileSync(project.filepath, project.writeSync());
 }
-
-export { setProvisioningProfileForPbxproj };

--- a/packages/config-plugins/src/ios/Target.ts
+++ b/packages/config-plugins/src/ios/Target.ts
@@ -56,6 +56,9 @@ export function getNativeTargets(project: XcodeProject): NativeTargetSectionEntr
 
 export function findFirstNativeTarget(project: XcodeProject): NativeTargetSectionEntry {
   const targets = getNativeTargets(project);
+  if (targets.length === 0) {
+    throw new Error(`Could not find any target in project.pbxproj`);
+  }
   return targets[0];
 }
 

--- a/packages/config-plugins/src/ios/Target.ts
+++ b/packages/config-plugins/src/ios/Target.ts
@@ -1,0 +1,83 @@
+import { PBXTargetDependency, XcodeProject } from 'xcode';
+
+import { getApplicationTargetNameForSchemeAsync } from './BuildScheme';
+import { getPbxproj, isNotComment, NativeTargetSectionEntry } from './utils/Xcodeproj';
+
+export enum TargetType {
+  APPLICATION = 'com.apple.product-type.application',
+  EXTENSION = 'com.apple.product-type.app-extension',
+  OTHER = 'other',
+}
+
+export interface Target {
+  name: string;
+  type: TargetType;
+  dependencies?: Target[];
+}
+
+export async function findApplicationTargetWithDependenciesAsync(
+  projectRoot: string,
+  scheme: string
+): Promise<Target> {
+  const applicationTargetName = await getApplicationTargetNameForSchemeAsync(projectRoot, scheme);
+  const project = getPbxproj(projectRoot);
+  const [, applicationTarget] = findNativeTargetByName(project, applicationTargetName);
+
+  const dependencies: Target[] = applicationTarget.dependencies.map(({ value }) => {
+    const { target: targetId } = project.getPBXGroupByKeyAndType(
+      value,
+      'PBXTargetDependency'
+    ) as PBXTargetDependency;
+
+    const [, target] = findNativeTargetById(project, targetId);
+
+    const type =
+      target.productType === TargetType.EXTENSION ||
+      target.productType === `"${TargetType.EXTENSION}"`
+        ? TargetType.EXTENSION
+        : TargetType.OTHER;
+    return {
+      name: target.name,
+      type,
+    };
+  });
+
+  return {
+    name: applicationTarget.name,
+    type: TargetType.APPLICATION,
+    dependencies,
+  };
+}
+
+export function getNativeTargets(project: XcodeProject): NativeTargetSectionEntry[] {
+  const section = project.pbxNativeTargetSection();
+  return Object.entries(section).filter(isNotComment);
+}
+
+export function findFirstNativeTarget(project: XcodeProject): NativeTargetSectionEntry {
+  const targets = getNativeTargets(project);
+  return targets[0];
+}
+
+export function findNativeTargetByName(
+  project: XcodeProject,
+  targetName: string
+): NativeTargetSectionEntry {
+  const nativeTargets = getNativeTargets(project);
+  const nativeTargetEntry = nativeTargets.find(
+    ([, i]) => i.name === targetName || i.name === `"${targetName}"`
+  );
+  if (!nativeTargetEntry) {
+    throw new Error(`Could not find target '${targetName}' in project.pbxproj`);
+  }
+  return nativeTargetEntry;
+}
+
+function findNativeTargetById(project: XcodeProject, targetId: string): NativeTargetSectionEntry {
+  const nativeTargets = getNativeTargets(project);
+  const nativeTargetEntry = nativeTargets.find(([key]) => key === targetId);
+  if (!nativeTargetEntry) {
+    throw new Error(`Could not find target with id '${targetId}' in project.pbxproj`);
+  }
+  return nativeTargetEntry;
+}

--- a/packages/config-plugins/src/ios/__tests__/BuildScheme-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/BuildScheme-test.ts
@@ -3,7 +3,7 @@ import { vol } from 'memfs';
 import path from 'path';
 
 import {
-  getApplicationTargetForSchemeAsync,
+  getApplicationTargetNameForSchemeAsync,
   getArchiveBuildConfigurationForSchemeAsync,
 } from '../BuildScheme';
 
@@ -11,7 +11,7 @@ const fsReal = jest.requireActual('fs') as typeof fs;
 
 jest.mock('fs');
 
-describe(getApplicationTargetForSchemeAsync, () => {
+describe(getApplicationTargetNameForSchemeAsync, () => {
   describe('single build action entry', () => {
     beforeAll(async () => {
       vol.fromJSON(
@@ -30,13 +30,13 @@ describe(getApplicationTargetForSchemeAsync, () => {
     });
 
     it('returns the target name for existing scheme', async () => {
-      const target = await getApplicationTargetForSchemeAsync('/app', 'testproject');
+      const target = await getApplicationTargetNameForSchemeAsync('/app', 'testproject');
       expect(target).toBe('testproject');
     });
 
     it('throws if the scheme does not exist', async () => {
       await expect(() =>
-        getApplicationTargetForSchemeAsync('/app', 'nonexistentscheme')
+        getApplicationTargetNameForSchemeAsync('/app', 'nonexistentscheme')
       ).rejects.toThrow(/does not exist/);
     });
   });
@@ -58,13 +58,13 @@ describe(getApplicationTargetForSchemeAsync, () => {
     });
 
     it('returns the target name for existing scheme', async () => {
-      const target = await getApplicationTargetForSchemeAsync('/app', 'testproject');
+      const target = await getApplicationTargetNameForSchemeAsync('/app', 'testproject');
       expect(target).toBe('testproject');
     });
 
     it('throws if the scheme does not exist', async () => {
       await expect(() =>
-        getApplicationTargetForSchemeAsync('/app', 'nonexistentscheme')
+        getApplicationTargetNameForSchemeAsync('/app', 'nonexistentscheme')
       ).rejects.toThrow(/does not exist/);
     });
   });

--- a/packages/config-plugins/src/ios/__tests__/BundleIdentifier-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/BundleIdentifier-test.ts
@@ -40,7 +40,8 @@ describe('BundleIdentifier module', () => {
 
     it('returns null if no project.pbxproj exists', () => {
       vol.mkdirpSync(projectRoot);
-      expect(getBundleIdentifierFromPbxproj(projectRoot)).toBeNull();
+      const bundleId = getBundleIdentifierFromPbxproj(projectRoot, { targetName: 'testproject' });
+      expect(bundleId).toBeNull();
     });
 
     it('returns the bundle identifier defined in project.pbxproj', () => {
@@ -53,20 +54,51 @@ describe('BundleIdentifier module', () => {
         },
         projectRoot
       );
-      expect(getBundleIdentifierFromPbxproj(projectRoot)).toBe('org.name.testproject');
+      const bundleId = getBundleIdentifierFromPbxproj(projectRoot, { targetName: 'testproject' });
+      expect(bundleId).toBe('org.name.testproject');
     });
 
-    it('returns the bundle identifier for the first native target in project.pbxproj (project initialized with react-native init)', () => {
-      vol.fromJSON(
-        {
-          'ios/testproject.xcodeproj/project.pbxproj': originalFs.readFileSync(
-            path.join(__dirname, 'fixtures/project-rni.pbxproj'),
-            'utf-8'
-          ),
-        },
-        projectRoot
-      );
-      expect(getBundleIdentifierFromPbxproj(projectRoot)).toBe('org.reactjs.native.example.rni');
+    describe('multi-target project', () => {
+      it('returns correct bundle identifier for the default build configuration (Release)', () => {
+        vol.fromJSON(
+          {
+            'ios/testproject.xcodeproj/project.pbxproj': originalFs.readFileSync(
+              path.join(__dirname, 'fixtures/project-multitarget.pbxproj'),
+              'utf-8'
+            ),
+            'ios/testproject.xcodeproj/xcshareddata/xcschemes/multitarget.xcscheme': originalFs.readFileSync(
+              path.join(__dirname, 'fixtures/multitarget.xcscheme'),
+              'utf-8'
+            ),
+          },
+          projectRoot
+        );
+        const bundleId = getBundleIdentifierFromPbxproj(projectRoot, {
+          targetName: 'multitarget',
+        });
+        expect(bundleId).toBe('com.swmansion.dominik.multitarget');
+      });
+
+      it('returns correct bundle identifier for Debug build configuration', () => {
+        vol.fromJSON(
+          {
+            'ios/testproject.xcodeproj/project.pbxproj': originalFs.readFileSync(
+              path.join(__dirname, 'fixtures/project-multitarget.pbxproj'),
+              'utf-8'
+            ),
+            'ios/testproject.xcodeproj/xcshareddata/xcschemes/multitarget.xcscheme': originalFs.readFileSync(
+              path.join(__dirname, 'fixtures/multitarget.xcscheme'),
+              'utf-8'
+            ),
+          },
+          projectRoot
+        );
+        const bundleId = getBundleIdentifierFromPbxproj(projectRoot, {
+          targetName: 'multitarget',
+          buildConfiguration: 'Debug',
+        });
+        expect(bundleId).toBe('com.swmansion.dominik.multitarget.debug');
+      });
     });
   });
 

--- a/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
@@ -28,7 +28,7 @@ describe('ProvisioningProfile module', () => {
       vol.reset();
     });
 
-    it('configures the project.pbxproj file with the profile name and apple team id', async () => {
+    it('configures the project.pbxproj file with the profile name and apple team id', () => {
       setProvisioningProfileForPbxproj(projectRoot, {
         profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
         appleTeamId: 'J5FM626PE2',
@@ -36,15 +36,14 @@ describe('ProvisioningProfile module', () => {
       const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
       expect(pbxprojContents).toMatchSnapshot();
     });
-    it('throws descriptive error when target name does not exist', async () => {
-      const fn = () => {
+    it('throws descriptive error when target name does not exist', () => {
+      expect(() =>
         setProvisioningProfileForPbxproj(projectRoot, {
           targetName: 'faketargetname',
           profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
           appleTeamId: 'J5FM626PE2',
-        });
-      };
-      expect(fn).toThrow('Unable to find a target named faketargetname');
+        })
+      ).toThrow("Could not find target 'faketargetname' in project.pbxproj");
     });
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/Target-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Target-test.ts
@@ -1,0 +1,40 @@
+import { vol } from 'memfs';
+import path from 'path';
+
+import { findApplicationTargetWithDependenciesAsync, TargetType } from '../Target';
+
+jest.mock('fs');
+
+const originalFs = jest.requireActual('fs');
+
+describe(findApplicationTargetWithDependenciesAsync, () => {
+  const projectRoot = '/app';
+
+  afterEach(() => vol.reset());
+
+  it('reads the application target and its dependencies', async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/project-multitarget.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject.xcodeproj/xcshareddata/xcschemes/multitarget.xcscheme': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/multitarget.xcscheme'),
+          'utf-8'
+        ),
+      },
+      projectRoot
+    );
+
+    const applicationTarget = await findApplicationTargetWithDependenciesAsync(
+      projectRoot,
+      'multitarget'
+    );
+    expect(applicationTarget.name).toBe('multitarget');
+    expect(applicationTarget.type).toBe(TargetType.APPLICATION);
+    expect(applicationTarget.dependencies.length).toBe(1);
+    expect(applicationTarget.dependencies[0].name).toBe('shareextension');
+    expect(applicationTarget.dependencies[0].type).toBe(TargetType.EXTENSION);
+  });
+});

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
@@ -300,10 +300,6 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures 
 				SWIFT_OPTIMIZATION_LEVEL = \\"-Onone\\";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = \\"apple-generic\\";
-				PROVISIONING_PROFILE_SPECIFIER = \\"*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z\\";
-				DEVELOPMENT_TEAM = J5FM626PE2;
-				CODE_SIGN_IDENTITY = \\"iPhone Distribution\\";
-				CODE_SIGN_STYLE = Manual;
 			};
 			name = Debug;
 		};

--- a/packages/config-plugins/src/ios/__tests__/fixtures/multitarget.xcscheme
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/multitarget.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "multitarget.app"
+               BlueprintName = "multitarget"
+               ReferencedContainer = "container:multitarget.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "00E356ED1AD99517003FC87E"
+               BuildableName = "multitargetTests.xctest"
+               BlueprintName = "multitargetTests"
+               ReferencedContainer = "container:multitarget.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "multitarget.app"
+            BlueprintName = "multitarget"
+            ReferencedContainer = "container:multitarget.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "multitarget.app"
+            BlueprintName = "multitarget"
+            ReferencedContainer = "container:multitarget.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/packages/config-plugins/src/ios/__tests__/fixtures/project-multitarget.pbxproj
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/project-multitarget.pbxproj
@@ -1,0 +1,655 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		6ADAD6E626493A420001F56E /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ADAD6E526493A420001F56E /* ShareViewController.m */; };
+		6ADAD6E926493A420001F56E /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6ADAD6E726493A420001F56E /* MainInterface.storyboard */; };
+		6ADAD6ED26493A420001F56E /* shareextension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6ADAD6E226493A420001F56E /* shareextension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		96905EF65AED1B983A6B3ABC /* libPods-multitarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6ADAD6EB26493A420001F56E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6ADAD6E126493A420001F56E;
+			remoteInfo = shareextension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		6ADAD6F126493A420001F56E /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				6ADAD6ED26493A420001F56E /* shareextension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		13B07F961A680F5B00A75B9A /* multitarget.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = multitarget.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = multitarget/AppDelegate.h; sourceTree = "<group>"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = multitarget/AppDelegate.m; sourceTree = "<group>"; };
+		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = multitarget/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = multitarget/Info.plist; sourceTree = "<group>"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = multitarget/main.m; sourceTree = "<group>"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-multitarget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADAD6E226493A420001F56E /* shareextension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = shareextension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADAD6E426493A420001F56E /* ShareViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = "<group>"; };
+		6ADAD6E526493A420001F56E /* ShareViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = "<group>"; };
+		6ADAD6E826493A420001F56E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		6ADAD6EA26493A420001F56E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-multitarget.debug.xcconfig"; path = "Target Support Files/Pods-multitarget/Pods-multitarget.debug.xcconfig"; sourceTree = "<group>"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-multitarget.release.xcconfig"; path = "Target Support Files/Pods-multitarget/Pods-multitarget.release.xcconfig"; sourceTree = "<group>"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = multitarget/SplashScreen.storyboard; sourceTree = "<group>"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-multitarget.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6DF26493A420001F56E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* multitarget */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+			);
+			name = multitarget;
+			sourceTree = "<group>";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6ADAD6E326493A420001F56E /* shareextension */ = {
+			isa = PBXGroup;
+			children = (
+				6ADAD6E426493A420001F56E /* ShareViewController.h */,
+				6ADAD6E526493A420001F56E /* ShareViewController.m */,
+				6ADAD6E726493A420001F56E /* MainInterface.storyboard */,
+				6ADAD6EA26493A420001F56E /* Info.plist */,
+			);
+			path = shareextension;
+			sourceTree = "<group>";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* multitarget */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				6ADAD6E326493A420001F56E /* shareextension */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* multitarget.app */,
+				6ADAD6E226493A420001F56E /* shareextension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = multitarget/Supporting;
+			sourceTree = "<group>";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* multitarget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "multitarget" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				FD10A7F022414F080027D42C /* Start Packager */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */,
+				6ADAD6F126493A420001F56E /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6ADAD6EC26493A420001F56E /* PBXTargetDependency */,
+			);
+			name = multitarget;
+			productName = multitarget;
+			productReference = 13B07F961A680F5B00A75B9A /* multitarget.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6ADAD6E126493A420001F56E /* shareextension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6ADAD6EE26493A420001F56E /* Build configuration list for PBXNativeTarget "shareextension" */;
+			buildPhases = (
+				6ADAD6DE26493A420001F56E /* Sources */,
+				6ADAD6DF26493A420001F56E /* Frameworks */,
+				6ADAD6E026493A420001F56E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = shareextension;
+			productName = shareextension;
+			productReference = 6ADAD6E226493A420001F56E /* shareextension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = QL76XYH73P;
+						LastSwiftMigration = 1120;
+					};
+					6ADAD6E126493A420001F56E = {
+						CreatedOnToolsVersion = 12.5;
+						DevelopmentTeam = QL76XYH73P;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "multitarget" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* multitarget */,
+				6ADAD6E126493A420001F56E /* shareextension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6E026493A420001F56E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ADAD6E926493A420001F56E /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f /Users/dsokal/.volta/bin/node ]]; then\n  export NODE_BINARY=/Users/dsokal/.volta/bin/node\nelse\n  export NODE_BINARY=node\nfi\n../node_modules/react-native/scripts/react-native-xcode.sh\n../node_modules/expo-constants/scripts/get-app-config-ios.sh\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\n";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-multitarget-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FD10A7F022414F080027D42C /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Start Packager";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6DE26493A420001F56E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ADAD6E626493A420001F56E /* ShareViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6ADAD6EC26493A420001F56E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6ADAD6E126493A420001F56E /* shareextension */;
+			targetProxy = 6ADAD6EB26493A420001F56E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13B07FB21A68108700A75B9A /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = multitarget;
+			sourceTree = "<group>";
+		};
+		6ADAD6E726493A420001F56E /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6ADAD6E826493A420001F56E /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.debug;
+				PRODUCT_NAME = multitarget;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget;
+				PRODUCT_NAME = multitarget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		6ADAD6EF26493A420001F56E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6ADAD6F026493A420001F56E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "multitarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6ADAD6EE26493A420001F56E /* Build configuration list for PBXNativeTarget "shareextension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6ADAD6EF26493A420001F56E /* Debug */,
+				6ADAD6F026493A420001F56E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "multitarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}

--- a/packages/config-plugins/src/ios/index.ts
+++ b/packages/config-plugins/src/ios/index.ts
@@ -20,6 +20,7 @@ import * as RequiresFullScreen from './RequiresFullScreen';
 import * as Scheme from './Scheme';
 import * as SplashScreen from './SplashScreen';
 import * as Swift from './Swift';
+import * as Target from './Target';
 import * as Updates from './Updates';
 import * as UserInterfaceStyle from './UserInterfaceStyle';
 import * as UsesNonExemptEncryption from './UsesNonExemptEncryption';
@@ -54,6 +55,7 @@ export {
   RequiresFullScreen,
   Scheme,
   Swift,
+  Target,
   Updates,
   UserInterfaceStyle,
   UsesNonExemptEncryption,

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -341,7 +341,7 @@ export function getXCConfigurationListEntries(project: XcodeProject): Configurat
   return Object.entries(lists).filter(isNotComment);
 }
 
-export function getBuildConfigurationForId(
+export function getBuildConfigurationsForListId(
   project: XcodeProject,
   configurationListId: string
 ): ConfigurationSectionEntry[] {

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config-types';
 import assert from 'assert';
-import * as path from 'path';
+import path from 'path';
 import xcode, {
   PBXFile,
   PBXGroup,
@@ -314,28 +314,6 @@ export function getProjectSection(project: XcodeProject) {
   return project.pbxProjectSection();
 }
 
-export function getNativeTargets(project: XcodeProject): NativeTargetSectionEntry[] {
-  const section = project.pbxNativeTargetSection();
-  return Object.entries(section).filter(isNotComment);
-}
-
-export function findFirstNativeTarget(project: XcodeProject): NativeTargetSectionEntry {
-  const { targets } = Object.values(getProjectSection(project))[0];
-  const target = targets[0].value;
-  const nativeTargets = getNativeTargets(project);
-  return nativeTargets.find(([key]) => key === target) as NativeTargetSectionEntry;
-}
-
-export function findNativeTargetByName(
-  project: XcodeProject,
-  targetName: string
-): NativeTargetSectionEntry {
-  const nativeTargets = getNativeTargets(project);
-  return nativeTargets.find(
-    ([, i]) => i.name === targetName || i.name === `"${targetName}"`
-  ) as NativeTargetSectionEntry;
-}
-
 export function getXCConfigurationListEntries(project: XcodeProject): ConfigurationListEntry[] {
   const lists = project.pbxXCConfigurationList();
   return Object.entries(lists).filter(isNotComment);
@@ -357,6 +335,25 @@ export function getBuildConfigurationsForListId(
     .filter(isBuildConfig)
     .filter(isNotTestHost)
     .filter(([key]: ConfigurationSectionEntry) => buildConfigurations.includes(key));
+}
+
+export function getBuildConfigurationForListIdAndName(
+  project: XcodeProject,
+  {
+    configurationListId,
+    buildConfiguration,
+  }: { configurationListId: string; buildConfiguration: string }
+): ConfigurationSectionEntry {
+  const xcBuildConfigurationEntry = getBuildConfigurationsForListId(
+    project,
+    configurationListId
+  ).find(i => i[1].name === buildConfiguration);
+  if (!xcBuildConfigurationEntry) {
+    throw new Error(
+      `Build configuration '${buildConfiguration} does not exist in list with id '${configurationListId}'`
+    );
+  }
+  return xcBuildConfigurationEntry;
 }
 
 export function isBuildConfig([, sectionItem]: ConfigurationSectionEntry): boolean {

--- a/packages/expo-cli/src/commands/run/ios/developmentCodeSigning.ts
+++ b/packages/expo-cli/src/commands/run/ios/developmentCodeSigning.ts
@@ -32,7 +32,7 @@ export function getCodeSigningInfoForPbxproj(projectRoot: string) {
   const developmentTeams: string[] = [];
   const provisioningProfiles: string[] = [];
 
-  IOSConfig.XcodeUtils.getBuildConfigurationForId(project, nativeTarget.buildConfigurationList)
+  IOSConfig.XcodeUtils.getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList)
     .filter(
       ([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => item.buildSettings.PRODUCT_NAME
     )
@@ -69,7 +69,7 @@ function setAutoCodeSigningInfoForPbxproj(
   const project = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
   const [nativeTargetId, nativeTarget] = IOSConfig.XcodeUtils.findFirstNativeTarget(project);
 
-  IOSConfig.XcodeUtils.getBuildConfigurationForId(project, nativeTarget.buildConfigurationList)
+  IOSConfig.XcodeUtils.getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList)
     .filter(
       ([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => item.buildSettings.PRODUCT_NAME
     )

--- a/packages/expo-cli/src/commands/run/ios/developmentCodeSigning.ts
+++ b/packages/expo-cli/src/commands/run/ios/developmentCodeSigning.ts
@@ -27,7 +27,7 @@ async function setLastDeveloperCodeSigningIdAsync(id: string) {
  */
 export function getCodeSigningInfoForPbxproj(projectRoot: string) {
   const project = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
-  const [, nativeTarget] = IOSConfig.XcodeUtils.findFirstNativeTarget(project);
+  const [, nativeTarget] = IOSConfig.Target.findFirstNativeTarget(project);
 
   const developmentTeams: string[] = [];
   const provisioningProfiles: string[] = [];
@@ -67,7 +67,7 @@ function setAutoCodeSigningInfoForPbxproj(
   { appleTeamId }: { appleTeamId: string }
 ): void {
   const project = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
-  const [nativeTargetId, nativeTarget] = IOSConfig.XcodeUtils.findFirstNativeTarget(project);
+  const [nativeTargetId, nativeTarget] = IOSConfig.Target.findFirstNativeTarget(project);
 
   IOSConfig.XcodeUtils.getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList)
     .filter(

--- a/ts-declarations/xcode/index.d.ts
+++ b/ts-declarations/xcode/index.d.ts
@@ -36,6 +36,7 @@ declare module 'xcode' {
     | 'PBXShellScriptBuildPhase'
     | 'PBXSourcesBuildPhase'
     | 'PBXVariantGroup'
+    | 'PBXTargetDependency'
     | 'XCBuildConfiguration'
     | 'XCConfigurationList';
 
@@ -81,7 +82,10 @@ declare module 'xcode' {
       comment: string;
     }[];
     buildRules: [];
-    dependencies: [];
+    dependencies: {
+      value: UUID;
+      comment: string;
+    }[];
     name: string;
     productName: string;
     productReference: UUID;
@@ -94,6 +98,12 @@ declare module 'xcode' {
     fileRef: UUID;
     // "AppDelegate.m"
     fileRef_comment: string;
+  }
+
+  interface PBXTargetDependency {
+    isa: 'PBXTargetDependency';
+    target: UUID;
+    targetProxy: UUID;
   }
 
   interface XCConfigurationList {
@@ -331,7 +341,7 @@ declare module 'xcode' {
      */
     pbxTargetByName(targetName: string): PBXNativeTarget | undefined;
     findTargetKey(name: string): string;
-    pbxItemByComment(name: string, pbxSectionName: unknown): unknown;
+    pbxItemByComment(name: string, pbxSectionName: XCObjectType): unknown;
     pbxSourcesBuildPhaseObj(target: unknown): unknown;
     pbxResourcesBuildPhaseObj(target: unknown): unknown;
     pbxFrameworksBuildPhaseObj(target: unknown): unknown;


### PR DESCRIPTION
# Why

In EAS CLI, we want to support managed credentials for multitarget iOS projects.
An example of a multitarget project is a project with a Share Extension. Such a project consists of a (main) application target and an extension target. They have distinct bundle identifiers. Currently, there's no way of reading the bundle id for a particular target. We always read the bundle id for the first native target defined in the .pbxproj file.

# How

The bundle identifier for a particular target is stored in an XCBuildConfiguration entry in .pbxproj. The entry can be found by the target name and build configuration pair, e.g. `target = myproject, build configuration = Release`.

- I made `IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj` accept a target name and build configuration. Unless the target name is passed the function returns the bundle identifier for the first native target found in the .pbxproj file (this is legacy behavior). 
- `IOSConfig.ProvisioningProfile.setProvisioningProfileForPbxproj` is used in https://github.com/expo/eas-build/blob/main/packages/build-tools/src/ios/configure.ts to configure the Xcode project to use the provisioning profile provided by a user for building the project. I made the function accept the build configuration so only the appropriate XCBuildConfiguration entry is updated. Previously, we would update all build configurations regardless if they were used to build the project.
- I added a function `findApplicationTargetWithDependenciesAsync` that returns a tree of targets for a build scheme. It'll be used to resolve all targets that should have credentials set up.

# Test Plan

- Unit tests.
- Tested in EAS CLI in https://github.com/expo/eas-cli/pull/414