### PR TITLE
[config-plugins] Add noop Swift file to fix builds with Swift deps

### DIFF
--- a/packages/config-plugins/src/ios/Swift.ts
+++ b/packages/config-plugins/src/ios/Swift.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { ConfigPlugin, XcodeProject } from '../Plugin.types';
 import { withXcodeProject } from '../plugins/ios-plugins';
 import { getAppDelegate, getSourceRoot } from './Paths';
+import { withBuildSourceFile } from './XcodeProjectFile';
 import { addResourceFileToGroup, getProjectName } from './utils/Xcodeproj';
 
 const templateBridgingHeader = `//
@@ -154,3 +155,16 @@ export function createBridgingHeaderFile({
   }
   return project;
 }
+
+export const withNoopSwiftFile: ConfigPlugin = config => {
+  return withBuildSourceFile(config, {
+    filePath: 'noop-file.swift',
+    contents: [
+      '//',
+      '// @generated',
+      '// A blank Swift file must be created for native modules with Swift files to work correctly.',
+      '//',
+      '',
+    ].join('\n'),
+  });
+};

--- a/packages/config-plugins/src/ios/SwiftBridgingHeader.ts
+++ b/packages/config-plugins/src/ios/SwiftBridgingHeader.ts
@@ -4,11 +4,22 @@ import path from 'path';
 import { ConfigPlugin, XcodeProject } from '../Plugin.types';
 import { withXcodeProject } from '../plugins/ios-plugins';
 import { getAppDelegate, getSourceRoot } from './Paths';
-import { addResourceFileToGroup, getProjectName } from './utils/Xcodeproj';
+import {
+  addBuildSourceFileToGroup,
+  addResourceFileToGroup,
+  getProjectName,
+} from './utils/Xcodeproj';
 
 const templateBridgingHeader = `//
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
+`;
+
+const templateSwiftNoop = `//
+//  This is an empty Swift file to ensure that any Swift project dependencies compile.
+//
+
+import Foundation
 `;
 
 /**
@@ -40,17 +51,29 @@ export function ensureSwiftBridgingHeaderSetup({
   if (shouldCreateSwiftBridgingHeader({ projectRoot, project })) {
     const projectName = getProjectName(projectRoot);
     const bridgingHeader = createBridgingHeaderFileName(projectName);
+
     // Ensure a bridging header is created in the Xcode project.
-    project = createBridgingHeaderFile({
+    project = createFile({
       project,
       projectName,
       projectRoot,
-      bridgingHeader,
+      filename: bridgingHeader,
+      contents: templateBridgingHeader,
     });
+
     // Designate the newly created file as the Swift bridging header in the Xcode project.
     project = linkBridgingHeaderFile({
       project,
       bridgingHeader: path.join(projectName, bridgingHeader),
+    });
+
+    // Create an empty Swift file
+    project = createFile({
+      project,
+      projectName,
+      projectRoot,
+      filename: 'noop.swift',
+      contents: templateSwiftNoop,
     });
   }
   return project;
@@ -122,35 +145,41 @@ export function linkBridgingHeaderFile({
   return project;
 }
 
-export function createBridgingHeaderFile({
+export function createFile({
   projectRoot,
   projectName,
   project,
-  bridgingHeader,
+  filename,
+  contents,
 }: {
   project: XcodeProject;
   projectName: string;
   projectRoot: string;
-  bridgingHeader: string;
+  filename: string;
+  contents: string;
 }): XcodeProject {
-  const bridgingHeaderProjectPath = path.join(getSourceRoot(projectRoot), bridgingHeader);
-  if (!fs.existsSync(bridgingHeaderProjectPath)) {
+  const fullPath = path.join(getSourceRoot(projectRoot), filename);
+  if (!fs.existsSync(fullPath)) {
     // Create the file
-    fs.writeFileSync(bridgingHeaderProjectPath, templateBridgingHeader, 'utf8');
+    fs.writeFileSync(fullPath, contents, 'utf8');
   }
 
   // This is non-standard, Xcode generates the bridging header in `/ios` which is kinda annoying.
   // Instead, this'll generate the default header in the application code folder `/ios/myproject/`.
-  const filePath = `${projectName}/${bridgingHeader}`;
+  const filepath = `${projectName}/${filename}`;
   // Ensure the file is linked with Xcode resource files
-  if (!project.hasFile(filePath)) {
-    project = addResourceFileToGroup({
-      filepath: filePath,
-      groupName: projectName,
-      project,
-      // Not sure why, but this is how Xcode generates it.
-      isBuildFile: false,
-    });
+  if (!project.hasFile(filepath)) {
+    if (filename.endsWith('.swift')) {
+      project = addBuildSourceFileToGroup({ filepath, groupName: projectName, project });
+    } else {
+      project = addResourceFileToGroup({
+        filepath,
+        groupName: projectName,
+        project,
+        // Not sure why, but this is how Xcode generates it.
+        isBuildFile: false,
+      });
+    }
   }
   return project;
 }

--- a/packages/config-plugins/src/ios/__tests__/Swift-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Swift-test.ts
@@ -1,11 +1,14 @@
+import { ExpoConfig } from '@expo/config-types';
 import * as fs from 'fs';
 import { vol } from 'memfs';
 import * as path from 'path';
 
+import { compileModsAsync } from '../../plugins/mod-compiler';
 import {
   ensureSwiftBridgingHeaderSetup,
   getDesignatedSwiftBridgingHeaderFileReference,
-} from '../SwiftBridgingHeader';
+  withNoopSwiftFile,
+} from '../Swift';
 import { getPbxproj } from '../utils/Xcodeproj';
 
 const fsReal = jest.requireActual('fs') as typeof fs;
@@ -67,5 +70,35 @@ describe(ensureSwiftBridgingHeaderSetup, () => {
     expect(
       vol.existsSync(path.join(projectRootSwift, 'ios/testproject/testproject-Bridging-Header.h'))
     ).toBe(false);
+  });
+});
+
+describe(withNoopSwiftFile, () => {
+  const projectRoot = '/alpha';
+  beforeAll(async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject/AppDelegate.m': '',
+      },
+      projectRoot
+    );
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it(`creates a noop swift file`, async () => {
+    const config = withNoopSwiftFile({
+      name: 'testproject',
+      slug: 'testproject',
+    });
+
+    await compileModsAsync(config, { projectRoot: '/alpha', platforms: ['ios'] });
+    expect(fs.existsSync('/alpha/ios/testproject/noop-file.swift')).toBeTruthy();
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/Swift-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Swift-test.ts
@@ -1,4 +1,3 @@
-import { ExpoConfig } from '@expo/config-types';
 import * as fs from 'fs';
 import { vol } from 'memfs';
 import * as path from 'path';

--- a/packages/config-plugins/src/ios/index.ts
+++ b/packages/config-plugins/src/ios/index.ts
@@ -19,7 +19,7 @@ import * as ProvisioningProfile from './ProvisioningProfile';
 import * as RequiresFullScreen from './RequiresFullScreen';
 import * as Scheme from './Scheme';
 import * as SplashScreen from './SplashScreen';
-import * as SwiftBridgingHeader from './SwiftBridgingHeader';
+import * as Swift from './Swift';
 import * as Updates from './Updates';
 import * as UserInterfaceStyle from './UserInterfaceStyle';
 import * as UsesNonExemptEncryption from './UsesNonExemptEncryption';
@@ -53,7 +53,7 @@ export {
   Permissions,
   RequiresFullScreen,
   Scheme,
-  SwiftBridgingHeader,
+  Swift,
   Updates,
   UserInterfaceStyle,
   UsesNonExemptEncryption,

--- a/packages/config-plugins/src/plugins/__tests__/expo-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/expo-plugins-test.ts
@@ -293,6 +293,7 @@ describe('built-in plugins', () => {
       'ios/ReactNativeProject/Supporting/en.lproj/InfoPlist.strings',
       'ios/ReactNativeProject/Supporting/es.lproj/InfoPlist.strings',
       'ios/ReactNativeProject/GoogleService-Info.plist',
+      'ios/ReactNativeProject/noop-file.swift',
       'ios/ReactNativeProject/ReactNativeProject-Bridging-Header.h',
       'ios/ReactNativeProject/ReactNativeProject.entitlements',
       'ios/ReactNativeProject.xcodeproj/project.pbxproj',

--- a/packages/config-plugins/src/plugins/expo-plugins.ts
+++ b/packages/config-plugins/src/plugins/expo-plugins.ts
@@ -28,7 +28,8 @@ export const withExpoIOSPlugins: ConfigPlugin<{
 
   return withPlugins(config, [
     [IOSConfig.BundleIdentifier.withBundleIdentifier, { bundleIdentifier }],
-    IOSConfig.SwiftBridgingHeader.withSwiftBridgingHeader,
+    IOSConfig.Swift.withSwiftBridgingHeader,
+    IOSConfig.Swift.withNoopSwiftFile,
     IOSConfig.Google.withGoogle,
     IOSConfig.Name.withDisplayName,
     IOSConfig.Orientation.withOrientation,


### PR DESCRIPTION
# Why

Installing `@react-native-menu/menu`, `react-native-blurhash` and `stripe-react-native` Just Work.

Q: Does this increase base binary size by too much?
A: No, according to TestFlight estimates:

![Screen Shot 2021-05-13 at 10 47 41 PM](https://user-images.githubusercontent.com/90494/118329392-cd3ad100-b4bb-11eb-9304-65e5f8ef53a9.png)

# How

Added an empty Swift file included in the target.

# Test Plan

```
expo init hello # some managed project
cd hello
yarn add @react-native-menu/menu
expod prebuild
expo run:ios
```

# Follow up

Possibly remove [this plugin from expo-facebook](https://github.com/expo/expo/blob/master/packages/expo-facebook/plugin/src/withNoopSwiftFile.ts)? Note that these plugins play together nicely so it's not strictly necessary.