### PR TITLE
[introspect] Add pipe sanitization

### DIFF
--- a/packages/expo-cli/scripts/introspect.ts
+++ b/packages/expo-cli/scripts/introspect.ts
@@ -49,8 +49,11 @@ function commandAsJSON(command: Command): CommandData {
   };
 }
 
+/** The easiest workaround for | (pipe) being confused with a markdown table
+ * separator and breaking marktown table autoformatting is to use ⎮ (U+23AE,
+ * Integral Extension) instead. <> are replaced by [] for HTML reasons. */
 function sanitizeFlags(flags: string) {
-  return flags.replace('<', '[').replace('>', ']');
+  return flags.replace('<', '[').replace('>', ']').replace('|', '⎮');
 }
 
 function formatOptionAsMarkdown(option: OptionData) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/pull/13036/files#r639228722

# How

This appears to be the easiest way for us to use `|` in our markdown doc tables, based on https://stackoverflow.com/a/43070960/659988

# Test Plan

- Run `yarn introspect md | pbcopy`
- Paste results in expo-cli docs as usual
- Format the markdown
- Notice that `expo publish:history` docs work as expected