### PR TITLE
Add analytics to dev client commands

### DIFF
--- a/packages/expo-cli/src/StatusEventEmitter.ts
+++ b/packages/expo-cli/src/StatusEventEmitter.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from 'events';
+
+type StatusEvent =
+  | { type: 'bundleBuildFinish'; totalBuildTimeMs: number }
+  | { type: 'deviceLogReceive'; deviceId: string; deviceName: string };
+type StatusEventFields<T> = Omit<T, 'type'>;
+
+declare interface StatusEventEmitter {
+  addListener<T extends StatusEvent>(
+    event: StatusEvent['type'],
+    listener: (fields: StatusEventFields<T>) => void
+  ): this;
+  once<T extends StatusEvent>(
+    event: StatusEvent['type'],
+    listener: (fields: StatusEventFields<T>) => void
+  ): this;
+  removeListener<T extends StatusEvent>(
+    event: StatusEvent['type'],
+    listener: (fields: StatusEventFields<T>) => void
+  ): this;
+  emit<T extends StatusEvent>(event: T['type'], fields: StatusEventFields<T>): boolean;
+}
+
+class StatusEventEmitter extends EventEmitter {}
+
+export default new StatusEventEmitter();

--- a/packages/expo-cli/src/StatusEventEmitter.ts
+++ b/packages/expo-cli/src/StatusEventEmitter.ts
@@ -1,24 +1,29 @@
 import { EventEmitter } from 'events';
 
