### PR TITLE
Stop running `adb shell monkey` when opening apps other than Expo Go

### DIFF
--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -529,20 +529,22 @@ async function _openUrlAsync({
   // launch the project!
   // https://github.com/expo/expo/issues/7772
   // adb shell monkey -p host.exp.exponent -c android.intent.category.LAUNCHER 1
-  const openClient = await getAdbOutputAsync(
-    adbPidArgs(
-      pid,
-      'shell',
-      'monkey',
-      '-p',
-      applicationId,
-      '-c',
-      'android.intent.category.LAUNCHER',
-      '1'
-    )
-  );
-  if (openClient.includes(CANT_START_ACTIVITY_ERROR)) {
-    throw new Error(openClient.substring(openClient.indexOf('Error: ')));
+  if (applicationId === 'host.exp.exponent') {
+    const openClient = await getAdbOutputAsync(
+      adbPidArgs(
+        pid,
+        'shell',
+        'monkey',
+        '-p',
+        applicationId,
+        '-c',
+        'android.intent.category.LAUNCHER',
+        '1'
+      )
+    );
+    if (openClient.includes(CANT_START_ACTIVITY_ERROR)) {
+      throw new Error(openClient.substring(openClient.indexOf('Error: ')));
+    }
   }
 
   const openProject = await getAdbOutputAsync(

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -529,6 +529,7 @@ async function _openUrlAsync({
   // launch the project!
   // https://github.com/expo/expo/issues/7772
   // adb shell monkey -p host.exp.exponent -c android.intent.category.LAUNCHER 1
+  // Note: this is not needed in Expo Development Client, it only applies to Expo Go
   if (applicationId === 'host.exp.exponent') {
     const openClient = await getAdbOutputAsync(
       adbPidArgs(


### PR DESCRIPTION
# Why

When opening an app in an Android device or emulator, Expo CLI runs `adb shell monkey` to trigger a launch of the application before opening the deep link.

This was added as a workaround to a bug before SDK 38 was released:
https://github.com/expo/expo-cli/blob/9a3afab44b5c28ec4baa7f0c3c3cf6440fcc68d7/packages/xdl/src/Android.ts#L528-L531

However running the `adb shell monkey` command when opening an app using dev client causes the dev launcher splash screen and UI to briefly flash before showing the app.

# How

Stopped triggering the monkey command when `applicationId` is not `host.exp.exponent` (Expo Go), since the workaround was made for Expo Go.

Note: I also toyed with removing the workaround altogether, since it seemed the issue referred to in the comment might be already fixed (https://github.com/expo/expo/pull/7800) since SDK 38 (and support for SDK 37 was dropped last month). However, during my tests with Android emulator, opening an app in Expo Go triggered an issue where the app got stuck on splash screen. Adding the monkey command back for Expo Go fixed the issue.

# Test Plan

Managed:
- Created a managed app with `expo init`, ran `expo start`, pressed `a`. Killed the app. Pressed `a` again. Observed that the app started.

Bare w/ dev client:
- Created an app with `npx crna -t with-dev-client`, ran `expo run:android`.
- Ran `expo start`, pressed `a`. Killed the app. Pressed `a` again.
- Observed that the app was opened without a flash of dev launcher.