### PR TITLE
[dev-server] Only check or build hermes stuffs for SDK 42 or higher

### DIFF
--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -42,9 +42,9 @@
     "fs-extra": "9.0.0",
     "open": "^8.2.0",
     "resolve-from": "^5.0.0",
+    "semver": "7.3.2",
     "serialize-error": "6.0.0",
-    "temp-dir": "^2.0.0",
-    "xdl": "59.0.46"
+    "temp-dir": "^2.0.0"
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.20",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -43,7 +43,8 @@
     "open": "^8.2.0",
     "resolve-from": "^5.0.0",
     "serialize-error": "6.0.0",
-    "temp-dir": "^2.0.0"
+    "temp-dir": "^2.0.0",
+    "xdl": "59.0.46"
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.20",

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -13,6 +13,7 @@ import type Metro from 'metro';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 import { parse as parseUrl } from 'url';
+import { Versions } from 'xdl';
 
 import {
   buildHermesBundleAsync,
@@ -165,51 +166,61 @@ export async function bundleAsync(
     return { code, map, assets };
   };
 
+  const maybeAddHermesBundleAsync = async (
+    bundle: BundleOptions,
+    bundleOutput: BundleOutput
+  ): Promise<BundleOutput> => {
+    if (!Versions.gteSdkVersion(expoConfig, '42.0.0')) {
+      return bundleOutput;
+    }
+    const isHermesManaged = isEnableHermesManaged(expoConfig, bundle.platform);
+
+    const maybeInconsistentEngine = await maybeInconsistentEngineAsync(
+      projectRoot,
+      bundle.platform,
+      isHermesManaged
+    );
+    if (maybeInconsistentEngine) {
+      const platform = bundle.platform === 'ios' ? 'iOS' : 'Android';
+      const paths = getConfigFilePaths(projectRoot);
+      const configFilePath = paths.dynamicConfigPath ?? paths.staticConfigPath ?? 'app.json';
+      const configFileName = path.basename(configFilePath);
+      throw new Error(
+        `JavaScript engine configuration is inconsistent between ${configFileName} and ${platform} native project.\n` +
+          `In ${configFileName}: Hermes is ${isHermesManaged ? 'enabled' : 'not enabled'}\n` +
+          `In ${platform} native project: Hermes is ${
+            isHermesManaged ? 'not enabled' : 'enabled'
+          }\n` +
+          `Please check the following files for inconsistencies:\n` +
+          `  - ${configFilePath}\n` +
+          `  - ${path.join(projectRoot, 'android', 'gradle.properties')}\n` +
+          `  - ${path.join(projectRoot, 'android', 'app', 'build.gradle')}\n`
+      );
+    }
+
+    if (isHermesManaged) {
+      options.logger.info(
+        { tag: 'expo' },
+        `💿 Building Hermes bytecode for the bundle - platform[${bundle.platform}]`
+      );
+      const hermesBundleOutput = await buildHermesBundleAsync(
+        projectRoot,
+        bundleOutput.code,
+        bundleOutput.map,
+        bundle.minify
+      );
+      bundleOutput.hermesBytecodeBundle = hermesBundleOutput.hbc;
+      bundleOutput.hermesSourcemap = hermesBundleOutput.sourcemap;
+    }
+
+    return bundleOutput;
+  };
+
   try {
     return await Promise.all(
       bundles.map(async (bundle: BundleOptions) => {
         const bundleOutput = await buildAsync(bundle);
-        const isHermesManaged = isEnableHermesManaged(expoConfig, bundle.platform);
-
-        const maybeInconsistentEngine = await maybeInconsistentEngineAsync(
-          projectRoot,
-          bundle.platform,
-          isHermesManaged
-        );
-        if (maybeInconsistentEngine) {
-          const platform = bundle.platform === 'ios' ? 'iOS' : 'Android';
-          const paths = getConfigFilePaths(projectRoot);
-          const configFilePath = paths.dynamicConfigPath ?? paths.staticConfigPath ?? 'app.json';
-          const configFileName = path.basename(configFilePath);
-          throw new Error(
-            `JavaScript engine configuration is inconsistent between ${configFileName} and ${platform} native project.\n` +
-              `In ${configFileName}: Hermes is ${isHermesManaged ? 'enabled' : 'not enabled'}\n` +
-              `In ${platform} native project: Hermes is ${
-                isHermesManaged ? 'not enabled' : 'enabled'
-              }\n` +
-              `Please check the following files for inconsistencies:\n` +
-              `  - ${configFilePath}\n` +
-              `  - ${path.join(projectRoot, 'android', 'gradle.properties')}\n` +
-              `  - ${path.join(projectRoot, 'android', 'app', 'build.gradle')}\n`
-          );
-        }
-
-        if (isHermesManaged) {
-          options.logger.info(
-            { tag: 'expo' },
-            `💿 Building Hermes bytecode for the bundle - platform[${bundle.platform}]`
-          );
-          const hermesBundleOutput = await buildHermesBundleAsync(
-            projectRoot,
-            bundleOutput.code,
-            bundleOutput.map,
-            bundle.minify
-          );
-          bundleOutput.hermesBytecodeBundle = hermesBundleOutput.hbc;
-          bundleOutput.hermesSourcemap = hermesBundleOutput.sourcemap;
-        }
-
-        return bundleOutput;
+        return maybeAddHermesBundleAsync(bundle, bundleOutput);
       })
     );
   } finally {

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -194,7 +194,8 @@ export async function bundleAsync(
           `Please check the following files for inconsistencies:\n` +
           `  - ${configFilePath}\n` +
           `  - ${path.join(projectRoot, 'android', 'gradle.properties')}\n` +
-          `  - ${path.join(projectRoot, 'android', 'app', 'build.gradle')}\n`
+          `  - ${path.join(projectRoot, 'android', 'app', 'build.gradle')}\n` +
+          'Learn more: https://expo.fyi/hermes-android-config'
       );
     }
 

--- a/packages/expo-cli/e2e/__tests__/export-test.ts
+++ b/packages/expo-cli/e2e/__tests__/export-test.ts
@@ -80,13 +80,13 @@ it('should export hbc bundle if jsEngine is hermes', async () => {
       tempDir,
       'export-test-app',
       {
-        sdkVersion: '41.0.0',
+        sdkVersion: '42.0.0',
         android: {
           jsEngine: 'hermes',
         },
       },
       {
-        expo: '41.0.1',
+        expo: '42.0.0-beta.1',
         'react-native': '0.63.2',
       }
     );


### PR DESCRIPTION
# Why

Users sometimes see the "JavaScript engine configuration is inconsistent" for SDK 41 or lower.
e.g. https://github.com/expo/expo-cli/pull/3536#issuecomment-867639323

# How

Only check or build hermes stuffs for SDK 42 or higher.
Includes a fix in `maybeInconsistentEngineAsync` that gradle.properties has no chances to be checked. 

# Test Plan
Verify matrix below by `expo export` command.

### Bare project generates from `expo init sdk41`
- android.jsEngine=hermes in app.json -> ✅
- enableHermes=true in android/app/build.gradle -> ✅
- android.jsEngine=hermes in app.json + enableHermes=true in android/app/build.gradle -> ✅

### Bare project generates from `EXPO_BETA=1 expo init sdk42`
- android.jsEngine=hermes in app.json -> ❌
- expo.jsEngine=hermes in android/gradle.properties ->  ❌
- android.jsEngine=hermes in app.json + expo.jsEngine=hermes in android/gradle.properties -> ✅
- android.jsEngine=hermes in app.json + enableHermes=false in android/app/build.gradle -> ❌