### PR TITLE
[config plugins] added provider validation

### DIFF
--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -67,9 +67,15 @@ export type ConfigPlugin<Props = void> = (config: ExpoConfig, props: Props) => E
 
 export type StaticPlugin<T = any> = [string | ConfigPlugin<T>, T];
 
-export type Mod<Props = any> = (
+export type Mod<Props = any> = ((
   config: ExportedConfigWithProps<Props>
-) => OptionalPromise<ExportedConfigWithProps<Props>>;
+) => OptionalPromise<ExportedConfigWithProps<Props>>) & {
+  /**
+   * Indicates that the mod provides data upstream to other mods.
+   * This mod should always be the last one added.
+   */
+  isProvider?: boolean;
+};
 
 export interface ModConfig {
   android?: {

--- a/packages/config-plugins/src/index.ts
+++ b/packages/config-plugins/src/index.ts
@@ -3,7 +3,6 @@
  */
 import * as AndroidConfig from './android';
 import * as IOSConfig from './ios';
-import { clearMods } from './plugins/createBaseMod';
 import {
   getAndroidIntrospectModFileProviders,
   getAndroidModFileProviders,
@@ -74,5 +73,4 @@ export const BaseMods = {
   withIosBaseMods,
   getIosModFileProviders,
   getIosIntrospectModFileProviders,
-  clearMods,
 };

--- a/packages/config-plugins/src/plugins/__tests__/android-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/android-plugins-test.ts
@@ -46,7 +46,7 @@ describe(withGradleProperties, () => {
       },
     });
 
-    await evalModsAsync(config, { projectRoot, platforms: ['android'] });
+    await evalModsAsync(config, { projectRoot, platforms: ['android'], strict: true });
 
     const contents = fs.readFileSync(path.join(projectRoot, 'android/gradle.properties'), 'utf8');
     expect(contents.endsWith('# expo-test\n\nfoo=bar\n\n# end-expo-test')).toBe(true);

--- a/packages/config-plugins/src/plugins/__tests__/withMod-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/withMod-test.ts
@@ -35,4 +35,65 @@ describe(withMod, () => {
       slug: '',
     });
   });
+  it('asserts multiple providers added', async () => {
+    // Apply a provider mod.
+    const config = withBaseMod<any>(
+      { name: 'app', slug: '', mods: null },
+      {
+        platform: 'android',
+        mod: 'custom',
+        isProvider: true,
+        action(props) {
+          // Capitalize app name
+          props.name = (props.name as string).toUpperCase();
+          return props;
+        },
+      }
+    );
+
+    expect(() =>
+      withBaseMod<any>(config, {
+        platform: 'android',
+        mod: 'custom',
+        isProvider: true,
+        action(props) {
+          // Capitalize app name
+          props.name = (props.name as string).toUpperCase();
+          return props;
+        },
+      })
+    ).toThrow(
+      'Cannot set provider mod for "android.custom" because another is already being used.'
+    );
+  });
+  it('throws when attempting to add a mod as the parent of a provider', async () => {
+    // Apply a provider mod.
+    const config = withBaseMod<any>(
+      { name: 'app', slug: '' },
+      {
+        platform: 'android',
+        mod: 'custom',
+        isProvider: true,
+        action(props) {
+          // Capitalize app name
+          props.name = (props.name as string).toUpperCase();
+          return props;
+        },
+      }
+    );
+
+    expect(() =>
+      withMod<any>(config, {
+        platform: 'android',
+        mod: 'custom',
+        action(props) {
+          // Capitalize app name
+          props.name = (props.name as string).toUpperCase();
+          return props;
+        },
+      })
+    ).toThrow(
+      'Cannot add mod to "android.custom" because the provider has already been added. Provider must be the last mod added.'
+    );
+  });
 });

--- a/packages/config-plugins/src/plugins/__tests__/withMod-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/withMod-test.ts
@@ -1,6 +1,6 @@
 import { ExportedConfig } from '../../Plugin.types';
 import { evalModsAsync } from '../mod-compiler';
