### PR TITLE
Limit manifest serving to a few URLs

### DIFF
--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -119,8 +119,15 @@ function getPlatformFromRequest(headers: http.IncomingHttpHeaders): string {
 export function getManifestHandler(projectRoot: string) {
   return async (
     req: express.Request | http.IncomingMessage,
-    res: express.Response | http.ServerResponse
+    res: express.Response | http.ServerResponse,
+    next: (err?: Error) => void
   ) => {
+    // Only support `/`, `/manifest`, `/index.exp` for the manifest middleware.
+    if (!req.url || !['/', '/manifest', '/index.exp'].includes(req.url)) {
+      next();
+      return;
+    }
+
     try {
       // We intentionally don't `await`. We want to continue trying even
       // if there is a potential error in the package.json and don't want to slow


### PR DESCRIPTION
# Why

- Prevent overwriting default metro features https://github.com/expo/expo-cli/pull/3490

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Only support `/`, `/manifest`, `/index.exp` for the manifest middleware.

# Test Plan

- Start expo, visit `/`, `/manifest`, `/index.exp` and get the manifest
- Visit `/json/version` to get something other than the manifest