### PR TITLE
[config plugins] Remove permission side effects

### DIFF
--- a/packages/config-plugins/src/android/Permissions.ts
+++ b/packages/config-plugins/src/android/Permissions.ts
@@ -6,45 +6,6 @@ import { AndroidManifest, ManifestUsesPermission } from './Manifest';
 
 const USES_PERMISSION = 'uses-permission';
 
-export const requiredPermissions = [
-  'android.permission.INTERNET',
-  'android.permission.ACCESS_NETWORK_STATE',
-  'android.permission.SYSTEM_ALERT_WINDOW',
-  'android.permission.WAKE_LOCK',
-  'com.google.android.c2dm.permission.RECEIVE',
-];
-
-export const allPermissions = [
-  ...requiredPermissions,
-  'android.permission.ACCESS_WIFI_STATE',
-  'android.permission.ACCESS_COARSE_LOCATION',
-  'android.permission.ACCESS_FINE_LOCATION',
-  'android.permission.CAMERA',
-  'android.permission.MANAGE_DOCUMENTS',
-  'android.permission.READ_CONTACTS',
-  'android.permission.WRITE_CONTACTS',
-  'android.permission.READ_CALENDAR',
-  'android.permission.WRITE_CALENDAR',
-  'android.permission.READ_EXTERNAL_STORAGE',
-  'android.permission.READ_INTERNAL_STORAGE',
-  'android.permission.READ_PHONE_STATE',
-  'android.permission.RECORD_AUDIO',
-  'android.permission.USE_FINGERPRINT',
-  'android.permission.VIBRATE',
-  'android.permission.WRITE_EXTERNAL_STORAGE',
-  'android.permission.READ_SMS',
-  'com.anddoes.launcher.permission.UPDATE_COUNT',
-  'com.android.launcher.permission.INSTALL_SHORTCUT',
-  'com.google.android.gms.permission.ACTIVITY_RECOGNITION',
-  'com.google.android.providers.gsf.permission.READ_GSERVICES',
-  'com.htc.launcher.permission.READ_SETTINGS',
-  'com.htc.launcher.permission.UPDATE_SHORTCUT',
-  'com.majeur.launcher.permission.UPDATE_BADGE',
-  'com.sec.android.provider.badge.permission.READ',
-  'com.sec.android.provider.badge.permission.WRITE',
-  'com.sonyericsson.home.permission.BROADCAST_BADGE',
-];
-
 export const withPermissions: ConfigPlugin<string[] | void> = (config, permissions) => {
   if (Array.isArray(permissions)) {
     permissions = permissions.filter(Boolean);
@@ -79,15 +40,8 @@ export function setAndroidPermissions(
   androidManifest: AndroidManifest
 ) {
   const permissions = getAndroidPermissions(config);
-  let permissionsToAdd = [];
-  if (permissions === null) {
-    // Use all Expo permissions
-    permissionsToAdd = allPermissions;
-  } else {
-    // Use minimum required, plus any specified in permissions array
-    const providedPermissions = prefixAndroidPermissionsIfNecessary(permissions);
-    permissionsToAdd = [...providedPermissions, ...requiredPermissions];
-  }
+  const providedPermissions = prefixAndroidPermissionsIfNecessary(permissions);
+  const permissionsToAdd = [...providedPermissions];
 
   if (!androidManifest.manifest.hasOwnProperty('uses-permission')) {
     androidManifest.manifest['uses-permission'] = [];

--- a/packages/config-plugins/src/android/__tests__/Permissions-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Permissions-test.ts
@@ -8,7 +8,6 @@ import {
   getAndroidPermissions,
   getPermissions,
   removePermissions,
-  requiredPermissions,
   setAndroidPermissions,
 } from '../Permissions';
 
@@ -41,11 +40,13 @@ describe('Android permissions', () => {
     const manifestPermissionsJSON = androidManifestJson.manifest['uses-permission'];
     const manifestPermissions = manifestPermissionsJSON.map(e => e.$['android:name']);
 
-    expect(
-      manifestPermissions.every(permission =>
-        givenPermissions.concat(requiredPermissions).includes(permission)
-      )
-    ).toBe(true);
+    expect(manifestPermissions.length).toBe(
+      // Account for INTERNET permission in fixture
+      givenPermissions.length + 1
+    );
+    expect(manifestPermissions.every(permission => givenPermissions.includes(permission))).toBe(
+      true
+    );
     expect(
       manifestPermissions.filter(e => e === 'com.android.launcher.permission.INSTALL_SHORTCUT')
     ).toHaveLength(1);

--- a/packages/config-plugins/src/android/__tests__/Permissions-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Permissions-test.ts
@@ -40,13 +40,13 @@ describe('Android permissions', () => {
     const manifestPermissionsJSON = androidManifestJson.manifest['uses-permission'];
     const manifestPermissions = manifestPermissionsJSON.map(e => e.$['android:name']);
 
-    expect(manifestPermissions.length).toBe(
-      // Account for INTERNET permission in fixture
-      givenPermissions.length + 1
-    );
-    expect(manifestPermissions.every(permission => givenPermissions.includes(permission))).toBe(
-      true
-    );
+    // Account for INTERNET permission in fixture
+    // No duplicates
+    expect(manifestPermissions).toStrictEqual([
+      'android.permission.INTERNET',
+      'android.permission.READ_CONTACTS',
+      'com.android.launcher.permission.INSTALL_SHORTCUT',
+    ]);
     expect(
       manifestPermissions.filter(e => e === 'com.android.launcher.permission.INSTALL_SHORTCUT')
     ).toHaveLength(1);

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -695,26 +695,6 @@ Object {
                   "android:name": "com.sec.android.provider.badge.permission.WRITE",
                 },
               },
-              Object {
-                "$": Object {
-                  "android:name": "android.permission.ACCESS_NETWORK_STATE",
-                },
-              },
-              Object {
-                "$": Object {
-                  "android:name": "android.permission.SYSTEM_ALERT_WINDOW",
-                },
-              },
-              Object {
-                "$": Object {
-                  "android:name": "android.permission.WAKE_LOCK",
-                },
-              },
-              Object {
-                "$": Object {
-                  "android:name": "com.google.android.c2dm.permission.RECEIVE",
-                },
-              },
             ],
           },
         },
@@ -1460,26 +1440,6 @@ Object {
               Object {
                 "$": Object {
                   "android:name": "com.sec.android.provider.badge.permission.WRITE",
-                },
-              },
-              Object {
-                "$": Object {
-                  "android:name": "android.permission.ACCESS_NETWORK_STATE",
-                },
-              },
-              Object {
-                "$": Object {
-                  "android:name": "android.permission.SYSTEM_ALERT_WINDOW",
-                },
-              },
-              Object {
-                "$": Object {
-                  "android:name": "android.permission.WAKE_LOCK",
-                },
-              },
-              Object {
-                "$": Object {
-                  "android:name": "com.google.android.c2dm.permission.RECEIVE",
                 },
               },
             ],


### PR DESCRIPTION
# Why

The android permissions code used to be used for something else and it injected "default permissions", along with adding "all permissions" if no permissions were defined. This leads to unfortunate side effects where removing permissions is difficult to do.

This PR removes all side-effects and simplifies permission adding, all android permissions will now come from plugins, config, and the template.

- ENG-1227

# Test Plan

Updated unit tests.