### PR TITLE
default translucent to off

### DIFF
--- a/packages/config-plugins/src/android/StatusBar.ts
+++ b/packages/config-plugins/src/android/StatusBar.ts
@@ -91,14 +91,14 @@ export function getStatusBarColor(config: Pick<ExpoConfig, 'androidStatusBar'>) 
 }
 
 /**
- * Specifies whether the status bar should be "translucent". When true, the status bar is drawn with `position: absolute`, when false `position: relative` (pushes content down).
+ * Specifies whether the status bar should be "translucent". When true, the status bar is drawn with `position: absolute` and a gray underlay, when false `position: relative` (pushes content down).
  *
- * @default true (default iOS behavior, the iOS status bar cannot be set translucent by the system)
+ * @default false
  * @param config
  * @returns
  */
 export function getStatusBarTranslucent(config: Pick<ExpoConfig, 'androidStatusBar'>): boolean {
-  return config.androidStatusBar?.translucent ?? true;
+  return config.androidStatusBar?.translucent ?? false;
 }
 
 export function getStatusBarStyle(config: Pick<ExpoConfig, 'androidStatusBar'>) {


### PR DESCRIPTION
# Why

This is the closest we can get to iOS parity atm.

