### PR TITLE
feat: serve new expo-updates format manifests

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -59,32 +59,56 @@ export type HookArguments = {
   log: (msg: any) => void;
 };
 
-export type ExpoAppManifest = ExpoConfig & {
-  sdkVersion: string;
-  bundledAssets?: string[];
-  isKernel?: boolean;
-  kernel?: { androidManifestPath?: string; iosManifestPath?: string };
-  assetUrlOverride?: string;
-  publishedTime?: string;
-  commitTime?: string;
-  releaseId?: string;
-  revisionId?: string;
-  mainModuleName?: string;
+export type ExpoGoConfig = {
+  mainModuleName: string;
   // A string that flipper checks to determine if Metro bundler is running
   // by adding it to the manifest, we can trick Flipper into working properly.
   // https://github.com/facebook/flipper/blob/9ca8bee208b7bfe2b8c0dab8eb4b79688a0c84bc/desktop/app/src/dispatcher/metroDevice.tsx#L37
-  __flipperHack?: 'React Native packager is running';
-  env?: Record<string, any>;
-  bundleUrl?: string;
-  debuggerHost?: string;
-  logUrl?: string;
-  hostUri?: string;
-  id?: string;
-  developer?: {
+  __flipperHack: 'React Native packager is running';
+  debuggerHost: string;
+  logUrl: string;
+  developer: {
     tool: string | null;
     projectRoot?: string;
   };
+  packagerOpts: {
+    [key: string]: any;
+  };
 };
+
+export type ExpoAppManifest = ExpoConfig &
+  Partial<ExpoGoConfig> & {
+    sdkVersion: string;
+    bundledAssets?: string[];
+    isKernel?: boolean;
+    kernel?: { androidManifestPath?: string; iosManifestPath?: string };
+    assetUrlOverride?: string;
+    publishedTime?: string;
+    commitTime?: string;
+    releaseId?: string;
+    revisionId?: string;
+    env?: Record<string, any>;
+    bundleUrl?: string;
+    hostUri?: string;
+    id?: string;
+  };
+
+export interface ExpoUpdatesManifestAsset {
+  url: string;
+  key: string;
+  contentType: string;
+  hash?: string;
+}
+
+export interface ExpoUpdatesManifest {
+  id: string;
+  createdAt: string;
+  runtimeVersion: string;
+  launchAsset: ExpoUpdatesManifestAsset;
+  assets: ExpoUpdatesManifestAsset[];
+  metadata: { [key: string]: string };
+  extra: { [key: string]: any };
+}
 
 export type Hook = {
   file: string;

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -41,6 +41,7 @@
     "@expo/package-manager": "0.0.43",
     "@expo/plist": "0.0.13",
     "@expo/schemer": "1.3.29",
+    "@expo/sdk-runtime-versions": "^1.0.0",
     "@expo/spawn-async": "1.5.0",
     "@expo/webpack-config": "0.12.82",
     "joi": "^17.4.0",

--- a/packages/xdl/src/DevSession.ts
+++ b/packages/xdl/src/DevSession.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from '@expo/config-types';
 import os from 'os';
 
 import {
@@ -15,7 +16,7 @@ let keepUpdating = true;
 // TODO notify www when a project is started, and every N seconds afterwards
 export async function startSession(
   projectRoot: string,
-  exp: any,
+  exp: ExpoConfig,
   platform: 'native' | 'web',
   forceUpdate: boolean = false
 ): Promise<void> {

--- a/packages/xdl/src/ProjectAssets.ts
+++ b/packages/xdl/src/ProjectAssets.ts
@@ -1,6 +1,7 @@
 import { ExpoAppManifest, ExpoConfig } from '@expo/config';
 import { BundleAssetWithFileHashes, BundleOutput } from '@expo/dev-server';
 import assert from 'assert';
+import crypto from 'crypto';
 import FormData from 'form-data';
 import fs from 'fs-extra';
 import chunk from 'lodash/chunk';
@@ -8,6 +9,7 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import uniqBy from 'lodash/uniqBy';
 import md5hex from 'md5hex';
+import mime from 'mime';
 import minimatch from 'minimatch';
 import path from 'path';
 import urljoin from 'url-join';
@@ -60,10 +62,55 @@ export async function resolveGoogleServicesFile(projectRoot: string, manifest: E
  * @param manifest
  * @returns Asset fields that the user has set like ["icon", "splash.image", ...]
  */
-async function getAssetFieldPathsForManifestAsync(manifest: ExpoAppManifest): Promise<string[]> {
+async function getAssetFieldPathsForManifestAsync(manifest: ExpoConfig): Promise<string[]> {
   // String array like ["icon", "notification.icon", "loading.icon", "loading.backgroundImage", "ios.icon", ...]
   const sdkAssetFieldPaths = await ExpSchema.getAssetSchemasAsync(manifest.sdkVersion);
   return sdkAssetFieldPaths.filter(assetSchema => get(manifest, assetSchema));
+}
+
+async function resolveExpoUpdatesManifestAssets({
+  projectRoot,
+  manifest,
+  assetKeyResolver,
+}: {
+  projectRoot: string;
+  manifest: ExpoConfig;
+  assetKeyResolver: (assetPath: string) => Promise<string>;
+}): Promise<void> {
+  const assetSchemas = await getAssetFieldPathsForManifestAsync(manifest);
+  // Get the URLs
+  const assetInfos = await Promise.all(
+    assetSchemas.map(async manifestField => {
+      const pathOrURL = get(manifest, manifestField);
+      if (/^https?:\/\//.test(pathOrURL)) {
+        // It's a remote URL
+        return {
+          assetKey: null,
+          rawUrl: pathOrURL,
+        };
+      } else if (fs.existsSync(path.resolve(projectRoot, pathOrURL))) {
+        const assetKey = await assetKeyResolver(pathOrURL);
+        return {
+          assetKey,
+          rawUrl: null,
+        };
+      } else {
+        ProjectUtils.logError(
+          projectRoot,
+          'expo',
+          `Unable to resolve asset "${pathOrURL}" from "${manifestField}" in your app.json or app.config.js`
+        );
+        const err: ManifestResolutionError = new Error('Could not resolve local asset.');
+        err.localAssetPath = pathOrURL;
+        err.manifestField = manifestField;
+        throw err;
+      }
+    })
+  );
+
+  assetSchemas.forEach((manifestField, index: number) =>
+    set(manifest, `${manifestField}Asset`, assetInfos[index])
+  );
 }
 
 export async function resolveManifestAssets({
@@ -73,7 +120,7 @@ export async function resolveManifestAssets({
   strict = false,
 }: {
   projectRoot: string;
-  manifest: ExpoAppManifest;
+  manifest: ExpoConfig;
   resolver: (assetPath: string) => Promise<string>;
   strict?: boolean;
 }) {
@@ -84,7 +131,7 @@ export async function resolveManifestAssets({
     const urls = await Promise.all(
       assetSchemas.map(async manifestField => {
         const pathOrURL = get(manifest, manifestField);
-        if (pathOrURL.match(/^https?:\/\/(.*)$/)) {
+        if (/^https?:\/\//.test(pathOrURL)) {
           // It's a remote URL
           return pathOrURL;
         } else if (fs.existsSync(path.resolve(projectRoot, pathOrURL))) {
@@ -348,4 +395,30 @@ async function collectAssets(
   });
 
   return [...bundles.ios.assets, ...bundles.android.assets, ...manifestAssets];
+}
+
+export async function resolveAndCollectExpoUpdatesManifestAssets(
+  projectRoot: string,
+  exp: ExpoConfig,
+  urlResolver: (path: string) => string
+): Promise<{ url: string; hash: string; key: string; contentType: string }[]> {
+  const manifestAssets: { url: string; hash: string; key: string; contentType: string }[] = [];
+  await resolveExpoUpdatesManifestAssets({
+    projectRoot,
+    manifest: exp,
+    async assetKeyResolver(assetPath) {
+      const absolutePath = path.resolve(projectRoot, assetPath);
+      const contents = await fs.readFile(absolutePath);
+      // Expo Updates spec dictates that this hash is sha256
+      const hash = crypto.createHash('sha256').update(contents).digest('hex');
+      manifestAssets.push({
+        url: urlResolver(assetPath),
+        hash,
+        key: assetPath,
+        contentType: mime.getType(absolutePath) ?? 'application/octet-stream',
+      });
+      return assetPath;
+    },
+  });
+  return manifestAssets;
 }

--- a/packages/xdl/src/internal.ts
+++ b/packages/xdl/src/internal.ts
@@ -100,5 +100,6 @@ export {
 } from './start/startDevServerAsync';
 export { startAsync, stopAsync, broadcastMessage } from './start/startAsync';
 export * as ManifestHandler from './start/ManifestHandler';
+export * as ExpoUpdatesManifestHandler from './start/ExpoUpdatesManifestHandler';
 export { getFreePortAsync } from './start/getFreePortAsync';
 export * as Project from './Project';

--- a/packages/xdl/src/project/ExpSchema.ts
+++ b/packages/xdl/src/project/ExpSchema.ts
@@ -44,7 +44,7 @@ export async function getSchemaAsync(sdkVersion: string): Promise<Schema> {
  *
  * @param sdkVersion
  */
-export async function getAssetSchemasAsync(sdkVersion: string): Promise<string[]> {
+export async function getAssetSchemasAsync(sdkVersion: string | undefined): Promise<string[]> {
   // If no SDK version is available then fall back to unversioned
   const schema = await getSchemaAsync(sdkVersion ?? 'UNVERSIONED');
   const assetSchemas: string[] = [];

--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -1,0 +1,155 @@
+import { ExpoUpdatesManifest, getConfig } from '@expo/config';
+import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
+import express from 'express';
+import http from 'http';
+import { parse } from 'url';
+import uuid from 'uuid';
+
+import {
+  Analytics,
+  Config,
+  ProjectAssets,
+  ProjectUtils,
+  resolveEntryPoint,
+  UrlUtils,
+} from '../internal';
+import {
+  getBundleUrlAsync,
+  getExpoGoConfig,
+  getPackagerOptionsAsync,
+  stripPort,
+} from './ManifestHandler';
+
+function getPlatformFromRequest(req: express.Request | http.IncomingMessage): string {
+  const url = req.url ? parse(req.url, /* parseQueryString */ true) : null;
+  const platform = url?.query.platform || req.headers['expo-platform'];
+  if (!platform) {
+    throw new Error('Must specify expo-platform header or query parameter');
+  }
+  return String(platform);
+}
+
+export async function getManifestResponseAsync({
+  projectRoot,
+  platform,
+  host,
+}: {
+  projectRoot: string;
+  platform: string;
+  host?: string;
+}): Promise<{
+  body: ExpoUpdatesManifest;
+  headers: Map<string, number | string | readonly string[]>;
+}> {
+  const headers = new Map<string, any>();
+  // set required headers for Expo Updates manifest specification
+  headers.set('expo-protocol-version', 0);
+  headers.set('expo-sfv-version', 0);
+  headers.set('cache-control', 'private, max-age=0');
+  headers.set('content-type', 'application/json');
+
+  const hostname = stripPort(host);
+  const [projectSettings, bundleUrlPackagerOpts] = await getPackagerOptionsAsync(projectRoot);
+  const projectConfig = getConfig(projectRoot);
+  const entryPoint = resolveEntryPoint(projectRoot, platform, projectConfig);
+  const mainModuleName = UrlUtils.stripJSExtension(entryPoint);
+  const expoConfig = projectConfig.exp;
+  const expoGoConfig = await getExpoGoConfig({
+    projectRoot,
+    projectSettings,
+    mainModuleName,
+    hostname,
+  });
+
+  const hostUri = await UrlUtils.constructHostUriAsync(projectRoot, hostname);
+
+  const runtimeVersion =
+    expoConfig.runtimeVersion ??
+    (expoConfig.sdkVersion ? getRuntimeVersionForSDKVersion(expoConfig.sdkVersion) : null);
+  if (!runtimeVersion) {
+    throw new Error('Must specify runtimeVersion or sdkVersion in app.json');
+  }
+
+  const bundleUrl = await getBundleUrlAsync({
+    projectRoot,
+    platform,
+    projectSettings,
+    bundleUrlPackagerOpts,
+    mainModuleName,
+    hostname,
+  });
+
+  // For each manifest asset (for example `icon`):
+  // - set a field on the manifest containing a reference to the asset: iconAsset: { rawUrl?: string, assetKey?: string }
+  // - gather the data needed to embed a reference to that asset in the expo-updates assets key
+  const assets = await ProjectAssets.resolveAndCollectExpoUpdatesManifestAssets(
+    projectRoot,
+    expoConfig,
+    path => bundleUrl!.match(/^https?:\/\/.*?\//)![0] + 'assets/' + path
+  );
+
+  const expoUpdatesManifest = {
+    id: uuid.v4(),
+    createdAt: new Date().toISOString(),
+    runtimeVersion,
+    launchAsset: {
+      key: mainModuleName,
+      contentType: 'application/javascript',
+      url: bundleUrl,
+    },
+    assets,
+    metadata: {}, // required for the client to detect that this is an expo-updates manifest
+    extra: {
+      eas: {}, // TODO(wschurman): somehow inject EAS config in here if known
+      expoClient: {
+        ...expoConfig,
+        hostUri,
+      },
+      expoGo: expoGoConfig,
+    },
+  };
+
+  return {
+    body: expoUpdatesManifest,
+    headers,
+  };
+}
+
+export function getManifestHandler(projectRoot: string) {
+  return async (
+    req: express.Request | http.IncomingMessage,
+    res: express.Response | http.ServerResponse,
+    next: (err?: Error) => void
+  ) => {
+    if (!req.url || parse(req.url).pathname !== '/update-manifest-experimental') {
+      next();
+      return;
+    }
+
+    try {
+      const { body, headers } = await getManifestResponseAsync({
+        projectRoot,
+        host: req.headers.host,
+        platform: getPlatformFromRequest(req),
+      });
+      for (const [headerName, headerValue] of headers) {
+        res.setHeader(headerName, headerValue);
+      }
+      res.end(JSON.stringify(body));
+
+      Analytics.logEvent('Serve Expo Updates Manifest', {
+        projectRoot,
+        developerTool: Config.developerTool,
+        runtimeVersion: (body as any).runtimeVersion,
+      });
+    } catch (e) {
+      ProjectUtils.logError(projectRoot, 'expo', e.stack);
+      res.statusCode = 520;
+      res.end(
+        JSON.stringify({
+          error: e.toString(),
+        })
+      );
+    }
+  };
+}

--- a/packages/xdl/src/start/__tests__/ExpoUpdatesManifestHandler-test.ts
+++ b/packages/xdl/src/start/__tests__/ExpoUpdatesManifestHandler-test.ts
@@ -1,0 +1,152 @@
+import fs from 'fs-extra';
+import { vol } from 'memfs';
+import path from 'path';
+
+import UserSettings from '../../UserSettings';
+import { ExpoUpdatesManifestHandler } from '../../internal';
+import { getManifestResponseAsync } from '../ManifestHandler';
+
+const actualFs = jest.requireActual('fs') as typeof fs;
+jest.mock('fs');
+
+describe('ExpoUpdatesManifestHandler', () => {
+  describe(getManifestResponseAsync, () => {
+    beforeAll(() => {
+      fs.removeSync(UserSettings.userSettingsFile());
+    });
+
+    beforeEach(() => {
+      const packageJson = JSON.stringify(
+        {
+          name: 'testing123',
+          version: '0.1.0',
+          main: 'index.js',
+        },
+        null,
+        2
+      );
+
+      const appJson = JSON.stringify(
+        {
+          expo: {
+            name: 'testing 123',
+            icon: './icon.png',
+            splash: { image: './assets/splash.png' },
+            version: '0.1.0',
+            sdkVersion: '38.0.0',
+            slug: 'testing-123',
+            extras: { myExtra: '123' },
+          },
+        },
+        null,
+        2
+      );
+
+      vol.fromJSON({
+        '/alpha/package.json': packageJson,
+        '/alpha/app.json': appJson,
+        '/alpha/index.js': 'console.log("lol")',
+      });
+
+      const iconPath = path.resolve(__dirname, './fixtures/icon.png');
+      const icon = actualFs.readFileSync(iconPath);
+      vol.mkdirpSync('/alpha/assets');
+      vol.writeFileSync('/alpha/icon.png', icon);
+      vol.writeFileSync('/alpha/assets/splash.png', icon);
+    });
+
+    afterEach(() => {
+      vol.reset();
+    });
+
+    it(`returns a minimal expected manifest`, async () => {
+      const res = await ExpoUpdatesManifestHandler.getManifestResponseAsync({
+        projectRoot: '/alpha',
+        host: '127.0.0.1:19000',
+        platform: 'ios',
+      });
+
+      expect(res.headers).toEqual(
+        new Map(
+          Object.entries({
+            'expo-protocol-version': 0,
+            'expo-sfv-version': 0,
+            'cache-control': 'private, max-age=0',
+            'content-type': 'application/json',
+          })
+        )
+      );
+
+      expect(res.body).toMatchObject({
+        id: expect.any(String),
+        createdAt: expect.any(String),
+        runtimeVersion: 'exposdk:38.0.0',
+        launchAsset: {
+          key: 'index',
+          contentType: 'application/javascript',
+          url: 'http://127.0.0.1:80/index.bundle?platform=ios&dev=true&hot=false&minify=false',
+        },
+        assets: [
+          {
+            contentType: 'image/png',
+            hash: 'bc8dff68bbfd008f5c5cd9f33711cb31d4ffc207d31e7da9b944f9d79a07e4ef',
+            key: './icon.png',
+            url: 'http://127.0.0.1:80/assets/./icon.png',
+          },
+          {
+            contentType: 'image/png',
+            hash: 'bc8dff68bbfd008f5c5cd9f33711cb31d4ffc207d31e7da9b944f9d79a07e4ef',
+            key: './assets/splash.png',
+            url: 'http://127.0.0.1:80/assets/./assets/splash.png',
+          },
+        ],
+        metadata: {},
+        extra: {
+          eas: {},
+          expoClient: {
+            name: 'testing 123',
+            description: undefined,
+            version: '0.1.0',
+            sdkVersion: '38.0.0',
+            slug: 'testing-123',
+            platforms: [],
+            extras: { myExtra: '123' },
+            icon: './icon.png',
+            iconAsset: { assetKey: './icon.png', rawUrl: null },
+            hostUri: '127.0.0.1:80',
+            splash: {
+              image: './assets/splash.png',
+              imageAsset: {
+                assetKey: './assets/splash.png',
+                rawUrl: null,
+              },
+            },
+            _internal: {
+              isDebug: expect.any(Boolean),
+              projectRoot: '/alpha',
+              dynamicConfigPath: null,
+              staticConfigPath: '/alpha/app.json',
+              packageJsonPath: '/alpha/package.json',
+            },
+          },
+          expoGo: {
+            developer: { tool: 'expo-cli', projectRoot: '/alpha' },
+            packagerOpts: {
+              scheme: null,
+              hostType: 'lan',
+              lanType: 'ip',
+              devClient: false,
+              dev: true,
+              minify: false,
+              urlRandomness: null,
+              https: false,
+            },
+            mainModuleName: 'index',
+            debuggerHost: '127.0.0.1:80',
+            logUrl: 'http://127.0.0.1:80/logs',
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/xdl/src/start/__tests__/ManifestHandler-test.ts
+++ b/packages/xdl/src/start/__tests__/ManifestHandler-test.ts
@@ -167,7 +167,7 @@ describe('getManifestResponseAsync', () => {
     // This value is blacklisted
     expect(res.exp.env.EXPO_APPLE_PASSWORD).not.toBeDefined();
     // Users should use app.config.js + extras now so test that it always works
-    expect(res.exp.extras.myExtra).toBe('123');
+    expect((res.exp as any).extras.myExtra).toBe('123');
 
     // Ensure the bundle URL is built correctly
     expect(res.exp.bundleUrl).toBe(
@@ -183,7 +183,7 @@ describe('getManifestResponseAsync', () => {
     expect(res.exp.developer.projectRoot).toBe('/alpha');
 
     // ProjectAssets gathered URLs
-    expect(res.exp.iconUrl).toBe('http://127.0.0.1:80/assets/./icon.png');
+    expect((res.exp as any).iconUrl).toBe('http://127.0.0.1:80/assets/./icon.png');
     expect(res.exp.splash.imageUrl).toBe('http://127.0.0.1:80/assets/./assets/splash.png');
   });
 });

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig, getConfig } from '@expo/config';
+import { MessageSocket } from '@expo/dev-server';
 import { Server } from 'http';
 
 import {
@@ -24,7 +25,7 @@ import {
 import { watchBabelConfigForProject } from './watchBabelConfig';
 
 let serverInstance: Server | null = null;
-let messageSocket: any | null = null;
+let messageSocket: MessageSocket | null = null;
 
 /**
  * Sends a message over web sockets to any connected device,

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -1,8 +1,10 @@
 import { ProjectTarget } from '@expo/config';
-import { MetroDevServerOptions, runMetroDevServerAsync } from '@expo/dev-server';
+import { MessageSocket, MetroDevServerOptions, runMetroDevServerAsync } from '@expo/dev-server';
+import http from 'http';
 
 import {
   assertValidProjectRoot,
+  ExpoUpdatesManifestHandler,
   getFreePortAsync,
   ManifestHandler,
   ProjectSettings,
@@ -23,7 +25,10 @@ export type StartOptions = {
   target?: ProjectTarget;
 };
 
-export async function startDevServerAsync(projectRoot: string, startOptions: StartOptions) {
+export async function startDevServerAsync(
+  projectRoot: string,
+  startOptions: StartOptions
+): Promise<[http.Server, any, MessageSocket]> {
   assertValidProjectRoot(projectRoot);
 
   let port: number;
@@ -56,6 +61,7 @@ export async function startDevServerAsync(projectRoot: string, startOptions: Sta
 
   const { server, middleware, messageSocket } = await runMetroDevServerAsync(projectRoot, options);
   middleware.use(ManifestHandler.getManifestHandler(projectRoot));
+  middleware.use(ExpoUpdatesManifestHandler.getManifestHandler(projectRoot));
 
   // We need the manifest handler to be the first middleware to run so our
   // routes take precedence over static files. For example, the manifest is

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,6 +1554,11 @@
   resolved "https://registry.yarnpkg.com/@expo/results/-/results-1.0.0.tgz#fd4b22f936ceafce23b04799f54b87fe2a9e18d1"
   integrity sha512-qECzzXX5oJot3m2Gu9pfRDz50USdBieQVwYAzeAtQRUTD3PVeTK1tlRUoDcrK8PSruDLuVYdKkLebX4w/o55VA==
 
+"@expo/sdk-runtime-versions@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
+  integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
+
 "@expo/simple-spinner@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@expo/simple-spinner/-/simple-spinner-1.0.2.tgz#b31447de60e5102837a4edf702839fcc8f7f31f3"
@@ -18992,8 +18997,10 @@ watchpack@^1.6.1, watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
# Why

We'd like to move `expo start` to use the [new format manifests](https://docs.expo.io/technical-specs/expo-updates-0/). This PR starts that process by serving the new format manifest at a separate URL on the local webserver.

Next up:
- figure out how to embed scopeKey in this manifest format (top level field on the manifest probably)
- figure out how to sign scopeKey for Expo Go (cert chain probably)
- figure out how this interacts with eas-cli for embedding things like extra.eas.projectId in the manifest and signing the scopeKey.
- create a way to run `expo start --new-manifest-format` (or something like that) that will serve the new manifest and use it for the development session and QR code by default

# `extra` field

This PR is where we're designing the format of the new manifest `extra` field. It's format has been discussed before (https://github.com/expo/universe/pull/7557, https://github.com/expo/eas-cli/pull/402) but we hadn't decided what the criteria for organization within the field should be. This PR formalizes it a bit with a definition of the sub fields:
- `eas` - contains Expo Application Services fields like `projectId`
- `expoClient` - contains fields necessary for the expo client. This is the non-development fields from the classic manifest, which is also really just the app.json (with assets "resolved").
- `expoGo` - contains fields that only are used within Expo Go for development like things about the packager, etc.

The idea is that app.json is fairly difficult to split into distinct logical units (library configs) in a maintainable way. We could require metadata in the version schema indicating what library the field belongs to, but doing that categorization this early in the process seemed like a non-starter. Instead, we put the entire app.json in it's own extra field for now, and then move specific app.json fields into their own library keys once we have a good way to separate them out. One future idea is to have a `libraries` key in app.json that is essentially a merge field for the `extra` field.

This approach was decided upon because it is easy to transition to from classic manifests in the client, clear how to transfer away from for separating out library-specific config into their own keys, and easy to maintain here in the CLI for now.

# How

Serve the new manifest format at `/update-manifest-experimental`.

# Test Plan

- Run the new test.
- `EXPO_DEBUG=true ~/expo/expo-cli/node_modules/.bin/expo start` in a project, navigate to http://192.168.86.113:19000/update-manifest-experimental?platform=ios, see new format manifest
- Load http://192.168.86.113:19000/update-manifest-experimental?platform=ios in the android simulator in combination with https://github.com/expo/expo/pull/13398