### PR TITLE
[xdl] Prepend manifest handler

### DIFF
--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -55,5 +55,14 @@ export async function startDevServerAsync(projectRoot: string, startOptions: Sta
 
   const { server, middleware, messageSocket } = await runMetroDevServerAsync(projectRoot, options);
   middleware.use(ManifestHandler.getManifestHandler(projectRoot));
+
+  // We need the manifest handler to be the first middleware to run so our
+  // routes take precedence over static files. For example, the manifest is
+  // served from '/' and if the user has an index.html file in their project
+  // then the manifest handler will never run, the static middleware will run
+  // and serve index.html instead of the manifest.
+  // https://github.com/expo/expo/issues/13114
+  middleware.stack.unshift(middleware.stack.pop());
+
   return [server, middleware, messageSocket];
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/13114 reported that serving an app in Expo Go doesn't work when there is an index.html in project root. I looked into it and it turns out that this is because static file serving from the React Native CLI server runs before our manifest handler. So, this is a little hack to move our manifest handler middleware to the front of the middleware stack.

# How

I'm not sure `stack` is meant to be part of the public API but looking at [the source code for `connect`](https://github.com/senchalabs/connect/blob/master/index.js) this seems fine to use.

# Test Plan

Follow steps from repro for https://github.com/expo/expo/issues/13114 then use Expo CLI with this patch.