### PR TITLE
Allow `expo start --dev-client` in managed projects

### DIFF
--- a/packages/expo-cli/src/schemes.ts
+++ b/packages/expo-cli/src/schemes.ts
@@ -1,10 +1,7 @@
 import { getConfig } from '@expo/config';
 import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
-import JsonFile from '@expo/json-file';
 import plist from '@expo/plist';
 import fs from 'fs';
-import path from 'path';
-import slugify from 'slugify';
 
 import { AbortCommandError } from './CommandError';
 import {
@@ -12,7 +9,6 @@ import {
   hasRequiredIOSFilesAsync,
 } from './commands/eject/clearNativeFolder';
 import Log from './log';
-import prompt from './prompts';
 
 export async function getSchemesForIosAsync(projectRoot: string) {
   try {

--- a/packages/expo-cli/src/schemes.ts
+++ b/packages/expo-cli/src/schemes.ts
@@ -100,44 +100,15 @@ async function getManagedDevClientSchemeAsync(projectRoot: string): Promise<stri
   }
 
   Log.warn(
-    '\nDev Client: No URI schemes could be found in configuration, this is required for opening the project\n'
+    `\nDev Client: No URI scheme could be found in configuration, this is required for opening the project.`
   );
-  if (dynamicConfigPath && !staticConfigPath) {
-    // Dynamic config (app.config.js/app.config.ts) can't be automatically updated.
-    Log.log(
-      `Add a common scheme in ${dynamicConfigPath} or provide a scheme with the ${Log.chalk.cyan(
-        '--scheme'
-      )} flag\n`
-    );
-    throw new AbortCommandError();
-  }
-
-  const { scheme } = await prompt({
-    type: 'text',
-    name: 'scheme',
-    validate: value =>
-      /^[a-z0-9-]+$/.test(value) || 'Only lowercase characters/numbers (a-z, 0-9) or hyphen (-)',
-    message: `Please choose a URI scheme for your app`,
-    initial: slugify(exp.slug, {
-      // Remove non-allowed characters and additionally hyphens, which are allowed but not idiomatic.
-      remove: /[^a-z0-9]/,
-      // Convert to lower case.
-      lower: true,
-    }),
-  });
-  if (staticConfigPath) {
-    // if app.json exists we can update it
-    const config = JsonFile.read(staticConfigPath, { json5: true });
-    config.expo = { ...(config.expo as object), scheme };
-    await JsonFile.writeAsync(staticConfigPath, config);
-    Log.log(`Scheme '${scheme}' updated in ${path.basename(staticConfigPath)}`);
-  } else {
-    // otherwise we'll create a new app.json
-    const newConfigPath = path.join(projectRoot, 'app.json');
-    await JsonFile.writeAsync(newConfigPath, { expo: { scheme } });
-    Log.log(`Created ${path.basename(newConfigPath)}`);
-  }
-  return scheme;
+  Log.log(
+    `Add the 'scheme' property in ${
+      dynamicConfigPath ?? staticConfigPath ?? 'app.json'
+    } or provide a scheme with the ${Log.chalk.cyan('--scheme')} flag.`
+  );
+  Log.log(`Note: you'll need to rebuild the app after adding a scheme.\n`);
+  throw new AbortCommandError();
 }
 
 // sort longest to ensure uniqueness.

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -71,21 +71,6 @@ async function optsAsync(projectRoot: string, options: any) {
     opts.hostType = 'localhost';
   }
 
-  // Prevent using --dev-client in a managed app.
-  if (options.devClient) {
-    const defaultTarget = getDefaultTarget(projectRoot);
-    if (defaultTarget !== 'bare') {
-      Log.warn(
-        `\nOption ${Log.chalk.bold(
-          '--dev-client'
-        )} can only be used in bare workflow apps. Run ${Log.chalk.bold(
-          'expo eject'
-        )} and try again.\n`
-      );
-      throw new AbortCommandError();
-    }
-  }
-
   if (typeof options.scheme === 'string') {
     // Use the custom scheme
     opts.scheme = options.scheme ?? null;

--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -1,10 +1,9 @@
-import { getDefaultTarget } from '@expo/config';
 import { Command } from 'commander';
 import indentString from 'indent-string';
 import qrcodeTerminal from 'qrcode-terminal';
 import { Android, ConnectionStatus, ProjectSettings, Simulator, Webpack } from 'xdl';
 
-import CommandError, { AbortCommandError } from './CommandError';
+import CommandError from './CommandError';
 import Log from './log';
 import { getDevClientSchemeAsync } from './schemes';
 


### PR DESCRIPTION
# Why

It should be possible to use dev client with a managed project.

# How

- Removed the "can only be used in bare workflow apps" warning
- Added a check to look up the schema in `app.json`/`app.config.*s` when there are no native project (managed project)
- ~Added a prompt for schema when it's not configured.~
- ~Prompt has a good default.~

<img width="1090" alt="Screen Shot 2021-06-08 at 15 17 02" src="https://user-images.githubusercontent.com/497214/121183327-9c587c80-c86c-11eb-831a-c759851a67c8.png">


# Test Plan

Created a managed project and verified that `expo start --dev-client` started the dev server. Tested with:
- `app.json` including a schema -> started without warnings
- no `scheme` -> error

Also set the `scheme` property in `app.json` to the URI scheme of an app that I had previously built and installed on my Android device. Running `expod start --dev-client` and pressing `a` opened the app.