### PR TITLE
Upgrade hapi/joi to joi

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -81,7 +81,7 @@
     "@expo/simple-spinner": "1.0.2",
     "@expo/spawn-async": "1.5.0",
     "@expo/xcpretty": "^3.0.1",
-    "@hapi/joi": "^17.1.1",
+    "joi": "^17.4.0",
     "babel-runtime": "6.26.0",
     "base32.js": "0.1.0",
     "boxen": "4.1.0",

--- a/packages/expo-cli/src/commands/build/startBuildAsync.ts
+++ b/packages/expo-cli/src/commands/build/startBuildAsync.ts
@@ -1,5 +1,5 @@
 import { configFilename, getConfig } from '@expo/config';
-import joi from '@hapi/joi';
+import Joi from 'joi';
 import slug from 'slugify';
 import { Analytics, ApiV2, Config, ThirdParty, UserManager, XDLError } from 'xdl';
 
@@ -25,16 +25,16 @@ export type GetExpConfigOptions = {
 };
 
 export function validateOptions(options: any) {
-  const schema = joi.object().keys({
-    current: joi.boolean(),
-    mode: joi.string(),
-    platform: joi.any().valid('ios', 'android', 'all'),
-    expIds: joi.array(),
-    type: joi.any().valid('archive', 'simulator', 'client', 'app-bundle', 'apk'),
-    releaseChannel: joi.string().regex(/[a-z\d][a-z\d._-]*/),
-    bundleIdentifier: joi.string().regex(/^[a-zA-Z0-9-.]+$/),
-    publicUrl: joi.string(),
-    sdkVersion: joi.string().strict(),
+  const schema = Joi.object().keys({
+    current: Joi.boolean(),
+    mode: Joi.string(),
+    platform: Joi.any().valid('ios', 'android', 'all'),
+    expIds: Joi.array(),
+    type: Joi.any().valid('archive', 'simulator', 'client', 'app-bundle', 'apk'),
+    releaseChannel: Joi.string().regex(/[a-z\d][a-z\d._-]*/),
+    bundleIdentifier: Joi.string().regex(/^[a-zA-Z0-9-.]+$/),
+    publicUrl: Joi.string(),
+    sdkVersion: Joi.string().strict(),
   });
 
   const { error } = schema.validate(options);

--- a/packages/expo-cli/src/credentials/credentialsJson/read.ts
+++ b/packages/expo-cli/src/credentials/credentialsJson/read.ts
@@ -1,5 +1,5 @@
-import Joi from '@hapi/joi';
 import fs from 'fs-extra';
+import Joi from 'joi';
 import path from 'path';
 
 import { Keystore } from '../credentials';

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -43,7 +43,7 @@
     "@expo/schemer": "1.3.29",
     "@expo/spawn-async": "1.5.0",
     "@expo/webpack-config": "0.12.82",
-    "@hapi/joi": "^17.1.1",
+    "joi": "^17.4.0",
     "analytics-node": "3.5.0",
     "axios": "0.21.1",
     "boxen": "4.1.0",

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig, getConfig } from '@expo/config';
-import joi from '@hapi/joi';
 import assert from 'assert';
+import Joi from 'joi';
 import os from 'os';
 import QueryString from 'querystring';
 import resolveFrom from 'resolve-from';
@@ -242,18 +242,18 @@ export async function constructWebAppUrlAsync(
 }
 
 function assertValidOptions(opts: Partial<URLOptions>): URLOptions {
-  const schema = joi.object().keys({
-    devClient: joi.boolean().optional(),
-    scheme: joi.string().optional().allow(null),
+  const schema = Joi.object().keys({
+    devClient: Joi.boolean().optional(),
+    scheme: Joi.string().optional().allow(null),
     // Replaced by `scheme`
-    urlType: joi.any().valid('exp', 'http', 'redirect', 'no-protocol').allow(null),
-    lanType: joi.any().valid('ip', 'hostname'),
-    hostType: joi.any().valid('localhost', 'lan', 'tunnel'),
-    dev: joi.boolean(),
-    strict: joi.boolean(),
-    minify: joi.boolean(),
-    https: joi.boolean().optional(),
-    urlRandomness: joi.string().optional().allow(null),
+    urlType: Joi.any().valid('exp', 'http', 'redirect', 'no-protocol').allow(null),
+    lanType: Joi.any().valid('ip', 'hostname'),
+    hostType: Joi.any().valid('localhost', 'lan', 'tunnel'),
+    dev: Joi.boolean(),
+    strict: Joi.boolean(),
+    minify: Joi.boolean(),
+    https: Joi.boolean().optional(),
+    urlRandomness: Joi.string().optional().allow(null),
   });
 
   const { error } = schema.validate(opts);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,13 +1607,6 @@
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
   integrity sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==
 
-"@hapi/address@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.0.1.tgz#267301ddf7bc453718377a6fb3832a2f04a721dd"
-  integrity sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
 "@hapi/boom@9.x.x":
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/@hapi/boom/-/boom-9.1.2.tgz#48bd41d67437164a2d636e3b5bc954f8c8dc5e38"
@@ -1625,11 +1618,6 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
   integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
-
-"@hapi/formula@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-2.0.0.tgz#edade0619ed58c8e4f164f233cda70211e787128"
-  integrity sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==
 
 "@hapi/hoek@8.x.x", "@hapi/hoek@^8.3.0":
   version "8.5.0"
@@ -1650,22 +1638,6 @@
     "@hapi/bourne" "1.x.x"
     "@hapi/hoek" "8.x.x"
     "@hapi/topo" "3.x.x"
-
-"@hapi/joi@^17.1.1":
-  version "17.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-17.1.1.tgz#9cc8d7e2c2213d1e46708c6260184b447c661350"
-  integrity sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==
-  dependencies:
-    "@hapi/address" "^4.0.1"
-    "@hapi/formula" "^2.0.0"
-    "@hapi/hoek" "^9.0.0"
-    "@hapi/pinpoint" "^2.0.0"
-    "@hapi/topo" "^5.0.0"
-
-"@hapi/pinpoint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.0.tgz#805b40d4dbec04fc116a73089494e00f073de8df"
-  integrity sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==
 
 "@hapi/topo@3.x.x":
   version "3.1.6"
@@ -3179,6 +3151,23 @@
   dependencies:
     component-type "^1.2.1"
     join-component "^1.1.0"
+
+"@sideway/address@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -11659,6 +11648,17 @@ joi@^11.1.1:
     hoek "4.x.x"
     isemail "3.x.x"
     topo "2.x.x"
+
+joi@^17.4.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.0.tgz#b5c2277c8519e016316e49ababd41a1908d9ef20"
+  integrity sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 join-component@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
# Why

Now that we've dropped support for Node 10, we can upgrade this dep.

related https://github.com/expo/expo-cli/issues/1659 https://github.com/expo/expo-cli/pull/3132