### PR TITLE
Cancel run commands better

### DIFF
--- a/packages/expo-cli/src/commands/run/android/spawnGradleAsync.ts
+++ b/packages/expo-cli/src/commands/run/android/spawnGradleAsync.ts
@@ -1,6 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
 import path from 'path';
 
+import { AbortCommandError } from '../../../CommandError';
 import Log from '../../../log';
 
 function capitalize(name: string) {
@@ -39,8 +40,17 @@ export async function spawnGradleAsync({
     args.push('--profile');
   }
   Log.debug(`  ${gradlew} ${args.join(' ')}`);
-  await spawnAsync(gradlew, args, {
-    cwd: androidProjectPath,
-    stdio: 'inherit',
-  });
+  try {
+    return await spawnAsync(gradlew, args, {
+      cwd: androidProjectPath,
+      stdio: 'inherit',
+    });
+  } catch (error) {
+    // User aborted the command with ctrl-c
+    if (error.status === 130) {
+      // Fail silently
+      throw new AbortCommandError();
+    }
+    throw error;
+  }
 }

--- a/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
+++ b/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
@@ -229,8 +229,12 @@ export async function buildAsync({
     buildProcess.on('close', (code: number) => {
       Log.debug(`Exited with code: ${code}`);
 
-      // User cancelled with ctrl-c
-      if (code === null) {
+      if (
+        // User cancelled with ctrl-c
+        code === null ||
+        // Build interrupted
+        code === 75
+      ) {
         reject(new AbortCommandError());
         return;
       }

--- a/packages/xdl/src/SimControl.ts
+++ b/packages/xdl/src/SimControl.ts
@@ -90,23 +90,6 @@ type SimulatorDeviceList = {
   };
 };
 
-export async function isSimulatorRunningAsync() {
-  try {
-    const zeroMeansNo = (
-      await osascript.execAsync(
-        'tell app "System Events" to count processes whose name is "Simulator"'
-      )
-    ).trim();
-    if (zeroMeansNo === '0') {
-      return false;
-    }
-  } catch {
-    return false;
-  }
-
-  return true;
-}
-
 export async function getDefaultSimulatorDeviceUDIDAsync() {
   try {
     const { stdout: defaultDeviceUDID } = await spawnAsync('defaults', [


### PR DESCRIPTION
# Why

Cancelling `run:android` or `run:ios` throw confusing error messages, this PR cleans the errors up a bit.

