### PR TITLE
Rename strict to assertMissingModProviders

### DIFF
--- a/packages/config-plugins/src/plugins/__tests__/android-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/android-plugins-test.ts
@@ -46,7 +46,11 @@ describe(withGradleProperties, () => {
       },
     });
 
-    await evalModsAsync(config, { projectRoot, platforms: ['android'], strict: true });
+    await evalModsAsync(config, {
+      projectRoot,
+      platforms: ['android'],
+      assertMissingModProviders: true,
+    });
 
     const contents = fs.readFileSync(path.join(projectRoot, 'android/gradle.properties'), 'utf8');
     expect(contents.endsWith('# expo-test\n\nfoo=bar\n\n# end-expo-test')).toBe(true);

--- a/packages/config-plugins/src/plugins/__tests__/mod-compiler-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/mod-compiler-test.ts
@@ -42,7 +42,10 @@ describe(compileModsAsync, () => {
       action,
     });
 
-    const config = await compileModsAsync(exportedConfig, { projectRoot, strict: false });
+    const config = await compileModsAsync(exportedConfig, {
+      projectRoot,
+      assertMissingModProviders: false,
+    });
 
     expect(config.name).toBe('app');
     // Base mods are skipped when no mods are applied, these shouldn't be defined.
@@ -54,7 +57,7 @@ describe(compileModsAsync, () => {
     expect(action).not.toBeCalled();
   });
 
-  it('asserts missing providers in strict mode', async () => {
+  it('asserts missing providers', async () => {
     // A basic plugin exported from an app.json
     let exportedConfig: ExportedConfig = {
       name: 'app',
@@ -71,7 +74,9 @@ describe(compileModsAsync, () => {
       },
     });
 
-    await expect(compileModsAsync(exportedConfig, { projectRoot, strict: true })).rejects.toThrow(
+    await expect(
+      compileModsAsync(exportedConfig, { projectRoot, assertMissingModProviders: true })
+    ).rejects.toThrow(
       `Initial base modifier for "android.custom" is not a provider and therefore will not provide modResults to child mods`
     );
   });

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -73,7 +73,12 @@ export function withIntrospectionBaseMods(
  */
 export async function compileModsAsync(
   config: ExportedConfig,
-  props: { projectRoot: string; platforms?: ModPlatform[]; introspect?: boolean; strict?: boolean }
+  props: {
+    projectRoot: string;
+    platforms?: ModPlatform[];
+    introspect?: boolean;
+    assertMissingModProviders?: boolean;
+  }
 ): Promise<ExportedConfig> {
   if (props.introspect === true) {
     config = withIntrospectionBaseMods(config);
@@ -121,8 +126,13 @@ export async function evalModsAsync(
      * Throw errors when mods are missing providers.
      * @default true
      */
-    strict,
-  }: { projectRoot: string; introspect?: boolean; strict?: boolean; platforms?: ModPlatform[] }
+    assertMissingModProviders,
+  }: {
+    projectRoot: string;
+    introspect?: boolean;
+    assertMissingModProviders?: boolean;
+    platforms?: ModPlatform[];
+  }
 ): Promise<ExportedConfig> {
   for (const [platformName, platform] of Object.entries(config.mods ?? ({} as ModConfig))) {
     if (platforms && !platforms.includes(platformName as any)) {
@@ -151,7 +161,7 @@ export async function evalModsAsync(
         if (!(mod as Mod).isProvider) {
           // In strict mode, throw an error.
           const errorMessage = `Initial base modifier for "${platformName}.${modName}" is not a provider and therefore will not provide modResults to child mods`;
-          if (strict !== false) {
+          if (assertMissingModProviders !== false) {
             throw new PluginError(errorMessage, 'MISSING_PROVIDER');
           } else {
             if (config._internal?.isDebug) {


### PR DESCRIPTION
# Why

`strict` is too vague.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->