-import { withMod } from '../withMod';
+import { withBaseMod, withMod } from '../withMod';
 
 describe(withMod, () => {
   it('compiles mods', async () => {
@@ -8,9 +8,10 @@ describe(withMod, () => {
     const exportedConfig: ExportedConfig = { name: 'app', slug: '', mods: null };
 
     // Apply mod
-    let config = withMod<any>(exportedConfig, {
+    let config = withBaseMod<any>(exportedConfig, {
       platform: 'android',
       mod: 'custom',
+      isProvider: true,
       action(props) {
         // Capitalize app name
         props.name = (props.name as string).toUpperCase();

--- a/packages/config-plugins/src/plugins/__tests__/withMod-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/withMod-test.ts
@@ -1,4 +1,4 @@
-import { ExportedConfig } from '../../Plugin.types';
+import { ExportedConfig, Mod } from '../../Plugin.types';
 import { evalModsAsync } from '../mod-compiler';
 import { withBaseMod, withMod } from '../withMod';
 
@@ -7,16 +7,17 @@ describe(withMod, () => {
     // A basic plugin exported from an app.json
     const exportedConfig: ExportedConfig = { name: 'app', slug: '', mods: null };
 
+    const action: Mod<any> = jest.fn(props => {
+      // Capitalize app name
+      props.name = (props.name as string).toUpperCase();
+      return props;
+    });
     // Apply mod
     let config = withBaseMod<any>(exportedConfig, {
       platform: 'android',
       mod: 'custom',
       isProvider: true,
-      action(props) {
-        // Capitalize app name
-        props.name = (props.name as string).toUpperCase();
-        return props;
-      },
+      action,
     });
 
     // Compile plugins generically
@@ -34,6 +35,8 @@ describe(withMod, () => {
       name: 'APP',
       slug: '',
     });
+
+    expect(action).toBeCalledWith(config);
   });
   it('asserts multiple providers added', async () => {
     // Apply a provider mod.

--- a/packages/config-plugins/src/plugins/createBaseMod.ts
+++ b/packages/config-plugins/src/plugins/createBaseMod.ts
@@ -2,7 +2,6 @@ import {
   ConfigPlugin,
   ExportedConfig,
   ExportedConfigWithProps,
-  ModConfig,
   ModPlatform,
 } from '../Plugin.types';
 import { BaseModOptions, withBaseMod } from './withMod';
@@ -108,26 +107,6 @@ export function assertModResults(results: any, platformName: string, modName: st
     );
   }
   return ensuredResults;
-}
-
-export function clearMods(
-  config: ExportedConfig,
-  { platform, preserve }: { platform: ModPlatform; preserve?: string[] }
-) {
-  const mods = (config as any).mods as ModConfig;
-
-  for (const platformKey of Object.keys(mods)) {
-    if (platformKey !== platform) {
-      delete mods[platformKey as ModPlatform];
-    }
-  }
-
-  for (const key of Object.keys(mods[platform] || {})) {
-    if (!preserve?.includes(key)) {
-      // @ts-ignore
-      delete mods[platform][key];
-    }
-  }
 }
 
 function upperFirst(name: string): string {

--- a/packages/config-plugins/src/plugins/createBaseMod.ts
+++ b/packages/config-plugins/src/plugins/createBaseMod.ts
@@ -55,6 +55,7 @@ export function createBaseMod<
       mod: modName,
       skipEmptyMod: props.skipEmptyMod ?? true,
       saveToInternal: props.saveToInternal ?? false,
+      isProvider: true,
       async action({ modRequest: { nextMod, ...modRequest }, ...config }) {
         try {
           let results: ExportedConfigWithProps<ModType> = {

--- a/packages/config-plugins/src/plugins/withDangerousMod.ts
+++ b/packages/config-plugins/src/plugins/withDangerousMod.ts
@@ -1,8 +1,5 @@
-import { JSONObject } from '@expo/json-file';
-
 import { ConfigPlugin, Mod, ModPlatform } from '../Plugin.types';
-import { assertModResults } from './createBaseMod';
-import { withBaseMod, withMod } from './withMod';
+import { withMod } from './withMod';
 
 /**
  * Mods that don't modify any data, all unresolved functionality is performed inside a dangerous mod.
@@ -20,22 +17,5 @@ export const withDangerousMod: ConfigPlugin<[ModPlatform, Mod<unknown>]> = (
     platform,
     mod: 'dangerous',
     action,
-  });
-};
-
-export const withDangerousBaseMod: ConfigPlugin<ModPlatform> = (config, platform) => {
-  // Used for scheduling when dangerous mods run.
-  return withBaseMod<JSONObject>(config, {
-    platform,
-    mod: 'dangerous',
-    skipEmptyMod: true,
-    async action({ modRequest: { nextMod, ...modRequest }, ...config }) {
-      const results = await nextMod!({
-        ...config,
-        modRequest,
-      });
-      assertModResults(results, modRequest.platform, modRequest.modName);
-      return results;
-    },
   });
 };

--- a/packages/config-plugins/src/plugins/withMod.ts
+++ b/packages/config-plugins/src/plugins/withMod.ts
@@ -76,13 +76,18 @@ export function withBaseMod<T>(
     debugTrace = `${modStack}: ${debugTrace}`;
   }
 
-  if (isProvider) {
-    // Prevent adding multiple providers to a mod.
-    // Base mods that provide files ignore any incoming modResults and therefore shouldn't have provider mods as parents.
-    if (interceptedMod.isProvider) {
+  // Prevent adding multiple providers to a mod.
+  // Base mods that provide files ignore any incoming modResults and therefore shouldn't have provider mods as parents.
+  if (interceptedMod.isProvider) {
+    if (isProvider) {
       throw new PluginError(
-        `Cannot add base modifier for "${platform}.${mod}" because another is already registered`,
+        `Cannot set provider mod for "${platform}.${mod}" because another is already being used.`,
         'CONFLICTING_PROVIDER'
+      );
+    } else {
+      throw new PluginError(
+        `Cannot add mod to "${platform}.${mod}" because the provider has already been added. Provider must be the last mod added.`,
+        'INVALID_MOD_ORDER'
       );
     }
   }
@@ -204,6 +209,7 @@ export function withMod<T>(
   return withBaseMod(config, {
     platform,
     mod,
+    isProvider: false,
     async action({ modRequest: { nextMod, ...modRequest }, modResults, ...config }) {
       const results = await action({ modRequest, modResults: modResults as T, ...config });
       return nextMod!(results as any);

--- a/packages/config-plugins/src/plugins/withMod.ts
+++ b/packages/config-plugins/src/plugins/withMod.ts
@@ -4,12 +4,14 @@ import chalk from 'chalk';
 import { boolish } from 'getenv';
 
 import { ExportedConfig, ExportedConfigWithProps, Mod, ModPlatform } from '../Plugin.types';
+import { PluginError } from '../utils/errors';
 
 const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
 
 export type BaseModOptions = {
   platform: ModPlatform;
   mod: string;
+  isProvider?: boolean;
   skipEmptyMod?: boolean;
   saveToInternal?: boolean;
 };
@@ -25,11 +27,19 @@ export type BaseModOptions = {
  * @param mod name of the platform function to intercept
  * @param skipEmptyMod should skip running the action if there is no existing mod to intercept
  * @param saveToInternal should save the results to `_internal.modResults`, only enable this when the results are pure JSON.
+ * @param isProvider should provide data up to the other mods.
  * @param action method to run on the mod when the config is compiled
  */
 export function withBaseMod<T>(
   config: ExportedConfig,
-  { platform, mod, action, skipEmptyMod, saveToInternal }: BaseModOptions & { action: Mod<T> }
+  {
+    platform,
+    mod,
+    action,
+    skipEmptyMod,
+    isProvider,
+    saveToInternal,
+  }: BaseModOptions & { action: Mod<T> }
 ): ExportedConfig {
   if (!config.mods) {
     config.mods = {};
@@ -66,6 +76,17 @@ export function withBaseMod<T>(
     debugTrace = `${modStack}: ${debugTrace}`;
   }
 
+  if (isProvider) {
+    // Prevent adding multiple providers to a mod.
+    // Base mods that provide files ignore any incoming modResults and therefore shouldn't have provider mods as parents.
+    if (interceptedMod.isProvider) {
+      throw new PluginError(
+        `Cannot add base modifier for "${platform}.${mod}" because another is already registered`,
+        'CONFLICTING_PROVIDER'
+      );
+    }
+  }
+
   async function interceptingMod({ modRequest, ...config }: ExportedConfigWithProps<T>) {
     if (isDebug) {
       // In debug mod, log the plugin stack in the order which they were invoked
@@ -81,6 +102,9 @@ export function withBaseMod<T>(
     }
     return results;
   }
+
+  // Ensure this base mod is registered as the provider.
+  interceptingMod.isProvider = isProvider;
 
   (config.mods[platform] as any)[mod] = interceptingMod;
 

--- a/packages/config-plugins/src/utils/errors.ts
+++ b/packages/config-plugins/src/utils/errors.ts
@@ -11,6 +11,7 @@ export type PluginErrorCode =
   | 'INVALID_PLUGIN_IMPORT'
   | 'PLUGIN_NOT_FOUND'
   | 'CONFLICTING_PROVIDER'
+  | 'INVALID_MOD_ORDER'
   | 'MISSING_PROVIDER';
 
 /**

--- a/packages/config-plugins/src/utils/errors.ts
+++ b/packages/config-plugins/src/utils/errors.ts
@@ -6,7 +6,12 @@ export class UnexpectedError extends Error {
   }
 }
 
-export type PluginErrorCode = 'INVALID_PLUGIN_TYPE' | 'INVALID_PLUGIN_IMPORT' | 'PLUGIN_NOT_FOUND';
+export type PluginErrorCode =
+  | 'INVALID_PLUGIN_TYPE'
+  | 'INVALID_PLUGIN_IMPORT'
+  | 'PLUGIN_NOT_FOUND'
+  | 'CONFLICTING_PROVIDER'
+  | 'MISSING_PROVIDER';
 
 /**
  * Based on `JsonFileError` from `@expo/json-file`


### PR DESCRIPTION
# Why

Add stricter rules to modifiers to help prevent any possible errors in setup. Also enables the ability to automatically skip running mods that don't have providers.

# How

- Added ability to specify if a mod is a "provider".
- Assert when adding multiple providers.
- Assert when adding a child mod after a provider has already been added.
- Added strict flag to compiler which skips mods that don't have a provider.
- Remove unused functions like `clearMods`

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Added tests