### PR TITLE
[expo-cli] Add "/projects/[project]" to website build url

### DIFF
--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -193,6 +193,7 @@ Please see the docs (${chalk.underline(
       Log.log(
         `### ${i} | ${platform} | ${UrlUtils.constructBuildLogsUrl({
           buildId: job.id,
+          projectSlug: this.manifest.slug,
           username: username ?? undefined,
         })} ###`
       );
@@ -386,6 +387,7 @@ ${job.id}
     if (buildId) {
       const url = UrlUtils.constructBuildLogsUrl({
         buildId,
+        projectSlug: this.manifest.slug,
         username: this.manifest.owner || (user?.kind === 'user' ? user.username : undefined),
       });
 

--- a/packages/expo-cli/src/commands/utils/__tests__/url-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/url-test.ts
@@ -1,0 +1,34 @@
+import { constructBuildLogsUrl } from '../url';
+
+describe(constructBuildLogsUrl, () => {
+  it('returns URL with project path', () => {
+    const result = constructBuildLogsUrl({
+      username: 'test-username',
+      projectSlug: 'test-project-slug',
+      buildId: 'test-build-id',
+    });
+
+    expect(result).toBe(
+      'https://expo.io/accounts/test-username/projects/test-project-slug/builds/test-build-id'
+    );
+  });
+
+  it('returns URL with account', () => {
+    const result = constructBuildLogsUrl({
+      username: 'test-username',
+      projectSlug: undefined,
+      buildId: 'test-build-id',
+    });
+
+    expect(result).toBe('https://expo.io/accounts/test-username/builds/test-build-id');
+  });
+  it('returns URL without account or project slug', () => {
+    const result = constructBuildLogsUrl({
+      username: undefined,
+      projectSlug: undefined,
+      buildId: 'test-build-id',
+    });
+
+    expect(result).toBe('https://expo.io/builds/test-build-id');
+  });
+});

--- a/packages/expo-cli/src/commands/utils/url.ts
+++ b/packages/expo-cli/src/commands/utils/url.ts
@@ -13,13 +13,16 @@ export function getExpoDomainUrl(): string {
 export function constructBuildLogsUrl({
   buildId,
   username,
-  v2 = false,
+  projectSlug,
 }: {
   buildId: string;
   username?: string;
+  projectSlug?: string;
   v2?: boolean;
 }): string {
-  if (username) {
+  if (username && projectSlug) {
+    return `${getExpoDomainUrl()}/accounts/${username}/projects/${projectSlug}/builds/${buildId}`;
+  } else if (username) {
     return `${getExpoDomainUrl()}/accounts/${username}/builds/${buildId}`;
   } else {
     return `${getExpoDomainUrl()}/builds/${buildId}`;


### PR DESCRIPTION
# Why

Our paths for build details pages are now: "/accounts/[account]/projects/[project]/builds/[buildId]". We are still showing the path without the "/projects/[project]" segment. This causes us to redirect to the correct page on the website. This change goes directly to the correct page, which makes it load faster.

## Before

<img width="752" alt="dbbad6bc-64fb-499c-a6ba-cf378a4807b4" src="https://user-images.githubusercontent.com/6455018/120664996-64f76380-c459-11eb-86f7-030bc310a581.png">

## After

<img width="988" alt="Screen Shot 2021-06-03 at 10 46 09 AM" src="https://user-images.githubusercontent.com/6455018/120665022-6a54ae00-c459-11eb-971e-2c29df33e620.png">


# Test Plan

Run `expo build:ios` or `expo build:android`, then check the output for the output above. You should see the projects path appear if it exists. Also, run unit tests.