### PR TITLE
[run:ios] Improve multi-target support by signing all targets at once

### DIFF
--- a/packages/config-plugins/src/ios/Target.ts
+++ b/packages/config-plugins/src/ios/Target.ts
@@ -6,6 +6,7 @@ import { getPbxproj, isNotComment, NativeTargetSectionEntry } from './utils/Xcod
 export enum TargetType {
   APPLICATION = 'com.apple.product-type.application',
   EXTENSION = 'com.apple.product-type.app-extension',
+  STICKER_PACK_EXTENSION = 'com.apple.product-type.app-extension.messages-sticker-pack',
   OTHER = 'other',
 }
 
@@ -54,6 +55,20 @@ function isTargetOfType(target: PBXNativeTarget, targetType: TargetType): boolea
 export function getNativeTargets(project: XcodeProject): NativeTargetSectionEntry[] {
   const section = project.pbxNativeTargetSection();
   return Object.entries(section).filter(isNotComment);
+}
+
+export function findSignableTargets(project: XcodeProject): NativeTargetSectionEntry[] {
+  const targets = getNativeTargets(project);
+  const applicationTargets = targets.filter(
+    ([, target]) =>
+      isTargetOfType(target, TargetType.APPLICATION) ||
+      isTargetOfType(target, TargetType.EXTENSION) ||
+      isTargetOfType(target, TargetType.STICKER_PACK_EXTENSION)
+  );
+  if (applicationTargets.length === 0) {
+    throw new Error(`Could not find any application targets in project.pbxproj`);
+  }
+  return applicationTargets;
 }
 
 export function findFirstNativeTarget(project: XcodeProject): NativeTargetSectionEntry {

--- a/packages/expo-cli/src/commands/run/ios/__tests__/developmentCodeSigning-test.ts
+++ b/packages/expo-cli/src/commands/run/ios/__tests__/developmentCodeSigning-test.ts
@@ -24,8 +24,10 @@ describe(getCodeSigningInfoForPbxproj, () => {
     );
 
     expect(getCodeSigningInfoForPbxproj(projectRoot)).toStrictEqual({
-      developmentTeams: [],
-      provisioningProfiles: [],
+      '13B07F861A680F5B00A75B9A': {
+        developmentTeams: [],
+        provisioningProfiles: [],
+      },
     });
   });
   it(`returns the existing code signing info`, () => {
@@ -40,8 +42,10 @@ describe(getCodeSigningInfoForPbxproj, () => {
     );
 
     expect(getCodeSigningInfoForPbxproj(projectRoot)).toStrictEqual({
-      developmentTeams: ['QQ57RJ5UTD', 'QQ57RJ5UTD'],
-      provisioningProfiles: [],
+      '13B07F861A680F5B00A75B9A': {
+        developmentTeams: ['QQ57RJ5UTD', 'QQ57RJ5UTD'],
+        provisioningProfiles: [],
+      },
     });
   });
 });

