### PR TITLE
[xdl] Update watchman version check to allow new format

### DIFF
--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -88,7 +88,16 @@ async function _checkWatchmanVersionAsync(projectRoot: string) {
     return;
   }
 
-  if (semver.lt(watchmanVersion, MIN_WATCHMAN_VERSION)) {
+  // Watchman versioning through homebrew is changed from semver to date since "2021.05.31.00"
+  // see: https://github.com/Homebrew/homebrew-core/commit/d299c2867503cb6ad8d90792343993c80e745071
+  const validSemver =
+    !!semver.valid(watchmanVersion) && semver.gte(watchmanVersion, MIN_WATCHMAN_VERSION);
+
+  // This new format is used later than the MIN_WATCHMAN_VERSION, we assume/estimate if the version is correct here.
+  const validNewVersion =
+    !validSemver && /[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]{2}/.test(watchmanVersion);
+
+  if (!validSemver && !validNewVersion) {
     let warningMessage = `Warning: You are using an old version of watchman (v${watchmanVersion}). This may cause problems for you.\n\nWe recommend that you either uninstall watchman (and XDE will try to use a copy it is bundled with) or upgrade watchman to a newer version, at least v${MIN_WATCHMAN_VERSION}.`;
 
     // Add a note about homebrew if the user is on a Mac
@@ -96,9 +105,10 @@ async function _checkWatchmanVersionAsync(projectRoot: string) {
       warningMessage += `\n\nIf you are using homebrew, try:\nbrew uninstall watchman; brew install watchman`;
     }
     ProjectUtils.logWarning(projectRoot, 'expo', warningMessage, 'doctor-watchman-version');
-  } else {
-    ProjectUtils.clearNotification(projectRoot, 'doctor-watchman-version');
+    return;
   }
+
+  ProjectUtils.clearNotification(projectRoot, 'doctor-watchman-version');
 }
 
 async function validateWithSchema(

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -98,7 +98,7 @@ async function _checkWatchmanVersionAsync(projectRoot: string) {
     !validSemver && /[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]{2}/.test(watchmanVersion);
 
   if (!validSemver && !validNewVersion) {
-    let warningMessage = `Warning: You are using an old version of watchman (v${watchmanVersion}). This may cause problems for you.\n\nWe recommend that you either uninstall watchman (and XDE will try to use a copy it is bundled with) or upgrade watchman to a newer version, at least v${MIN_WATCHMAN_VERSION}.`;
+    let warningMessage = `Warning: You are using an old version of watchman (v${watchmanVersion}).\n\nIt is recommend to always use the latest version, or at least v${MIN_WATCHMAN_VERSION}.`;
 
     // Add a note about homebrew if the user is on a Mac
     if (process.platform === 'darwin') {


### PR DESCRIPTION
# Why

Who needs proper semver versions when you can have a custom internal format that nobody can parse? 😄  This checks on both the existing semver and if the pattern [matches the newer version in Homebrew](https://github.com/Homebrew/homebrew-core/commit/d299c2867503cb6ad8d90792343993c80e745071#diff-35c4226d33f9dd956e8656e92e9ba8606ae1ddea05fff181850e81751d8b1103).

![Screenshot 2021-06-07 at 14 03 29](https://user-images.githubusercontent.com/1203991/121017170-41a41f80-c79d-11eb-8449-671888b55e8e.png)

# How

- Added "is valid semver" check for the semver format
- If the semver isn't valid, try validating if the version format is equal to `XXXX.XX.XX.XX` (where `X` is a number).

# Test Plan

- `$ brew upgrade watchman`
- `$ expo doctor` (on any project)
- Invalid watchman version shouldn't pop up