### PR TITLE
Migrate expo-ads-admob plugin to prebuild-config

### DIFF
--- a/packages/config-plugins/src/android/index.ts
+++ b/packages/config-plugins/src/android/index.ts
@@ -1,4 +1,3 @@
-import * as AdMob from './AdMob';
 import * as AllowBackup from './AllowBackup';
 import * as Branch from './Branch';
 import * as Colors from './Colors';
@@ -34,7 +33,6 @@ export {
   Colors,
   Facebook,
   GoogleMapsApiKey,
-  AdMob,
   GoogleServices,
   IntentFilters,
   Name,

--- a/packages/config-plugins/src/ios/index.ts
+++ b/packages/config-plugins/src/ios/index.ts
@@ -1,4 +1,3 @@
-import * as AdMob from './AdMob';
 import * as Branch from './Branch';
 import * as BuildScheme from './BuildScheme';
 import * as BundleIdentifier from './BundleIdentifier';
@@ -29,7 +28,6 @@ import * as XcodeUtils from './utils/Xcodeproj';
 // https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#export-star-as-namespace-syntax
 // .. but we should wait for this to be the default VSCode version.
 export {
-  AdMob,
   Branch,
   BuildScheme,
   BundleIdentifier,

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob.ts
@@ -1,8 +1,0 @@
-import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
-
-import { createLegacyPlugin } from './createLegacyPlugin';
-
-export default createLegacyPlugin({
-  packageName: 'expo-ads-admob',
-  fallback: [AndroidConfig.AdMob.withAdMob, IOSConfig.AdMob.withAdMob],
-});

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/__tests__/withAndroidAdMob-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/__tests__/withAndroidAdMob-test.ts
@@ -1,10 +1,18 @@
+import { AndroidConfig } from '@expo/config-plugins';
 import { resolve } from 'path';
 
-import { getGoogleMobileAdsAppId, getGoogleMobileAdsAutoInit, setAdMobConfig } from '../AdMob';
-import { getMainApplicationOrThrow, readAndroidManifestAsync } from '../Manifest';
+import {
+  getGoogleMobileAdsAppId,
+  getGoogleMobileAdsAutoInit,
+  setAdMobConfig,
+} from '../withAndroidAdMob';
+const { getMainApplicationOrThrow, readAndroidManifestAsync } = AndroidConfig.Manifest;
 
-const fixturesPath = resolve(__dirname, 'fixtures');
-const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+const sampleManifestPath = resolve(
+  __dirname,
+  '../../__tests__/fixtures',
+  'react-native-AndroidManifest.xml'
+);
 
 describe('Android permissions', () => {
   it(`returns falsey for both if no android GoogleMobileAds config is provided`, () => {

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/__tests__/withAndroidAdMob-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/__tests__/withAndroidAdMob-test.ts
@@ -10,7 +10,7 @@ const { getMainApplicationOrThrow, readAndroidManifestAsync } = AndroidConfig.Ma
 
 const sampleManifestPath = resolve(
   __dirname,
-  '../../__tests__/fixtures',
+  '../../../__tests__/fixtures',
   'react-native-AndroidManifest.xml'
 );
 

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/__tests__/withIosAdMob-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/__tests__/withIosAdMob-test.ts
@@ -1,6 +1,4 @@
-import { getGoogleMobileAdsAppId, setGoogleMobileAdsAppId } from '../AdMob';
-
-jest.mock('../Scheme');
+import { getGoogleMobileAdsAppId, setGoogleMobileAdsAppId } from '../withIosAdMob';
 
 describe(getGoogleMobileAdsAppId, () => {
   it(`returns null from all getters if no value provided`, () => {

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/expo-ads-admob.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/expo-ads-admob.ts
@@ -1,5 +1,3 @@
-import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
-
 import { createLegacyPlugin } from '../createLegacyPlugin';
 import { withAndroidAdMob } from './withAndroidAdMob';
 import { withIosAdMob } from './withIosAdMob';

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/expo-ads-admob.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/expo-ads-admob.ts
@@ -1,0 +1,10 @@
+import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
+
+import { createLegacyPlugin } from '../createLegacyPlugin';
+import { withAndroidAdMob } from './withAndroidAdMob';
+import { withIosAdMob } from './withIosAdMob';
+
+export default createLegacyPlugin({
+  packageName: 'expo-ads-admob',
+  fallback: [withAndroidAdMob, withIosAdMob],
+});

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/withAndroidAdMob.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/withAndroidAdMob.ts
@@ -1,17 +1,22 @@
+import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
-import { createAndroidManifestPlugin } from '../plugins/android-plugins';
-import {
+const {
   addMetaDataItemToMainApplication,
-  AndroidManifest,
+
   getMainApplicationOrThrow,
   removeMetaDataItemFromMainApplication,
-} from './Manifest';
+} = AndroidConfig.Manifest;
 
 const META_APPLICATION_ID = 'com.google.android.gms.ads.APPLICATION_ID';
 const META_DELAY_APP_MEASUREMENT_INIT = 'com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT';
 
-export const withAdMob = createAndroidManifestPlugin(setAdMobConfig, 'withAdMob');
+export const withAndroidAdMob: ConfigPlugin = config => {
+  return withAndroidManifest(config, config => {
+    config.modResults = setAdMobConfig(config, config.modResults);
+    return config;
+  });
+};
 
 export function getGoogleMobileAdsAppId(config: Pick<ExpoConfig, 'android'>) {
   return config.android?.config?.googleMobileAdsAppId ?? null;
@@ -23,7 +28,7 @@ export function getGoogleMobileAdsAutoInit(config: Pick<ExpoConfig, 'android'>) 
 
 export function setAdMobConfig(
   config: Pick<ExpoConfig, 'android'>,
-  androidManifest: AndroidManifest
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
 ) {
   const appId = getGoogleMobileAdsAppId(config);
   const autoInit = getGoogleMobileAdsAutoInit(config);

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/withAndroidAdMob.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/withAndroidAdMob.ts
@@ -3,7 +3,6 @@ import { ExpoConfig } from '@expo/config-types';
 
 const {
   addMetaDataItemToMainApplication,
-
   getMainApplicationOrThrow,
   removeMetaDataItemFromMainApplication,
 } = AndroidConfig.Manifest;

--- a/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/withIosAdMob.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-ads-admob/withIosAdMob.ts
@@ -1,9 +1,12 @@
+import { ConfigPlugin, InfoPlist, withInfoPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
-import { createInfoPlistPlugin } from '../plugins/ios-plugins';
-import { InfoPlist } from './IosConfig.types';
-
-export const withAdMob = createInfoPlistPlugin(setAdMobConfig, 'withAdMob');
+export const withIosAdMob: ConfigPlugin = config => {
+  return withInfoPlist(config, config => {
+    config.modResults = setAdMobConfig(config, config.modResults);
+    return config;
+  });
+};
 
 // NOTE(brentvatne): if the developer has installed the google ads sdk and does
 // not provide an app id their app will crash. Standalone apps get around this by

--- a/packages/prebuild-config/src/plugins/withDefaultPlugins.ts
+++ b/packages/prebuild-config/src/plugins/withDefaultPlugins.ts
@@ -13,7 +13,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { withAndroidIcons } from './icons/withAndroidIcons';
 import { withIosIcons } from './icons/withIosIcons';
-import withAdMob from './unversioned/expo-ads-admob';
+import withAdMob from './unversioned/expo-ads-admob/expo-ads-admob';
 import withAppleAuthentication from './unversioned/expo-apple-authentication';
 import withBranch from './unversioned/expo-branch';
 import withContacts from './unversioned/expo-contacts';


### PR DESCRIPTION
# Why

- Make `expo/config-plugins` smaller
- Make AdMob modules less accessible
- Starts possible deprecation process for unversioned expo-ads-admob module


# Test Plan

- Moved tests