### PR TITLE
[expo-cli] fix expo export so it finds the correct projectDir

### DIFF
--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -125,7 +125,7 @@ export async function exportAppAsync(
     exp,
     hostedUrl: publicUrl,
     assetPath: 'assets',
-    outputDir,
+    outputDir: absoluteOutputDir,
     bundles,
     experimentalBundle,
   });

--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -82,6 +82,12 @@ export async function exportAppAsync(
     Log.newLine();
   }
 
+  // TODO-JJ delete the assetPathToWrite check when xdl is bumped: existence of assetPathToWrite is now done there.
+  const assetPathToWrite = path.resolve(absoluteOutputDir, 'assets');
+  await fs.ensureDir(assetPathToWrite);
+  const bundlesPathToWrite = path.resolve(absoluteOutputDir, 'bundles');
+  await fs.ensureDir(bundlesPathToWrite);
+
   const { exp, pkg, hooks } = await Project.getPublishExpConfigAsync(
     projectRoot,
     options.publishOptions || {}
@@ -99,27 +105,22 @@ export async function exportAppAsync(
 
   const iosBundleHash = crypto.createHash('md5').update(iosBundle).digest('hex');
   const iosBundleUrl = `ios-${iosBundleHash}.js`;
-  const iosJsPath = path.join(absoluteOutputDir, 'bundles', iosBundleUrl);
+  const iosJsPath = path.join(bundlesPathToWrite, iosBundleUrl);
 
   const androidBundleHash = crypto.createHash('md5').update(androidBundle).digest('hex');
   const androidBundleUrl = `android-${androidBundleHash}.js`;
-  const androidJsPath = path.join(absoluteOutputDir, 'bundles', androidBundleUrl);
+  const androidJsPath = path.join(bundlesPathToWrite, androidBundleUrl);
 
   const relativeBundlePaths = {
     android: path.join('bundles', androidBundleUrl),
     ios: path.join('bundles', iosBundleUrl),
   };
 
-  const bundlesPathToWrite = path.resolve(absoluteOutputDir, 'bundles');
-  await fs.ensureDir(bundlesPathToWrite);
-  await Project.writeArtifactSafelyAsync(bundlesPathToWrite, null, iosJsPath, iosBundle);
+  await Project.writeArtifactSafelyAsync(bundlesPathToWrite, null, iosBundleUrl, iosBundle);
   await Project.writeArtifactSafelyAsync(bundlesPathToWrite, null, androidJsPath, androidBundle);
 
   Log.log('Finished saving JS Bundles.');
 
-  // TODO-JJ delete this when xdl is bumped, ensuring the existence of assetPathToWrite is now done there.
-  const assetPathToWrite = path.resolve(projectRoot, path.join(outputDir, 'assets'));
-  await fs.ensureDir(assetPathToWrite);
   const { assets } = await ProjectAssets.exportAssetsAsync({
     projectRoot,
     exp,

--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -82,7 +82,6 @@ export async function exportAppAsync(
     Log.newLine();
   }
 
-  // TODO-JJ delete the assetPathToWrite check when xdl is bumped: existence of assetPathToWrite is now done there.
   const assetPathToWrite = path.resolve(absoluteOutputDir, 'assets');
   await fs.ensureDir(assetPathToWrite);
   const bundlesPathToWrite = path.resolve(absoluteOutputDir, 'bundles');

--- a/packages/xdl/src/ProjectAssets.ts
+++ b/packages/xdl/src/ProjectAssets.ts
@@ -297,6 +297,8 @@ async function saveAssetsAsync(projectRoot: string, assets: Asset[], outputDir: 
   // Collect paths by key, also effectively handles duplicates in the array
   const paths = collectAssetPaths(assets);
 
+  const assetRoot = path.resolve(projectRoot, path.join(outputDir, 'assets'));
+  await fs.ensureDir(assetRoot);
   // save files one chunk at a time
   const keyChunks = chunk(Object.keys(paths), 5);
   for (const keys of keyChunks) {
@@ -306,9 +308,7 @@ async function saveAssetsAsync(projectRoot: string, assets: Asset[], outputDir: 
 
       logAssetTask(projectRoot, 'saving', pathName);
 
-      const assetPath = path.resolve(outputDir, 'assets', key);
-
-      // copy file over to assetPath
+      const assetPath = path.resolve(assetRoot, key);
       promises.push(fs.copy(pathName, assetPath));
     }
     await Promise.all(promises);

--- a/packages/xdl/src/ProjectAssets.ts
+++ b/packages/xdl/src/ProjectAssets.ts
@@ -297,8 +297,6 @@ async function saveAssetsAsync(projectRoot: string, assets: Asset[], outputDir: 
   // Collect paths by key, also effectively handles duplicates in the array
   const paths = collectAssetPaths(assets);
 
-  const assetRoot = path.resolve(projectRoot, path.join(outputDir, 'assets'));
-  await fs.ensureDir(assetRoot);
   // save files one chunk at a time
   const keyChunks = chunk(Object.keys(paths), 5);
   for (const keys of keyChunks) {
@@ -308,7 +306,9 @@ async function saveAssetsAsync(projectRoot: string, assets: Asset[], outputDir: 
 
       logAssetTask(projectRoot, 'saving', pathName);
 
-      const assetPath = path.resolve(assetRoot, key);
+      const assetPath = path.resolve(outputDir, 'assets', key);
+
+      // copy file over to assetPath
       promises.push(fs.copy(pathName, assetPath));
     }
     await Promise.all(promises);


### PR DESCRIPTION
# Why
`expo export` doesn't work when run outside of a project directory: https://github.com/expo/expo-cli/issues/3478

# How

Set the `absoluteOutputDir` by resolving to the `projectDir` instead of `process.cwd()`

Went through and enforced usage of `*PathToWrite` by both the section where the directories are created as well as the section where the files are written.

# Test Plan

Repro'd the bug in #3478, confirmed that this PR fixes it.

Tested that `expo export` works both inside and outside a project dir.