### PR TITLE
[ENG-1460][config-plugins] fix expo updates native configuration checks

### DIFF
--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -222,13 +222,18 @@ export function areVersionsSynced(
 ): boolean {
   const expectedRuntimeVersion = getRuntimeVersion(config);
   const expectedSdkVersion = getSDKVersion(config);
+
   const currentRuntimeVersion = getMainApplicationMetaDataValue(
     androidManifest,
     Config.RUNTIME_VERSION
   );
   const currentSdkVersion = getMainApplicationMetaDataValue(androidManifest, Config.SDK_VERSION);
 
-  return (
-    currentRuntimeVersion === expectedRuntimeVersion && currentSdkVersion === expectedSdkVersion
-  );
+  if (expectedRuntimeVersion !== null) {
+    return currentRuntimeVersion === expectedRuntimeVersion && currentSdkVersion === null;
+  } else if (expectedSdkVersion !== null) {
+    return currentSdkVersion === expectedSdkVersion && currentRuntimeVersion === null;
+  } else {
+    return true;
+  }
 }

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -211,10 +211,15 @@ export function isPlistVersionConfigurationSynced(
 ): boolean {
   const expectedRuntimeVersion = getRuntimeVersion(config);
   const expectedSdkVersion = getSDKVersion(config);
+
   const currentRuntimeVersion = expoPlist.EXUpdatesRuntimeVersion ?? null;
   const currentSdkVersion = expoPlist.EXUpdatesSDKVersion ?? null;
 
-  return (
-    currentSdkVersion === expectedSdkVersion && currentRuntimeVersion === expectedRuntimeVersion
-  );
+  if (expectedRuntimeVersion !== null) {
+    return currentRuntimeVersion === expectedRuntimeVersion && currentSdkVersion === null;
+  } else if (expectedSdkVersion !== null) {
+    return currentSdkVersion === expectedSdkVersion && currentRuntimeVersion === null;
+  } else {
+    return true;
+  }
 }


### PR DESCRIPTION
# Why

When working on https://linear.app/expo/issue/ENG-1460/add-runtimeversion-to-build-job-metadata I've noticed that EAS CLI always prints "Native project configuration is not synced with values present in your app.json" even if the native project is properly configured.
It turns out that when we configure the native configuration and the runtime version is defined in the app config, we remove the value of the SDK version. Later, we once again check if the values are synced. But this time we're checking if the SDK version from the app config (which is always defined) matches the nonexistent value in the native config. 

# How

I fixed the `areVersionsSynced` (Android) and `isPlistVersionConfigurationSynced` (iOS) functions so they check if the versions are synced conditionally (similarly to how `setVersionsConfig` works).

# Test Plan

I had a project with `runtimeVersion` defined in app.json. Before patching the code in `config-plugins` I ran a build and saw that the warning was printed. Later, after patching it, I ran another build and the warning went away.