### PR TITLE
Resolve exact Info.plist filepath

### DIFF
--- a/packages/config-plugins/src/ios/BundleIdentifier.ts
+++ b/packages/config-plugins/src/ios/BundleIdentifier.ts
@@ -8,7 +8,11 @@ import { ConfigPlugin } from '../Plugin.types';
 import { withDangerousMod } from '../plugins/withDangerousMod';
 import { InfoPlist } from './IosConfig.types';
 import { getAllInfoPlistPaths, getAllPBXProjectPaths, getPBXProjectPath } from './Paths';
-import { findFirstNativeTarget, findNativeTargetByName } from './Target';
+import {
+  findFirstNativeTarget,
+  findNativeTargetByName,
+  getXCBuildConfigurationFromPbxproj,
+} from './Target';
 import {
   ConfigurationSectionEntry,
   getBuildConfigurationForListIdAndName,
@@ -85,13 +89,13 @@ function getBundleIdentifierFromPbxproj(
   const project = xcode.project(pbxprojPath);
   project.parseSync();
 
-  const [, nativeTarget] = targetName
-    ? findNativeTargetByName(project, targetName)
-    : findFirstNativeTarget(project);
-  const [, xcBuildConfiguration] = getBuildConfigurationForListIdAndName(project, {
-    configurationListId: nativeTarget.buildConfigurationList,
+  const xcBuildConfiguration = getXCBuildConfigurationFromPbxproj(project, {
+    targetName,
     buildConfiguration,
   });
+  if (!xcBuildConfiguration) {
+    return null;
+  }
   return getProductBundleIdentifierFromBuildConfiguration(xcBuildConfiguration);
 }
 

--- a/packages/config-plugins/src/ios/BundleIdentifier.ts
+++ b/packages/config-plugins/src/ios/BundleIdentifier.ts
@@ -8,16 +8,8 @@ import { ConfigPlugin } from '../Plugin.types';
 import { withDangerousMod } from '../plugins/withDangerousMod';
 import { InfoPlist } from './IosConfig.types';
 import { getAllInfoPlistPaths, getAllPBXProjectPaths, getPBXProjectPath } from './Paths';
-import {
-  findFirstNativeTarget,
-  findNativeTargetByName,
-  getXCBuildConfigurationFromPbxproj,
-} from './Target';
-import {
-  ConfigurationSectionEntry,
-  getBuildConfigurationForListIdAndName,
-  getBuildConfigurationsForListId,
-} from './utils/Xcodeproj';
+import { findFirstNativeTarget, getXCBuildConfigurationFromPbxproj } from './Target';
+import { ConfigurationSectionEntry, getBuildConfigurationsForListId } from './utils/Xcodeproj';
 
 export const withBundleIdentifier: ConfigPlugin<{ bundleIdentifier?: string }> = (
   config,

--- a/packages/config-plugins/src/ios/InfoPlist.ts
+++ b/packages/config-plugins/src/ios/InfoPlist.ts
@@ -18,6 +18,9 @@ export function getInfoPlistPathFromPbxproj(
   }: { targetName?: string; buildConfiguration?: string } = {}
 ): string | null {
   const project = resolvePathOrProject(projectRootOrProject);
+  if (!project) {
+    return null;
+  }
 
   const xcBuildConfiguration = getXCBuildConfigurationFromPbxproj(project, {
     targetName,

--- a/packages/config-plugins/src/ios/InfoPlist.ts
+++ b/packages/config-plugins/src/ios/InfoPlist.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { XcodeProject } from 'xcode';
 
 import { getXCBuildConfigurationFromPbxproj } from './Target';
@@ -27,22 +26,10 @@ export function getInfoPlistPathFromPbxproj(
   if (!xcBuildConfiguration) {
     return null;
   }
-  const infoPlist = xcBuildConfiguration.buildSettings.INFOPLIST_FILE;
-  if (!infoPlist) {
-    return null;
-  }
   // The `INFOPLIST_FILE` is relative to the project folder, ex: app/Info.plist.
-  const xcodeProjectParentFolder = path.dirname(findUpPbxprojRoot(project.filepath));
-
-  const infoPlistPath = path.join(xcodeProjectParentFolder, infoPlist);
-  return infoPlistPath;
+  return sanitizeInfoPlistBuildProperty(xcBuildConfiguration.buildSettings.INFOPLIST_FILE);
 }
 
-function findUpPbxprojRoot(projPath: string) {
-  let root = projPath;
-
-  while (root.length > 2 && path.extname(root) !== '.xcodeproj') {
-    root = path.dirname(root);
-  }
-  return root;
+function sanitizeInfoPlistBuildProperty(infoPlist?: string): string | null {
+  return infoPlist?.replace(/"/g, '').replace('$(SRCROOT)', '') ?? null;
 }

--- a/packages/config-plugins/src/ios/InfoPlist.ts
+++ b/packages/config-plugins/src/ios/InfoPlist.ts
@@ -1,0 +1,48 @@
+import path from 'path';
+import { XcodeProject } from 'xcode';
+
+import { getXCBuildConfigurationFromPbxproj } from './Target';
+import { resolvePathOrProject } from './utils/Xcodeproj';
+
+/**
+ * Find the Info.plist path linked to a specific build configuration.
+ *
+ * @param projectRoot
+ * @param param1
+ * @returns
+ */
+export function getInfoPlistPathFromPbxproj(
+  projectRootOrProject: string | XcodeProject,
+  {
+    targetName,
+    buildConfiguration = 'Release',
+  }: { targetName?: string; buildConfiguration?: string } = {}
+): string | null {
+  const project = resolvePathOrProject(projectRootOrProject);
+
+  const xcBuildConfiguration = getXCBuildConfigurationFromPbxproj(project, {
+    targetName,
+    buildConfiguration,
+  });
+  if (!xcBuildConfiguration) {
+    return null;
+  }
+  const infoPlist = xcBuildConfiguration.buildSettings.INFOPLIST_FILE;
+  if (!infoPlist) {
+    return null;
+  }
+  // The `INFOPLIST_FILE` is relative to the project folder, ex: app/Info.plist.
+  const xcodeProjectParentFolder = path.dirname(findUpPbxprojRoot(project.filepath));
+
+  const infoPlistPath = path.join(xcodeProjectParentFolder, infoPlist);
+  return infoPlistPath;
+}
+
+function findUpPbxprojRoot(projPath: string) {
+  let root = projPath;
+
+  while (root.length > 2 && path.extname(root) !== '.xcodeproj') {
+    root = path.dirname(root);
+  }
+  return root;
+}

--- a/packages/config-plugins/src/ios/Target.ts
+++ b/packages/config-plugins/src/ios/Target.ts
@@ -1,7 +1,12 @@
-import { PBXNativeTarget, PBXTargetDependency, XcodeProject } from 'xcode';
+import { PBXNativeTarget, PBXTargetDependency, XCBuildConfiguration, XcodeProject } from 'xcode';
 
 import { getApplicationTargetNameForSchemeAsync } from './BuildScheme';
-import { getPbxproj, isNotComment, NativeTargetSectionEntry } from './utils/Xcodeproj';
+import {
+  getBuildConfigurationForListIdAndName,
+  getPbxproj,
+  isNotComment,
+  NativeTargetSectionEntry,
+} from './utils/Xcodeproj';
 
 export enum TargetType {
   APPLICATION = 'com.apple.product-type.application',
@@ -14,6 +19,23 @@ export interface Target {
   name: string;
   type: TargetType;
   dependencies?: Target[];
+}
+
+export function getXCBuildConfigurationFromPbxproj(
+  project: XcodeProject,
+  {
+    targetName,
+    buildConfiguration = 'Release',
+  }: { targetName?: string; buildConfiguration?: string } = {}
+): XCBuildConfiguration | null {
+  const [, nativeTarget] = targetName
+    ? findNativeTargetByName(project, targetName)
+    : findFirstNativeTarget(project);
+  const [, xcBuildConfiguration] = getBuildConfigurationForListIdAndName(project, {
+    configurationListId: nativeTarget.buildConfigurationList,
+    buildConfiguration,
+  });
+  return xcBuildConfiguration ?? null;
 }
 
 export async function findApplicationTargetWithDependenciesAsync(

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -33,9 +33,15 @@ export function getProjectName(projectRoot: string) {
   return path.basename(sourceRoot);
 }
 
-export function resolvePathOrProject(projectRootOrProject: string | XcodeProject): XcodeProject {
+export function resolvePathOrProject(
+  projectRootOrProject: string | XcodeProject
+): XcodeProject | null {
   if (typeof projectRootOrProject === 'string') {
-    return getPbxproj(projectRootOrProject);
+    try {
+      return getPbxproj(projectRootOrProject);
+    } catch {
+      return null;
+    }
   }
   return projectRootOrProject;
 }

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -33,6 +33,13 @@ export function getProjectName(projectRoot: string) {
   return path.basename(sourceRoot);
 }
 
+export function resolvePathOrProject(projectRootOrProject: string | XcodeProject): XcodeProject {
+  if (typeof projectRootOrProject === 'string') {
+    return getPbxproj(projectRootOrProject);
+  }
+  return projectRootOrProject;
+}
+
 // TODO: come up with a better solution for using app.json expo.name in various places
 function sanitizedName(name: string) {
   return name

--- a/packages/config-plugins/src/ios/utils/__tests__/getInfoPlistPath-test.ts
+++ b/packages/config-plugins/src/ios/utils/__tests__/getInfoPlistPath-test.ts
@@ -1,0 +1,45 @@
+import { vol } from 'memfs';
+import path from 'path';
+
+import { getInfoPlistPathFromPbxproj } from '../getInfoPlistPath';
+
+jest.mock('fs');
+
+const originalFs = jest.requireActual('fs');
+
+const projectRoot = '/app/';
+
+beforeAll(() => {
+  vol.fromJSON(
+    {
+      'ios/testproject.xcodeproj/project.pbxproj': originalFs.readFileSync(
+        path.join(__dirname, '../../__tests__/fixtures/project-multitarget.pbxproj'),
+        'utf-8'
+      ),
+      'ios/testproject.xcodeproj/xcshareddata/xcschemes/multitarget.xcscheme': originalFs.readFileSync(
+        path.join(__dirname, '../../__tests__/fixtures/multitarget.xcscheme'),
+        'utf-8'
+      ),
+    },
+    projectRoot
+  );
+});
+it('returns correct Info.plist path for the default build configuration (Release)', () => {
+  const plistPath = getInfoPlistPathFromPbxproj(projectRoot, {
+    targetName: 'multitarget',
+  });
+  expect(plistPath).toBe('multitarget/Info.plist');
+});
+it('returns with default props', () => {
+  const plistPath = getInfoPlistPathFromPbxproj(projectRoot);
+  expect(plistPath).toBe('multitarget/Info.plist');
+});
+it('returns with custom target name', () => {
+  const plistPath = getInfoPlistPathFromPbxproj(projectRoot, { targetName: 'shareextension' });
+  expect(plistPath).toBe('shareextension/Info.plist');
+});
+it('throws on invalid target name', () => {
+  expect(() =>
+    getInfoPlistPathFromPbxproj(projectRoot, { targetName: 'shareextension-invalid' })
+  ).toThrowError(/Could not find target/);
+});

--- a/packages/config-plugins/src/ios/utils/getInfoPlistPath.ts
+++ b/packages/config-plugins/src/ios/utils/getInfoPlistPath.ts
@@ -1,7 +1,7 @@
 import { XcodeProject } from 'xcode';
 
-import { getXCBuildConfigurationFromPbxproj } from './Target';
-import { resolvePathOrProject } from './utils/Xcodeproj';
+import { getXCBuildConfigurationFromPbxproj } from '../Target';
+import { resolvePathOrProject } from './Xcodeproj';
 
 /**
  * Find the Info.plist path linked to a specific build configuration.
@@ -15,7 +15,7 @@ export function getInfoPlistPathFromPbxproj(
   {
     targetName,
     buildConfiguration = 'Release',
-  }: { targetName?: string; buildConfiguration?: string } = {}
+  }: { targetName?: string; buildConfiguration?: string | 'Release' | 'Debug' } = {}
 ): string | null {
   const project = resolvePathOrProject(projectRootOrProject);
   if (!project) {

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -69,8 +69,16 @@ const defaultProviders = {
   // Append a rule to supply Info.plist data to mods on `mods.ios.infoPlist`
   infoPlist: provider<InfoPlist, ForwardedBaseModOptions>({
     getFilePath(config) {
-      const infoPlistPath = getInfoPlistPathFromPbxproj(config.modRequest.projectRoot);
-      if (infoPlistPath) {
+      const infoPlistBuildProperty = getInfoPlistPathFromPbxproj(config.modRequest.projectRoot);
+
+      if (infoPlistBuildProperty) {
+        //: [root]/myapp/ios/MyApp/Info.plist
+        const infoPlistPath = path.join(
+          //: myapp/ios
+          config.modRequest.platformProjectRoot,
+          //: MyApp/Info.plist
+          infoPlistBuildProperty
+        );
         if (fileExists(infoPlistPath)) {
           return infoPlistPath;
         }

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -89,6 +89,7 @@ const defaultProviders = {
       } else {
         addWarningIOS('mods.ios.infoPlist', 'Failed to find Info.plist linked to Xcode project.');
       }
+      // Fallback on glob...
       return Paths.getInfoPlistPath(config.modRequest.projectRoot);
     },
     async read(filePath, config) {

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -7,8 +7,8 @@ import xcode, { XcodeProject } from 'xcode';
 
 import { ExportedConfig, ModConfig } from '../Plugin.types';
 import { Entitlements, Paths } from '../ios';
-import { getInfoPlistPathFromPbxproj } from '../ios/InfoPlist';
 import { InfoPlist } from '../ios/IosConfig.types';
+import { getInfoPlistPathFromPbxproj } from '../ios/utils/getInfoPlistPath';
 import { fileExists } from '../utils/modules';
 import { addWarningIOS } from '../utils/warnings';
 import { ForwardedBaseModOptions, provider, withGeneratedBaseMods } from './createBaseMod';

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -7,7 +7,10 @@ import xcode, { XcodeProject } from 'xcode';
 
 import { ExportedConfig, ModConfig } from '../Plugin.types';
 import { Entitlements, Paths } from '../ios';
+import { getInfoPlistPathFromPbxproj } from '../ios/InfoPlist';
 import { InfoPlist } from '../ios/IosConfig.types';
+import { fileExists } from '../utils/modules';
+import { addWarningIOS } from '../utils/warnings';
 import { ForwardedBaseModOptions, provider, withGeneratedBaseMods } from './createBaseMod';
 
 const { readFile, writeFile } = promises;
@@ -66,6 +69,18 @@ const defaultProviders = {
   // Append a rule to supply Info.plist data to mods on `mods.ios.infoPlist`
   infoPlist: provider<InfoPlist, ForwardedBaseModOptions>({
     getFilePath(config) {
+      const infoPlistPath = getInfoPlistPathFromPbxproj(config.modRequest.projectRoot);
+      if (infoPlistPath) {
+        if (fileExists(infoPlistPath)) {
+          return infoPlistPath;
+        }
+        addWarningIOS(
+          'mods.ios.infoPlist',
+          `Info.plist file linked to Xcode project does not exist: ${infoPlistPath}`
+        );
+      } else {
+        addWarningIOS('mods.ios.infoPlist', 'Failed to find Info.plist linked to Xcode project.');
+      }
       return Paths.getInfoPlistPath(config.modRequest.projectRoot);
     },
     async read(filePath, config) {


### PR DESCRIPTION
# Why

In multi-target projects, there will be more than one Info.plist, right now we warn and guess, this PR uses the Xcode project to resolve the exact Info.plist. If the fs doesn't have a pbxproj, then fallback on the existing behavior.

# Test Plan

- Added tests
- Ran locally with ios-stickers