--- a/packages/expo-cli/src/commands/run/ios/developmentCodeSigning.ts
+++ b/packages/expo-cli/src/commands/run/ios/developmentCodeSigning.ts
@@ -27,32 +27,46 @@ async function setLastDeveloperCodeSigningIdAsync(id: string) {
  */
 export function getCodeSigningInfoForPbxproj(projectRoot: string) {
   const project = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
-  const [, nativeTarget] = IOSConfig.Target.findFirstNativeTarget(project);
+  const targets = IOSConfig.Target.findSignableTargets(project);
 
-  const developmentTeams: string[] = [];
-  const provisioningProfiles: string[] = [];
+  const signingInfo: Record<
+    string,
+    { developmentTeams: string[]; provisioningProfiles: string[] }
+  > = {};
+  for (const [nativeTargetId, nativeTarget] of targets) {
+    const developmentTeams: string[] = [];
+    const provisioningProfiles: string[] = [];
 
-  IOSConfig.XcodeUtils.getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList)
-    .filter(
-      ([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => item.buildSettings.PRODUCT_NAME
+    IOSConfig.XcodeUtils.getBuildConfigurationsForListId(
+      project,
+      nativeTarget.buildConfigurationList
     )
-    .forEach(([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => {
-      const { DEVELOPMENT_TEAM, PROVISIONING_PROFILE } = item.buildSettings;
-      if (
-        typeof DEVELOPMENT_TEAM === 'string' &&
-        // If the user selects "Team: none" in Xcode, it'll be an empty string.
-        !!DEVELOPMENT_TEAM &&
-        // xcode package sometimes reads an empty string as a quoted empty string.
-        DEVELOPMENT_TEAM !== '""'
-      ) {
-        developmentTeams.push(DEVELOPMENT_TEAM);
-      }
-      if (typeof PROVISIONING_PROFILE === 'string' && !!PROVISIONING_PROFILE) {
-        provisioningProfiles.push(PROVISIONING_PROFILE);
-      }
-    });
+      .filter(
+        ([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) =>
+          item.buildSettings.PRODUCT_NAME
+      )
+      .forEach(([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => {
+        const { DEVELOPMENT_TEAM, PROVISIONING_PROFILE } = item.buildSettings;
+        if (
+          typeof DEVELOPMENT_TEAM === 'string' &&
+          // If the user selects "Team: none" in Xcode, it'll be an empty string.
+          !!DEVELOPMENT_TEAM &&
+          // xcode package sometimes reads an empty string as a quoted empty string.
+          DEVELOPMENT_TEAM !== '""'
+        ) {
+          developmentTeams.push(DEVELOPMENT_TEAM);
+        }
+        if (typeof PROVISIONING_PROFILE === 'string' && !!PROVISIONING_PROFILE) {
+          provisioningProfiles.push(PROVISIONING_PROFILE);
+        }
+      });
+    signingInfo[nativeTargetId] = {
+      developmentTeams,
+      provisioningProfiles,
+    };
+  }
 
-  return { developmentTeams, provisioningProfiles };
+  return signingInfo;
 }
 
 /**
@@ -67,24 +81,33 @@ function setAutoCodeSigningInfoForPbxproj(
   { appleTeamId }: { appleTeamId: string }
 ): void {
   const project = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
-  const [nativeTargetId, nativeTarget] = IOSConfig.Target.findFirstNativeTarget(project);
+  const targets = IOSConfig.Target.findSignableTargets(project);
 
-  IOSConfig.XcodeUtils.getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList)
-    .filter(
-      ([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => item.buildSettings.PRODUCT_NAME
+  for (const [nativeTargetId, nativeTarget] of targets) {
+    IOSConfig.XcodeUtils.getBuildConfigurationsForListId(
+      project,
+      nativeTarget.buildConfigurationList
     )
-    .forEach(([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => {
-      item.buildSettings.DEVELOPMENT_TEAM = appleTeamId;
-      item.buildSettings.CODE_SIGN_IDENTITY = '"Apple Development"';
-      item.buildSettings.CODE_SIGN_STYLE = 'Automatic';
-    });
+      .filter(
+        ([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) =>
+          item.buildSettings.PRODUCT_NAME
+      )
+      .forEach(([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => {
+        item.buildSettings.DEVELOPMENT_TEAM = appleTeamId;
+        item.buildSettings.CODE_SIGN_IDENTITY = '"Apple Development"';
+        item.buildSettings.CODE_SIGN_STYLE = 'Automatic';
+      });
 
-  Object.entries(IOSConfig.XcodeUtils.getProjectSection(project))
-    .filter(IOSConfig.XcodeUtils.isNotComment)
-    .forEach(([, item]: IOSConfig.XcodeUtils.ProjectSectionEntry) => {
-      item.attributes.TargetAttributes[nativeTargetId].DevelopmentTeam = appleTeamId;
-      item.attributes.TargetAttributes[nativeTargetId].ProvisioningStyle = 'Automatic';
-    });
+    Object.entries(IOSConfig.XcodeUtils.getProjectSection(project))
+      .filter(IOSConfig.XcodeUtils.isNotComment)
+      .forEach(([, item]: IOSConfig.XcodeUtils.ProjectSectionEntry) => {
+        if (!item.attributes.TargetAttributes[nativeTargetId]) {
+          item.attributes.TargetAttributes[nativeTargetId] = {};
+        }
+        item.attributes.TargetAttributes[nativeTargetId].DevelopmentTeam = appleTeamId;
+        item.attributes.TargetAttributes[nativeTargetId].ProvisioningStyle = 'Automatic';
+      });
+  }
 
   fs.writeFileSync(project.filepath, project.writeSync());
 }
@@ -93,13 +116,24 @@ export async function ensureDeviceIsCodeSignedForDeploymentAsync(
   projectRoot: string
 ): Promise<string | null> {
   // Check if the app already has a development team defined.
-  const { developmentTeams, provisioningProfiles } = getCodeSigningInfoForPbxproj(projectRoot);
-  if (developmentTeams.length) {
-    Log.log(chalk.dim`\u203A Auto signing app using team: ${developmentTeams[0]}`);
+  const signingInfo = getCodeSigningInfoForPbxproj(projectRoot);
+
+  const allTargetsHaveTeams = Object.values(signingInfo).reduce((prev, curr) => {
+    return prev && !!curr.developmentTeams.length;
+  }, true);
+
+  if (allTargetsHaveTeams) {
+    const teamList = Object.values(signingInfo).reduce<string[]>((prev, curr) => {
+      return prev.concat([curr.developmentTeams[0]]);
+    }, []);
+    Log.log(chalk.dim`\u203A Auto signing app using team(s): ${teamList.join(', ')}`);
     return null;
   }
 
-  if (provisioningProfiles.length) {
+  const allTargetsHaveProfiles = Object.values(signingInfo).reduce((prev, curr) => {
+    return prev && !!curr.provisioningProfiles.length;
+  }, true);
+  if (allTargetsHaveProfiles) {
     // this indicates that the user has manual code signing setup (possibly for production).
     return null;
   }


### PR DESCRIPTION
# Why

When you have a multi-target app, you need to setup signing for each bundle identifier, it doesn't seem likely that a user would want to register a child bundle id with a different account than their parent bundle id. This PR will sign all runnable targets with the same Apple team in development before running.

# Test Plan

- Setup a multi target iOS app in Xcode, run locally with `expo run:ios -d` (select a connected device).