### PR TITLE
fix #3473

### DIFF
--- a/packages/expo-cli/src/utils/matchFileNameOrURLFromStackTrace.ts
+++ b/packages/expo-cli/src/utils/matchFileNameOrURLFromStackTrace.ts
@@ -13,8 +13,12 @@ export function matchFileNameOrURLFromStackTrace(traceMessage: string): string |
   if (traceLine.match(/https?:\/\//g)) {
     const [url, params] = traceLine.split('?');
 
-    const paramsWithoutLocation = params.replace(/:(\d+)/g, '').trim();
-    return `${url}?${paramsWithoutLocation}`;
+    const results: string[] = [url];
+    if (params) {
+      const paramsWithoutLocation = params.replace(/:(\d+)/g, '').trim();
+      results.push(paramsWithoutLocation);
+    }
+    return results.filter(Boolean).join('?');
   }
 
   // "node_modules/react-native/Libraries/LogBox/LogBox.js:117:10 in registerWarning"


### PR DESCRIPTION
# Why

sometimes there are no params in metro bundler response I guess (couldn't repro).