### PR TITLE
[expo-cli][config][xdl] support runtimeVersion in classic updates

### DIFF
--- a/packages/expo-cli/src/commands/publish/getUsageAsync.ts
+++ b/packages/expo-cli/src/commands/publish/getUsageAsync.ts
@@ -52,7 +52,7 @@ async function _getUsageAsync(projectRoot: string): Promise<string> {
   const timeDifferenceString = _getTimeDifferenceString(new Date(), new Date(publishedTime));
 
   return (
-    `--release-channel and --sdk-version arguments are required. \n` +
+    `--release-channel and either --sdk-version or --runtime-version arguments are required. \n` +
     `For example, to roll back the revision [${revisionId}] on release channel [${channel}] (published ${timeDifferenceString}), \n` +
     `run: expo publish:rollback --release-channel ${channel} --sdk-version ${sdkVersion}`
   );
@@ -84,7 +84,7 @@ function _getTimeDifferenceString(t0: Date, t1: Date): string {
 
 function _getGenericUsage(): string {
   return (
-    `--release-channel and --sdk-version arguments are required. \n` +
+    `--release-channel and either --sdk-version or --runtime-version arguments are required. \n` +
     `For example, to roll back the latest publishes on the default channel for sdk 37.0.0, \n` +
     `run: expo publish:rollback --release-channel defaul --sdk-version 37.0.0 \n` +
     `To rollback a specific platform, use the --platform flag.`

--- a/packages/expo-cli/src/commands/publish/publishHistoryAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishHistoryAsync.ts
@@ -5,6 +5,7 @@ import { getPublishHistoryAsync, HistoryOptions, Publication } from '../utils/Pu
 import * as table from '../utils/cli-table';
 
 const HORIZ_CELL_WIDTH_SMALL = 15;
+const HORIZ_CELL_WIDTH_MEDIUM = 20;
 const HORIZ_CELL_WIDTH_BIG = 40;
 
 export async function actionAsync(projectRoot: string, options: HistoryOptions) {
@@ -26,11 +27,19 @@ export async function actionAsync(projectRoot: string, options: HistoryOptions) 
     );
     Log.log(generalTableString);
 
+    const hasRuntimeVersion = result.queryResult.some(
+      (publication: Publication) => !!publication.runtimeVersion
+    );
+    const hasSdkVersion = result.queryResult.some(
+      (publication: Publication) => !!publication.sdkVersion
+    );
+
     // Print info specific to each publication
     const headers = [
       'publishedTime',
       'appVersion',
-      'sdkVersion',
+      ...(hasSdkVersion ? ['sdkVersion'] : []),
+      ...(hasRuntimeVersion ? ['runtimeVersion'] : []),
       'platform',
       'channel',
       'publicationId',
@@ -39,9 +48,12 @@ export async function actionAsync(projectRoot: string, options: HistoryOptions) 
     // colWidths contains the cell size of each header
     const colWidths: number[] = [];
     const bigCells = new Set(['publicationId', 'publishedTime', 'channel']);
+    const mediumCells = new Set(['runtimeVersion']);
     headers.forEach(header => {
       if (bigCells.has(header)) {
         colWidths.push(HORIZ_CELL_WIDTH_BIG);
+      } else if (mediumCells.has(header)) {
+        colWidths.push(HORIZ_CELL_WIDTH_MEDIUM);
       } else {
         colWidths.push(HORIZ_CELL_WIDTH_SMALL);
       }

--- a/packages/expo-cli/src/commands/utils/PublishUtils.ts
+++ b/packages/expo-cli/src/commands/utils/PublishUtils.ts
@@ -13,6 +13,7 @@ export type HistoryOptions = {
   platform?: 'android' | 'ios';
   raw?: boolean;
   sdkVersion?: string;
+  runtimeVersion?: string;
 };
 
 export type DetailOptions = {
@@ -25,6 +26,7 @@ export type SetOptions = { releaseChannel: string; publishId: string };
 export type RollbackOptions = {
   releaseChannel: string;
   sdkVersion: string;
+  runtimeVersion?: string;
   platform?: 'android' | 'ios';
   parent?: { nonInteractive?: boolean };
 };
@@ -36,6 +38,7 @@ export type Publication = {
   publicationId: string;
   appVersion: string;
   sdkVersion: string;
+  runtimeVersion?: string;
   publishedTime: string;
   platform: 'android' | 'ios';
 };
@@ -51,6 +54,7 @@ export type PublicationDetail = {
   fullName: string;
   hash: string;
   sdkVersion: string;
+  runtimeVersion?: string;
   s3Key: string;
   s3Url: string;
   abiVersion: string | null;
@@ -87,6 +91,7 @@ export async function getPublishHistoryAsync(
     count: options.count,
     platform: options.platform,
     sdkVersion: options.sdkVersion,
+    runtimeVersion: options.runtimeVersion,
   });
 }
 
@@ -109,12 +114,13 @@ async function _rollbackPublicationFromChannelForPlatformAsync(
   platform: 'android' | 'ios',
   options: Omit<RollbackOptions, 'platform'>
 ) {
-  const { releaseChannel, sdkVersion } = options;
+  const { releaseChannel, sdkVersion, runtimeVersion } = options;
   // get the 2 most recent things in the channel history
   const historyQueryResult = await getPublishHistoryAsync(projectRoot, {
     releaseChannel,
     platform,
     sdkVersion,
+    runtimeVersion,
     count: 2,
   });
 

--- a/packages/xdl/src/project/__tests__/getPublishExpConfigAsync-test.ts
+++ b/packages/xdl/src/project/__tests__/getPublishExpConfigAsync-test.ts
@@ -1,0 +1,72 @@
+import { vol } from 'memfs';
+
+import { getPublishExpConfigAsync } from '../getPublishExpConfigAsync';
+
+jest.mock('fs');
+
+describe(getPublishExpConfigAsync, () => {
+  afterAll(() => {
+    vol.reset();
+  });
+
+  const runtimeVersion = 'one';
+  const sdkVersion = '40.0.0';
+  it('throws if sdkVersion is not specified', async () => {
+    vol.fromJSON(
+      {
+        'package.json': JSON.stringify({}),
+        'app.json': JSON.stringify({
+          name: 'hello',
+          slug: 'hello',
+          version: '1.0.0',
+          runtimeVersion,
+          platforms: [],
+        }),
+      },
+      'runtimeVersion'
+    );
+    await expect(
+      getPublishExpConfigAsync('runtimeVersion', { releaseChannel: 'default' })
+    ).rejects.toThrow(
+      'Config is missing an SDK version. See https://docs.expo.io/bare/installing-updates/'
+    );
+  });
+  it('reads sdkVersion from node module', async () => {
+    vol.fromJSON(
+      {
+        'package.json': JSON.stringify({}),
+        'app.json': JSON.stringify({
+          name: 'hello',
+          slug: 'hello',
+          version: '1.0.0',
+          platforms: [],
+        }),
+        'node_modules/expo/package.json': JSON.stringify({
+          version: sdkVersion,
+        }),
+      },
+      'sdkVersion'
+    );
+    const config = await getPublishExpConfigAsync('sdkVersion', { releaseChannel: 'default' });
+    expect(config.exp).toMatchObject({ sdkVersion });
+  });
+  it('reads sdkVersion from app.json', async () => {
+    vol.fromJSON(
+      {
+        'package.json': JSON.stringify({}),
+        'app.json': JSON.stringify({
+          name: 'hello',
+          slug: 'hello',
+          version: '1.0.0',
+          sdkVersion,
+          platforms: [],
+        }),
+      },
+      'sdkVersionInAppDotJson'
+    );
+    const config = await getPublishExpConfigAsync('sdkVersionInAppDotJson', {
+      releaseChannel: 'default',
+    });
+    expect(config.exp).toMatchObject({ sdkVersion });
+  });
+});

--- a/packages/xdl/src/project/__tests__/getPublishExpConfigAsync-test.ts
+++ b/packages/xdl/src/project/__tests__/getPublishExpConfigAsync-test.ts
@@ -11,7 +11,7 @@ describe(getPublishExpConfigAsync, () => {
 
   const runtimeVersion = 'one';
   const sdkVersion = '40.0.0';
-  it('throws if sdkVersion is not specified', async () => {
+  it('Passes if sdkVersion is not specified', async () => {
     vol.fromJSON(
       {
         'package.json': JSON.stringify({}),
@@ -25,11 +25,8 @@ describe(getPublishExpConfigAsync, () => {
       },
       'runtimeVersion'
     );
-    await expect(
-      getPublishExpConfigAsync('runtimeVersion', { releaseChannel: 'default' })
-    ).rejects.toThrow(
-      'Config is missing an SDK version. See https://docs.expo.io/bare/installing-updates/'
-    );
+    const config = await getPublishExpConfigAsync('runtimeVersion', { releaseChannel: 'default' });
+    expect(config.exp).toMatchObject({ sdkVersion: undefined, runtimeVersion });
   });
   it('reads sdkVersion from node module', async () => {
     vol.fromJSON(

--- a/packages/xdl/src/project/getPublishExpConfigAsync.ts
+++ b/packages/xdl/src/project/getPublishExpConfigAsync.ts
@@ -30,11 +30,20 @@ export async function getPublishExpConfigAsync(
   options.releaseChannel = options.releaseChannel || 'default';
 
   // Verify that exp/app.json and package.json exist
-  const { exp: privateExp } = getConfig(projectRoot);
-  const { hooks } = privateExp;
-  const { exp, pkg } = getConfig(projectRoot, { isPublicConfig: true });
-
+  const {
+    exp: { hooks, runtimeVersion },
+  } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const { exp, pkg } = getConfig(projectRoot, {
+    isPublicConfig: true,
+    // enforce sdk validation if user is not using runtimeVersion
+    skipSDKVersionRequirement: !!runtimeVersion,
+  });
   const { sdkVersion } = exp;
+  if (!sdkVersion) {
+    throw new Error(
+      'Config is missing an SDK version. See https://docs.expo.io/bare/installing-updates/'
+    );
+  }
 
   // Only allow projects to be published with UNVERSIONED if a correct token is set in env
   if (sdkVersion === 'UNVERSIONED' && !Env.maySkipManifestValidation()) {

--- a/packages/xdl/src/project/getPublishExpConfigAsync.ts
+++ b/packages/xdl/src/project/getPublishExpConfigAsync.ts
@@ -39,12 +39,6 @@ export async function getPublishExpConfigAsync(
     skipSDKVersionRequirement: !!runtimeVersion,
   });
   const { sdkVersion } = exp;
-  if (!sdkVersion) {
-    throw new Error(
-      'Config is missing an SDK version. See https://docs.expo.io/bare/installing-updates/'
-    );
-  }
-
   // Only allow projects to be published with UNVERSIONED if a correct token is set in env
   if (sdkVersion === 'UNVERSIONED' && !Env.maySkipManifestValidation()) {
     throw new XDLError('INVALID_OPTIONS', 'Cannot publish with sdkVersion UNVERSIONED.');


### PR DESCRIPTION
# Why

Support `runtimeVersion` in classic updates. 
Companion PR to https://github.com/expo/universe/pull/7663.

If the user wishes to publish with a `runtimeVersion`, they can add it to the app.json and the `sdkVersion` will be ignored.

<img width="258" alt="Screen Shot 2021-06-04 at 12 58 56 PM" src="https://user-images.githubusercontent.com/1220444/120856386-a27cef00-c534-11eb-9bc3-8c4f63987aff.png">


If the user wishes to go back to `sdkVersion`, they just need to delete the `runtimeVersion` key from the app.json.

# How

 - Made @expo/config not define `sdkversion` <-> `runtimeVersion` is not defined in the config.
   - `@expo/config.getConfig` is called here: https://github.com/expo/expo-cli/blob/master/packages/xdl/src/project/getPublishExpConfigAsync.ts#L33 when we publish an update.
 - In expo-cli, updated types and added extra column where necessary.

# Test Plan

Tested in demo repo against https://github.com/expo/universe/pull/7663 running on docker.

- [x] expo publish
- [x] expo publish:details
With only sdkVersion:
  
<img width="1202" alt="Screen Shot 2021-06-04 at 12 51 28 PM" src="https://user-images.githubusercontent.com/1220444/120855636-96446200-c533-11eb-9b2e-e7ad7ea9f409.png">
With only runtimeVersion:
    
    
<img width="1339" alt="Screen Shot 2021-06-04 at 12 51 58 PM" src="https://user-images.githubusercontent.com/1220444/120855687-a8260500-c533-11eb-903d-318cd602111b.png">
With both:
  
<img width="1376" alt="Screen Shot 2021-06-04 at 12 52 26 PM" src="https://user-images.githubusercontent.com/1220444/120855736-b8d67b00-c533-11eb-89dd-8d1959c2a474.png">

- [x] expo publish:set

<img width="1390" alt="Screen Shot 2021-06-04 at 12 52 55 PM" src="https://user-images.githubusercontent.com/1220444/120855791-ca1f8780-c533-11eb-8aee-3ebda70a5ebc.png">

- [x] expo publish:details

<img width="677" alt="Screen Shot 2021-06-04 at 12 53 49 PM" src="https://user-images.githubusercontent.com/1220444/120855898-eae7dd00-c533-11eb-9e29-f016958cc30e.png">



