### PR TITLE
[config plugins] add styles and colors mods

### DIFF
--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -102,6 +102,14 @@ export interface ModConfig {
      */
     strings?: Mod<ResourceXML>;
     /**
+     * Modify the `android/app/src/main/res/values/colors.xml` as JSON (parsed with [`xml2js`](https://www.npmjs.com/package/xml2js)).
+     */
+    colors?: Mod<ResourceXML>;
+    /**
+     * Modify the `android/app/src/main/res/values/styles.xml` as JSON (parsed with [`xml2js`](https://www.npmjs.com/package/xml2js)).
+     */
+    styles?: Mod<ResourceXML>;
+    /**
      * Modify the `android/app/src/main/<package>/MainActivity.java` as a string.
      */
     mainActivity?: Mod<AndroidPaths.ApplicationProjectFile>;

--- a/packages/config-plugins/src/android/Colors.ts
+++ b/packages/config-plugins/src/android/Colors.ts
@@ -1,5 +1,5 @@
 import { getResourceXMLPathAsync } from './Paths';
-import { ResourceItemXML, ResourceKind, ResourceXML } from './Resources';
+import { buildResourceItem, ResourceItemXML, ResourceKind, ResourceXML } from './Resources';
 
 export function getProjectColorsXMLPathAsync(
   projectRoot: string,
@@ -37,4 +37,30 @@ export function removeColorItem(named: string, contents: ResourceXML) {
     }
   }
   return contents;
+}
+
+/**
+ * Set or remove value in XML based on nullish factor of the `value` property.
+ */
+export function assignColorValue(
+  xml: ResourceXML,
+  {
+    value,
+    name,
+  }: {
+    value?: string | null;
+    name: string;
+  }
+) {
+  if (value) {
+    return setColorItem(
+      buildResourceItem({
+        name,
+        value,
+      }),
+      xml
+    );
+  }
+
+  return removeColorItem(name, xml);
 }

--- a/packages/config-plugins/src/android/Colors.ts
+++ b/packages/config-plugins/src/android/Colors.ts
@@ -1,5 +1,12 @@
 import { getResourceXMLPathAsync } from './Paths';
-import { buildResourceItem, ResourceItemXML, ResourceKind, ResourceXML } from './Resources';
+import {
+  buildResourceItem,
+  getObjectAsResourceItems,
+  getResourceItemsAsObject,
+  ResourceItemXML,
+  ResourceKind,
+  ResourceXML,
+} from './Resources';
 
 export function getProjectColorsXMLPathAsync(
   projectRoot: string,
@@ -63,4 +70,34 @@ export function assignColorValue(
   }
 
   return removeColorItem(name, xml);
+}
+
+/**
+ * Helper to convert a basic XML object into a simple k/v pair.
+ * `colors.xml` is a very basic XML file so this is pretty safe to do.
+ * Added for testing purposes.
+ *
+ * @param xml
+ * @returns
+ */
+export function getColorsAsObject(xml: ResourceXML): Record<string, string> | null {
+  if (!xml?.resources?.color) {
+    return null;
+  }
+
+  return getResourceItemsAsObject(xml.resources.color);
+}
+
+/**
+ * Helper to convert a basic k/v object to a colors XML object.
+ *
+ * @param xml
+ * @returns
+ */
+export function getObjectAsColorsXml(obj: Record<string, string>): ResourceXML {
+  return {
+    resources: {
+      color: getObjectAsResourceItems(obj),
+    },
+  };
 }

