### PR TITLE
Add additional hermes resolution

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -130,5 +130,8 @@
     "uuid": "^8.0.0",
     "wrap-ansi": "^7.0.0",
     "xdl": "59.0.36"
+  },
+  "resolutions": {
+    "hermes-engine": "0.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9986,10 +9986,10 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
-  integrity sha512-eNHUQHuadDMJARpaqvlCZoK/Nitpj6oywq3vQ3wCwEsww5morX34mW5PmKWQTO7aU0ck0hgulxR+EVDlXygGxQ==
+hermes-engine@0.0.0, hermes-engine@^0.2.1:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
+  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
 
 hex-color-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
# Why

The yarn.lock file introduced here: https://github.com/expo/expo-cli/pull/2913/files was accidentally overwritten here: https://github.com/expo/expo-cli/commit/ab8843a81effd66b418f800ba73c6af40e7eec56

# How

Add additional resolution

# Test Plan

tried to install a different module and confirmed it did not overwrite the yarn.lock resolution.