-type StatusEvent =
-  | { type: 'bundleBuildFinish'; totalBuildTimeMs: number }
-  | { type: 'deviceLogReceive'; deviceId: string; deviceName: string };
-type StatusEventFields<T> = Omit<T, 'type'>;
+interface BundleBuildFinishEvent {
+  totalBuildTimeMs: number;
+}
+interface DeviceLogReceiveEvent {
+  deviceId: string;
+  deviceName: string;
+}
+interface StatusEvents {
+  bundleBuildFinish: BundleBuildFinishEvent;
+  deviceLogReceive: DeviceLogReceiveEvent;
+}
+type StatusEventKey = keyof StatusEvents;
 
 declare interface StatusEventEmitter {
-  addListener<T extends StatusEvent>(
-    event: StatusEvent['type'],
-    listener: (fields: StatusEventFields<T>) => void
+  addListener<K extends StatusEventKey>(
+    event: K,
+    listener: (fields: StatusEvents[K]) => void
   ): this;
-  once<T extends StatusEvent>(
-    event: StatusEvent['type'],
-    listener: (fields: StatusEventFields<T>) => void
+  once<K extends StatusEventKey>(event: K, listener: (fields: StatusEvents[K]) => void): this;
+  removeListener<K extends StatusEventKey>(
+    event: K,
+    listener: (fields: StatusEvents[K]) => void
   ): this;
-  removeListener<T extends StatusEvent>(
-    event: StatusEvent['type'],
-    listener: (fields: StatusEventFields<T>) => void
-  ): this;
-  emit<T extends StatusEvent>(event: T['type'], fields: StatusEventFields<T>): boolean;
+  emit<K extends StatusEventKey>(event: K, fields: StatusEvents[K]): boolean;
 }
 
 class StatusEventEmitter extends EventEmitter {}

--- a/packages/expo-cli/src/analytics/getDevClientProperties.ts
+++ b/packages/expo-cli/src/analytics/getDevClientProperties.ts
@@ -1,0 +1,27 @@
+import { ExpoConfig, getDefaultTarget } from '@expo/config';
+import JsonFile, { JSONValue } from '@expo/json-file';
+import memoize from 'lodash/memoize';
+import resolveFrom from 'resolve-from';
+
+const getDevClientVersion = memoize((projectRoot: string): JSONValue | undefined => {
+  try {
+    const devClientPackage = resolveFrom.silent(projectRoot, 'expo-dev-client/package.json');
+    if (devClientPackage) {
+      return JsonFile.read(devClientPackage).version;
+    }
+  } catch {}
+  return undefined;
+});
+
+const isManaged = memoize((projectRoot: string): boolean => {
+  return getDefaultTarget(projectRoot) === 'managed';
+});
+
+export default function getDevClientProperties(projectRoot: string, exp: ExpoConfig) {
+  return {
+    accountName: exp.currentFullName,
+    devClientVersion: getDevClientVersion(projectRoot),
+    isManaged: isManaged(projectRoot),
+    uptimeMs: process.uptime() * 1000,
+  };
+}

--- a/packages/expo-cli/src/analytics/getDevClientProperties.ts
+++ b/packages/expo-cli/src/analytics/getDevClientProperties.ts
@@ -1,7 +1,11 @@
-import { ExpoConfig, getDefaultTarget } from '@expo/config';
+import { ExpoConfig, getAccountUsername, getDefaultTarget } from '@expo/config';
 import JsonFile, { JSONValue } from '@expo/json-file';
 import memoize from 'lodash/memoize';
 import resolveFrom from 'resolve-from';
+
+const getAccountName = memoize((exp: Pick<ExpoConfig, 'owner'>) => {
+  return getAccountUsername(exp);
+});
 
 const getDevClientVersion = memoize((projectRoot: string): JSONValue | undefined => {
   try {
@@ -13,15 +17,15 @@ const getDevClientVersion = memoize((projectRoot: string): JSONValue | undefined
   return undefined;
 });
 
-const isManaged = memoize((projectRoot: string): boolean => {
-  return getDefaultTarget(projectRoot) === 'managed';
+const getProjectType = memoize((projectRoot: string): 'managed' | 'generic' => {
+  return getDefaultTarget(projectRoot) === 'managed' ? 'managed' : 'generic';
 });
 
 export default function getDevClientProperties(projectRoot: string, exp: ExpoConfig) {
   return {
-    accountName: exp.currentFullName,
-    devClientVersion: getDevClientVersion(projectRoot),
-    isManaged: isManaged(projectRoot),
-    uptimeMs: process.uptime() * 1000,
+    account_name: getAccountName({ owner: exp.owner }),
+    dev_client_version: getDevClientVersion(projectRoot),
+    project_type: getProjectType(projectRoot),
+    uptime_ms: process.uptime() * 1000,
   };
 }

--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -107,13 +107,6 @@ export async function runAndroidActionAsync(projectRoot: string, options: Option
 
   await spawnGradleAsync({ androidProjectPath, variant: options.variant });
 
-  // Send the 'ready' event once the app is runing in the device.
-  UnifiedAnalytics.logEvent('dev client run command', {
-    status: 'ready',
-    platform: 'android',
-    ...getDevClientProperties(projectRoot, exp),
-  });
-
   if (props.bundler) {
     await startBundlerAsync(projectRoot, {
       metroPort: props.port,

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -88,11 +88,6 @@ export async function runIosActionAsync(projectRoot: string, options: Options) {
   if (props.shouldStartBundler) {
     Log.nested(`\nLogs for your project will appear below. ${chalk.dim(`Press Ctrl+C to exit.`)}`);
   }
-  UnifiedAnalytics.logEvent('dev client run command', {
-    status: 'ready',
-    platform: 'ios',
-    ...getDevClientProperties(projectRoot, exp),
-  });
 }
 
 function track(projectRoot: string, exp: ExpoConfig) {

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -1,4 +1,4 @@
-import { ConfigError, getConfig, isLegacyImportsEnabled } from '@expo/config';
+import { ConfigError, ExpoConfig, getConfig, isLegacyImportsEnabled } from '@expo/config';
 import chalk from 'chalk';
 import path from 'path';
 import resolveFrom from 'resolve-from';
@@ -43,17 +43,7 @@ async function action(projectRoot: string, options: NormalizedOptions): Promise<
   });
 
   if (options.devClient) {
-    UnifiedAnalytics.logEvent('dev client start command', {
-      status: 'started',
-      ...getDevClientProperties(projectRoot, exp),
-    });
-    installCustomExitHook(() => {
-      UnifiedAnalytics.logEvent('dev client start command', {
-        status: 'finished',
-        ...getDevClientProperties(projectRoot, exp),
-      });
-      UnifiedAnalytics.flush();
-    });
+    track(projectRoot, exp);
   }
 
   // Assert various random things
@@ -130,6 +120,21 @@ async function action(projectRoot: string, options: NormalizedOptions): Promise<
       ...getDevClientProperties(projectRoot, exp),
     });
   }
+}
+
+function track(projectRoot: string, exp: ExpoConfig) {
+  UnifiedAnalytics.logEvent('dev client start command', {
+    status: 'started',
+    platform: 'ios',
+    ...getDevClientProperties(projectRoot, exp),
+  });
+  installCustomExitHook(() => {
+    UnifiedAnalytics.logEvent('dev client start command', {
+      status: 'finished',
+      ...getDevClientProperties(projectRoot, exp),
+    });
+    UnifiedAnalytics.flush();
+  });
 }
 
 export default (program: any) => {

--- a/packages/expo-cli/src/commands/start/installExitHooks.ts
+++ b/packages/expo-cli/src/commands/start/installExitHooks.ts
@@ -21,3 +21,10 @@ export function installExitHooks(projectRoot: string): void {
     });
   }
 }
+
+export function installCustomExitHook(listener: NodeJS.SignalsListener) {
+  const killSignals: ['SIGINT', 'SIGTERM'] = ['SIGINT', 'SIGTERM'];
+  for (const signal of killSignals) {
+    process.on(signal, listener);
+  }
+}

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -33,6 +33,7 @@ import {
 } from 'xdl';
 
 import { AbortCommandError, SilentError } from './CommandError';
+import StatusEventEmitter from './StatusEventEmitter';
 import { loginOrRegisterAsync } from './accounts';
 import { registerCommands } from './commands';
 import { learnMore } from './commands/utils/TerminalLink';
@@ -644,13 +645,9 @@ Command.prototype.asyncActionProjectDir = function (
           if (err) {
             Log.log(chalk.red('Failed building JavaScript bundle.'));
           } else {
-            Log.log(
-              chalk.green(
-                `Finished building JavaScript bundle in ${
-                  endTime.getTime() - startTime.getTime()
-                }ms.`
-              )
-            );
+            const totalBuildTimeMs = endTime.getTime() - startTime.getTime();
+            Log.log(chalk.green(`Finished building JavaScript bundle in ${totalBuildTimeMs}ms.`));
+            StatusEventEmitter.emit('bundleBuildFinish', { totalBuildTimeMs });
           }
         }
       },

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -668,6 +668,10 @@ Command.prototype.asyncActionProjectDir = function (
         write: (chunk: LogRecord) => {
           if (chunk.tag === 'device') {
             logWithLevel(chunk);
+            StatusEventEmitter.emit('deviceLogReceive', {
+              deviceId: chunk.deviceId,
+              deviceName: chunk.deviceName,
+            });
           }
         },
       },

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -490,6 +490,7 @@ export class UserManagerInstance {
           currentConnection: user.currentConnection,
           username: user.username,
           userType: user.kind,
+          primaryAccountId: user.primaryAccountId,
         }
       );
 
@@ -498,6 +499,7 @@ export class UserManagerInstance {
         currentConnection: user.currentConnection,
         username: user.username,
         userType: user.kind,
+        primaryAccountId: user.primaryAccountId,
       });
     }
 

