### PR TITLE
Skip unprovided mods and warn

### DIFF
--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import path from 'path';
 
 import { ExportedConfig, Mod, ModConfig, ModPlatform } from '../Plugin.types';

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -1,8 +1,10 @@
+import chalk from 'chalk';
 import path from 'path';
 
 import { ExportedConfig, Mod, ModConfig, ModPlatform } from '../Plugin.types';
 import { getHackyProjectName } from '../ios/utils/Xcodeproj';
 import { PluginError } from '../utils/errors';
+import * as Warnings from '../utils/warnings';
 import { assertModResults, ForwardedBaseModOptions } from './createBaseMod';
 import { getAndroidIntrospectModFileProviders, withAndroidBaseMods } from './withAndroidBaseMods';
 import { getIosIntrospectModFileProviders, withIosBaseMods } from './withIosBaseMods';
@@ -164,9 +166,11 @@ export async function evalModsAsync(
           if (assertMissingModProviders !== false) {
             throw new PluginError(errorMessage, 'MISSING_PROVIDER');
           } else {
-            if (config._internal?.isDebug) {
-              console.warn(errorMessage);
-            }
+            Warnings.addWarningForPlatform(
+              platformName as ModPlatform,
+              `${platformName}.${modName}`,
+              `Skipping: Initial base modifier for "${platformName}.${modName}" is not a provider and therefore will not provide modResults to child mods`
+            );
             // In loose mode, just skip the mod entirely.
             continue;
           }

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -168,7 +168,7 @@ export async function evalModsAsync(
             Warnings.addWarningForPlatform(
               platformName as ModPlatform,
               `${platformName}.${modName}`,
-              `Skipping: Initial base modifier for "${platformName}.${modName}" is not a provider and therefore will not provide modResults to child mods`
+              `Skipping: Initial base modifier for "${platformName}.${modName}" is not a provider and therefore will not provide modResults to child mods. This may be due to an outdated version of Expo CLI.`
             );
             // In loose mode, just skip the mod entirely.
             continue;

--- a/packages/expo-cli/src/commands/config/config.ts
+++ b/packages/expo-cli/src/commands/config/config.ts
@@ -29,6 +29,7 @@ async function actionAsync(projectRoot: string, options: Options) {
       projectRoot,
       introspect: true,
       platforms: ['ios', 'android'],
+      assertMissingModProviders: false,
     });
     // @ts-ignore
     delete config.modRequest;

--- a/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
@@ -61,7 +61,11 @@ export default async function configureManagedProjectAsync({
   });
 
   // compile all plugins and mods
-  config = await compileModsAsync(config, { projectRoot, platforms });
+  config = await compileModsAsync(config, {
+    projectRoot,
+    platforms,
+    assertMissingModProviders: false,
+  });
 
   if (Log.isDebug) {
     Log.debug();


### PR DESCRIPTION
# Why

As new versions of config plugins come out there may be mismatched providers, this PR will prevent them from breaking and instead warn that a mod will be skipped in expo prebuild, eject, and config.

# Test Plan

In a project:

`plugin.js`
```js
module.exports = (config) => {
  config.mods = {};
  config.mods.ios = {};
  config.mods.ios.foobar = () => null;
  return config;
};
```

`app.json`

```json
{ "expo": { "plugins": ["./plugin"] } }
```