### PR TITLE
[config-plugins] Default version number to 1.0.0

### DIFF
--- a/packages/config-plugins/src/ios/Version.ts
+++ b/packages/config-plugins/src/ios/Version.ts
@@ -8,7 +8,7 @@ export const withVersion = createInfoPlistPlugin(setVersion, 'withVersion');
 export const withBuildNumber = createInfoPlistPlugin(setBuildNumber, 'withBuildNumber');
 
 export function getVersion(config: Pick<ExpoConfig, 'version'>) {
-  return config.version || '0.0.0';
+  return config.version || '1.0.0';
 }
 
 export function setVersion(config: Pick<ExpoConfig, 'version'>, infoPlist: InfoPlist): InfoPlist {

--- a/packages/config-plugins/src/ios/__tests__/Version-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Version-test.ts
@@ -5,8 +5,8 @@ describe('version', () => {
     expect(getVersion({ version: '1.2.3' })).toBe('1.2.3');
   });
 
-  it(`uses 0.0.0 if no version is given`, () => {
-    expect(getVersion({})).toBe('0.0.0');
+  it(`uses 1.0.0 if no version is given`, () => {
+    expect(getVersion({})).toBe('1.0.0');
   });
 
   it(`sets the CFBundleShortVersionString`, () => {


### PR DESCRIPTION
# Why

Apple rejects apps that use version `0.0.0`.