--- a/packages/xdl/src/logs/PackagerLogsStream.ts
+++ b/packages/xdl/src/logs/PackagerLogsStream.ts
@@ -32,6 +32,8 @@ type DeviceLogRecord = {
   shouldHide: boolean;
   msg: any;
   level: number;
+  deviceId: string;
+  deviceName: string;
 };
 export type LogRecord = (MetroLogRecord | ExpoLogRecord | DeviceLogRecord) & ProjectUtils.LogFields;
 


### PR DESCRIPTION
# Why

In order to improve the experience of using dev client, we're recording a few key events from the CLI.

# How

Events:
- `expo start --dev-client`: event `dev client start command`
- `expo run:ios`: event `dev client run command` with property `platform: "ios"`
- `expo run:android`: event `dev client run command` with property `platform: "android"`

Properties included in all of these events:
- `account_name`: the `owner` of the project, if defined. Otherwise current username.
- `dev_client_version`: semver version of the currently installed `expo-dev-client` package (if installed)
- `is_managed`: `true` if the project has `managed` as it's default target, i.e. iOS and Android native projects don't exist.
- `status`: `started` when the command is starting, `ready` once the dev server is running (`expo start`) or app is running (`expo run`), and `finished` when the command exits
- `uptime_ms`: time (in milliseconds) since the CLI process started. In other words, time elapsed since the user ran the command.

New user trait:
- `primaryAccountId`

# Test Plan

Added some temporary logging to the `logEvent` method in `Analytics.ts`, ran `start --dev-client`, `run:ios` and `run:android` commands and observed that the events were sent.