### PR TITLE
[dev-server] Support metro-inspector-proxy for hermes debugging

### DIFF
--- a/ts-declarations/metro-inspector-proxy/index.d.ts
+++ b/ts-declarations/metro-inspector-proxy/index.d.ts
@@ -1,0 +1,13 @@
+declare module 'metro-inspector-proxy' {
+  import type { IncomingMessage, ServerResponse } from 'http';
+
+  export class InspectorProxy {
+    constructor();
+
+    processRequest(
+      request: IncomingMessage,
+      response: ServerResponse,
+      next: (error?: Error) => void
+    );
+  }
+}


### PR DESCRIPTION
# Why

To support Hermes inspector, metro-inspector-proxy acts as the websocket proxy server role to pass _Chrome DevTools Protocol_ commands to Hermes on device.
For Chrome DevTools to discover devices, endpoints like `/json/version` or `/json/list` should be reachable.
However, for Expo + Metro case, these endpoints will return the manifest.

The root cause is that metro-inspector-proxy middleware is added [after server started](https://github.com/facebook/metro/blob/master/packages/metro/src/index.js#L241-L256).
Other middlewares, like custom extensive middleware or Expo manifest middleware [are added before that](https://github.com/facebook/metro/blob/master/packages/metro/src/index.js#L241-L256).
In theory, the manifest middleware should be put at last for unmatched routes to return the manifest.
Since metro-inspector-proxy is handled after the manifest middleware, `/json/version` and `/json/list` returns the manifest but not device inspector information.



# How

The reason for metro-inspector-proxy to do that because [it needs the httpServer to attach the websocket handler](https://github.com/facebook/metro/blob/master/packages/metro/src/index.js#L248).
Before there are better solution from metro,
the way to add yet another metro-inspector-proxy middleware before manifest middleware and make it work.
There will be two metro-inspector-proxy middlewares in fact, but should not take too much resources.

# Test Plan

1. `expo start --dev-client` in bare workflow apps
2. Expect the request to `http://localhost:8081/json/version` should return
```json
{
    "Browser": "Mobile JavaScript",
    "Protocol-Version": "1.1"
}
```
3. Expect the request to `http://localhost:8081/json/list` should return just an empty array `[]` (assuming no debuggable hermes on devices)