### PR TITLE
[expo-cli] Enhance Hermes support for expo export and publish

### DIFF
--- a/packages/dev-server/src/HermesBundler.ts
+++ b/packages/dev-server/src/HermesBundler.ts
@@ -8,31 +8,14 @@ import path from 'path';
 import process from 'process';
 import resolveFrom from 'resolve-from';
 
-export async function shouldBuildHermesBundleAsync(
-  projectRoot: string,
-  target: ProjectTarget,
-  platform: Platform
-): Promise<boolean> {
-  if (target === 'managed') {
-    const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
-    switch (platform) {
-      case 'android':
-        return exp.android?.jsEngine === 'hermes';
-      default:
-        return false;
-    }
+export function shouldBuildHermesBundle(projectRoot: string, platform: Platform): boolean {
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  switch (platform) {
+    case 'android':
+      return exp.android?.jsEngine === 'hermes';
+    default:
+      return false;
   }
-
-  if (target === 'bare') {
-    switch (platform) {
-      case 'android':
-        return isHermesEnabledForBareAndroidAsync(projectRoot);
-      default:
-        return false;
-    }
-  }
-
-  return false;
 }
 
 interface HermesBundleOutput {

--- a/packages/dev-server/src/HermesBundler.ts
+++ b/packages/dev-server/src/HermesBundler.ts
@@ -22,11 +22,10 @@ export async function shouldBuildHermesBundleAsync(
     const gradlePropertiesPath = path.join(projectRoot, 'android', 'gradle.properties');
     if (fs.existsSync(gradlePropertiesPath)) {
       const properties = parseGradleProperties(await fs.readFile(gradlePropertiesPath, 'utf8'));
-      if (properties['expo.jsEngine'] === 'hermes') {
-        return true;
-      }
+      return properties['expo.jsEngine'] === 'hermes';
     }
   }
+
   return false;
 }
 

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -1,4 +1,5 @@
 import Log from '@expo/bunyan';
+import type { ProjectTarget } from '@expo/config';
 import * as ExpoMetroConfig from '@expo/metro-config';
 import {
   createDevServerMiddleware,
@@ -100,6 +101,7 @@ let nextBuildID = 0;
 // TODO: deprecate options.target
 export async function bundleAsync(
   projectRoot: string,
+  target: ProjectTarget,
   options: MetroDevServerOptions,
   bundles: BundleOptions[]
 ): Promise<BundleOutput[]> {
@@ -164,6 +166,7 @@ export async function bundleAsync(
         const bundleOutput = await buildAsync(bundle);
         const shouldBuildHermesBundle = await shouldBuildHermesBundleAsync(
           projectRoot,
+          target,
           bundle.platform
         );
 

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -1,5 +1,4 @@
 import Log from '@expo/bunyan';
-import type { ProjectTarget } from '@expo/config';
 import * as ExpoMetroConfig from '@expo/metro-config';
 import {
   createDevServerMiddleware,
@@ -13,7 +12,7 @@ import type Metro from 'metro';
 import resolveFrom from 'resolve-from';
 import { parse as parseUrl } from 'url';
 
-import { buildHermesBundleAsync, shouldBuildHermesBundleAsync } from './HermesBundler';
+import { buildHermesBundleAsync, shouldBuildHermesBundle } from './HermesBundler';
 import LogReporter from './LogReporter';
 import clientLogsMiddleware from './middleware/clientLogsMiddleware';
 import createJsInspectorMiddleware from './middleware/createJsInspectorMiddleware';
@@ -101,7 +100,6 @@ let nextBuildID = 0;
 // TODO: deprecate options.target
 export async function bundleAsync(
   projectRoot: string,
-  target: ProjectTarget,
   options: MetroDevServerOptions,
   bundles: BundleOptions[]
 ): Promise<BundleOutput[]> {
@@ -164,13 +162,8 @@ export async function bundleAsync(
     return await Promise.all(
       bundles.map(async (bundle: BundleOptions) => {
         const bundleOutput = await buildAsync(bundle);
-        const shouldBuildHermesBundle = await shouldBuildHermesBundleAsync(
-          projectRoot,
-          target,
-          bundle.platform
-        );
 
-        if (shouldBuildHermesBundle) {
+        if (shouldBuildHermesBundle(projectRoot, bundle.platform)) {
           options.logger.info(
             { tag: 'expo' },
             `💿 Building Hermes bytecode for the bundle - platform[${bundle.platform}]`

--- a/packages/dev-server/src/__tests__/HermesBundler-test.ts
+++ b/packages/dev-server/src/__tests__/HermesBundler-test.ts
@@ -53,11 +53,6 @@ describe('getHermesBytecodeBundleVersionAsync', () => {
     const file = path.join(__dirname, 'fixtures', 'plain.js');
     await expect(getHermesBytecodeBundleVersionAsync(file)).rejects.toThrow();
   });
-
-  it('should throw exception for nonexistent file', async () => {
-    const file = path.join(__dirname, 'fixtures', 'nonexistent.js');
-    await expect(isHermesBytecodeBundleAsync(file)).rejects.toThrow();
-  });
 });
 
 describe('isHermesBytecodeBundleAsync', () => {
@@ -76,5 +71,205 @@ describe('isHermesBytecodeBundleAsync', () => {
   it('should throw exception for nonexistent file', async () => {
     const file = path.join(__dirname, 'fixtures', 'nonexistent.js');
     await expect(isHermesBytecodeBundleAsync(file)).rejects.toThrow();
+  });
+});
+
+describe('maybeInconsistentEngineAsync - android', () => {
+  let fs = require('fs-extra');
+  let { maybeInconsistentEngineAsync } = require('../HermesBundler');
+
+  beforeAll(() => {
+    jest.resetModules();
+    jest.doMock('fs-extra');
+    fs = require('fs-extra');
+    maybeInconsistentEngineAsync = require('../HermesBundler').maybeInconsistentEngineAsync;
+  });
+  afterAll(() => {
+    jest.dontMock('fs-extra');
+    jest.resetModules();
+  });
+
+  it('should return false for managed project', async () => {
+    const mockFsExistSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+    mockFsExistSync.mockReturnValue(false);
+    const result = await maybeInconsistentEngineAsync(
+      '/expo',
+      'android',
+      /* isHermesManaged */ true
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return false if "enableHermes: true" in app/build.gradle and "jsEngine: \'hermes\'" in app.json', async () => {
+    const appBuildGradlePath = '/expo/android/app/build.gradle';
+    const mockFsExistSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+    mockFsExistSync.mockImplementation((file: string) => file === appBuildGradlePath);
+
+    const mockFsReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+    const appBuildGradleTestCases = [
+      `
+project.ext.react = [
+    enableHermes: true
+]`,
+      `
+project.ext.react = [
+    foo: 123,
+    enableHermes: true
+]`,
+      `
+project.ext.react = [
+    foo: 123,
+    enableHermes: true, // with comments
+    bar: 123
+]`,
+    ];
+
+    for (const content of appBuildGradleTestCases) {
+      mockFsReadFile.mockImplementationOnce((file: string) => {
+        return Promise.resolve(file === appBuildGradlePath ? content : '');
+      });
+      const result = await maybeInconsistentEngineAsync(
+        '/expo',
+        'android',
+        /* isHermesManaged */ true
+      );
+      expect(result).toBe(false);
+    }
+  });
+
+  it('should return true if "enableHermes: false" in app/build.gradle and "jsEngine: \'hermes\'" in app.json', async () => {
+    const appBuildGradlePath = '/expo/android/app/build.gradle';
+    const mockFsExistSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+    mockFsExistSync.mockImplementation((file: string) => file === appBuildGradlePath);
+
+    const mockFsReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+    const appBuildGradleTestCases = [
+      `
+// empty build.gradle`,
+      `
+project.ext.react = [
+]`,
+      `
+project.ext.react = [
+    enableHermes: false
+]`,
+      `
+project.ext.react = [
+    foo: 123,
+    enableHermes: false, // with comments
+    bar: 123
+]`,
+    ];
+
+    for (const content of appBuildGradleTestCases) {
+      mockFsReadFile.mockImplementationOnce((file: string) => {
+        return Promise.resolve(file === appBuildGradlePath ? content : '');
+      });
+      const result = await maybeInconsistentEngineAsync(
+        '/expo',
+        'android',
+        /* isHermesManaged */ true
+      );
+      expect(result).toBe(true);
+    }
+  });
+
+  it('should return false if "expo.jsEngine=hermes" in gradle.properties and "jsEngine: \'hermes\'" in app.json', async () => {
+    const gradlePropertiesPath = '/expo/android/gradle.properties';
+    const mockFsExistSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+    mockFsExistSync.mockImplementation((file: string) => file === gradlePropertiesPath);
+
+    const mockFsReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+    mockFsReadFile.mockImplementation((file: string) => {
+      return Promise.resolve(file === gradlePropertiesPath ? 'expo.jsEngine=hermes' : '');
+    });
+
+    const result = await maybeInconsistentEngineAsync(
+      '/expo',
+      'android',
+      /* isHermesManaged */ true
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return false for default sdk41 bare project', async () => {
+    const appBuildGradlePath = '/expo/android/app/build.gradle';
+    const mockFsExistSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+    mockFsExistSync.mockImplementation((file: string) => file === appBuildGradlePath);
+
+    const appBuildGradleContent = `
+project.ext.react = [
+    enableHermes: false
+]`;
+
+    const mockFsReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+    mockFsReadFile.mockImplementation((file: string) => {
+      return Promise.resolve(file === appBuildGradlePath ? appBuildGradleContent : '');
+    });
+
+    const result = await maybeInconsistentEngineAsync(
+      '/expo',
+      'android',
+      /* isHermesManaged */ false
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return true for default sdk41 bare project but user enabled hermes manually', async () => {
+    const appBuildGradlePath = '/expo/android/app/build.gradle';
+    const mockFsExistSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+    mockFsExistSync.mockImplementation((file: string) => file === appBuildGradlePath);
+
+    const appBuildGradleContent = `
+project.ext.react = [
+    enableHermes: true
+]`;
+
+    const mockFsReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+    mockFsReadFile.mockImplementation((file: string) => {
+      return Promise.resolve(file === appBuildGradlePath ? appBuildGradleContent : '');
+    });
+
+    const result = await maybeInconsistentEngineAsync(
+      '/expo',
+      'android',
+      /* isHermesManaged */ false
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should handle the inconsistency between app/build.gradle and gradle.properties', async () => {
+    const appBuildGradlePath = '/expo/android/app/build.gradle';
+    const gradlePropertiesPath = '/expo/android/gradle.properties';
+    const mockFsExistSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+    mockFsExistSync.mockImplementation(
+      (file: string) => file === appBuildGradlePath || file === gradlePropertiesPath
+    );
+
+    const mockFsReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+    const appBuildGradleContent = `
+project.ext.react = [
+    enableHermes: false
+]`;
+    const gradlePropertiesContent = `
+expo.jsEngine=hermes
+`;
+
+    mockFsReadFile.mockImplementation((file: string) => {
+      if (file === appBuildGradlePath) {
+        return Promise.resolve(appBuildGradleContent);
+      }
+      if (file === gradlePropertiesPath) {
+        return Promise.resolve(gradlePropertiesContent);
+      }
+      return Promise.reject(new Error('File not found.'));
+    });
+
+    const result = await maybeInconsistentEngineAsync(
+      '/expo',
+      'android',
+      /* isHermesManaged */ true
+    );
+    expect(result).toBe(true);
   });
 });

--- a/packages/expo-cli/e2e/__tests__/export-test.ts
+++ b/packages/expo-cli/e2e/__tests__/export-test.ts
@@ -55,7 +55,7 @@ it('exports the project for a self-hosted production deployment', async () => {
   expect(distFiles).toMatchSnapshot();
 });
 
-it('should export hbc bundle if running with hermes', async () => {
+it('should export hbc bundle if jsEngine is hermes', async () => {
   jest.setTimeout(5 * 60e3);
   const tempDir = temporary.directory();
   try {
@@ -65,15 +65,15 @@ it('should export hbc bundle if running with hermes', async () => {
       'export-test-app',
       {
         sdkVersion: '41.0.0',
+        android: {
+          jsEngine: 'hermes',
+        },
       },
       {
         expo: '41.0.1',
         'react-native': '0.63.2',
       }
     );
-    const androidRoot = path.join(projectRoot, 'android');
-    await fs.ensureDir(androidRoot);
-    await fs.writeFile(path.join(androidRoot, 'gradle.properties'), 'expo.jsEngine=hermes');
     await fs.writeFile(
       path.join(projectRoot, 'babel.config.js'),
       `

--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -97,7 +97,7 @@ export async function exportAppAsync(
     useDevServer: Env.shouldUseDevServer(exp),
   });
 
-  printBundleSizes(bundles, /* isHermesPreferable */ true);
+  printBundleSizes(bundles);
 
   const iosBundle = bundles.ios.hermesBytecodeBundle ?? bundles.ios.code;
   const androidBundle = bundles.android.hermesBytecodeBundle ?? bundles.android.code;

--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -99,8 +99,8 @@ export async function exportAppAsync(
 
   printBundleSizes(bundles, /* isHermesPreferable */ true);
 
-  const iosBundle = bundles.ios.hermesBytecodeBundle || bundles.ios.code;
-  const androidBundle = bundles.android.hermesBytecodeBundle || bundles.android.code;
+  const iosBundle = bundles.ios.hermesBytecodeBundle ?? bundles.ios.code;
+  const androidBundle = bundles.android.hermesBytecodeBundle ?? bundles.android.code;
 
   const iosBundleHash = crypto.createHash('md5').update(iosBundle).digest('hex');
   const iosBundleUrl = `ios-${iosBundleHash}.js`;
@@ -173,8 +173,8 @@ export async function exportAppAsync(
     );
   }
 
-  const iosSourceMap = bundles.ios.hermesSourcemap || bundles.ios.map;
-  const androidSourceMap = bundles.android.hermesSourcemap || bundles.android.map;
+  const iosSourceMap = bundles.ios.hermesSourcemap ?? bundles.ios.map;
+  const androidSourceMap = bundles.android.hermesSourcemap ?? bundles.android.map;
 
   // build source maps
   if (options.dumpSourcemap) {

--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -97,7 +97,7 @@ export async function exportAppAsync(
     useDevServer: Env.shouldUseDevServer(exp),
   });
 
-  printBundleSizes(bundles, true);
+  printBundleSizes(bundles, /* isHermesPreferable */ true);
 
   const iosBundle = bundles.ios.hermesBytecodeBundle || bundles.ios.code;
   const androidBundle = bundles.android.hermesBytecodeBundle || bundles.android.code;

--- a/packages/expo-cli/src/commands/export/exportAppAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAppAsync.ts
@@ -97,7 +97,7 @@ export async function exportAppAsync(
     useDevServer: Env.shouldUseDevServer(exp),
   });
 
-  printBundleSizes(bundles);
+  printBundleSizes(bundles, true);
 
   const iosBundle = bundles.ios.hermesBytecodeBundle || bundles.ios.code;
   const androidBundle = bundles.android.hermesBytecodeBundle || bundles.android.code;

--- a/packages/xdl/src/logs/TableText.ts
+++ b/packages/xdl/src/logs/TableText.ts
@@ -3,7 +3,7 @@ import prettyBytes from 'pretty-bytes';
 import stripAnsi from 'strip-ansi';
 import table from 'text-table';
 
-export function createFilesTable(files: string[][]): string {
+export function createFilesTable(files: [string, string | Uint8Array][]): string {
   const tableData = files.map((item, index) => {
     const fileBranch = index === 0 ? '┌' : index === files.length - 1 ? '└' : '├';
 

--- a/packages/xdl/src/project/createBundlesAsync.ts
+++ b/packages/xdl/src/project/createBundlesAsync.ts
@@ -120,7 +120,7 @@ export async function createBundlesAsync(
     projectRoot,
     publishOptions.target ?? getDefaultTarget(projectRoot),
     {
-      // If not legacy, delete the target option to prevent warnings from being thrown.
+      // If not legacy, ignore the target option to prevent warnings from being thrown.
       target: !isLegacy ? undefined : publishOptions.target,
       resetCache: publishOptions.resetCache,
       logger: ProjectUtils.getLogger(projectRoot),

--- a/packages/xdl/src/project/createBundlesAsync.ts
+++ b/packages/xdl/src/project/createBundlesAsync.ts
@@ -1,4 +1,4 @@
-import { getConfig, isLegacyImportsEnabled, Platform } from '@expo/config';
+import { getConfig, getDefaultTarget, isLegacyImportsEnabled, Platform } from '@expo/config';
 import { bundleAsync, BundleOutput } from '@expo/dev-server';
 import axios from 'axios';
 import chalk from 'chalk';
@@ -113,18 +113,15 @@ export async function createBundlesAsync(
     }
   }
 
-  const isLegacy = isLegacyImportsEnabled(
-    getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp
-  );
-  // If not legacy, delete the target option to prevent warnings from being thrown.
-  if (!isLegacy) {
-    delete publishOptions.target;
-  }
+  const config = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const isLegacy = isLegacyImportsEnabled(config.exp);
   const platforms: Platform[] = ['android', 'ios'];
   const [android, ios] = await bundleAsync(
     projectRoot,
+    publishOptions.target ?? getDefaultTarget(projectRoot),
     {
-      target: publishOptions.target,
+      // If not legacy, delete the target option to prevent warnings from being thrown.
+      target: !isLegacy ? undefined : publishOptions.target,
       resetCache: publishOptions.resetCache,
       logger: ProjectUtils.getLogger(projectRoot),
       quiet: publishOptions.quiet,

--- a/packages/xdl/src/project/createBundlesAsync.ts
+++ b/packages/xdl/src/project/createBundlesAsync.ts
@@ -89,6 +89,7 @@ export async function createBundlesAsync(
   const platforms: Platform[] = ['android', 'ios'];
   const [android, ios] = await bundleAsync(
     projectRoot,
+    config.exp,
     {
       // If not legacy, ignore the target option to prevent warnings from being thrown.
       target: !isLegacy ? undefined : publishOptions.target,

--- a/packages/xdl/src/project/createBundlesAsync.ts
+++ b/packages/xdl/src/project/createBundlesAsync.ts
@@ -24,59 +24,30 @@ type PackagerOptions = {
   minify: boolean;
 };
 
-// If `isHermesPreferable` is true, will try use hermes bytecode bundle as primary output.
-// This if for classic `expo export` or `expo publish` flows.
-export function printBundleSizes(
-  bundles: { android: BundleOutput; ios: BundleOutput },
-  isHermesPreferable: boolean
-) {
+export function printBundleSizes(bundles: { android: BundleOutput; ios: BundleOutput }) {
   const files: [string, string | Uint8Array][] = [];
 
-  if (isHermesPreferable) {
-    if (bundles.ios.hermesBytecodeBundle) {
-      files.push(['index.ios.js (Hermes)', bundles.ios.hermesBytecodeBundle]);
-    } else {
-      files.push(['index.ios.js', bundles.ios.code]);
-    }
-    if (bundles.android.hermesBytecodeBundle) {
-      files.push(['index.android.js (Hermes)', bundles.android.hermesBytecodeBundle]);
-    } else {
-      files.push(['index.android.js', bundles.android.code]);
-    }
-
-    // Account for inline source maps
-    if (bundles.ios.hermesSourcemap) {
-      files.push([chalk.dim('index.ios.js.map (Hermes)'), bundles.ios.hermesSourcemap]);
-    } else if (bundles.ios.map) {
-      files.push([chalk.dim('index.ios.js.map'), bundles.ios.map]);
-    }
-    if (bundles.android.hermesSourcemap) {
-      files.push([chalk.dim('index.android.js.map (Hermes)'), bundles.android.hermesSourcemap]);
-    } else if (bundles.android.map) {
-      files.push([chalk.dim('index.android.js.map'), bundles.android.map]);
-    }
+  if (bundles.ios.hermesBytecodeBundle) {
+    files.push(['index.ios.js (Hermes)', bundles.ios.hermesBytecodeBundle]);
   } else {
-    files.push(['index.ios.js', bundles.ios.code], ['index.android.js', bundles.android.code]);
-    if (bundles.ios.hermesBytecodeBundle) {
-      files.push(['index.ios.js (Hermes)', bundles.ios.hermesBytecodeBundle]);
-    }
-    if (bundles.android.hermesBytecodeBundle) {
-      files.push(['index.android.js (Hermes)', bundles.android.hermesBytecodeBundle]);
-    }
+    files.push(['index.ios.js', bundles.ios.code]);
+  }
+  if (bundles.android.hermesBytecodeBundle) {
+    files.push(['index.android.js (Hermes)', bundles.android.hermesBytecodeBundle]);
+  } else {
+    files.push(['index.android.js', bundles.android.code]);
+  }
 
-    // Account for inline source maps
-    if (bundles.ios.map) {
-      files.push([chalk.dim('index.ios.js.map'), bundles.ios.map]);
-    }
-    if (bundles.android.map) {
-      files.push([chalk.dim('index.android.js.map'), bundles.android.map]);
-    }
-    if (bundles.ios.hermesSourcemap) {
-      files.push([chalk.dim('index.ios.js.map (Hermes)'), bundles.ios.hermesSourcemap]);
-    }
-    if (bundles.android.hermesSourcemap) {
-      files.push([chalk.dim('index.android.js.map (Hermes)'), bundles.android.hermesSourcemap]);
-    }
+  // Account for inline source maps
+  if (bundles.ios.hermesSourcemap) {
+    files.push([chalk.dim('index.ios.js.map (Hermes)'), bundles.ios.hermesSourcemap]);
+  } else if (bundles.ios.map) {
+    files.push([chalk.dim('index.ios.js.map'), bundles.ios.map]);
+  }
+  if (bundles.android.hermesSourcemap) {
+    files.push([chalk.dim('index.android.js.map (Hermes)'), bundles.android.hermesSourcemap]);
+  } else if (bundles.android.map) {
+    files.push([chalk.dim('index.android.js.map'), bundles.android.map]);
   }
 
   logger.global.info('');

--- a/packages/xdl/src/project/createBundlesAsync.ts
+++ b/packages/xdl/src/project/createBundlesAsync.ts
@@ -1,4 +1,4 @@
-import { getConfig, getDefaultTarget, isLegacyImportsEnabled, Platform } from '@expo/config';
+import { getConfig, isLegacyImportsEnabled, Platform } from '@expo/config';
 import { bundleAsync, BundleOutput } from '@expo/dev-server';
 import axios from 'axios';
 import chalk from 'chalk';
@@ -89,7 +89,6 @@ export async function createBundlesAsync(
   const platforms: Platform[] = ['android', 'ios'];
   const [android, ios] = await bundleAsync(
     projectRoot,
-    publishOptions.target ?? getDefaultTarget(projectRoot),
     {
       // If not legacy, ignore the target option to prevent warnings from being thrown.
       target: !isLegacy ? undefined : publishOptions.target,

--- a/packages/xdl/src/project/createBundlesAsync.ts
+++ b/packages/xdl/src/project/createBundlesAsync.ts
@@ -24,17 +24,59 @@ type PackagerOptions = {
   minify: boolean;
 };
 
-export function printBundleSizes(bundles: { android: BundleOutput; ios: BundleOutput }) {
-  const files = [
-    ['index.ios.js', bundles.ios.code],
-    ['index.android.js', bundles.android.code],
-  ];
-  // Account for inline source maps
-  if (bundles.ios.map) {
-    files.push([chalk.dim('index.ios.js.map'), bundles.ios.map]);
-  }
-  if (bundles.android.map) {
-    files.push([chalk.dim('index.android.js.map'), bundles.android.map]);
+// If `isHermesPreferable` is true, will try use hermes bytecode bundle as primary output.
+// This if for classic `expo export` or `expo publish` flows.
+export function printBundleSizes(
+  bundles: { android: BundleOutput; ios: BundleOutput },
+  isHermesPreferable: boolean
+) {
+  const files: [string, string | Uint8Array][] = [];
+
+  if (isHermesPreferable) {
+    if (bundles.ios.hermesBytecodeBundle) {
+      files.push(['index.ios.js (Hermes)', bundles.ios.hermesBytecodeBundle]);
+    } else {
+      files.push(['index.ios.js', bundles.ios.code]);
+    }
+    if (bundles.android.hermesBytecodeBundle) {
+      files.push(['index.android.js (Hermes)', bundles.android.hermesBytecodeBundle]);
+    } else {
+      files.push(['index.android.js', bundles.android.code]);
+    }
+
+    // Account for inline source maps
+    if (bundles.ios.hermesSourcemap) {
+      files.push([chalk.dim('index.ios.js.map (Hermes)'), bundles.ios.hermesSourcemap]);
+    } else if (bundles.ios.map) {
+      files.push([chalk.dim('index.ios.js.map'), bundles.ios.map]);
+    }
+    if (bundles.android.hermesSourcemap) {
+      files.push([chalk.dim('index.android.js.map (Hermes)'), bundles.android.hermesSourcemap]);
+    } else if (bundles.android.map) {
+      files.push([chalk.dim('index.android.js.map'), bundles.android.map]);
+    }
+  } else {
+    files.push(['index.ios.js', bundles.ios.code], ['index.android.js', bundles.android.code]);
+    if (bundles.ios.hermesBytecodeBundle) {
+      files.push(['index.ios.js (Hermes)', bundles.ios.hermesBytecodeBundle]);
+    }
+    if (bundles.android.hermesBytecodeBundle) {
+      files.push(['index.android.js (Hermes)', bundles.android.hermesBytecodeBundle]);
+    }
+
+    // Account for inline source maps
+    if (bundles.ios.map) {
+      files.push([chalk.dim('index.ios.js.map'), bundles.ios.map]);
+    }
+    if (bundles.android.map) {
+      files.push([chalk.dim('index.android.js.map'), bundles.android.map]);
+    }
+    if (bundles.ios.hermesSourcemap) {
+      files.push([chalk.dim('index.ios.js.map (Hermes)'), bundles.ios.hermesSourcemap]);
+    }
+    if (bundles.android.hermesSourcemap) {
+      files.push([chalk.dim('index.android.js.map (Hermes)'), bundles.android.hermesSourcemap]);
+    }
   }
 
   logger.global.info('');

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -93,7 +93,7 @@ export async function publishAsync(
     useDevServer: Env.shouldUseDevServer(exp),
   });
 
-  printBundleSizes(bundles, /* isHermesPreferable */ true);
+  printBundleSizes(bundles);
 
   await ProjectAssets.publishAssetsAsync({ projectRoot, exp, bundles });
 

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -93,7 +93,7 @@ export async function publishAsync(
     useDevServer: Env.shouldUseDevServer(exp),
   });
 
-  printBundleSizes(bundles,  /* isHermesPreferable* / true);
+  printBundleSizes(bundles, /* isHermesPreferable */ true);
 
   await ProjectAssets.publishAssetsAsync({ projectRoot, exp, bundles });
 

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -93,17 +93,17 @@ export async function publishAsync(
     useDevServer: Env.shouldUseDevServer(exp),
   });
 
-  printBundleSizes(bundles, true);
+  printBundleSizes(bundles,  /* isHermesPreferable* / true);
 
   await ProjectAssets.publishAssetsAsync({ projectRoot, exp, bundles });
 
-  const androidBundle = bundles.android.hermesBytecodeBundle || bundles.android.code;
-  const iosBundle = bundles.ios.hermesBytecodeBundle || bundles.ios.code;
+  const androidBundle = bundles.android.hermesBytecodeBundle ?? bundles.android.code;
+  const iosBundle = bundles.ios.hermesBytecodeBundle ?? bundles.ios.code;
 
   const hasHooks = validPostPublishHooks.length > 0;
 
-  const androidSourceMap = hasHooks ? bundles.android.hermesSourcemap || bundles.android.map : null;
-  const iosSourceMap = hasHooks ? bundles.ios.hermesSourcemap || bundles.ios.map : null;
+  const androidSourceMap = hasHooks ? bundles.android.hermesSourcemap ?? bundles.android.map : null;
+  const iosSourceMap = hasHooks ? bundles.ios.hermesSourcemap ?? bundles.ios.map : null;
 
   let response;
   try {

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -97,13 +97,13 @@ export async function publishAsync(
 
   await ProjectAssets.publishAssetsAsync({ projectRoot, exp, bundles });
 
-  const androidBundle = bundles.android.code;
-  const iosBundle = bundles.ios.code;
+  const androidBundle = bundles.android.hermesBytecodeBundle || bundles.android.code;
+  const iosBundle = bundles.ios.hermesBytecodeBundle || bundles.ios.code;
 
   const hasHooks = validPostPublishHooks.length > 0;
 
-  const androidSourceMap = hasHooks ? bundles.android.map : null;
-  const iosSourceMap = hasHooks ? bundles.ios.map : null;
+  const androidSourceMap = hasHooks ? bundles.android.hermesSourcemap || bundles.android.map : null;
+  const iosSourceMap = hasHooks ? bundles.ios.hermesSourcemap || bundles.ios.map : null;
 
   let response;
   try {
@@ -227,8 +227,8 @@ async function _uploadArtifactsAsync({
   pkg,
 }: {
   exp: ExpoConfig;
-  iosBundle: string;
-  androidBundle: string;
+  iosBundle: string | Uint8Array;
+  androidBundle: string | Uint8Array;
   options: PublishOptions;
   pkg: PackageJSONConfig;
 }) {

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -93,7 +93,7 @@ export async function publishAsync(
     useDevServer: Env.shouldUseDevServer(exp),
   });
 
-  printBundleSizes(bundles);
+  printBundleSizes(bundles, true);
 
   await ProjectAssets.publishAssetsAsync({ projectRoot, exp, bundles });
 


### PR DESCRIPTION
# Why

this pr addresses some missing parts of hermes support.
closes [ENG-1223](https://linear.app/expo/issue/ENG-1223)

# How

1. add hermes bytecode bundle to `printBundleSizes`.
2. add hermes bytecode bundle support for `expo publish`.
3. support managed workflow by reading the `android.jsEngine` config in app.json.
4. `android.jsEngine` in app.json is now the single source of truth to determine  if we need to generate hermes bytecode bundle.
5. introduce `maybeInconsistentEngineAsync()` to show an error prompt if there are inconsistencies between app config and native project.
![Screen Shot 2021-06-08 at 4 32 59 PM](https://user-images.githubusercontent.com/46429/121153231-776a0680-c878-11eb-8d34-358385cd1b27.png)


# Test Plan

1. expo export + managed workflow app with `android.jsEngine=hermes` in app.json.
    make sure exported assets has hermes bytecode bundle.

2. expo publish + managed workflow app with `android.jsEngine=hermes` in app.json.
    download the asset and make sure it is a hermes bytecode bundle.

### Unit Test

```
packages/dev-server/src/__tests__/HermesBundler-test.ts
  maybeInconsistentEngineAsync - android
    ✅  should return false for managed project
    ✅  should return false if "enableHermes: true" in app/build.gradle and "jsEngine: 'hermes'" in app.json (1 ms)
    ✅  should return true if "enableHermes: false" in app/build.gradle and "jsEngine: 'hermes'" in app.json
    ✅  should return false if "expo.jsEngine=hermes" in gradle.properties and "jsEngine: 'hermes'" in app.json (2 ms)
    ✅  should return false for default sdk41 bare project
    ✅  should return true for default sdk41 bare project but user enabled hermes manually
    ✅  should handle the inconsistency between app/build.gradle and gradle.properties
```