### PR TITLE
Add `originalFullName` to the public config

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -22,7 +22,7 @@ import {
 import { ConfigError } from './Errors';
 import { getExpoSDKVersion } from './Project';
 import { getDynamicConfig, getStaticConfig } from './getConfig';
-import { getCurrentFullName } from './getCurrentFullName';
+import { getFullName } from './getFullName';
 import { withConfigPlugins } from './plugins/withConfigPlugins';
 import { withInternal } from './plugins/withInternal';
 import { getRootPackageJsonPath } from './resolvePackageJson';
@@ -143,9 +143,11 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
         delete configWithDefaultValues.exp.android.config;
       }
 
-      // This value will be overwritten when the manifest is being served from the host (i.e. not completely accurate).
+      // These value will be overwritten when the manifest is being served from the host (i.e. not completely accurate).
       // @ts-ignore: currentFullName not on type yet.
-      configWithDefaultValues.exp.currentFullName = getCurrentFullName(configWithDefaultValues.exp);
+      configWithDefaultValues.exp.currentFullName = getFullName(configWithDefaultValues.exp);
+      // @ts-ignore: originalFullName not on type yet.
+      configWithDefaultValues.exp.originalFullName = getFullName(configWithDefaultValues.exp);
     }
 
     return configWithDefaultValues;

--- a/packages/config/src/__tests__/getFullName-test.ts
+++ b/packages/config/src/__tests__/getFullName-test.ts
@@ -1,6 +1,6 @@
 import { ensureDir } from 'fs-extra';
 
-import { getAccountUsername } from '../getCurrentFullName';
+import { getAccountUsername } from '../getFullName';
 import { getExpoHomeDirectory, getUserState } from '../getUserState';
 
 jest.mock('os');

--- a/packages/config/src/getFullName.ts
+++ b/packages/config/src/getFullName.ts
@@ -11,7 +11,7 @@ const ANONYMOUS_USERNAME = 'anonymous';
  * @param manifest
  * @returns
  */
-export function getCurrentFullName(manifest: Pick<ExpoConfig, 'owner' | 'slug'>): string {
+export function getFullName(manifest: Pick<ExpoConfig, 'owner' | 'slug'>): string {
   const username = getAccountUsername(manifest);
   return `@${username}/${manifest.slug}`;
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo-cli/pull/3376 added `currentFullName` for use as a stable identifier, but it is not stable through project transfers. `originalFullName` is, so it should be used instead in libraries like auth-session and notifications.

# How

1. The xdl schema was defined in https://github.com/expo/universe/pull/7590
2. This PR is the equivalent of https://github.com/expo/expo-cli/pull/3376 but for `originalFullName`. `currentFullName` is kept so that the CLI continues to function until we change the auth-session and notifications libraries to use `originalFullName`.
3. Next up, I'll change the auth-session and notifications libraries to use `originalFullName` similar to expo/expo#12465 and expo/expo#12464.

# Test Plan

Run same unit tests that were added in https://github.com/expo/expo-cli/pull/3376.

In a sample project run:
`~/expo/expo-cli/node_modules/.bin/expo config --type public`, see both `currentFullName` and `originalFullName` in output.