### PR TITLE
[config-plugins] add config request headers enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [config-plugins] add config request headers to Updates Config enum ([#3571](https://github.com/expo/expo-cli/pull/3571))
+
 ### 🧹 Chores
 
 ## [Tue, 1 Jun 2021 13:02:23 +0200](https://github.com/expo/expo-cli/commit/6cd679038b3474954c8018f539432ff62b2ff72f)

--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -27,6 +27,7 @@ export enum Config {
   RUNTIME_VERSION = 'expo.modules.updates.EXPO_RUNTIME_VERSION',
   UPDATE_URL = 'expo.modules.updates.EXPO_UPDATE_URL',
   RELEASE_CHANNEL = 'expo.modules.updates.EXPO_RELEASE_CHANNEL',
+  UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = 'expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY',
 }
 
 export const withUpdates: ConfigPlugin<{ expoUsername: string | null }> = (

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -22,6 +22,7 @@ export enum Config {
   SDK_VERSION = 'EXUpdatesSDKVersion',
   UPDATE_URL = 'EXUpdatesURL',
   RELEASE_CHANNEL = 'EXUpdatesReleaseChannel',
+  UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = 'EXUpdatesRequestHeaders',
 }
 
 export function getUpdateUrl(


### PR DESCRIPTION
# Why

For EAS updates, we use are able to set the "update request headers" through the plist/manifest. This adds it to the config-plugin enum
