### PR TITLE
[run] prompt for scheme

### DIFF
--- a/packages/config-plugins/src/ios/BuildScheme.ts
+++ b/packages/config-plugins/src/ios/BuildScheme.ts
@@ -1,6 +1,6 @@
 import { readXMLAsync } from '../utils/XML';
 import { findSchemeNames, findSchemePaths } from './Paths';
-import { findSignableTargets, isTargetOfType, TargetType } from './Target';
+import { findSignableTargets } from './Target';
 import { getPbxproj } from './utils/Xcodeproj';
 
 interface SchemeXML {

--- a/packages/config-plugins/src/ios/BuildScheme.ts
+++ b/packages/config-plugins/src/ios/BuildScheme.ts
@@ -1,5 +1,7 @@
 import { readXMLAsync } from '../utils/XML';
 import { findSchemeNames, findSchemePaths } from './Paths';
+import { findSignableTargets, isTargetOfType, TargetType } from './Target';
+import { getPbxproj } from './utils/Xcodeproj';
 
 interface SchemeXML {
   Scheme?: {
@@ -27,6 +29,22 @@ interface BuildActionEntryType {
 
 export function getSchemesFromXcodeproj(projectRoot: string): string[] {
   return findSchemeNames(projectRoot);
+}
+
+export function getRunnableSchemesFromXcodeproj(
+  projectRoot: string
+): { name: string; type: string }[] {
+  const project = getPbxproj(projectRoot);
+
+  return findSignableTargets(project).map(([, target]) => {
+    // Remove surrounding double quotes if they exist.
+    const match = target.name.match(/^"(.*)"$/)?.[1];
+    const productType = target.productType.match(/^"(.*)"$/)?.[1];
+    return {
+      name: match || target.name,
+      type: productType || target.productType,
+    };
+  });
 }
 
 async function readSchemeAsync(

--- a/packages/config-plugins/src/ios/BuildScheme.ts
+++ b/packages/config-plugins/src/ios/BuildScheme.ts
@@ -1,7 +1,7 @@
 import { readXMLAsync } from '../utils/XML';
 import { findSchemeNames, findSchemePaths } from './Paths';
 import { findSignableTargets } from './Target';
-import { getPbxproj } from './utils/Xcodeproj';
+import { getPbxproj, unquote } from './utils/Xcodeproj';
 
 interface SchemeXML {
   Scheme?: {
@@ -36,15 +36,10 @@ export function getRunnableSchemesFromXcodeproj(
 ): { name: string; type: string }[] {
   const project = getPbxproj(projectRoot);
 
-  return findSignableTargets(project).map(([, target]) => {
-    // Remove surrounding double quotes if they exist.
-    const match = target.name.match(/^"(.*)"$/)?.[1];
-    const productType = target.productType.match(/^"(.*)"$/)?.[1];
-    return {
-      name: match || target.name,
-      type: productType || target.productType,
-    };
-  });
+  return findSignableTargets(project).map(([, target]) => ({
+    name: unquote(target.name),
+    type: unquote(target.productType),
+  }));
 }
 
 async function readSchemeAsync(

--- a/packages/config-plugins/src/ios/Target.ts
+++ b/packages/config-plugins/src/ios/Target.ts
@@ -48,7 +48,7 @@ export async function findApplicationTargetWithDependenciesAsync(
   };
 }
 
-function isTargetOfType(target: PBXNativeTarget, targetType: TargetType): boolean {
+export function isTargetOfType(target: PBXNativeTarget, targetType: TargetType): boolean {
   return target.productType === targetType || target.productType === `"${targetType}"`;
 }
 

--- a/packages/config-plugins/src/ios/Target.ts
+++ b/packages/config-plugins/src/ios/Target.ts
@@ -66,7 +66,7 @@ export function findSignableTargets(project: XcodeProject): NativeTargetSectionE
       isTargetOfType(target, TargetType.STICKER_PACK_EXTENSION)
   );
   if (applicationTargets.length === 0) {
-    throw new Error(`Could not find any application targets in project.pbxproj`);
+    throw new Error(`Could not find any signable targets in project.pbxproj`);
   }
   return applicationTargets;
 }

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -380,3 +380,8 @@ export function isNotComment([key]:
   | NativeTargetSectionEntry): boolean {
   return !key.endsWith(`_comment`);
 }
+
+// Remove surrounding double quotes if they exist.
+export function unquote(value: string): string {
+  return value.match(/^"(.*)"$/)?.[1] ?? value;
+}

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -20,7 +20,7 @@ export default function (program: Command) {
     .option('--no-bundler', 'Skip starting the Metro bundler')
     .option('-d, --device [device]', 'Device name or UDID to build the app on')
     .option('-p, --port <port>', 'Port to start the Metro bundler on. Default: 8081')
-    .option('--scheme <scheme>', 'Scheme to build')
+    .option('--scheme [scheme]', 'Scheme to build')
     .option(
       '--configuration <configuration>',
       'Xcode configuration to use. Debug or Release. Default: Debug'

--- a/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
@@ -1,4 +1,5 @@
 import { IOSConfig } from '@expo/config-plugins';
+import chalk from 'chalk';
 import { sync as globSync } from 'glob';
 import * as path from 'path';
 
@@ -90,19 +91,20 @@ export async function resolveOptionsAsync(
 
   // @ts-ignore
   if (options.scheme === true) {
-    const schemes = IOSConfig.BuildScheme.getSchemesFromXcodeproj(projectRoot);
+    const schemes = IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj(projectRoot);
     if (!schemes.length) {
       throw new CommandError('No native iOS build schemes found');
     }
-    options.scheme = schemes[0];
+    options.scheme = schemes[0].name;
     if (schemes.length > 1) {
       options.scheme = await selectAsync(
         {
           message: 'Select a scheme',
           choices: schemes.map(value => {
+            const isApp = value.type === IOSConfig.Target.TargetType.APPLICATION;
             return {
-              value,
-              title: value,
+              value: value.name,
+              title: isApp ? chalk.bold(value.name) + chalk.gray(' (default)') : value.name,
             };
           }),
         },


### PR DESCRIPTION
# Why

It's not always clear what build schemes are available, so if the user passes `--scheme` with no name, then we'll fetch a list of schemes and prompt the user which to pick. If only one is available (most projects) then we'll default to that. 

# How

- It's not clear if this is the correct way to read all of the build schemes, but the existing method `getSchemesFromXcodeproj` doesn't work. Afaict, the files in `ios/*.xcodeproj/xcshareddata/xcschemes/*.xcscheme` don't represent the valid schemes, it's unclear to me why this approach is used.
- Determine the default scheme by comparing it against the type `com.apple.product-type.application` and label it as default.

# Test Plan

- In a project, add an extra target, then run `expo run:ios --scheme`.
- In a regular project run `expo run:ios --scheme` and it'll log that it's defaulting to the only scheme.
- Run `expo run:ios --scheme "yolo31"` and have it run a valid scheme.
- - Run `expo run:ios --scheme "yolo31 invalid"` and have it fail to run an invalid scheme.