### PR TITLE
Warn about babel config changing

### DIFF
--- a/packages/config-plugins/src/ios/Scheme.ts
+++ b/packages/config-plugins/src/ios/Scheme.ts
@@ -88,7 +88,7 @@ export function hasScheme(scheme: string, infoPlist: InfoPlist): boolean {
 
   if (!Array.isArray(existingSchemes)) return false;
 
-  return existingSchemes.some(({ CFBundleURLSchemes: schemes }: any) => 
+  return existingSchemes.some(({ CFBundleURLSchemes: schemes }: any) =>
     Array.isArray(schemes) ? schemes.includes(scheme) : false
   );
 }

--- a/packages/xdl/src/internal.ts
+++ b/packages/xdl/src/internal.ts
@@ -19,6 +19,7 @@ export { default as NotificationCode } from './NotificationCode';
 export { learnMore } from './logs/TerminalLink';
 export { default as Analytics, AnalyticsClient } from './Analytics';
 export { default as UnifiedAnalytics } from './UnifiedAnalytics';
+export { watchBabelConfigForProject } from './start/watchBabelConfig';
 export * as Android from './Android';
 export { default as ApiV2 } from './ApiV2';
 export * as Binaries from './Binaries';

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -21,6 +21,7 @@ import {
   stopTunnelsAsync,
   Webpack,
 } from '../internal';
+import { watchBabelConfigForProject } from './watchBabelConfig';
 
 let serverInstance: Server | null = null;
 let messageSocket: any | null = null;
@@ -56,6 +57,8 @@ export async function startAsync(
     developerTool: Config.developerTool,
     sdkVersion: exp.sdkVersion ?? null,
   });
+
+  watchBabelConfigForProject(projectRoot);
 
   if (options.webOnly) {
     await Webpack.restartAsync(projectRoot, options);

--- a/packages/xdl/src/start/watchBabelConfig.ts
+++ b/packages/xdl/src/start/watchBabelConfig.ts
@@ -1,0 +1,51 @@
+import chalk from 'chalk';
+import { watchFile } from 'fs';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+import { ProjectUtils } from '../internal';
+
+// List of files that are being observed.
+const watchingFiles: string[] = [];
+
+/**
+ * Get the babel configuration file for the project.
+ */
+export function getProjectBabelConfigFile(projectRoot: string): string | undefined {
+  return (
+    resolveFrom.silent(projectRoot, './babel.config.js') ||
+    resolveFrom.silent(projectRoot, './.babelrc') ||
+    resolveFrom.silent(projectRoot, './.babelrc.js')
+  );
+}
+
+export function watchBabelConfigForProject(projectRoot: string) {
+  const configPath = getProjectBabelConfigFile(projectRoot);
+  if (configPath) {
+    return watchBabelConfig(projectRoot, configPath);
+  }
+  return configPath;
+}
+
+/**
+ * Watch the babel configuration file and warn to reload the CLI if it changes.
+ */
+export function watchBabelConfig(projectRoot: string, configPath: string): void {
+  if (watchingFiles.includes(configPath)) {
+    return;
+  }
+
+  watchingFiles.push(configPath);
+  const configName = path.relative(projectRoot, configPath);
+  watchFile(configPath, (cur: any, prev: any) => {
+    if (prev.size || cur.size) {
+      ProjectUtils.logInfo(
+        projectRoot,
+        'expo',
+        `\u203A Detected a change in ${chalk.bold(
+          configName
+        )}. Restart the server to see the new results.`
+      );
+    }
+  });
+}


### PR DESCRIPTION
# Why

Resolve https://github.com/expo/expo-cli/issues/151

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Observe file changes for babel config and log a warning to restart the server. 


# Test Plan

- `expo start` 
- modify the babel.config.js 
- See logs in terminal
- Repeat but with `expo web`

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->