### PR TITLE
[config-plugins][ENG-1225] fix finding first native target

### DIFF
--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -333,7 +333,6 @@ export function getBuildConfigurationsForListId(
   return Object.entries(project.pbxXCBuildConfigurationSection())
     .filter(isNotComment)
     .filter(isBuildConfig)
-    .filter(isNotTestHost)
     .filter(([key]: ConfigurationSectionEntry) => buildConfigurations.includes(key));
 }
 
@@ -350,7 +349,7 @@ export function getBuildConfigurationForListIdAndName(
   ).find(i => i[1].name === buildConfiguration);
   if (!xcBuildConfigurationEntry) {
     throw new Error(
-      `Build configuration '${buildConfiguration} does not exist in list with id '${configurationListId}'`
+      `Build configuration '${buildConfiguration}' does not exist in list with id '${configurationListId}'`
     );
   }
   return xcBuildConfigurationEntry;


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/430

In https://github.com/expo/expo-cli/pull/3483 I unintentionally changed the behavior of `findFirstNativeTarget` so it can return a non-application target (e.g. test target). Also, `getBuildConfigurationsForListId` had a bug when getting build configurations for a configuration list associated with a test target (because of the `.filter(isNotTestHost)` filter) so the `Build configuration 'Release does not exist in list with id` error.

# How

- I made `findFirstNativeTarget` always return an application target (if exists).
- I fixed the `getBuildConfigurationsForListId` so it works for test targets.

# Test Plan

yarn link-ed `@expo/config-plugin` to local EAS CLI and followed the repro steps from https://github.com/expo/eas-cli/issues/430#issuecomment-850932792