### PR TITLE
Skip prompting to start dev server on another port

### DIFF
--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -71,7 +71,9 @@ async function resolveOptionsAsync(
     throw new CommandError(`Could not find package name in AndroidManifest.xml at "${filePath}"`);
   }
 
-  let port = options.bundler ? await resolvePortAsync(projectRoot, options.port) : null;
+  let port = options.bundler
+    ? await resolvePortAsync(projectRoot, { defaultPort: options.port, reuseExistingPort: true })
+    : null;
   options.bundler = !!port;
   if (!port) {
     // Skip bundling if the port is null

--- a/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
@@ -81,7 +81,9 @@ export async function resolveOptionsAsync(
 
   const isSimulator = !('deviceType' in device);
 
-  let port = options.bundler ? await resolvePortAsync(projectRoot, options.port) : null;
+  let port = options.bundler
+    ? await resolvePortAsync(projectRoot, { reuseExistingPort: true, defaultPort: options.port })
+    : null;
   // Skip bundling if the port is null
   options.bundler = !!port;
   if (!port) {

--- a/packages/expo-cli/src/commands/run/utils/resolvePortAsync.ts
+++ b/packages/expo-cli/src/commands/run/utils/resolvePortAsync.ts
@@ -5,7 +5,13 @@ import Log from '../../../log';
 
 export async function resolvePortAsync(
   projectRoot: string,
-  defaultPort?: string | number
+  {
+    reuseExistingPort,
+    defaultPort,
+  }: {
+    reuseExistingPort?: boolean;
+    defaultPort?: string | number;
+  } = {}
 ): Promise<number | null> {
   let port: number;
   if (typeof defaultPort === 'string') {
@@ -19,7 +25,7 @@ export async function resolvePortAsync(
   // Only check the port when the bundler is running.
   const resolvedPort = await choosePortAsync(projectRoot, {
     defaultPort: port,
-    reuseExistingPort: true,
+    reuseExistingPort,
   });
   if (resolvedPort == null) {
     Log.log('\u203A Skipping dev server');

--- a/packages/expo-cli/src/commands/run/utils/resolvePortAsync.ts
+++ b/packages/expo-cli/src/commands/run/utils/resolvePortAsync.ts
@@ -17,7 +17,10 @@ export async function resolvePortAsync(
   }
 
   // Only check the port when the bundler is running.
-  const resolvedPort = await choosePortAsync(projectRoot, port);
+  const resolvedPort = await choosePortAsync(projectRoot, {
+    defaultPort: port,
+    reuseExistingPort: true,
+  });
   if (resolvedPort == null) {
     Log.log('\u203A Skipping dev server');
     // Skip bundling if the port is null

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -439,11 +439,10 @@ async function getAvailablePortAsync(options: {
       'defaultPort' in options && options.defaultPort
         ? options.defaultPort
         : WebpackEnvironment.DEFAULT_PORT;
-    const port = await choosePortAsync(
-      options.projectRoot,
+    const port = await choosePortAsync(options.projectRoot, {
       defaultPort,
-      'host' in options && options.host ? options.host : WebpackEnvironment.HOST
-    );
+      host: 'host' in options && options.host ? options.host : WebpackEnvironment.HOST,
+    });
     if (!port) {
       throw new Error(`Port ${defaultPort} not available.`);
     }

--- a/packages/xdl/src/utils/choosePortAsync.ts
+++ b/packages/xdl/src/utils/choosePortAsync.ts
@@ -8,8 +8,15 @@ import { getRunningProcess } from './getRunningProcess';
 
 export async function choosePortAsync(
   projectRoot: string,
-  defaultPort: number,
-  host?: string
+  {
+    defaultPort,
+    host,
+    reuseExistingPort,
+  }: {
+    defaultPort: number;
+    host?: string;
+    reuseExistingPort?: boolean;
+  }
 ): Promise<number | null> {
   try {
     const port = await freeportAsync(defaultPort, { hostnames: [host ?? null] });
@@ -29,6 +36,9 @@ export async function choosePortAsync(
       const pidTag = chalk.gray(`(pid ${runningProcess.pid})`);
       if (runningProcess.directory === projectRoot) {
         message += ` running this app in another window`;
+        if (reuseExistingPort) {
+          return null;
+        }
       } else {
         message += ` running ${chalk.cyan(runningProcess.command)} in another window`;
       }


### PR DESCRIPTION
# Why

We want to prompt users to use another port if the 8081 is too busy for the project they are currently starting. We have the ability to loosely identify if the port is already running the current project in another window. 
This PR bails out when the project is already being hosted on the requested port elsewhere. 

Only reuse the default port for `run:ios` and `run:android`, and skip this behavior for `expo start`.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `expo run:ios` 
- in another window, run `expo run:ios`, it should print `skipping dev server...`

- Running `expo start --dev-client` in multiple windows should always prompt.


<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->