### PR TITLE
Silence duplicate file warnings

### DIFF
--- a/packages/config-plugins/src/ios/Google.ts
+++ b/packages/config-plugins/src/ios/Google.ts
@@ -71,6 +71,7 @@ export function setGoogleServicesFile(
       groupName: projectName,
       project,
       isBuildFile: true,
+      verbose: true,
     });
   }
   return project;

--- a/packages/config-plugins/src/ios/Locales.ts
+++ b/packages/config-plugins/src/ios/Locales.ts
@@ -68,6 +68,7 @@ export async function setLocalesAsync(
         groupName: `${projectName}/Supporting/${lang}.lproj`,
         project,
         isBuildFile: true,
+        verbose: true,
       });
     }
   }

--- a/packages/config-plugins/src/ios/Swift.ts
+++ b/packages/config-plugins/src/ios/Swift.ts
@@ -151,6 +151,7 @@ export function createBridgingHeaderFile({
       project,
       // Not sure why, but this is how Xcode generates it.
       isBuildFile: false,
+      verbose: false,
     });
   }
   return project;

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -79,16 +79,19 @@ export function addResourceFileToGroup({
   // Should add to `PBXBuildFile Section`
   isBuildFile,
   project,
+  verbose,
 }: {
   filepath: string;
   groupName: string;
   isBuildFile?: boolean;
   project: XcodeProject;
+  verbose?: boolean;
 }): XcodeProject {
   return addFileToGroupAndLink({
     filepath,
     groupName,
     project,
+    verbose,
     addFileToProject({ project, file }) {
       project.addToPbxFileReferenceSection(file);
       if (isBuildFile) {
@@ -107,15 +110,18 @@ export function addBuildSourceFileToGroup({
   filepath,
   groupName,
   project,
+  verbose,
 }: {
   filepath: string;
   groupName: string;
   project: XcodeProject;
+  verbose?: boolean;
 }): XcodeProject {
   return addFileToGroupAndLink({
     filepath,
     groupName,
     project,
+    verbose,
     addFileToProject({ project, file }) {
       project.addToPbxFileReferenceSection(file);
       project.addToPbxBuildFileSection(file);
@@ -131,11 +137,13 @@ export function addFileToGroupAndLink({
   filepath,
   groupName,
   project,
+  verbose,
   addFileToProject,
 }: {
   filepath: string;
   groupName: string;
   project: XcodeProject;
+  verbose?: boolean;
   addFileToProject: (props: { file: PBXFile; project: XcodeProject }) => void;
 }): XcodeProject {
   const group = pbxGroupByPathOrAssert(project, groupName);
@@ -143,12 +151,14 @@ export function addFileToGroupAndLink({
   const file = createProjectFileForGroup({ filepath, group });
 
   if (!file) {
-    // This can happen when a file like the GoogleService-Info.plist needs to be added and the eject command is run twice.
-    // Not much we can do here since it might be a conflicting file.
-    addWarningIOS(
-      'ios-xcode-project',
-      `Skipped adding duplicate file "${filepath}" to PBXGroup named "${groupName}"`
-    );
+    if (verbose) {
+      // This can happen when a file like the GoogleService-Info.plist needs to be added and the eject command is run twice.
+      // Not much we can do here since it might be a conflicting file.
+      addWarningIOS(
+        'ios-xcode-project',
+        `Skipped adding duplicate file "${filepath}" to PBXGroup named "${groupName}"`
+      );
+    }
     return project;
   }
 


### PR DESCRIPTION
# Why

Silence the `noop-file.swift` warning