### PR TITLE
Handle empty entries when parsing URL types in iOS projects

### DIFF
--- a/packages/config-plugins/src/ios/Scheme.ts
+++ b/packages/config-plugins/src/ios/Scheme.ts
@@ -88,7 +88,9 @@ export function hasScheme(scheme: string, infoPlist: InfoPlist): boolean {
 
   if (!Array.isArray(existingSchemes)) return false;
 
-  return existingSchemes.some(({ CFBundleURLSchemes: schemes }: any) => Array.isArray(schemes) ? schemes.includes(scheme) : false);
+  return existingSchemes.some(({ CFBundleURLSchemes: schemes }: any) => 
+    Array.isArray(schemes) ? schemes.includes(scheme) : false
+  );
 }
 
 export function getSchemesFromPlist(infoPlist: InfoPlist): string[] {

--- a/packages/config-plugins/src/ios/Scheme.ts
+++ b/packages/config-plugins/src/ios/Scheme.ts
@@ -88,7 +88,7 @@ export function hasScheme(scheme: string, infoPlist: InfoPlist): boolean {
 
   if (!Array.isArray(existingSchemes)) return false;
 
-  return existingSchemes.some(({ CFBundleURLSchemes: schemes }: any) => schemes.includes(scheme));
+  return existingSchemes.some(({ CFBundleURLSchemes: schemes }: any) => Array.isArray(schemes) ? schemes.includes(scheme) : false);
 }
 
 export function getSchemesFromPlist(infoPlist: InfoPlist): string[] {


### PR DESCRIPTION
# Why

As described in #3625, a newly created URL type entry in XCode doesn't have any properties yet, so it's not safe to assume the CFBundleURLSchemes property exists and is an array, in fact it crashes the `uri-scheme` CLI tool.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

This fix adds a type check in the same coding style as the one right above it to ensure the existence of the array before trying to access it.
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

As I am not extremely familiar with this huge monorepo, I am not aware of any automated test cases covering this functionality. However, the fix is small and self-explanatory, and aligns perfectly with the stacktrace thrown by the `uri-scheme` CLI tool.
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->