### PR TITLE
Revert "[expo-cli][xdl] return correct project page url after expo pu…

### DIFF
--- a/packages/expo-cli/src/commands/publish.ts
+++ b/packages/expo-cli/src/commands/publish.ts
@@ -91,7 +91,6 @@ export async function action(
   });
 
   const url = result.url;
-  const projectPageUrl = result.projectPageUrl;
 
   if (options.quiet) {
     simpleSpinner.stop();
@@ -102,19 +101,22 @@ export async function action(
 
   logManifestUrl({ url, sdkVersion: exp.sdkVersion });
 
-  if (target === 'managed' && projectPageUrl) {
+  if (target === 'managed') {
+    // TODO: replace with websiteUrl from server when it is available, if that makes sense.
+    const websiteUrl = url.replace('exp.host', 'expo.io');
+
     // note(brentvatne): disable copy to clipboard functionality for now, need to think more about
     // whether this is desirable.
     //
     // Attempt to copy the URL to the clipboard, if it succeeds then append a notice to the log.
     // const copiedToClipboard = copyToClipboard(websiteUrl);
 
-    logProjectPageUrl({ url: projectPageUrl, copiedToClipboard: false });
+    logProjectPageUrl({ url: websiteUrl, copiedToClipboard: false });
 
     // Only send the link for managed projects.
     const recipient = await sendTo.getRecipient(options.sendTo);
     if (recipient) {
-      await sendTo.sendUrlAsync(projectPageUrl, recipient);
+      await sendTo.sendUrlAsync(websiteUrl, recipient);
     }
   }
 
@@ -152,7 +154,7 @@ function logManifestUrl({ url, sdkVersion }: { url: string; sdkVersion?: string 
 
 /**
  *
- * @example ⚙️   Project page: https://expo.io/@bacon/projects/my-app [copied to clipboard] Learn more: https://expo.fyi/project-page
+ * @example ⚙️   Project page: https://expo.io/@bacon/my-app [copied to clipboard] Learn more: https://expo.fyi/project-page
  * @param options
  */
 function logProjectPageUrl({

--- a/packages/xdl/src/__tests__/Project-publishAsync-test.ts
+++ b/packages/xdl/src/__tests__/Project-publishAsync-test.ts
@@ -78,7 +78,6 @@ jest.mock('axios', () => ({
         return mockApiV2Response(
           {
             url: 'https://test.exp.host/@testing/publish-test-app',
-            projectPageUrl: 'https://test.expo.io/@testing/projects/publish-test-app',
             ids: ['1', '2'],
           },
           options
@@ -124,7 +123,6 @@ describe('publishAsync', () => {
     process.env.EXPO_USE_DEV_SERVER = 'true';
     const result = await publishAsync(projectRoot, { resetCache: true });
     expect(result.url).toBe('https://test.exp.host/@testing/publish-test-app');
-    expect(result.projectPageUrl).toBe('https://test.expo.io/@testing/projects/publish-test-app');
 
     process.env.EXPO_USE_DEV_SERVER = 'false';
     const resultOld = await publishAsync(projectRoot, { resetCache: true });

--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -38,10 +38,6 @@ export interface PublishedProjectResult {
    */
   url: string;
   /**
-   * Project page URL
-   */
-  projectPageUrl: string;
-  /**
    * TODO: What is this?
    */
   ids: string[];
@@ -199,23 +195,12 @@ export async function publishAsync(
     });
   }
 
-  // Create project manifest URL
-  const url =
-    options.releaseChannel && options.releaseChannel !== 'default'
-      ? `${response.url}?release-channel=${options.releaseChannel}`
-      : response.url;
-
-  // Create project page URL
-  const projectPageUrl = response.projectPageUrl
-    ? options.releaseChannel && options.releaseChannel !== 'default'
-      ? `${response.projectPageUrl}?release-channel=${options.releaseChannel}`
-      : response.projectPageUrl
-    : null;
-
   return {
     ...response,
-    url,
-    projectPageUrl,
+    url:
+      options.releaseChannel && options.releaseChannel !== 'default'
+        ? `${response.url}?release-channel=${options.releaseChannel}`
+        : response.url,
   };
 }
 


### PR DESCRIPTION
# Why

This reverts https://github.com/expo/expo-cli/pull/3398. We changed our minds about how averse we are to clawback on public pages, and people liked shorter project page URLs, so reverting this PR to go back to displaying "@[username]/[project]" URLs.

This PR is related to this www PR: https://github.com/expo/universe/pull/7668

# How

Reverts the commit from the PR above.

# Test Plan

Run `expo publish`, and make sure the URL is correct.