### PR TITLE
[expo-cli] Add workaround for glob abort

### DIFF
--- a/packages/expo-cli/src/commands/utils/glob.ts
+++ b/packages/expo-cli/src/commands/utils/glob.ts
@@ -1,0 +1,61 @@
+import G, { Glob } from 'glob';
+
+export function everyMatchAsync(pattern: string, options: G.IOptions) {
+  return new Promise<string[]>((resolve, reject) => {
+    const g = new Glob(pattern, options);
+    let called = false;
+    const callback = (er: Error | null, matched: string[]) => {
+      if (called) return;
+      called = true;
+      if (er) reject(er);
+      else resolve(matched);
+    };
+    g.on('error', callback);
+    g.on('end', matches => callback(null, matches));
+  });
+}
+
+export function anyMatchAsync(pattern: string, options: G.IOptions) {
+  return new Promise<string[]>((resolve, reject) => {
+    const g = new Glob(pattern, options);
+    let called = false;
+    const callback = (er: Error | null, matched: string[]) => {
+      if (called) return;
+      called = true;
+      if (er) reject(er);
+      else resolve(matched);
+    };
+    g.on('error', callback);
+    g.on('match', matched => {
+      // We've disabled using abort as it breaks the entire glob package across all instances.
+      // https://github.com/isaacs/node-glob/issues/279 & https://github.com/isaacs/node-glob/issues/342
+      // For now, just collect every match.
+      // g.abort();
+      callback(null, [matched]);
+    });
+    g.on('end', matches => callback(null, matches));
+  });
+}
+
+export function wrapGlobWithTimeout(
+  query: () => Promise<string[]>,
+  duration: number
+): Promise<string[] | false> {
+  return new Promise(async (resolve, reject) => {
+    // Wait some time, then escape...
+    // Adding this because glob can sometimes freeze and fail to resolve if any other glob uses `.abort()`.
+    const timeout = setTimeout(() => {
+      resolve(false);
+    }, duration);
+
+    process.on('SIGINT', () => clearTimeout(timeout));
+
+    try {
+      resolve(await query());
+    } catch (error) {
+      reject(error);
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+}

--- a/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
@@ -1,7 +1,8 @@
 import { stat } from 'fs-extra';
-import { Glob } from 'glob';
 import * as path from 'path';
 import resolveFrom from 'resolve-from';
+
+import { everyMatchAsync, wrapGlobWithTimeout } from '../glob';
 
 async function fileExistsAsync(file: string): Promise<boolean> {
   return (await stat(file).catch(() => null))?.isFile() ?? false;
@@ -20,30 +21,23 @@ export const baseTSConfigName = 'expo/tsconfig.base';
 export async function queryFirstProjectTypeScriptFileAsync(
   projectRoot: string
 ): Promise<null | string> {
-  return new Promise<null | string>((resolve, reject) => {
-    const mg = new Glob(
-      '**/*.@(ts|tsx)',
-      {
+  const results = await wrapGlobWithTimeout(
+    () =>
+      everyMatchAsync('**/*.@(ts|tsx)', {
         cwd: projectRoot,
         ignore: [
           '**/@(Carthage|Pods|node_modules)/**',
           '**/*.d.ts',
           '@(ios|android|web|web-build|dist)/**',
         ],
-      },
-      (error, matches) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(matches[0] ?? null);
-        }
-      }
-    );
-    mg.once('match', matched => {
-      mg.abort();
-      resolve(matched);
-    });
-  });
+      }),
+    5000
+  );
+
+  if (results === false) {
+    return null;
+  }
+  return results[0] ?? null;
 }
 
 export function resolveBaseTSConfig(projectRoot: string): string | null {


### PR DESCRIPTION
# Why

Disabled using `abort()` as it breaks the entire glob package across all instances.
https://github.com/isaacs/node-glob/issues/279 & https://github.com/isaacs/node-glob/issues/342 
For now, just collect every match, which is much slower in the case where a large project is not using TypeScript.

Also added a timeout functionality in case another library accidentally uses abort in the future and breaks it again.

# Test Plan

`rm -rf tsconfig.json && expo start` in a project with a `*.ts` file should no longer hang.