### PR TITLE
[splash-screen] Extend default theme

### DIFF
--- a/packages/config-plugins/src/android/__tests__/Styles-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Styles-test.ts
@@ -23,7 +23,7 @@ const mockStyles = `
     <item name="android:windowTranslucentStatus">true</item>
     <item name="colorPrimary">@color/colorPrimary</item>
   </style>
-  <style name="Theme.App.SplashScreen" parent="Theme.AppCompat.Light.NoActionBar">
+  <style name="Theme.App.SplashScreen" parent="AppTheme">
     <item name="android:windowBackground">@drawable/splashscreen</item>
   </style>
 </resources>`;
@@ -61,7 +61,7 @@ describe('Styles', () => {
   it(`changes the value of a style`, async () => {
     const stylesPath = await getProjectStylesXMLPathAsync('/app')!;
     const xml = await readResourcesXMLAsync({ path: stylesPath });
-    const parent = { name: 'Theme.App.SplashScreen', parent: 'Theme.AppCompat.Light.NoActionBar' };
+    const parent = { name: 'Theme.App.SplashScreen', parent: 'AppTheme' };
     setStylesItem({
       xml,
       parent,
@@ -72,7 +72,7 @@ describe('Styles', () => {
     const modifiedXml = await readResourcesXMLAsync({ path: stylesPath });
 
     expect(getStyleParent(modifiedXml, parent)).toStrictEqual({
-      $: { name: 'Theme.App.SplashScreen', parent: 'Theme.AppCompat.Light.NoActionBar' },
+      $: { name: 'Theme.App.SplashScreen', parent: 'AppTheme' },
       item: [
         { $: { name: 'android:windowBackground' }, _: '@drawable/splashscreen' },
         {
@@ -88,7 +88,7 @@ describe('Styles', () => {
   it(`removes a value`, async () => {
     const stylesPath = await getProjectStylesXMLPathAsync('/app')!;
     const xml = await readResourcesXMLAsync({ path: stylesPath });
-    const parent = { name: 'Theme.App.SplashScreen', parent: 'Theme.AppCompat.Light.NoActionBar' };
+    const parent = { name: 'Theme.App.SplashScreen', parent: 'AppTheme' };
     expect(getStylesItem({ xml, parent, name: 'android:textColor' })).toStrictEqual({
       $: {
         name: 'android:textColor',

--- a/unlinked-packages/configure-splash-screen/src/android/Styles.xml.ts
+++ b/unlinked-packages/configure-splash-screen/src/android/Styles.xml.ts
@@ -38,7 +38,7 @@ function configureStyle(
             name: 'style',
             attributes: {
               name: STYLE_NAME,
-              parent: 'Theme.AppCompat.Light.NoActionBar',
+              parent: 'AppTheme',
             },
             elements: [
               {

--- a/unlinked-packages/configure-splash-screen/src/android/__tests__/Styles.xml-test.ts
+++ b/unlinked-packages/configure-splash-screen/src/android/__tests__/Styles.xml-test.ts
@@ -33,7 +33,7 @@ describe('Styles.xml', () => {
     <item name="android:textColor">#000000</item>
   </style>`
       }
-  <style name="Theme.App.SplashScreen" parent="Theme.AppCompat.Light.NoActionBar">
+  <style name="Theme.App.SplashScreen" parent="AppTheme">
     <!-- Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually -->
     <item name="android:windowBackground">@drawable/splashscreen</item>${
       windowFullscreenItemValue === undefined

--- a/unlinked-packages/configure-splash-screen/src/android/__tests__/fixtures/react-native-project-structure-with-splash-screen-configured.ts
+++ b/unlinked-packages/configure-splash-screen/src/android/__tests__/fixtures/react-native-project-structure-with-splash-screen-configured.ts
@@ -74,7 +74,7 @@ public class MainActivity extends ReactActivity {
     <!-- Customize your theme here. -->
     <item name="android:textColor">#000000</item>
   </style>
-  <style name="Theme.App.SplashScreen" parent="Theme.AppCompat.Light.NoActionBar">
+  <style name="Theme.App.SplashScreen" parent="AppTheme">
     <!-- Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually -->
     <item name="android:windowBackground">@drawable/splashscreen</item>
     <!-- Customize your splash screen theme here -->


### PR DESCRIPTION
# Why

By not extending the default theme, we lose all of the predefined styles. Related https://github.com/expo/expo/pull/13196