--- a/packages/config-plugins/src/android/NavigationBar.ts
+++ b/packages/config-plugins/src/android/NavigationBar.ts
@@ -13,7 +13,8 @@ const WINDOW_LIGHT_NAVIGATION_BAR = 'android:windowLightNavigationBar';
 export const withNavigationBar: ConfigPlugin = config => {
   const immersiveMode = getNavigationBarImmersiveMode(config);
   if (immersiveMode) {
-    // Immersive mode needs to be set programatically
+    // Immersive mode needs to be set programmatically
+    // TODO: Resolve
     WarningAggregator.addWarningAndroid(
       'androidNavigationBar.visible',
       'Hiding the navigation bar must be done programmatically. Refer to the Android documentation - https://developer.android.com/training/system-ui/immersive - for instructions.'
@@ -25,62 +26,67 @@ export const withNavigationBar: ConfigPlugin = config => {
   return config;
 };
 
-const withNavigationBarColors: ConfigPlugin = config =>
-  withAndroidColors(config, config => {
+const withNavigationBarColors: ConfigPlugin = config => {
+  return withAndroidColors(config, config => {
     config.modResults = setNavigationBarColors(config, config.modResults);
     return config;
   });
+};
 
-const withNavigationBarStyles: ConfigPlugin = config =>
-  withAndroidStyles(config, config => {
+const withNavigationBarStyles: ConfigPlugin = config => {
+  return withAndroidStyles(config, config => {
     config.modResults = setNavigationBarStyles(config, config.modResults);
     return config;
   });
+};
 
 export function setNavigationBarColors(
   config: Pick<ExpoConfig, 'androidNavigationBar'>,
-  colorsJSON: ResourceXML
+  colors: ResourceXML
 ): ResourceXML {
   const hexString = getNavigationBarColor(config);
   if (hexString) {
-    const colorItemToAdd = buildResourceItem({ name: NAVIGATION_BAR_COLOR, value: hexString });
-    colorsJSON = setColorItem(colorItemToAdd, colorsJSON);
+    colors = setColorItem(
+      buildResourceItem({
+        name: NAVIGATION_BAR_COLOR,
+        value: hexString,
+      }),
+      colors
+    );
   }
-  return colorsJSON;
+  return colors;
 }
 
 export function setNavigationBarStyles(
   config: Pick<ExpoConfig, 'androidNavigationBar'>,
-  stylesJSON: ResourceXML
+  styles: ResourceXML
 ): ResourceXML {
   const hexString = getNavigationBarColor(config);
   const barStyle = getNavigationBarStyle(config);
-
+  const parent = { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
   if (hexString) {
-    const styleItemToAdd = buildResourceItem({
-      name: `android:${NAVIGATION_BAR_COLOR}`,
-      value: `@color/${NAVIGATION_BAR_COLOR}`,
-    });
-    stylesJSON = setStylesItem({
-      item: styleItemToAdd,
-      xml: stylesJSON,
-      parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
+    styles = setStylesItem({
+      xml: styles,
+      parent,
+      item: buildResourceItem({
+        name: `android:${NAVIGATION_BAR_COLOR}`,
+        value: `@color/${NAVIGATION_BAR_COLOR}`,
+      }),
     });
   }
 
   if (barStyle === 'dark-content') {
-    const navigationBarStyleItem = buildResourceItem({
-      name: WINDOW_LIGHT_NAVIGATION_BAR,
-      value: 'true',
-    });
-    stylesJSON = setStylesItem({
-      item: navigationBarStyleItem,
-      xml: stylesJSON,
-      parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
+    styles = setStylesItem({
+      xml: styles,
+      parent,
+      item: buildResourceItem({
+        name: WINDOW_LIGHT_NAVIGATION_BAR,
+        value: 'true',
+      }),
     });
   }
 
-  return stylesJSON;
+  return styles;
 }
 
 export function getNavigationBarImmersiveMode(config: Pick<ExpoConfig, 'androidNavigationBar'>) {

--- a/packages/config-plugins/src/android/NavigationBar.ts
+++ b/packages/config-plugins/src/android/NavigationBar.ts
@@ -5,10 +5,9 @@ import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins
 import * as WarningAggregator from '../utils/warnings';
 import { setColorItem } from './Colors';
 import { buildResourceItem, ResourceXML } from './Resources';
-import { setStylesItem } from './Styles';
+import { assignStylesValue, getAppThemeLightNoActionBarParent } from './Styles';
 
 const NAVIGATION_BAR_COLOR = 'navigationBarColor';
-const WINDOW_LIGHT_NAVIGATION_BAR = 'android:windowLightNavigationBar';
 
 export const withNavigationBar: ConfigPlugin = config => {
   const immersiveMode = getNavigationBarImmersiveMode(config);
@@ -61,30 +60,19 @@ export function setNavigationBarStyles(
   config: Pick<ExpoConfig, 'androidNavigationBar'>,
   styles: ResourceXML
 ): ResourceXML {
-  const hexString = getNavigationBarColor(config);
-  const barStyle = getNavigationBarStyle(config);
-  const parent = { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
-  if (hexString) {
-    styles = setStylesItem({
-      xml: styles,
-      parent,
-      item: buildResourceItem({
-        name: `android:${NAVIGATION_BAR_COLOR}`,
-        value: `@color/${NAVIGATION_BAR_COLOR}`,
-      }),
-    });
-  }
+  styles = assignStylesValue(styles, {
+    add: !!getNavigationBarColor(config),
+    parent: getAppThemeLightNoActionBarParent(),
+    name: `android:${NAVIGATION_BAR_COLOR}`,
+    value: `@color/${NAVIGATION_BAR_COLOR}`,
+  });
 
-  if (barStyle === 'dark-content') {
-    styles = setStylesItem({
-      xml: styles,
-      parent,
-      item: buildResourceItem({
-        name: WINDOW_LIGHT_NAVIGATION_BAR,
-        value: 'true',
-      }),
-    });
-  }
+  styles = assignStylesValue(styles, {
+    add: getNavigationBarStyle(config) === 'dark-content',
+    parent: getAppThemeLightNoActionBarParent(),
+    name: 'android:windowLightNavigationBar',
+    value: 'true',
+  });
 
   return styles;
 }

--- a/packages/config-plugins/src/android/NavigationBar.ts
+++ b/packages/config-plugins/src/android/NavigationBar.ts
@@ -5,7 +5,7 @@ import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins
 import * as WarningAggregator from '../utils/warnings';
 import { setColorItem } from './Colors';
 import { buildResourceItem, ResourceXML } from './Resources';
-import { assignStylesValue, getAppThemeLightNoActionBarParent } from './Styles';
+import { assignStylesValue, getAppThemeLightNoActionBarGroup } from './Styles';
 
 const NAVIGATION_BAR_COLOR = 'navigationBarColor';
 
@@ -62,14 +62,14 @@ export function setNavigationBarStyles(
 ): ResourceXML {
   styles = assignStylesValue(styles, {
     add: !!getNavigationBarColor(config),
-    parent: getAppThemeLightNoActionBarParent(),
+    parent: getAppThemeLightNoActionBarGroup(),
     name: `android:${NAVIGATION_BAR_COLOR}`,
     value: `@color/${NAVIGATION_BAR_COLOR}`,
   });
 
   styles = assignStylesValue(styles, {
     add: getNavigationBarStyle(config) === 'dark-content',
-    parent: getAppThemeLightNoActionBarParent(),
+    parent: getAppThemeLightNoActionBarGroup(),
     name: 'android:windowLightNavigationBar',
     value: 'true',
   });

--- a/packages/config-plugins/src/android/PrimaryColor.ts
+++ b/packages/config-plugins/src/android/PrimaryColor.ts
@@ -3,8 +3,7 @@ import { ExpoConfig } from '@expo/config-types';
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
 import { assignColorValue } from './Colors';
-import { ResourceXML } from './Resources';
-import { assignStylesValue, getAppThemeLightNoActionBarParent } from './Styles';
+import { assignStylesValue, getAppThemeLightNoActionBarGroup } from './Styles';
 
 const COLOR_PRIMARY_KEY = 'colorPrimary';
 const DEFAULT_PRIMARY_COLOR = '#023c69';
@@ -15,42 +14,28 @@ export const withPrimaryColor: ConfigPlugin = config => {
   return config;
 };
 
-const withPrimaryColorColors: ConfigPlugin = config => {
+export const withPrimaryColorColors: ConfigPlugin = config => {
   return withAndroidColors(config, config => {
-    config.modResults = setPrimaryColorColors(config, config.modResults);
+    config.modResults = assignColorValue(config.modResults, {
+      name: COLOR_PRIMARY_KEY,
+      value: getPrimaryColor(config),
+    });
     return config;
   });
 };
 
-const withPrimaryColorStyles: ConfigPlugin = config => {
+export const withPrimaryColorStyles: ConfigPlugin = config => {
   return withAndroidStyles(config, config => {
-    config.modResults = setPrimaryColorStyles(config, config.modResults);
+    config.modResults = assignStylesValue(config.modResults, {
+      add: !!getPrimaryColor(config),
+      parent: getAppThemeLightNoActionBarGroup(),
+      name: COLOR_PRIMARY_KEY,
+      value: `@color/${COLOR_PRIMARY_KEY}`,
+    });
     return config;
   });
 };
 
 export function getPrimaryColor(config: Pick<ExpoConfig, 'primaryColor'>) {
   return config.primaryColor ?? DEFAULT_PRIMARY_COLOR;
-}
-
-export function setPrimaryColorColors(
-  config: Pick<ExpoConfig, 'primaryColor'>,
-  colors: ResourceXML
-): ResourceXML {
-  return assignColorValue(colors, {
-    name: COLOR_PRIMARY_KEY,
-    value: getPrimaryColor(config),
-  });
-}
-
-export function setPrimaryColorStyles(
-  config: Pick<ExpoConfig, 'primaryColor'>,
-  xml: ResourceXML
-): ResourceXML {
-  return assignStylesValue(xml, {
-    add: !!getPrimaryColor(config),
-    parent: getAppThemeLightNoActionBarParent(),
-    name: COLOR_PRIMARY_KEY,
-    value: `@color/${COLOR_PRIMARY_KEY}`,
-  });
 }

--- a/packages/config-plugins/src/android/PrimaryColor.ts
+++ b/packages/config-plugins/src/android/PrimaryColor.ts
@@ -15,17 +15,19 @@ export const withPrimaryColor: ConfigPlugin = config => {
   return config;
 };
 
-const withPrimaryColorColors: ConfigPlugin = config =>
-  withAndroidColors(config, config => {
+const withPrimaryColorColors: ConfigPlugin = config => {
+  return withAndroidColors(config, config => {
     config.modResults = setPrimaryColorColors(config, config.modResults);
     return config;
   });
+};
 
-const withPrimaryColorStyles: ConfigPlugin = config =>
-  withAndroidStyles(config, config => {
+const withPrimaryColorStyles: ConfigPlugin = config => {
+  return withAndroidStyles(config, config => {
     config.modResults = setPrimaryColorStyles(config, config.modResults);
     return config;
   });
+};
 
 export function getPrimaryColor(config: Pick<ExpoConfig, 'primaryColor'>) {
   return config.primaryColor ?? DEFAULT_PRIMARY_COLOR;
@@ -39,8 +41,7 @@ export function setPrimaryColorColors(
   if (!hexString) {
     return removeColorItem(COLOR_PRIMARY_KEY, xml);
   }
-  const item = buildResourceItem({ name: COLOR_PRIMARY_KEY, value: hexString });
-  return setColorItem(item, xml);
+  return setColorItem(buildResourceItem({ name: COLOR_PRIMARY_KEY, value: hexString }), xml);
 }
 
 export function setPrimaryColorStyles(
@@ -48,17 +49,21 @@ export function setPrimaryColorStyles(
   xml: ResourceXML
 ): ResourceXML {
   const hexString = getPrimaryColor(config);
+  const parent = { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
   if (!hexString) {
     return removeStylesItem({
-      name: COLOR_PRIMARY_KEY,
       xml,
-      parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
+      parent,
+      name: COLOR_PRIMARY_KEY,
     });
   }
 
   return setStylesItem({
-    item: buildResourceItem({ name: COLOR_PRIMARY_KEY, value: `@color/${COLOR_PRIMARY_KEY}` }),
     xml,
-    parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
+    parent,
+    item: buildResourceItem({
+      name: COLOR_PRIMARY_KEY,
+      value: `@color/${COLOR_PRIMARY_KEY}`,
+    }),
   });
 }

--- a/packages/config-plugins/src/android/PrimaryColor.ts
+++ b/packages/config-plugins/src/android/PrimaryColor.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
-import { removeColorItem, setColorItem } from './Colors';
+import { assignColorValue } from './Colors';
 import { buildResourceItem, ResourceXML } from './Resources';
 import { removeStylesItem, setStylesItem } from './Styles';
 
@@ -35,13 +35,12 @@ export function getPrimaryColor(config: Pick<ExpoConfig, 'primaryColor'>) {
 
 export function setPrimaryColorColors(
   config: Pick<ExpoConfig, 'primaryColor'>,
-  xml: ResourceXML
+  colors: ResourceXML
 ): ResourceXML {
-  const hexString = getPrimaryColor(config);
-  if (!hexString) {
-    return removeColorItem(COLOR_PRIMARY_KEY, xml);
-  }
-  return setColorItem(buildResourceItem({ name: COLOR_PRIMARY_KEY, value: hexString }), xml);
+  return assignColorValue(colors, {
+    name: COLOR_PRIMARY_KEY,
+    value: getPrimaryColor(config),
+  });
 }
 
 export function setPrimaryColorStyles(

--- a/packages/config-plugins/src/android/PrimaryColor.ts
+++ b/packages/config-plugins/src/android/PrimaryColor.ts
@@ -3,8 +3,8 @@ import { ExpoConfig } from '@expo/config-types';
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
 import { assignColorValue } from './Colors';
-import { buildResourceItem, ResourceXML } from './Resources';
-import { removeStylesItem, setStylesItem } from './Styles';
+import { ResourceXML } from './Resources';
+import { assignStylesValue, getAppThemeLightNoActionBarParent } from './Styles';
 
 const COLOR_PRIMARY_KEY = 'colorPrimary';
 const DEFAULT_PRIMARY_COLOR = '#023c69';
@@ -47,22 +47,10 @@ export function setPrimaryColorStyles(
   config: Pick<ExpoConfig, 'primaryColor'>,
   xml: ResourceXML
 ): ResourceXML {
-  const hexString = getPrimaryColor(config);
-  const parent = { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
-  if (!hexString) {
-    return removeStylesItem({
-      xml,
-      parent,
-      name: COLOR_PRIMARY_KEY,
-    });
-  }
-
-  return setStylesItem({
-    xml,
-    parent,
-    item: buildResourceItem({
-      name: COLOR_PRIMARY_KEY,
-      value: `@color/${COLOR_PRIMARY_KEY}`,
-    }),
+  return assignStylesValue(xml, {
+    add: !!getPrimaryColor(config),
+    parent: getAppThemeLightNoActionBarParent(),
+    name: COLOR_PRIMARY_KEY,
+    value: `@color/${COLOR_PRIMARY_KEY}`,
   });
 }

--- a/packages/config-plugins/src/android/Resources.ts
+++ b/packages/config-plugins/src/android/Resources.ts
@@ -94,3 +94,60 @@ export function buildResourceGroup(parent: {
     item: parent.items ?? [],
   };
 }
+
+export function findResourceGroup(
+  xml: ResourceGroupXML[] | undefined,
+  group: { name: string; parent?: string }
+): ResourceGroupXML | null {
+  const app = xml?.filter?.(({ $: head }) => {
+    let matches = head.name === group.name;
+    if (group.parent != null && matches) {
+      matches = head.parent === group.parent;
+    }
+    return matches;
+  })?.[0];
+  return app ?? null;
+}
+
+/**
+ * Helper to convert a basic XML object into a simple k/v pair.
+ *
+ * @param xml
+ * @returns
+ */
+export function getResourceItemsAsObject(xml: ResourceItemXML[]): Record<string, string> | null {
+  return xml.reduce(
+    (prev, curr) => ({
+      ...prev,
+      [curr.$.name]: curr._,
+    }),
+    {}
+  );
+}
+
+/**
+ * Helper to convert a basic k/v object to a ResourceItemXML array.
+ *
+ * @param xml
+ * @returns
+ */
+export function getObjectAsResourceItems(obj: Record<string, string>): ResourceItemXML[] {
+  return Object.entries(obj).map(([name, value]) => ({
+    $: { name },
+    _: value,
+  }));
+}
+
+export function getObjectAsResourceGroup(group: {
+  name: string;
+  parent: string;
+  item: Record<string, string>;
+}): ResourceGroupXML {
+  return {
+    $: {
+      name: group.name,
+      parent: group.parent,
+    },
+    item: getObjectAsResourceItems(group.item),
+  };
+}

--- a/packages/config-plugins/src/android/RootViewBackgroundColor.ts
+++ b/packages/config-plugins/src/android/RootViewBackgroundColor.ts
@@ -10,74 +10,66 @@ const ANDROID_WINDOW_BACKGROUND = 'android:windowBackground';
 const WINDOW_BACKGROUND_COLOR = 'activityBackground';
 
 export const withRootViewBackgroundColor: ConfigPlugin = config => {
-  const hexString = getRootViewBackgroundColor(config);
-  config = withRootViewBackgroundColorColors(config, { hexString });
-  config = withRootViewBackgroundColorStyles(config, { hexString });
+  config = withRootViewBackgroundColorColors(config);
+  config = withRootViewBackgroundColorStyles(config);
   return config;
 };
 
-const withRootViewBackgroundColorColors: ConfigPlugin<{ hexString: string | null }> = (
-  config,
-  props
-) => {
+const withRootViewBackgroundColorColors: ConfigPlugin = config => {
   return withAndroidColors(config, async config => {
-    config.modResults = setRootViewBackgroundColorColors(props, config.modResults);
+    config.modResults = setRootViewBackgroundColorColors(config, config.modResults);
     return config;
   });
 };
 
-const withRootViewBackgroundColorStyles: ConfigPlugin<{ hexString: string | null }> = (
-  config,
-  props
-) => {
+const withRootViewBackgroundColorStyles: ConfigPlugin = config => {
   return withAndroidStyles(config, async config => {
-    config.modResults = setRootViewBackgroundColorStyles(props, config.modResults);
+    config.modResults = setRootViewBackgroundColorStyles(config, config.modResults);
     return config;
   });
 };
 
 export function setRootViewBackgroundColorColors(
-  { hexString }: { hexString: string | null },
-  colorsJSON: ResourceXML
+  config: Pick<ExpoConfig, 'android' | 'backgroundColor'>,
+  colors: ResourceXML
 ) {
+  const hexString = getRootViewBackgroundColor(config);
+
   if (!hexString) {
-    return removeColorItem(WINDOW_BACKGROUND_COLOR, colorsJSON);
+    return removeColorItem(WINDOW_BACKGROUND_COLOR, colors);
   }
-  const colorItemToAdd = buildResourceItem({ name: WINDOW_BACKGROUND_COLOR, value: hexString });
-  return setColorItem(colorItemToAdd, colorsJSON);
+  return setColorItem(
+    buildResourceItem({ name: WINDOW_BACKGROUND_COLOR, value: hexString }),
+    colors
+  );
 }
 
 export function setRootViewBackgroundColorStyles(
-  { hexString }: { hexString: string | null },
-  stylesJSON: ResourceXML
+  config: Pick<ExpoConfig, 'android' | 'backgroundColor'>,
+  styles: ResourceXML
 ) {
+  const hexString = getRootViewBackgroundColor(config);
+  const parent = { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
   if (!hexString) {
     return removeStylesItem({
+      xml: styles,
+      parent,
       name: ANDROID_WINDOW_BACKGROUND,
-      xml: stylesJSON,
-      parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
     });
   }
-  const styleItemToAdd = buildResourceItem({
-    name: ANDROID_WINDOW_BACKGROUND,
-    value: `@color/${WINDOW_BACKGROUND_COLOR}`,
-  });
+
   return setStylesItem({
-    item: styleItemToAdd,
-    xml: stylesJSON,
-    parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
+    xml: styles,
+    parent,
+    item: buildResourceItem({
+      name: ANDROID_WINDOW_BACKGROUND,
+      value: `@color/${WINDOW_BACKGROUND_COLOR}`,
+    }),
   });
 }
 
 export function getRootViewBackgroundColor(
   config: Pick<ExpoConfig, 'android' | 'backgroundColor'>
 ) {
-  if (config.android?.backgroundColor) {
-    return config.android.backgroundColor;
-  }
-  if (config.backgroundColor) {
-    return config.backgroundColor;
-  }
-
-  return null;
+  return config.android?.backgroundColor || config.backgroundColor || null;
 }

--- a/packages/config-plugins/src/android/RootViewBackgroundColor.ts
+++ b/packages/config-plugins/src/android/RootViewBackgroundColor.ts
@@ -1,24 +1,73 @@
 import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
-import { withDangerousMod } from '../plugins/withDangerousMod';
-import { writeXMLAsync } from '../utils/XML';
-import { getProjectColorsXMLPathAsync, setColorItem } from './Colors';
-import { buildResourceItem, readResourcesXMLAsync } from './Resources';
-import { getProjectStylesXMLPathAsync, setStylesItem } from './Styles';
+import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
+import { removeColorItem, setColorItem } from './Colors';
+import { buildResourceItem, ResourceXML } from './Resources';
+import { removeStylesItem, setStylesItem } from './Styles';
 
 const ANDROID_WINDOW_BACKGROUND = 'android:windowBackground';
 const WINDOW_BACKGROUND_COLOR = 'activityBackground';
 
 export const withRootViewBackgroundColor: ConfigPlugin = config => {
-  return withDangerousMod(config, [
-    'android',
-    async config => {
-      await setRootViewBackgroundColor(config, config.modRequest.projectRoot);
-      return config;
-    },
-  ]);
+  const hexString = getRootViewBackgroundColor(config);
+  config = withRootViewBackgroundColorColors(config, { hexString });
+  config = withRootViewBackgroundColorStyles(config, { hexString });
+  return config;
 };
+
+const withRootViewBackgroundColorColors: ConfigPlugin<{ hexString: string | null }> = (
+  config,
+  props
+) => {
+  return withAndroidColors(config, async config => {
+    config.modResults = setRootViewBackgroundColorColors(props, config.modResults);
+    return config;
+  });
+};
+
+const withRootViewBackgroundColorStyles: ConfigPlugin<{ hexString: string | null }> = (
+  config,
+  props
+) => {
+  return withAndroidStyles(config, async config => {
+    config.modResults = setRootViewBackgroundColorStyles(props, config.modResults);
+    return config;
+  });
+};
+
+export function setRootViewBackgroundColorColors(
+  { hexString }: { hexString: string | null },
+  colorsJSON: ResourceXML
+) {
+  if (!hexString) {
+    return removeColorItem(WINDOW_BACKGROUND_COLOR, colorsJSON);
+  }
+  const colorItemToAdd = buildResourceItem({ name: WINDOW_BACKGROUND_COLOR, value: hexString });
+  return setColorItem(colorItemToAdd, colorsJSON);
+}
+
+export function setRootViewBackgroundColorStyles(
+  { hexString }: { hexString: string | null },
+  stylesJSON: ResourceXML
+) {
+  if (!hexString) {
+    return removeStylesItem({
+      name: ANDROID_WINDOW_BACKGROUND,
+      xml: stylesJSON,
+      parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
+    });
+  }
+  const styleItemToAdd = buildResourceItem({
+    name: ANDROID_WINDOW_BACKGROUND,
+    value: `@color/${WINDOW_BACKGROUND_COLOR}`,
+  });
+  return setStylesItem({
+    item: styleItemToAdd,
+    xml: stylesJSON,
+    parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
+  });
+}
 
 export function getRootViewBackgroundColor(
   config: Pick<ExpoConfig, 'android' | 'backgroundColor'>
@@ -31,45 +80,4 @@ export function getRootViewBackgroundColor(
   }
 
   return null;
-}
-
-export async function setRootViewBackgroundColor(
-  config: Pick<ExpoConfig, 'android' | 'backgroundColor'>,
-  projectRoot: string
-) {
-  const hexString = getRootViewBackgroundColor(config);
-  if (!hexString) {
-    return false;
-  }
-
-  const stylesPath = await getProjectStylesXMLPathAsync(projectRoot);
-  const colorsPath = await getProjectColorsXMLPathAsync(projectRoot);
-
-  let stylesJSON = await readResourcesXMLAsync({ path: stylesPath });
-  let colorsJSON = await readResourcesXMLAsync({ path: colorsPath });
-
-  const colorItemToAdd = buildResourceItem({ name: WINDOW_BACKGROUND_COLOR, value: hexString });
-  const styleItemToAdd = buildResourceItem({
-    name: ANDROID_WINDOW_BACKGROUND,
-    value: `@color/${WINDOW_BACKGROUND_COLOR}`,
-  });
-
-  colorsJSON = setColorItem(colorItemToAdd, colorsJSON);
-  stylesJSON = setStylesItem({
-    item: styleItemToAdd,
-    xml: stylesJSON,
-    parent: { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' },
-  });
-
-  try {
-    await Promise.all([
-      writeXMLAsync({ path: colorsPath, xml: colorsJSON }),
-      writeXMLAsync({ path: stylesPath, xml: stylesJSON }),
-    ]);
-  } catch (e) {
-    throw new Error(
-      `Error setting Android root view background color. Cannot write new styles.xml to ${stylesPath}.`
-    );
-  }
-  return true;
 }

--- a/packages/config-plugins/src/android/RootViewBackgroundColor.ts
+++ b/packages/config-plugins/src/android/RootViewBackgroundColor.ts
@@ -4,7 +4,7 @@ import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
 import { assignColorValue } from './Colors';
 import { ResourceXML } from './Resources';
-import { assignStylesValue, getAppThemeLightNoActionBarParent } from './Styles';
+import { assignStylesValue, getAppThemeLightNoActionBarGroup } from './Styles';
 
 const ANDROID_WINDOW_BACKGROUND = 'android:windowBackground';
 const WINDOW_BACKGROUND_COLOR = 'activityBackground';
@@ -45,7 +45,7 @@ export function setRootViewBackgroundColorStyles(
 ) {
   return assignStylesValue(styles, {
     add: !!getRootViewBackgroundColor(config),
-    parent: getAppThemeLightNoActionBarParent(),
+    parent: getAppThemeLightNoActionBarGroup(),
     name: ANDROID_WINDOW_BACKGROUND,
     value: `@color/${WINDOW_BACKGROUND_COLOR}`,
   });

--- a/packages/config-plugins/src/android/RootViewBackgroundColor.ts
+++ b/packages/config-plugins/src/android/RootViewBackgroundColor.ts
@@ -3,7 +3,6 @@ import { ExpoConfig } from '@expo/config-types';
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
 import { assignColorValue } from './Colors';
-import { ResourceXML } from './Resources';
 import { assignStylesValue, getAppThemeLightNoActionBarGroup } from './Styles';
 
 const ANDROID_WINDOW_BACKGROUND = 'android:windowBackground';
@@ -15,41 +14,27 @@ export const withRootViewBackgroundColor: ConfigPlugin = config => {
   return config;
 };
 
-const withRootViewBackgroundColorColors: ConfigPlugin = config => {
+export const withRootViewBackgroundColorColors: ConfigPlugin = config => {
   return withAndroidColors(config, async config => {
-    config.modResults = setRootViewBackgroundColorColors(config, config.modResults);
+    config.modResults = assignColorValue(config.modResults, {
+      value: getRootViewBackgroundColor(config),
+      name: WINDOW_BACKGROUND_COLOR,
+    });
     return config;
   });
 };
 
-const withRootViewBackgroundColorStyles: ConfigPlugin = config => {
+export const withRootViewBackgroundColorStyles: ConfigPlugin = config => {
   return withAndroidStyles(config, async config => {
-    config.modResults = setRootViewBackgroundColorStyles(config, config.modResults);
+    config.modResults = assignStylesValue(config.modResults, {
+      add: !!getRootViewBackgroundColor(config),
+      parent: getAppThemeLightNoActionBarGroup(),
+      name: ANDROID_WINDOW_BACKGROUND,
+      value: `@color/${WINDOW_BACKGROUND_COLOR}`,
+    });
     return config;
   });
 };
-
-export function setRootViewBackgroundColorColors(
-  config: Pick<ExpoConfig, 'android' | 'backgroundColor'>,
-  colors: ResourceXML
-) {
-  return assignColorValue(colors, {
-    value: getRootViewBackgroundColor(config),
-    name: WINDOW_BACKGROUND_COLOR,
-  });
-}
-
-export function setRootViewBackgroundColorStyles(
-  config: Pick<ExpoConfig, 'android' | 'backgroundColor'>,
-  styles: ResourceXML
-) {
-  return assignStylesValue(styles, {
-    add: !!getRootViewBackgroundColor(config),
-    parent: getAppThemeLightNoActionBarGroup(),
-    name: ANDROID_WINDOW_BACKGROUND,
-    value: `@color/${WINDOW_BACKGROUND_COLOR}`,
-  });
-}
 
 export function getRootViewBackgroundColor(
   config: Pick<ExpoConfig, 'android' | 'backgroundColor'>

--- a/packages/config-plugins/src/android/RootViewBackgroundColor.ts
+++ b/packages/config-plugins/src/android/RootViewBackgroundColor.ts
@@ -3,8 +3,8 @@ import { ExpoConfig } from '@expo/config-types';
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
 import { assignColorValue } from './Colors';
-import { buildResourceItem, ResourceXML } from './Resources';
-import { removeStylesItem, setStylesItem } from './Styles';
+import { ResourceXML } from './Resources';
+import { assignStylesValue, getAppThemeLightNoActionBarParent } from './Styles';
 
 const ANDROID_WINDOW_BACKGROUND = 'android:windowBackground';
 const WINDOW_BACKGROUND_COLOR = 'activityBackground';
@@ -43,23 +43,11 @@ export function setRootViewBackgroundColorStyles(
   config: Pick<ExpoConfig, 'android' | 'backgroundColor'>,
   styles: ResourceXML
 ) {
-  const hexString = getRootViewBackgroundColor(config);
-  const parent = { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
-  if (!hexString) {
-    return removeStylesItem({
-      xml: styles,
-      parent,
-      name: ANDROID_WINDOW_BACKGROUND,
-    });
-  }
-
-  return setStylesItem({
-    xml: styles,
-    parent,
-    item: buildResourceItem({
-      name: ANDROID_WINDOW_BACKGROUND,
-      value: `@color/${WINDOW_BACKGROUND_COLOR}`,
-    }),
+  return assignStylesValue(styles, {
+    add: !!getRootViewBackgroundColor(config),
+    parent: getAppThemeLightNoActionBarParent(),
+    name: ANDROID_WINDOW_BACKGROUND,
+    value: `@color/${WINDOW_BACKGROUND_COLOR}`,
   });
 }
 

--- a/packages/config-plugins/src/android/RootViewBackgroundColor.ts
+++ b/packages/config-plugins/src/android/RootViewBackgroundColor.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
-import { removeColorItem, setColorItem } from './Colors';
+import { assignColorValue } from './Colors';
 import { buildResourceItem, ResourceXML } from './Resources';
 import { removeStylesItem, setStylesItem } from './Styles';
 
@@ -33,15 +33,10 @@ export function setRootViewBackgroundColorColors(
   config: Pick<ExpoConfig, 'android' | 'backgroundColor'>,
   colors: ResourceXML
 ) {
-  const hexString = getRootViewBackgroundColor(config);
-
-  if (!hexString) {
-    return removeColorItem(WINDOW_BACKGROUND_COLOR, colors);
-  }
-  return setColorItem(
-    buildResourceItem({ name: WINDOW_BACKGROUND_COLOR, value: hexString }),
-    colors
-  );
+  return assignColorValue(colors, {
+    value: getRootViewBackgroundColor(config),
+    name: WINDOW_BACKGROUND_COLOR,
+  });
 }
 
 export function setRootViewBackgroundColorStyles(

--- a/packages/config-plugins/src/android/StatusBar.ts
+++ b/packages/config-plugins/src/android/StatusBar.ts
@@ -2,7 +2,6 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
-import * as WarningAggregator from '../utils/warnings';
 import { removeColorItem, setColorItem } from './Colors';
 import { buildResourceItem, ResourceXML } from './Resources';
 import { removeStylesItem, setStylesItem } from './Styles';
@@ -11,107 +10,108 @@ const COLOR_PRIMARY_DARK_KEY = 'colorPrimaryDark';
 const WINDOW_TRANSLUCENT_STATUS = 'android:windowTranslucentStatus';
 const WINDOW_LIGHT_STATUS_BAR = 'android:windowLightStatusBar';
 
-type Props = {
-  hexString: string;
-  style: NonNullable<NonNullable<ExpoConfig['androidStatusBar']>['barStyle']>;
-};
-
 export const withStatusBar: ConfigPlugin = config => {
-  const props = {
-    style: getStatusBarStyle(config),
-    hexString: getStatusBarColor(config),
-  };
-
-  config = withStatusBarColors(config, props);
-  config = withStatusBarStyles(config, props);
-
+  config = withStatusBarColors(config);
+  config = withStatusBarStyles(config);
   return config;
 };
 
-const withStatusBarColors: ConfigPlugin<Props> = (config, props) => {
+const withStatusBarColors: ConfigPlugin = config => {
   return withAndroidColors(config, async config => {
-    config.modResults = setStatusBarColors(props, config.modResults);
+    config.modResults = setStatusBarColors(config, config.modResults);
     return config;
   });
 };
 
-const withStatusBarStyles: ConfigPlugin<Props> = (config, props) => {
+const withStatusBarStyles: ConfigPlugin = config => {
   return withAndroidStyles(config, async config => {
-    config.modResults = setStatusBarStyles(props, config.modResults);
+    config.modResults = setStatusBarStyles(config, config.modResults);
     return config;
   });
 };
 
-export function setStatusBarColors({ hexString }: Props, xml: ResourceXML): ResourceXML {
+export function setStatusBarColors(
+  config: Pick<ExpoConfig, 'androidStatusBar'>,
+  colors: ResourceXML
+): ResourceXML {
+  const hexString = getStatusBarColor(config);
+
   if (hexString === 'translucent') {
-    return removeColorItem(COLOR_PRIMARY_DARK_KEY, xml);
+    return removeColorItem(COLOR_PRIMARY_DARK_KEY, colors);
   }
 
   // Need to add a color key to colors.xml to use in styles.xml
-  return setColorItem(buildResourceItem({ name: COLOR_PRIMARY_DARK_KEY, value: hexString }), xml);
+  return setColorItem(
+    buildResourceItem({
+      name: COLOR_PRIMARY_DARK_KEY,
+      value: hexString,
+    }),
+    colors
+  );
 }
 
-export function setStatusBarStyles({ hexString, style }: Props, xml: ResourceXML): ResourceXML {
+export function setStatusBarStyles(
+  config: Pick<ExpoConfig, 'androidStatusBar'>,
+  styles: ResourceXML
+): ResourceXML {
+  const style = getStatusBarStyle(config);
+  const hexString = getStatusBarColor(config);
+
   const parent = { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
 
   // Default is light-content, don't need to do anything to set it
   if (style === 'dark-content') {
-    xml = setStylesItem({
+    styles = setStylesItem({
+      xml: styles,
+      parent,
       item: buildResourceItem({
         name: WINDOW_LIGHT_STATUS_BAR,
         value: `true`,
       }),
-      xml,
-      parent,
     });
   } else {
-    xml = removeStylesItem({
-      xml,
+    styles = removeStylesItem({
+      xml: styles,
       parent,
       name: WINDOW_LIGHT_STATUS_BAR,
     });
   }
 
   if (hexString === 'translucent') {
-    xml = removeStylesItem({
-      xml,
+    styles = removeStylesItem({
+      xml: styles,
       parent,
       name: COLOR_PRIMARY_DARK_KEY,
     });
     // translucent status bar set in theme
-    xml = setStylesItem({
-      item: buildResourceItem({ name: WINDOW_TRANSLUCENT_STATUS, value: 'true' }),
-      xml,
+    styles = setStylesItem({
+      xml: styles,
       parent,
+      item: buildResourceItem({
+        name: WINDOW_TRANSLUCENT_STATUS,
+        value: 'true',
+      }),
     });
   } else {
-    xml = removeStylesItem({
-      xml,
+    styles = removeStylesItem({
+      xml: styles,
       parent,
       name: WINDOW_TRANSLUCENT_STATUS,
     });
-    xml = setStylesItem({
+    styles = setStylesItem({
+      xml: styles,
+      parent,
       item: buildResourceItem({
         name: COLOR_PRIMARY_DARK_KEY,
         value: `@color/${COLOR_PRIMARY_DARK_KEY}`,
       }),
-      xml,
-      parent,
     });
   }
 
-  return xml;
+  return styles;
 }
 
-export function getStatusBarColor(
-  config: Pick<ExpoConfig, 'androidStatusBarColor' | 'androidStatusBar'>
-) {
-  if (config.androidStatusBarColor != null) {
-    WarningAggregator.addWarningAndroid(
-      'status-bar',
-      '`androidStatusBarColor` is deprecated, use `androidStatusBar.backgroundColor` instead.'
-    );
-  }
+export function getStatusBarColor(config: Pick<ExpoConfig, 'androidStatusBar'>) {
   return config.androidStatusBar?.backgroundColor || 'translucent';
 }
 

--- a/packages/config-plugins/src/android/StatusBar.ts
+++ b/packages/config-plugins/src/android/StatusBar.ts
@@ -4,7 +4,7 @@ import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
 import { assignColorValue } from './Colors';
 import { ResourceXML } from './Resources';
-import { assignStylesValue, getAppThemeLightNoActionBarParent } from './Styles';
+import { assignStylesValue, getAppThemeLightNoActionBarGroup } from './Styles';
 
 const COLOR_PRIMARY_DARK_KEY = 'colorPrimaryDark';
 const WINDOW_TRANSLUCENT_STATUS = 'android:windowTranslucentStatus';
@@ -47,7 +47,7 @@ export function setStatusBarStyles(
   const hexString = getStatusBarColor(config);
 
   styles = assignStylesValue(styles, {
-    parent: getAppThemeLightNoActionBarParent(),
+    parent: getAppThemeLightNoActionBarGroup(),
     name: WINDOW_LIGHT_STATUS_BAR,
     value: 'true',
     // Default is light-content, don't need to do anything to set it
@@ -55,7 +55,7 @@ export function setStatusBarStyles(
   });
 
   styles = assignStylesValue(styles, {
-    parent: getAppThemeLightNoActionBarParent(),
+    parent: getAppThemeLightNoActionBarGroup(),
     name: WINDOW_TRANSLUCENT_STATUS,
     value: 'true',
     // translucent status bar set in theme
@@ -63,7 +63,7 @@ export function setStatusBarStyles(
   });
 
   styles = assignStylesValue(styles, {
-    parent: getAppThemeLightNoActionBarParent(),
+    parent: getAppThemeLightNoActionBarGroup(),
     name: COLOR_PRIMARY_DARK_KEY,
     value: `@color/${COLOR_PRIMARY_DARK_KEY}`,
     // Remove the color if translucent is used

--- a/packages/config-plugins/src/android/StatusBar.ts
+++ b/packages/config-plugins/src/android/StatusBar.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
-import { removeColorItem, setColorItem } from './Colors';
+import { assignColorValue } from './Colors';
 import { buildResourceItem, ResourceXML } from './Resources';
 import { removeStylesItem, setStylesItem } from './Styles';
 
@@ -34,20 +34,10 @@ export function setStatusBarColors(
   config: Pick<ExpoConfig, 'androidStatusBar'>,
   colors: ResourceXML
 ): ResourceXML {
-  const hexString = getStatusBarColor(config);
-
-  if (hexString === 'translucent') {
-    return removeColorItem(COLOR_PRIMARY_DARK_KEY, colors);
-  }
-
-  // Need to add a color key to colors.xml to use in styles.xml
-  return setColorItem(
-    buildResourceItem({
-      name: COLOR_PRIMARY_DARK_KEY,
-      value: hexString,
-    }),
-    colors
-  );
+  return assignColorValue(colors, {
+    name: COLOR_PRIMARY_DARK_KEY,
+    value: config.androidStatusBar?.backgroundColor,
+  });
 }
 
 export function setStatusBarStyles(

--- a/packages/config-plugins/src/android/Styles.ts
+++ b/packages/config-plugins/src/android/Styles.ts
@@ -3,6 +3,8 @@ import {
   buildResourceGroup,
   buildResourceItem,
   ensureDefaultResourceXML,
+  findResourceGroup,
+  getResourceItemsAsObject,
   ResourceGroupXML,
   ResourceItemXML,
   ResourceKind,
@@ -26,16 +28,9 @@ function ensureDefaultStyleResourceXML(xml: ResourceXML): ResourceXML {
 
 export function getStyleParent(
   xml: ResourceXML,
-  parent: { name: string; parent?: string }
+  group: { name: string; parent?: string }
 ): ResourceGroupXML | null {
-  const app = xml?.resources?.style?.filter?.((e: any) => {
-    let matches = e.$.name === parent.name;
-    if (parent.parent != null && matches) {
-      matches = e.$.parent === parent.parent;
-    }
-    return matches;
-  })?.[0];
-  return app ?? null;
+  return findResourceGroup(xml.resources.style, group);
 }
 
 export function getStylesItem({
@@ -120,7 +115,7 @@ export function removeStylesItem({
 }
 
 // This is a very common theme so make it reusable.
-export function getAppThemeLightNoActionBarParent() {
+export function getAppThemeLightNoActionBarGroup() {
   return { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
 }
 
@@ -153,4 +148,19 @@ export function assignStylesValue(
     parent,
     name,
   });
+}
+
+/**
+ * Helper to convert a styles.xml parent's children into a simple k/v pair.
+ * Added for testing purposes.
+ *
+ * @param xml
+ * @returns
+ */
+export function getStylesGroupAsObject(
+  xml: ResourceXML,
+  group: { name: string; parent: string }
+): Record<string, string> | null {
+  const xmlGroup = getStyleParent(xml, group);
+  return xmlGroup?.item ? getResourceItemsAsObject(xmlGroup.item) : null;
 }

--- a/packages/config-plugins/src/android/Styles.ts
+++ b/packages/config-plugins/src/android/Styles.ts
@@ -1,6 +1,7 @@
 import { getResourceXMLPathAsync } from './Paths';
 import {
   buildResourceGroup,
+  buildResourceItem,
   ensureDefaultResourceXML,
   ResourceGroupXML,
   ResourceItemXML,
@@ -55,7 +56,7 @@ export function getStylesItem({
   }
 
   if (appTheme.item) {
-    const existingItem = appTheme.item.filter(_item => _item.$.name === name)[0];
+    const existingItem = appTheme.item.filter(({ $: head }) => head.name === name)[0];
 
     // Don't want to 2 of the same item, so if one exists, we overwrite it
     if (existingItem) {
@@ -84,7 +85,7 @@ export function setStylesItem({
   }
 
   if (appTheme.item) {
-    const existingItem = appTheme.item.filter(_item => _item.$.name === item.$.name)[0];
+    const existingItem = appTheme.item.filter(({ $: head }) => head.name === item.$.name)[0];
 
     // Don't want to 2 of the same item, so if one exists, we overwrite it
     if (existingItem) {
@@ -110,10 +111,46 @@ export function removeStylesItem({
   xml = ensureDefaultStyleResourceXML(xml);
   const appTheme = getStyleParent(xml, parent);
   if (appTheme?.item) {
-    const index = appTheme.item.findIndex((e: ResourceItemXML) => e.$.name === name);
+    const index = appTheme.item.findIndex(({ $: head }: ResourceItemXML) => head.name === name);
     if (index > -1) {
       appTheme.item.splice(index, 1);
     }
   }
   return xml;
+}
+
+// This is a very common theme so make it reusable.
+export function getAppThemeLightNoActionBarParent() {
+  return { name: 'AppTheme', parent: 'Theme.AppCompat.Light.NoActionBar' };
+}
+
+export function assignStylesValue(
+  xml: ResourceXML,
+  {
+    add,
+    value,
+    name,
+    parent,
+  }: {
+    add: boolean;
+    value: string;
+    name: string;
+    parent: { name: string; parent: string };
+  }
+): ResourceXML {
+  if (add) {
+    return setStylesItem({
+      xml,
+      parent,
+      item: buildResourceItem({
+        name,
+        value,
+      }),
+    });
+  }
+  return removeStylesItem({
+    xml,
+    parent,
+    name,
+  });
 }

--- a/packages/config-plugins/src/android/__tests__/Colors-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Colors-test.ts
@@ -1,6 +1,13 @@
 import { vol } from 'memfs';
 
-import { getProjectColorsXMLPathAsync, removeColorItem, setColorItem } from '../Colors';
+import { parseXMLAsync } from '../../utils/XML';
+import {
+  getColorsAsObject,
+  getObjectAsColorsXml,
+  getProjectColorsXMLPathAsync,
+  removeColorItem,
+  setColorItem,
+} from '../Colors';
 import { buildResourceItem, readResourcesXMLAsync } from '../Resources';
 
 jest.mock('fs');
@@ -45,5 +52,47 @@ describe(setColorItem, () => {
     colors = removeColorItem('somn', colors);
     // doesn't fully reset the colors.
     expect(colors).toStrictEqual({ resources: { color: [] } });
+  });
+});
+
+describe(getColorsAsObject, () => {
+  it(`converts as expected`, async () => {
+    // Parsed from a string for DX readability
+    const xml = await parseXMLAsync(
+      [
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+        '<resources>',
+        '  <color name="colorPrimary">#FFBB86FC</color>',
+        '  <color name="navigationBar">red</color>',
+        '  <color name="foobar">@bacon</color>',
+        '</resources>',
+      ].join('\n')
+    );
+
+    const colors = getColorsAsObject(xml as any);
+
+    expect(colors).toStrictEqual({
+      colorPrimary: '#FFBB86FC',
+      foobar: '@bacon',
+      navigationBar: 'red',
+    });
+  });
+});
+
+describe(getObjectAsColorsXml, () => {
+  it(`converts object to object matching parsed colors.xml`, async () => {
+    // Parsed from a string for DX readability
+    const colors = [
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+      '<resources>',
+      '  <color name="colorPrimary">#FFBB86FC</color>',
+      '  <color name="navigationBar">red</color>',
+      '  <color name="foobar">@bacon</color>',
+      '</resources>',
+    ].join('\n');
+
+    expect(
+      getObjectAsColorsXml({ colorPrimary: '#FFBB86FC', navigationBar: 'red', foobar: '@bacon' })
+    ).toStrictEqual(await parseXMLAsync(colors));
   });
 });

--- a/packages/config-plugins/src/android/__tests__/NavigationBar-test.ts
+++ b/packages/config-plugins/src/android/__tests__/NavigationBar-test.ts
@@ -1,3 +1,4 @@
+import { getColorsAsObject } from '../Colors';
 import {
   getNavigationBarColor,
   getNavigationBarImmersiveMode,
@@ -6,6 +7,7 @@ import {
   setNavigationBarStyles,
   withNavigationBar,
 } from '../NavigationBar';
+import { getAppThemeLightNoActionBarGroup, getStylesGroupAsObject } from '../Styles';
 
 jest.mock('../../utils/warnings');
 
@@ -50,31 +52,22 @@ describe('Android navigation bar', () => {
         { resources: {} }
       );
 
-      expect(
-        stylesJSON.resources.style
-          .filter(({ $: head }) => head.name === 'AppTheme')[0]
-          .item.filter(({ $: head }) => head.name === 'android:navigationBarColor')[0]._
-      ).toMatch('@color/navigationBarColor');
-      expect(
-        stylesJSON.resources.style
-          .filter(({ $: head }) => head.name === 'AppTheme')[0]
-          .item.filter(({ $: head }) => head.name === 'android:windowLightNavigationBar')[0]._
-      ).toMatch('true');
+      const group = getStylesGroupAsObject(stylesJSON, getAppThemeLightNoActionBarGroup());
+      expect(group['android:navigationBarColor']).toBe('@color/navigationBarColor');
+      expect(group['android:windowLightNavigationBar']).toBe('true');
     });
+
     it(`sets the navigationBarColor item in styles.xml and adds color to colors.xml if 'androidNavigationBar.backgroundColor' is given. sets windowLightNavigation bar true`, async () => {
       const colorsJSON = await setNavigationBarColors(
         { androidNavigationBar: { backgroundColor: '#111111', barStyle: 'dark-content' } },
         { resources: {} }
       );
 
-      expect(
-        colorsJSON.resources.color.filter(e => e.$.name === 'navigationBarColor')[0]._
-      ).toMatch('#111111');
+      expect(getColorsAsObject(colorsJSON).navigationBarColor).toBe('#111111');
     });
 
     it(`adds android warning androidNavigationBar.visible is provided`, async () => {
       addWarningAndroid.mockImplementationOnce();
-
       withNavigationBar({ androidNavigationBar: { visible: 'leanback' } } as any);
       expect(addWarningAndroid).toHaveBeenCalledTimes(1);
     });

--- a/packages/config-plugins/src/android/__tests__/NavigationBar-test.ts
+++ b/packages/config-plugins/src/android/__tests__/NavigationBar-test.ts
@@ -52,13 +52,13 @@ describe('Android navigation bar', () => {
 
       expect(
         stylesJSON.resources.style
-          .filter(e => e.$.name === 'AppTheme')[0]
-          .item.filter(item => item.$.name === 'android:navigationBarColor')[0]._
+          .filter(({ $: head }) => head.name === 'AppTheme')[0]
+          .item.filter(({ $: head }) => head.name === 'android:navigationBarColor')[0]._
       ).toMatch('@color/navigationBarColor');
       expect(
         stylesJSON.resources.style
-          .filter(e => e.$.name === 'AppTheme')[0]
-          .item.filter(item => item.$.name === 'android:windowLightNavigationBar')[0]._
+          .filter(({ $: head }) => head.name === 'AppTheme')[0]
+          .item.filter(({ $: head }) => head.name === 'android:windowLightNavigationBar')[0]._
       ).toMatch('true');
     });
     it(`sets the navigationBarColor item in styles.xml and adds color to colors.xml if 'androidNavigationBar.backgroundColor' is given. sets windowLightNavigation bar true`, async () => {

--- a/packages/config-plugins/src/android/__tests__/PrimaryColor-test.ts
+++ b/packages/config-plugins/src/android/__tests__/PrimaryColor-test.ts
@@ -1,50 +1,22 @@
-import { vol } from 'memfs';
+import { getPrimaryColor, setPrimaryColorColors, setPrimaryColorStyles } from '../PrimaryColor';
 
-import { getPrimaryColor, setPrimaryColor } from '../PrimaryColor';
-import { readResourcesXMLAsync } from '../Resources';
-import { sampleStylesXML } from './StatusBar-test';
+it(`returns default if no primary color is provided`, () => {
+  expect(getPrimaryColor({})).toBe('#023c69');
+});
 
-jest.mock('fs');
+it(`returns primary color if provided`, () => {
+  expect(getPrimaryColor({ primaryColor: '#111111' })).toMatch('#111111');
+});
 
-describe('Android primary color', () => {
-  it(`returns default if no primary color is provided`, () => {
-    expect(getPrimaryColor({})).toBe('#023c69');
-  });
+it(`sets the colorPrimary item in styles.xml if backgroundColor is given`, async () => {
+  const config = { primaryColor: '#654321' };
+  const colors = setPrimaryColorColors(config, { resources: {} });
+  const styles = setPrimaryColorStyles(config, { resources: {} });
 
-  it(`returns primary color if provided`, () => {
-    expect(getPrimaryColor({ primaryColor: '#111111' })).toMatch('#111111');
-  });
-
-  describe('E2E: write primary color to colors.xml and styles.xml correctly', () => {
-    beforeAll(async () => {
-      const directoryJSON = {
-        './android/app/src/main/res/values/styles.xml': sampleStylesXML,
-      };
-      vol.fromJSON(directoryJSON, '/app');
-    });
-
-    afterAll(async () => {
-      vol.reset();
-    });
-
-    it(`sets the colorPrimary item in Styles.xml if backgroundColor is given`, async () => {
-      expect(await setPrimaryColor({ primaryColor: '#654321' }, '/app')).toBe(true);
-
-      const stylesJSON = await readResourcesXMLAsync({
-        path: '/app/android/app/src/main/res/values/styles.xml',
-      });
-      const colorsJSON = await readResourcesXMLAsync({
-        path: '/app/android/app/src/main/res/values/colors.xml',
-      });
-
-      expect(
-        stylesJSON.resources.style
-          .filter(e => e.$.name === 'AppTheme')[0]
-          .item.filter(item => item.$.name === 'colorPrimary')[0]._
-      ).toMatch('@color/colorPrimary');
-      expect(colorsJSON.resources.color.filter(e => e.$.name === 'colorPrimary')[0]._).toMatch(
-        '#654321'
-      );
-    });
-  });
+  expect(
+    styles.resources.style
+      .filter(e => e.$.name === 'AppTheme')[0]
+      .item.filter(item => item.$.name === 'colorPrimary')[0]._
+  ).toMatch('@color/colorPrimary');
+  expect(colors.resources.color.filter(e => e.$.name === 'colorPrimary')[0]._).toMatch('#654321');
 });

--- a/packages/config-plugins/src/android/__tests__/PrimaryColor-test.ts
+++ b/packages/config-plugins/src/android/__tests__/PrimaryColor-test.ts
@@ -15,8 +15,10 @@ it(`sets the colorPrimary item in styles.xml if backgroundColor is given`, async
 
   expect(
     styles.resources.style
-      .filter(e => e.$.name === 'AppTheme')[0]
-      .item.filter(item => item.$.name === 'colorPrimary')[0]._
+      .filter(({ $: head }) => head.name === 'AppTheme')[0]
+      .item.filter(({ $: head }) => head.name === 'colorPrimary')[0]._
   ).toMatch('@color/colorPrimary');
-  expect(colors.resources.color.filter(e => e.$.name === 'colorPrimary')[0]._).toMatch('#654321');
+  expect(colors.resources.color.filter(({ $: head }) => head.name === 'colorPrimary')[0]._).toMatch(
+    '#654321'
+  );
 });

--- a/packages/config-plugins/src/android/__tests__/PrimaryColor-test.ts
+++ b/packages/config-plugins/src/android/__tests__/PrimaryColor-test.ts
@@ -1,4 +1,11 @@
-import { getPrimaryColor, setPrimaryColorColors, setPrimaryColorStyles } from '../PrimaryColor';
+import { compileMockModWithResultsAsync } from '../../plugins/__tests__/mockMods';
+import { withAndroidColors, withAndroidStyles } from '../../plugins/android-plugins';
+import { parseXMLAsync } from '../../utils/XML';
+import { getColorsAsObject, getObjectAsColorsXml } from '../Colors';
+import { getPrimaryColor, withPrimaryColorColors, withPrimaryColorStyles } from '../PrimaryColor';
+import { getAppThemeLightNoActionBarGroup, getStylesGroupAsObject } from '../Styles';
+
+jest.mock('../../plugins/android-plugins');
 
 it(`returns default if no primary color is provided`, () => {
   expect(getPrimaryColor({})).toBe('#023c69');
@@ -8,17 +15,76 @@ it(`returns primary color if provided`, () => {
   expect(getPrimaryColor({ primaryColor: '#111111' })).toMatch('#111111');
 });
 
-it(`sets the colorPrimary item in styles.xml if backgroundColor is given`, async () => {
-  const config = { primaryColor: '#654321' };
-  const colors = setPrimaryColorColors(config, { resources: {} });
-  const styles = setPrimaryColorStyles(config, { resources: {} });
+it(`returns empty string`, () => {
+  expect(getPrimaryColor({ primaryColor: '' })).toMatch('');
+});
 
-  expect(
-    styles.resources.style
-      .filter(({ $: head }) => head.name === 'AppTheme')[0]
-      .item.filter(({ $: head }) => head.name === 'colorPrimary')[0]._
-  ).toMatch('@color/colorPrimary');
-  expect(colors.resources.color.filter(({ $: head }) => head.name === 'colorPrimary')[0]._).toMatch(
-    '#654321'
-  );
+describe(withPrimaryColorColors, () => {
+  it(`applies a custom color`, async () => {
+    const { modResults } = await compileMockModWithResultsAsync(
+      { primaryColor: '#FF00FF' },
+      {
+        plugin: withPrimaryColorColors,
+        mod: withAndroidColors,
+        modResults: { resources: {} },
+      }
+    );
+    expect(getColorsAsObject(modResults)).toStrictEqual({ colorPrimary: '#FF00FF' });
+  });
+  it(`removes color with empty string`, async () => {
+    const { modResults } = await compileMockModWithResultsAsync(
+      { primaryColor: '' },
+      {
+        plugin: withPrimaryColorColors,
+        mod: withAndroidColors,
+        // Create a colors.xml JSON from a k/v pair
+        modResults: getObjectAsColorsXml({ colorPrimary: '#FFF000' }),
+      }
+    );
+    expect(getColorsAsObject(modResults)).toStrictEqual({});
+  });
+});
+
+describe(withPrimaryColorStyles, () => {
+  it(`links a style to the custom color`, async () => {
+    const { modResults } = await compileMockModWithResultsAsync(
+      { primaryColor: '#FF00FF' },
+      {
+        plugin: withPrimaryColorStyles,
+        mod: withAndroidStyles,
+        // Empty styles object
+        modResults: { resources: {} },
+      }
+    );
+    expect(getStylesGroupAsObject(modResults, getAppThemeLightNoActionBarGroup())).toStrictEqual({
+      colorPrimary: '@color/colorPrimary',
+    });
+  });
+
+  it(`removes styles with empty string`, async () => {
+    // Parsed from a string for DX readability
+    const styles = [
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+      '<resources>',
+      '  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">',
+      '    <item name="colorPrimary">@color/colorPrimary</item>',
+      '  </style>',
+      '</resources>',
+    ].join('\n');
+
+    const { modResults } = await compileMockModWithResultsAsync(
+      // Empty string in Expo config should disable the style
+      { primaryColor: '' },
+      {
+        plugin: withPrimaryColorStyles,
+        mod: withAndroidStyles,
+        modResults: (await parseXMLAsync(styles)) as any,
+      }
+    );
+    // Extract the styles group items given the group
+    expect(getStylesGroupAsObject(modResults, getAppThemeLightNoActionBarGroup())).toStrictEqual(
+      // Should be an empty k/v pair
+      {}
+    );
+  });
 });

--- a/packages/config-plugins/src/android/__tests__/Resources-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Resources-test.ts
@@ -1,8 +1,9 @@
 import { vol } from 'memfs';
 
+import { parseXMLAsync } from '../../utils/XML';
 import { fileExistsAsync } from '../../utils/modules';
 import { getResourceXMLPathAsync } from '../Paths';
-import { readResourcesXMLAsync } from '../Resources';
+import { getObjectAsResourceGroup, readResourcesXMLAsync } from '../Resources';
 
 jest.mock('fs');
 
@@ -39,5 +40,30 @@ describe(getResourceXMLPathAsync, () => {
     expect(await fileExistsAsync(path)).toBe(true);
     // read the file with a default fallback
     expect(await readResourcesXMLAsync({ path })).toStrictEqual({ resources: {} });
+  });
+});
+
+describe(getObjectAsResourceGroup, () => {
+  it(`matches parsed xml`, async () => {
+    // Parsed from a string for DX readability
+    const styles = await parseXMLAsync(
+      [
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+        '<resources>',
+        '  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">',
+        '    <item name="key">value</item>',
+        '    <item name="foo">bar</item>',
+        '  </style>',
+        '</resources>',
+      ].join('\n')
+    );
+
+    expect(
+      getObjectAsResourceGroup({
+        name: 'AppTheme',
+        parent: 'Theme.AppCompat.Light.NoActionBar',
+        item: { key: 'value', foo: 'bar' },
+      })
+    ).toStrictEqual((styles.resources as any).style[0]);
   });
 });

--- a/packages/config-plugins/src/android/__tests__/RootViewBackgroundColor-test.ts
+++ b/packages/config-plugins/src/android/__tests__/RootViewBackgroundColor-test.ts
@@ -22,20 +22,19 @@ it(`returns the backgroundColor under android if provided`, () => {
 });
 
 describe('write colors.xml correctly', () => {
+  const config = { backgroundColor: '#654321' };
+  it(`sets the windowBackground in colors.xml if backgroundColor is given`, async () => {
+    const colors = setRootViewBackgroundColorColors(config, { resources: {} });
+    expect(
+      colors.resources.color.filter(({ $: head }) => head.name === 'activityBackground')[0]._
+    ).toMatch('#654321');
+  });
   it(`sets the android:windowBackground in styles.xml if backgroundColor is given`, async () => {
-    const config = { backgroundColor: '#654321' };
-    const props = {
-      hexString: getRootViewBackgroundColor(config),
-    };
-    const styles = setRootViewBackgroundColorStyles(props, { resources: {} });
-    const colors = setRootViewBackgroundColorColors(props, { resources: {} });
+    const styles = setRootViewBackgroundColorStyles(config, { resources: {} });
     expect(
       styles.resources.style
-        .filter(e => e.$.name === 'AppTheme')[0]
-        .item.filter(item => item.$.name === 'android:windowBackground')[0]._
+        .filter(({ $: head }) => head.name === 'AppTheme')[0]
+        .item.filter(({ $: head }) => head.name === 'android:windowBackground')[0]._
     ).toMatch('@color/activityBackground');
-    expect(colors.resources.color.filter(e => e.$.name === 'activityBackground')[0]._).toMatch(
-      '#654321'
-    );
   });
 });

--- a/packages/config-plugins/src/android/__tests__/StatusBar-test.ts
+++ b/packages/config-plugins/src/android/__tests__/StatusBar-test.ts
@@ -1,5 +1,4 @@
 import { ExpoConfig } from '@expo/config-types';
-import { vol } from 'memfs';
 
 import {
   getStatusBarColor,
@@ -8,112 +7,95 @@ import {
   setStatusBarStyles,
 } from '../StatusBar';
 
-jest.mock('fs');
-
 export const sampleStylesXML = `
 <resources>
-    <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <!-- Customize your theme here. -->
         <item name="android:windowBackground">#222222</item>
     </style>
 </resources>`;
 
-describe('Android status bar', () => {
-  it(`returns 'translucent' if no status bar color is provided`, () => {
-    expect(getStatusBarColor({})).toMatch('translucent');
-    expect(getStatusBarColor({ androidStatusBar: {} })).toMatch('translucent');
-  });
+it(`returns 'translucent' if no status bar color is provided`, () => {
+  expect(getStatusBarColor({})).toMatch('translucent');
+  expect(getStatusBarColor({ androidStatusBar: {} })).toMatch('translucent');
+});
 
-  it(`returns statusbar color if provided`, () => {
-    expect(getStatusBarColor({ androidStatusBar: { backgroundColor: '#111111' } })).toMatch(
-      '#111111'
+it(`returns statusbar color if provided`, () => {
+  expect(getStatusBarColor({ androidStatusBar: { backgroundColor: '#111111' } })).toMatch(
+    '#111111'
+  );
+});
+
+it(`returns statusbar style if provided`, () => {
+  expect(getStatusBarStyle({ androidStatusBar: { barStyle: 'dark-content' } })).toMatch(
+    'dark-content'
+  );
+});
+
+it(`default statusbar style to light-content if none provided`, () => {
+  expect(getStatusBarStyle({})).toMatch('light-content');
+});
+
+describe('e2e: write statusbar color and style to files correctly', () => {
+  it(`sets the colorPrimaryDark item in styles.xml and adds color to colors.xml if 'androidStatusBar.backgroundColor' is given`, async () => {
+    const config: ExpoConfig = {
+      name: 'foo',
+      slug: 'bar',
+      androidStatusBar: { backgroundColor: '#654321', barStyle: 'dark-content' },
+    };
+    const props = {
+      style: getStatusBarStyle(config),
+      hexString: getStatusBarColor(config),
+    };
+    const styles = setStatusBarStyles(props, { resources: {} });
+    const colors = setStatusBarColors(props, { resources: {} });
+    expect(
+      styles.resources.style
+        .filter(e => e.$.name === 'AppTheme')[0]
+        .item.filter(item => item.$.name === 'colorPrimaryDark')[0]._
+    ).toMatch('@color/colorPrimaryDark');
+    expect(colors.resources.color.filter(e => e.$.name === 'colorPrimaryDark')[0]._).toMatch(
+      '#654321'
     );
+    expect(
+      styles.resources.style
+        .filter(e => e.$.name === 'AppTheme')[0]
+        .item.filter(item => item.$.name === 'android:windowLightStatusBar')[0]._
+    ).toMatch('true');
   });
 
-  it(`returns statusbar style if provided`, () => {
-    expect(getStatusBarStyle({ androidStatusBar: { barStyle: 'dark-content' } })).toMatch(
-      'dark-content'
-    );
-  });
+  it(`sets the status bar to translucent if no 'androidStatusBar.backgroundColor' is given`, async () => {
+    const config: ExpoConfig = {
+      name: 'foo',
+      slug: 'bar',
+      androidStatusBar: {},
+    };
 
-  it(`default statusbar style to light-content if none provided`, () => {
-    expect(getStatusBarStyle({})).toMatch('light-content');
-  });
+    const props = {
+      style: getStatusBarStyle(config),
+      hexString: getStatusBarColor(config),
+    };
 
-  describe('e2e: write statusbar color and style to files correctly', () => {
-    beforeAll(async () => {
-      const directoryJSON = {
-        './android/app/src/main/res/values/styles.xml': sampleStylesXML,
-      };
-      vol.fromJSON(directoryJSON, '/app');
-    });
+    const styles = setStatusBarStyles(props, { resources: {} });
+    const colors = setStatusBarColors(props, { resources: {} });
 
-    afterAll(async () => {
-      vol.reset();
-    });
-
-    it(`sets the colorPrimaryDark item in styles.xml and adds color to colors.xml if 'androidStatusBar.backgroundColor' is given`, async () => {
-      const config: ExpoConfig = {
-        name: 'foo',
-        slug: 'bar',
-        androidStatusBar: { backgroundColor: '#654321', barStyle: 'dark-content' },
-      };
-      const props = {
-        style: getStatusBarStyle(config),
-        hexString: getStatusBarColor(config),
-      };
-      const styles = setStatusBarStyles(props, { resources: {} });
-      const colors = setStatusBarColors(props, { resources: {} });
-      expect(
-        styles.resources.style
-          .filter(e => e.$.name === 'AppTheme')[0]
-          .item.filter(item => item.$.name === 'colorPrimaryDark')[0]._
-      ).toMatch('@color/colorPrimaryDark');
-      expect(colors.resources.color.filter(e => e.$.name === 'colorPrimaryDark')[0]._).toMatch(
-        '#654321'
-      );
-      expect(
-        styles.resources.style
-          .filter(e => e.$.name === 'AppTheme')[0]
-          .item.filter(item => item.$.name === 'android:windowLightStatusBar')[0]._
-      ).toMatch('true');
-    });
-
-    it(`sets the status bar to translucent if no 'androidStatusBar.backgroundColor' is given`, async () => {
-      const config: ExpoConfig = {
-        name: 'foo',
-        slug: 'bar',
-        androidStatusBar: {},
-      };
-
-      const props = {
-        style: getStatusBarStyle(config),
-        hexString: getStatusBarColor(config),
-      };
-
-      const styles = setStatusBarStyles(props, { resources: {} });
-      const colors = setStatusBarColors(props, { resources: {} });
-
-      expect(styles.resources).toStrictEqual({
-        style: [
-          {
-            $: {
-              name: 'AppTheme',
-              parent: 'Theme.AppCompat.Light.NoActionBar',
-            },
-            item: [
-              {
-                $: {
-                  name: 'android:windowTranslucentStatus',
-                },
-                _: 'true',
-              },
-            ],
+    expect(styles.resources).toStrictEqual({
+      style: [
+        {
+          $: {
+            name: 'AppTheme',
+            parent: 'Theme.AppCompat.Light.NoActionBar',
           },
-        ],
-      });
-      expect(colors.resources).toStrictEqual({});
+          item: [
+            {
+              $: {
+                name: 'android:windowTranslucentStatus',
+              },
+              _: 'true',
+            },
+          ],
+        },
+      ],
     });
+    expect(colors.resources).toStrictEqual({});
   });
 });

--- a/packages/config-plugins/src/android/__tests__/StatusBar-test.ts
+++ b/packages/config-plugins/src/android/__tests__/StatusBar-test.ts
@@ -1,11 +1,13 @@
 import { ExpoConfig } from '@expo/config-types';
 
+import { getColorsAsObject } from '../Colors';
 import {
   getStatusBarColor,
   getStatusBarStyle,
   setStatusBarColors,
   setStatusBarStyles,
 } from '../StatusBar';
+import { getAppThemeLightNoActionBarGroup, getStylesGroupAsObject } from '../Styles';
 
 it(`returns 'translucent' if no status bar color is provided`, () => {
   expect(getStatusBarColor({})).toMatch('translucent');
@@ -37,19 +39,11 @@ describe('e2e: write statusbar color and style to files correctly', () => {
     };
     const styles = setStatusBarStyles(config, { resources: {} });
     const colors = setStatusBarColors(config, { resources: {} });
-    expect(
-      styles.resources.style
-        .filter(({ $: head }) => head.name === 'AppTheme')[0]
-        .item.filter(({ $: head }) => head.name === 'colorPrimaryDark')[0]._
-    ).toMatch('@color/colorPrimaryDark');
-    expect(
-      colors.resources.color.filter(({ $: head }) => head.name === 'colorPrimaryDark')[0]._
-    ).toMatch('#654321');
-    expect(
-      styles.resources.style
-        .filter(({ $: head }) => head.name === 'AppTheme')[0]
-        .item.filter(({ $: head }) => head.name === 'android:windowLightStatusBar')[0]._
-    ).toMatch('true');
+
+    const group = getStylesGroupAsObject(styles, getAppThemeLightNoActionBarGroup());
+    expect(group.colorPrimaryDark).toBe('@color/colorPrimaryDark');
+    expect(group['android:windowLightStatusBar']).toBe('true');
+    expect(getColorsAsObject(colors).colorPrimaryDark).toBe('#654321');
   });
 
   it(`sets the status bar to translucent if no 'androidStatusBar.backgroundColor' is given`, async () => {
@@ -62,23 +56,10 @@ describe('e2e: write statusbar color and style to files correctly', () => {
     const styles = setStatusBarStyles(config, { resources: {} });
     const colors = setStatusBarColors(config, { resources: {} });
 
-    expect(styles.resources).toStrictEqual({
-      style: [
-        {
-          $: {
-            name: 'AppTheme',
-            parent: 'Theme.AppCompat.Light.NoActionBar',
-          },
-          item: [
-            {
-              $: {
-                name: 'android:windowTranslucentStatus',
-              },
-              _: 'true',
-            },
-          ],
-        },
-      ],
+    const group = getStylesGroupAsObject(styles, getAppThemeLightNoActionBarGroup());
+
+    expect(group).toStrictEqual({
+      'android:windowTranslucentStatus': 'true',
     });
     expect(colors.resources).toStrictEqual({});
   });

--- a/packages/config-plugins/src/android/__tests__/StatusBar-test.ts
+++ b/packages/config-plugins/src/android/__tests__/StatusBar-test.ts
@@ -7,13 +7,6 @@ import {
   setStatusBarStyles,
 } from '../StatusBar';
 
-export const sampleStylesXML = `
-<resources>
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:windowBackground">#222222</item>
-    </style>
-</resources>`;
-
 it(`returns 'translucent' if no status bar color is provided`, () => {
   expect(getStatusBarColor({})).toMatch('translucent');
   expect(getStatusBarColor({ androidStatusBar: {} })).toMatch('translucent');
@@ -42,24 +35,20 @@ describe('e2e: write statusbar color and style to files correctly', () => {
       slug: 'bar',
       androidStatusBar: { backgroundColor: '#654321', barStyle: 'dark-content' },
     };
-    const props = {
-      style: getStatusBarStyle(config),
-      hexString: getStatusBarColor(config),
-    };
-    const styles = setStatusBarStyles(props, { resources: {} });
-    const colors = setStatusBarColors(props, { resources: {} });
+    const styles = setStatusBarStyles(config, { resources: {} });
+    const colors = setStatusBarColors(config, { resources: {} });
     expect(
       styles.resources.style
-        .filter(e => e.$.name === 'AppTheme')[0]
-        .item.filter(item => item.$.name === 'colorPrimaryDark')[0]._
+        .filter(({ $: head }) => head.name === 'AppTheme')[0]
+        .item.filter(({ $: head }) => head.name === 'colorPrimaryDark')[0]._
     ).toMatch('@color/colorPrimaryDark');
-    expect(colors.resources.color.filter(e => e.$.name === 'colorPrimaryDark')[0]._).toMatch(
-      '#654321'
-    );
+    expect(
+      colors.resources.color.filter(({ $: head }) => head.name === 'colorPrimaryDark')[0]._
+    ).toMatch('#654321');
     expect(
       styles.resources.style
-        .filter(e => e.$.name === 'AppTheme')[0]
-        .item.filter(item => item.$.name === 'android:windowLightStatusBar')[0]._
+        .filter(({ $: head }) => head.name === 'AppTheme')[0]
+        .item.filter(({ $: head }) => head.name === 'android:windowLightStatusBar')[0]._
     ).toMatch('true');
   });
 
@@ -70,13 +59,8 @@ describe('e2e: write statusbar color and style to files correctly', () => {
       androidStatusBar: {},
     };
 
-    const props = {
-      style: getStatusBarStyle(config),
-      hexString: getStatusBarColor(config),
-    };
-
-    const styles = setStatusBarStyles(props, { resources: {} });
-    const colors = setStatusBarColors(props, { resources: {} });
+    const styles = setStatusBarStyles(config, { resources: {} });
+    const colors = setStatusBarColors(config, { resources: {} });
 
     expect(styles.resources).toStrictEqual({
       style: [

--- a/packages/config-plugins/src/index.ts
+++ b/packages/config-plugins/src/index.ts
@@ -45,6 +45,8 @@ export {
 export {
   withAndroidManifest,
   withStringsXml,
+  withAndroidColors,
+  withAndroidStyles,
   withMainActivity,
   withProjectBuildGradle,
   withAppBuildGradle,

--- a/packages/config-plugins/src/plugins/__tests__/mockMods.ts
+++ b/packages/config-plugins/src/plugins/__tests__/mockMods.ts
@@ -1,0 +1,34 @@
+import { ExpoConfig } from '@expo/config';
+
+import { ConfigPlugin, ExportedConfigWithProps, Mod } from '../../Plugin.types';
+
+// Usage: add the following mock to the mods you are using:
+// jest.mock('../../plugins/android-plugins');
+
+export function mockModWithResults(withMod, modResults) {
+  withMod.mockImplementationOnce((config, action) => {
+    return action({ ...config, modResults });
+  });
+}
+
+/**
+ * Mock a single mod and evaluate the plugin that uses that mod
+ * @param config
+ * @param param1
+ * @returns
+ */
+export async function compileMockModWithResultsAsync<T>(
+  config: Partial<ExpoConfig>,
+  {
+    mod,
+    plugin,
+    modResults,
+  }: {
+    mod: ConfigPlugin<Mod<T>>;
+    plugin: ConfigPlugin;
+    modResults: T;
+  }
+): Promise<ExportedConfigWithProps<T>> {
+  mockModWithResults(mod, modResults);
+  return (await plugin(config as any)) as ExportedConfigWithProps<T>;
+}

--- a/packages/config-plugins/src/plugins/android-plugins.ts
+++ b/packages/config-plugins/src/plugins/android-plugins.ts
@@ -79,6 +79,34 @@ export const withStringsXml: ConfigPlugin<Mod<Resources.ResourceXML>> = (config,
 };
 
 /**
+ * Provides the `android/app/src/main/res/values/colors.xml` as JSON (parsed with [`xml2js`](https://www.npmjs.com/package/xml2js)).
+ *
+ * @param config
+ * @param action
+ */
+export const withAndroidColors: ConfigPlugin<Mod<Resources.ResourceXML>> = (config, action) => {
+  return withMod(config, {
+    platform: 'android',
+    mod: 'colors',
+    action,
+  });
+};
+
+/**
+ * Provides the `android/app/src/main/res/values/styles.xml` as JSON (parsed with [`xml2js`](https://www.npmjs.com/package/xml2js)).
+ *
+ * @param config
+ * @param action
+ */
+export const withAndroidStyles: ConfigPlugin<Mod<Resources.ResourceXML>> = (config, action) => {
+  return withMod(config, {
+    platform: 'android',
+    mod: 'styles',
+    action,
+  });
+};
+
+/**
  * Provides the project MainActivity for modification.
  *
  * @param config

--- a/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
@@ -2,7 +2,7 @@ import { promises } from 'fs';
 import path from 'path';
 
 import { ExportedConfig, ModConfig } from '../Plugin.types';
-import { Manifest, Paths, Properties, Resources, Strings } from '../android';
+import { Colors, Manifest, Paths, Properties, Resources, Strings, Styles } from '../android';
 import { writeXMLAsync } from '../utils/XML';
 import { ForwardedBaseModOptions, provider, withGeneratedBaseMods } from './createBaseMod';
 
@@ -51,6 +51,30 @@ const defaultProviders = {
   strings: provider<Resources.ResourceXML>({
     getFilePath({ modRequest: { projectRoot } }) {
       return Strings.getProjectStringsXMLPathAsync(projectRoot);
+    },
+    async read(filePath) {
+      return Resources.readResourcesXMLAsync({ path: filePath });
+    },
+    async write(filePath, { modResults }) {
+      await writeXMLAsync({ path: filePath, xml: modResults });
+    },
+  }),
+
+  colors: provider<Resources.ResourceXML>({
+    getFilePath({ modRequest: { projectRoot } }) {
+      return Colors.getProjectColorsXMLPathAsync(projectRoot);
+    },
+    async read(filePath) {
+      return Resources.readResourcesXMLAsync({ path: filePath });
+    },
+    async write(filePath, { modResults }) {
+      await writeXMLAsync({ path: filePath, xml: modResults });
+    },
+  }),
+
+  styles: provider<Resources.ResourceXML>({
+    getFilePath({ modRequest: { projectRoot } }) {
+      return Styles.getProjectStylesXMLPathAsync(projectRoot);
     },
     async read(filePath) {
       return Resources.readResourcesXMLAsync({ path: filePath });
@@ -236,6 +260,12 @@ export function getAndroidIntrospectModFileProviders(): Omit<
     }),
     gradleProperties: createIntrospectionProvider('gradleProperties', { fallbackContents: [] }),
     strings: createIntrospectionProvider('strings', {
+      fallbackContents: { resources: {} } as Resources.ResourceXML,
+    }),
+    colors: createIntrospectionProvider('colors', {
+      fallbackContents: { resources: {} } as Resources.ResourceXML,
+    }),
+    styles: createIntrospectionProvider('styles', {
       fallbackContents: { resources: {} } as Resources.ResourceXML,
     }),
     // projectBuildGradle: createIntrospectionProvider('projectBuildGradle', {

--- a/packages/config-plugins/src/utils/XML.ts
+++ b/packages/config-plugins/src/utils/XML.ts
@@ -32,6 +32,11 @@ export async function readXMLAsync(options: {
   return manifest;
 }
 
+export async function parseXMLAsync(contents: string): Promise<XMLObject> {
+  const xml = await new Parser().parseStringPromise(contents);
+  return xml;
+}
+
 const stringTimesN = (n: number, char: string) => Array(n + 1).join(char);
 
 export function format(manifest: any, { indentLevel = 2, newline = EOL } = {}): string {

--- a/packages/prebuild-config/src/plugins/icons/__tests__/withAndroidIcons-test.ts
+++ b/packages/prebuild-config/src/plugins/icons/__tests__/withAndroidIcons-test.ts
@@ -71,7 +71,9 @@ describe('Android Icon', () => {
   });
 
   it('returns null if no icon config provided', async () => {
-    expect(await setIconAsync({} as ExpoConfig, './')).toBe(null);
+    expect(
+      await setIconAsync('./', { icon: null, backgroundImage: null, backgroundColor: null })
+    ).toBe(null);
   });
 });
 
@@ -90,18 +92,11 @@ describe('e2e: ONLY android legacy icon', () => {
     vol.mkdirpSync('/app/assets');
     vol.writeFileSync('/app/assets/iconForeground.png', icon);
 
-    await setIconAsync(
-      {
-        slug: 'testproject',
-        version: '1',
-        name: 'testproject',
-        platforms: ['ios', 'android'],
-        android: {
-          icon: '/app/assets/iconForeground.png',
-        },
-      },
-      projectRoot
-    );
+    await setIconAsync(projectRoot, {
+      icon: '/app/assets/iconForeground.png',
+      backgroundColor: null,
+      backgroundImage: null,
+    });
   });
 
   afterAll(() => {
@@ -138,22 +133,11 @@ describe('e2e: android adaptive icon', () => {
     vol.writeFileSync('/app/assets/iconForeground.png', adaptiveIconForeground);
     vol.writeFileSync('/app/assets/iconBackground.png', adaptiveIconBackground);
 
-    await setIconAsync(
-      {
-        slug: 'testproject',
-        version: '1',
-        name: 'testproject',
-        platforms: ['ios', 'android'],
-        android: {
-          adaptiveIcon: {
-            foregroundImage: '/app/assets/iconForeground.png',
-            backgroundImage: '/app/assets/iconBackground.png',
-            backgroundColor: '#123456',
-          },
-        },
-      },
-      projectRoot
-    );
+    await setIconAsync(projectRoot, {
+      icon: '/app/assets/iconForeground.png',
+      backgroundImage: '/app/assets/iconBackground.png',
+      backgroundColor: '#123456',
+    });
   });
 
   afterAll(() => {

--- a/packages/prebuild-config/src/plugins/icons/withAndroidIcons.ts
+++ b/packages/prebuild-config/src/plugins/icons/withAndroidIcons.ts
@@ -252,12 +252,14 @@ export async function configureAdaptiveIconAsync(
   await createAdaptiveIconXmlFiles(projectRoot, icLauncherXmlString);
 }
 
-function setBackgroundColor(colorsJson: ResourceXML, backgroundColor: string | null) {
+function setBackgroundColor(colors: ResourceXML, backgroundColor: string | null) {
   if (backgroundColor) {
-    const colorItemToAdd = buildResourceItem({ name: ICON_BACKGROUND, value: backgroundColor });
-    return Colors.setColorItem(colorItemToAdd, colorsJson);
+    return Colors.setColorItem(
+      buildResourceItem({ name: ICON_BACKGROUND, value: backgroundColor }),
+      colors
+    );
   }
-  return Colors.removeColorItem(ICON_BACKGROUND, colorsJson);
+  return Colors.removeColorItem(ICON_BACKGROUND, colors);
 }
 
 export const createAdaptiveIconXmlString = (backgroundImage: string | null) => {

--- a/packages/prebuild-config/src/plugins/icons/withAndroidIcons.ts
+++ b/packages/prebuild-config/src/plugins/icons/withAndroidIcons.ts
@@ -11,7 +11,6 @@ import fs from 'fs-extra';
 import path from 'path';
 
 const { Colors } = AndroidConfig;
-const { buildResourceItem } = AndroidConfig.Resources;
 
 type DPIString = 'mdpi' | 'hdpi' | 'xhdpi' | 'xxhdpi' | 'xxxhdpi';
 type dpiMap = Record<DPIString, { folderName: string; scale: number }>;
@@ -55,7 +54,7 @@ export const withAndroidIcons: ConfigPlugin = config => {
 
 const withAndroidAdaptiveIconColors: ConfigPlugin<string | null> = (config, backgroundColor) => {
   return withAndroidColors(config, config => {
-    config.modResults = setBackgroundColor(config.modResults, backgroundColor ?? '#FFFFFF');
+    config.modResults = setBackgroundColor(backgroundColor ?? '#FFFFFF', config.modResults);
     return config;
   });
 };
@@ -252,14 +251,11 @@ export async function configureAdaptiveIconAsync(
   await createAdaptiveIconXmlFiles(projectRoot, icLauncherXmlString);
 }
 
-function setBackgroundColor(colors: ResourceXML, backgroundColor: string | null) {
-  if (backgroundColor) {
-    return Colors.setColorItem(
-      buildResourceItem({ name: ICON_BACKGROUND, value: backgroundColor }),
-      colors
-    );
-  }
-  return Colors.removeColorItem(ICON_BACKGROUND, colors);
+function setBackgroundColor(backgroundColor: string | null, colors: ResourceXML) {
+  return Colors.assignColorValue(colors, {
+    value: backgroundColor,
+    name: ICON_BACKGROUND,
+  });
 }
 
 export const createAdaptiveIconXmlString = (backgroundImage: string | null) => {

--- a/packages/prebuild-config/src/plugins/unversioned/expo-notifications/__tests__/withAndroidNotifications-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-notifications/__tests__/withAndroidNotifications-test.ts
@@ -1,4 +1,6 @@
 import { AndroidConfig } from '@expo/config-plugins';
+import { Colors } from '@expo/config-plugins/build/android';
+import { readResourcesXMLAsync } from '@expo/config-plugins/build/android/Resources';
 import { ExpoConfig } from '@expo/config-types';
 import { fs, vol } from 'memfs';
 import * as path from 'path';
@@ -14,9 +16,9 @@ import {
   NOTIFICATION_ICON_COLOR,
   NOTIFICATION_ICON_COLOR_RESOURCE,
   NOTIFICATION_ICON_RESOURCE,
-  setNotificationConfigAsync,
+  setNotificationConfig,
   setNotificationIconAsync,
-  setNotificationIconColorAsync,
+  setNotificationIconColor,
 } from '../withAndroidNotifications';
 
 jest.mock('fs');
@@ -57,7 +59,13 @@ describe('Android notifications configuration', () => {
       },
     };
     await setNotificationIconAsync(expoConfig, projectRoot);
-    await setNotificationIconColorAsync(expoConfig, projectRoot);
+
+    setNotificationIconColor(
+      expoConfig,
+      await readResourcesXMLAsync({
+        path: await Colors.getProjectColorsXMLPathAsync(projectRoot, {}),
+      })
+    );
   });
 
   afterAll(() => {
@@ -125,9 +133,9 @@ describe('Applies proper Android Notification configuration to AndroidManifest.x
       './AndroidManifest.xml'
     );
 
-    androidManifestJson = await setNotificationConfigAsync(notificationConfig, androidManifestJson);
+    androidManifestJson = setNotificationConfig(notificationConfig, androidManifestJson);
     // Run this twice to ensure copies don't get added.
-    androidManifestJson = await setNotificationConfigAsync(notificationConfig, androidManifestJson);
+    androidManifestJson = setNotificationConfig(notificationConfig, androidManifestJson);
 
     const mainApplication = getMainApplication(androidManifestJson);
 
@@ -149,9 +157,9 @@ describe('Applies proper Android Notification configuration to AndroidManifest.x
       './AndroidManifest.xml'
     );
 
-    androidManifestJson = await setNotificationConfigAsync(notificationConfig, androidManifestJson);
+    androidManifestJson = setNotificationConfig(notificationConfig, androidManifestJson);
     // Now let's get rid of the configuration:
-    androidManifestJson = await setNotificationConfigAsync({} as ExpoConfig, androidManifestJson);
+    androidManifestJson = setNotificationConfig({} as ExpoConfig, androidManifestJson);
 
     const mainApplication = getMainApplication(androidManifestJson);
 

--- a/packages/prebuild-config/src/plugins/unversioned/expo-notifications/withAndroidNotifications.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-notifications/withAndroidNotifications.ts
@@ -13,7 +13,6 @@ import path from 'path';
 import { ANDROID_RES_PATH, dpiValues } from '../../icons/withAndroidIcons';
 
 const { Colors } = AndroidConfig;
-const { buildResourceItem } = AndroidConfig.Resources;
 const {
   addMetaDataItemToMainApplication,
   getMainApplicationOrThrow,
@@ -106,18 +105,10 @@ export function setNotificationIconColor(
   config: ExpoConfig,
   colors: AndroidConfig.Resources.ResourceXML
 ) {
-  const color = getNotificationColor(config);
-  if (color) {
-    return Colors.setColorItem(
-      buildResourceItem({
-        name: NOTIFICATION_ICON_COLOR,
-        value: color,
-      }),
-      colors
-    );
-  }
-
-  return Colors.removeColorItem(NOTIFICATION_ICON_COLOR, colors);
+  return Colors.assignColorValue(colors, {
+    name: NOTIFICATION_ICON_COLOR,
+    value: getNotificationColor(config),
+  });
 }
 
 async function writeNotificationIconImageFilesAsync(icon: string, projectRoot: string) {

--- a/packages/prebuild-config/src/plugins/unversioned/expo-notifications/withAndroidNotifications.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-notifications/withAndroidNotifications.ts
@@ -47,11 +47,13 @@ export const withNotificationIconColor: ConfigPlugin = config => {
   });
 };
 
-export const withNotificationManifest: ConfigPlugin = config =>
-  withAndroidManifest(config, config => {
+export const withNotificationManifest: ConfigPlugin = config => {
+  return withAndroidManifest(config, config => {
     config.modResults = setNotificationConfig(config, config.modResults);
     return config;
   });
+};
+
 export function getNotificationIcon(config: ExpoConfig) {
   return config.notification?.icon || null;
 }
@@ -102,16 +104,20 @@ export function setNotificationConfig(config: ExpoConfig, manifest: AndroidManif
 
 export function setNotificationIconColor(
   config: ExpoConfig,
-  colorsJson: AndroidConfig.Resources.ResourceXML
+  colors: AndroidConfig.Resources.ResourceXML
 ) {
   const color = getNotificationColor(config);
   if (color) {
-    const colorItemToAdd = buildResourceItem({ name: NOTIFICATION_ICON_COLOR, value: color });
-    colorsJson = Colors.setColorItem(colorItemToAdd, colorsJson);
-  } else {
-    colorsJson = Colors.removeColorItem(NOTIFICATION_ICON_COLOR, colorsJson);
+    return Colors.setColorItem(
+      buildResourceItem({
+        name: NOTIFICATION_ICON_COLOR,
+        value: color,
+      }),
+      colors
+    );
   }
-  return colorsJson;
+
+  return Colors.removeColorItem(NOTIFICATION_ICON_COLOR, colors);
 }
 
 async function writeNotificationIconImageFilesAsync(icon: string, projectRoot: string) {


### PR DESCRIPTION
# Why

- Too many android plugins are using dangerous for very simple static modifications
- We held off on adding these mods because it was unclear if we wanted to add support for multi-file mods. It's been a while and we still haven't _needed_ them so it seems safe to proceed without them. Re: https://github.com/expo/expo-cli/pull/2992
- I'm thinking for splash screen we will just manually add colorsNight or colorsDark, colorsV23, etc. to support other file variations. This will work better for dev tooling like the vscode extension which previews a single mod as a file.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Created withAndroidColors & withAndroidStyles for providing the default colors.xml and styles.xml for a project.
- Added support for two new base mods android.colors android.styles
- Migrated all plugins using colors and styles to use the new mods.
- Added colors and styles to introspection, this means a lot more of the project can be statically introspected.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Updated unit tests
- [x] Local E2E testing
