### PR TITLE
[expo-cli] upgrade @expo/prebuild-config to fix tsc

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -77,7 +77,7 @@
     "@expo/osascript": "2.0.28",
     "@expo/package-manager": "0.0.43",
     "@expo/plist": "0.0.13",
-    "@expo/prebuild-config": "1.0.1",
+    "@expo/prebuild-config": "^1.0.1",
     "@expo/results": "^1.0.0",
     "@expo/simple-spinner": "1.0.2",
     "@expo/spawn-async": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,6 +1446,11 @@
     mv "~2"
     safe-json-stringify "~1"
 
+"@expo/config-types@^40.0.0-beta.2":
+  version "40.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-40.0.0-beta.2.tgz#4fea4ef5654d02218b02b0b3772529a9ce5b0471"
+  integrity sha512-t9pHCQMXOP4nwd7LGXuHkLlFy0JdfknRSCAeVF4Kw2/y+5OBbR9hW9ZVnetpBf0kORrekgiI7K/qDaa3hh5+Qg==
+
 "@expo/configure-splash-screen@~0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.4.0.tgz#dad43fccae4525e32ec25d22c7338b2c3cbf6170"


### PR DESCRIPTION
# Why

yarn tsc is broken

# How

ran `yarn add @expo/prebuild-config`

# Test Plan

tsc passes.