### PR TITLE
Patch android status bar to match the color of the splash screen

### DIFF
--- a/packages/config-plugins/src/android/StatusBar.ts
+++ b/packages/config-plugins/src/android/StatusBar.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
-import { assert } from 'console';
+import assert from 'assert';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';

--- a/packages/config-plugins/src/android/StatusBar.ts
+++ b/packages/config-plugins/src/android/StatusBar.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
+import { assert } from 'console';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
@@ -17,14 +18,14 @@ export const withStatusBar: ConfigPlugin = config => {
 };
 
 const withStatusBarColors: ConfigPlugin = config => {
-  return withAndroidColors(config, async config => {
+  return withAndroidColors(config, config => {
     config.modResults = setStatusBarColors(config, config.modResults);
     return config;
   });
 };
 
 const withStatusBarStyles: ConfigPlugin = config => {
-  return withAndroidStyles(config, async config => {
+  return withAndroidStyles(config, config => {
     config.modResults = setStatusBarStyles(config, config.modResults);
     return config;
   });
@@ -36,7 +37,7 @@ export function setStatusBarColors(
 ): ResourceXML {
   return assignColorValue(colors, {
     name: COLOR_PRIMARY_DARK_KEY,
-    value: config.androidStatusBar?.backgroundColor,
+    value: getStatusBarColor(config),
   });
 }
 
@@ -59,7 +60,7 @@ export function setStatusBarStyles(
     name: WINDOW_TRANSLUCENT_STATUS,
     value: 'true',
     // translucent status bar set in theme
-    add: hexString === 'translucent',
+    add: !hexString,
   });
 
   styles = assignStylesValue(styles, {
@@ -67,14 +68,20 @@ export function setStatusBarStyles(
     name: COLOR_PRIMARY_DARK_KEY,
     value: `@color/${COLOR_PRIMARY_DARK_KEY}`,
     // Remove the color if translucent is used
-    add: hexString !== 'translucent',
+    add: !!hexString,
   });
 
   return styles;
 }
 
 export function getStatusBarColor(config: Pick<ExpoConfig, 'androidStatusBar'>) {
-  return config.androidStatusBar?.backgroundColor || 'translucent';
+  const backgroundColor = config.androidStatusBar?.backgroundColor;
+  // Drop support for translucent
+  assert(
+    backgroundColor === 'translucent',
+    'androidStatusBar.backgroundColor must be a valid hex string'
+  );
+  return backgroundColor;
 }
 
 export function getStatusBarStyle(config: Pick<ExpoConfig, 'androidStatusBar'>) {

--- a/packages/config-plugins/src/android/StatusBar.ts
+++ b/packages/config-plugins/src/android/StatusBar.ts
@@ -76,11 +76,13 @@ export function setStatusBarStyles(
 
 export function getStatusBarColor(config: Pick<ExpoConfig, 'androidStatusBar'>) {
   const backgroundColor = config.androidStatusBar?.backgroundColor;
-  // Drop support for translucent
-  assert(
-    backgroundColor === 'translucent',
-    'androidStatusBar.backgroundColor must be a valid hex string'
-  );
+  if (backgroundColor) {
+    // Drop support for translucent
+    assert(
+      backgroundColor !== 'translucent',
+      `androidStatusBar.backgroundColor must be a valid hex string, instead got: "${backgroundColor}"`
+    );
+  }
   return backgroundColor;
 }
 

--- a/packages/config-plugins/src/android/__tests__/StatusBar-test.ts
+++ b/packages/config-plugins/src/android/__tests__/StatusBar-test.ts
@@ -9,11 +9,6 @@ import {
 } from '../StatusBar';
 import { getAppThemeLightNoActionBarGroup, getStylesGroupAsObject } from '../Styles';
 
-it(`returns 'translucent' if no status bar color is provided`, () => {
-  expect(getStatusBarColor({})).toMatch('translucent');
-  expect(getStatusBarColor({ androidStatusBar: {} })).toMatch('translucent');
-});
-
 it(`returns statusbar color if provided`, () => {
   expect(getStatusBarColor({ androidStatusBar: { backgroundColor: '#111111' } })).toMatch(
     '#111111'

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
@@ -7,25 +7,23 @@ import {
 } from '@expo/configure-splash-screen';
 
 export const withAndroidSplashScreen: ConfigPlugin = config => {
+  // Update the android status bar to match the splash screen
+  // androidStatusBar applies info to the app activity style.
+  const backgroundColor = getSplashBackgroundColor(config);
+  if (config.androidStatusBar?.backgroundColor) {
+    if (backgroundColor.toLowerCase() !== config.androidStatusBar?.backgroundColor.toLowerCase()) {
+      WarningAggregator.addWarningAndroid(
+        'androidStatusBar.backgroundColor',
+        'The androidStatusBar.backgroundColor color conflicts with the splash backgroundColor on Android'
+      );
+    }
+  } else {
+    if (!config.androidStatusBar) config.androidStatusBar = {};
+    config.androidStatusBar.backgroundColor = backgroundColor;
+  }
   return withDangerousMod(config, [
     'android',
     async config => {
-      // Update the android status bar to match the splash screen
-      // androidStatusBar applies info to the app activity style.
-      const backgroundColor = getSplashBackgroundColor(config);
-      if (config.androidStatusBar?.backgroundColor) {
-        if (
-          backgroundColor.toLowerCase() !== config.androidStatusBar?.backgroundColor.toLowerCase()
-        ) {
-          WarningAggregator.addWarningAndroid(
-            'androidStatusBar.backgroundColor',
-            'The androidStatusBar.backgroundColor color conflicts with the splash backgroundColor on Android'
-          );
-        }
-      } else {
-        if (!config.androidStatusBar) config.androidStatusBar = {};
-        config.androidStatusBar.backgroundColor = backgroundColor;
-      }
       await setSplashScreenAsync(config, config.modRequest.projectRoot);
       return config;
     },

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
@@ -10,24 +10,47 @@ export const withAndroidSplashScreen: ConfigPlugin = config => {
   return withDangerousMod(config, [
     'android',
     async config => {
+      // Update the android status bar to match the splash screen
+      // androidStatusBar applies info to the app activity style.
+      const backgroundColor = getSplashBackgroundColor(config);
+      if (config.androidStatusBar?.backgroundColor) {
+        if (
+          backgroundColor.toLowerCase() !== config.androidStatusBar?.backgroundColor.toLowerCase()
+        ) {
+          WarningAggregator.addWarningAndroid(
+            'androidStatusBar.backgroundColor',
+            'The androidStatusBar.backgroundColor color conflicts with the splash backgroundColor on Android'
+          );
+        }
+      } else {
+        if (!config.androidStatusBar) config.androidStatusBar = {};
+        config.androidStatusBar.backgroundColor = backgroundColor;
+      }
       await setSplashScreenAsync(config, config.modRequest.projectRoot);
       return config;
     },
   ]);
 };
 
+function getSplashBackgroundColor(config: ExpoConfig) {
+  const backgroundColor =
+    config.android?.splash?.backgroundColor ?? config.splash?.backgroundColor ?? '#FFFFFF'; // white
+  return backgroundColor;
+}
+
 export function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenConfig | undefined {
   if (!config.splash && !config.android?.splash) {
     return;
   }
+
+  const backgroundColor = getSplashBackgroundColor(config);
 
   const result: AndroidSplashScreenConfig = {
     imageResizeMode:
       config.android?.splash?.resizeMode ??
       config.splash?.resizeMode ??
       SplashScreenImageResizeMode.CONTAIN,
-    backgroundColor:
-      config.android?.splash?.backgroundColor ?? config.splash?.backgroundColor ?? '#FFFFFF', // white
+    backgroundColor,
     image:
       config.android?.splash?.xxxhdpi ??
       config.android?.splash?.xxhdpi ??
@@ -35,6 +58,13 @@ export function getSplashScreenConfig(config: ExpoConfig): AndroidSplashScreenCo
       config.android?.splash?.hdpi ??
       config.android?.splash?.mdpi ??
       config.splash?.image,
+    statusBar: {
+      backgroundColor,
+      // Use the settings from androidStatusBar to keep the transition as smooth as possible.
+      hidden: config.androidStatusBar?.hidden,
+      translucent: config.androidStatusBar?.translucent,
+      style: config.androidStatusBar?.barStyle,
+    },
   };
 
   return result;


### PR DESCRIPTION
# Why

Prevent the status bar from flashing to the background color by setting the androidStatusBar.backgroundColor to the splash screen background color. This will cause the status bar to be an unexpected color in the app unless `<StatusBar style="auto"/>` is used (which seems reasonable enough).

This PR also drops support for `translucent` as the backgroundColor as this breaks things