### PR TITLE
[expo-cli] Use the default scheme to launch managed dev client apps

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -64,7 +64,6 @@
     "klaw-sync": "6.0.0",
     "memfs": "^3.2.0",
     "pretty-bytes": "^5.3.0",
-    "resolve-from": "^5.0.0",
     "rimraf": "^3.0.2"
   },
   "dependencies": {
@@ -118,6 +117,7 @@
     "qrcode-terminal": "0.11.0",
     "react-dev-utils": "~11.0.1",
     "read-last-lines": "1.6.0",
+    "resolve-from": "^5.0.0",
     "semver": "7.3.2",
     "slugify": "^1.3.4",
     "strip-ansi": "^6.0.0",


### PR DESCRIPTION
# Why

We're starting to support dev client in managed projects. However, the project might not have a URI scheme defined that's same for iOS and Android, which is currently a requirement for launching the client app. To fix this we have made the `expo-dev-client` config plugin always add a default scheme generated from the slug (e.g. slug `1-up-app` -> scheme `exp+1-up-app`).

Scheme generation was added in https://github.com/expo/expo/pull/13147 and refined & publicly exposed in https://github.com/expo/expo/pull/13230.

This PR makes the `expo start --dev-client` command always use the autogenerated default scheme for managed projects.

# How

- Import the module `expo-dev-client/getDefaultScheme` from the project and run it, passing the app config as an argument.
- Use the returned string as a scheme.

# Test Plan

I used this test setup to get an app on the emulator first (as is required for using `expo start --dev-client`):
```sh
expo init hello --yes
cd hello

yarn add expo-dev-client

# Use the plugin from the local expo-dev-client package to prebuild,
# because changes haven't bee published yet.
# This requires prebuild w/o busting the node_modules folder.
yarn link expo-dev-client
expo prebuild --no-install

# Remove link to local package and build the app.
yarn unlink expo-dev-client
yarn install --force
expo run:android

# Go back to managed.
rm -rf android ios
```
Then did this to run the command:
```sh
# Test the local changes
yarn link expo-dev-client
expod start --dev-client
```
The dev server started successfully and the app started when pressing `a`.
<img width="946" alt="Screen Shot 2021-06-10 at 14 02 20" src="https://user-images.githubusercontent.com/497214/121514356-97bed000-c9f4-11eb-8f34-4ee0943d1efe.png">

When I ran `yarn unlink expo-dev-client` to use an old dev client package (without scheme generation), the following error message was shown, as expected:
<img width="946" alt="Screen Shot 2021-06-10 at 14 03 27" src="https://user-images.githubusercontent.com/497214/121514534-cd63b900-c9f4-11eb-9f3f-9a31aa70510a.png">
