### PR TITLE
[config-plugins] add EXUpdatesRequestHeaders to ExpoPlist type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
-- [config-plugins] add config request headers to Updates Config enum ([#3571](https://github.com/expo/expo-cli/pull/3571))
+- [config-plugins] add config request headers to Updates Config Enum and ExpoPlist Type ([#3571](https://github.com/expo/expo-cli/pull/3571))([##3577](https://github.com/expo/expo-cli/pull/3577))
 
 ### 🧹 Chores
 

--- a/packages/config-plugins/src/ios/IosConfig.types.ts
+++ b/packages/config-plugins/src/ios/IosConfig.types.ts
@@ -47,6 +47,7 @@ export type ExpoPlist = {
   EXUpdatesLaunchWaitMs?: number;
   EXUpdatesReleaseChannel?: string;
   EXUpdatesRuntimeVersion?: string;
+  EXUpdatesRequestHeaders: Record<string, string>;
   EXUpdatesSDKVersion?: string;
   EXUpdatesURL?: string;
 };

--- a/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
+++ b/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
@@ -37,8 +37,8 @@ Array [
   "dist/assets/f6c6f6c8cb7784254ad00056f6fbd74e (34.1 kB)",
   "dist/assets/fdc01171a7a7ea76b187afcd162dee7d (3.99 kB)",
   "dist/bundles (dir)",
-  "dist/bundles/android-a952131562db3b407dbb1a89e94a1c3b.js (1.17 MB)",
-  "dist/bundles/ios-4b897ba59b72efc35675e7946c0dd5d6.js (1.16 MB)",
+  "dist/bundles/android-4108b3f49a2b86ffb0954bf4347f41c3.js (1.17 MB)",
+  "dist/bundles/ios-d772c79218ba5f7a59963af6313ea18b.js (1.16 MB)",
   "dist/ios-index.json (708 B)",
 ]
 `;
@@ -49,7 +49,7 @@ Object {
     "package": "com.example.minimal",
   },
   "assetUrlOverride": "./assets",
-  "bundleUrl": "https://example.com/export-test-app/bundles/android-a952131562db3b407dbb1a89e94a1c3b.js",
+  "bundleUrl": "https://example.com/export-test-app/bundles/android-4108b3f49a2b86ffb0954bf4347f41c3.js",
   "commitTime": Any<String>,
   "currentFullName": "@anonymous/export-test-app",
   "dependencies": Array [


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/expo-cli/pull/3571

This adds typing to the `ExpoPlist`.

There is no analog for Android.