### PR TITLE
Added flipper hack to manifest JSON

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -70,6 +70,10 @@ export type ExpoAppManifest = ExpoConfig & {
   releaseId?: string;
   revisionId?: string;
   mainModuleName?: string;
+  // A string that flipper checks to determine if Metro bundler is running
+  // by adding it to the manifest, we can trick Flipper into working properly.
+  // https://github.com/facebook/flipper/blob/9ca8bee208b7bfe2b8c0dab8eb4b79688a0c84bc/desktop/app/src/dispatcher/metroDevice.tsx#L37
+  __flipperHack?: 'React Native packager is running';
   env?: Record<string, any>;
   bundleUrl?: string;
   debuggerHost?: string;

--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -219,6 +219,13 @@ export async function getManifestResponseAsync({
   if (manifest.sdkVersion && Versions.lteSdkVersion(manifest, '40.0.0')) {
     manifest.env = getManifestEnvironment();
   }
+
+  // Add this string to make Flipper register React Native / Metro as "running".
+  // Can be tested by running:
+  // `METRO_SERVER_PORT=19000 open -a flipper.app`
+  // Where 19000 is the port where the Expo project is being hosted.
+  manifest.__flipperHack = 'React Native packager is running';
+
   // Add URLs to the manifest
   manifest.bundleUrl = await getBundleUrlAsync({
     projectRoot,


### PR DESCRIPTION
# Why

Flipper's "React Native" section only works if it can detect a certain string in the `/` path of the server hosted at `localhost:8081` [ref](https://github.com/facebook/flipper/blob/9ca8bee208b7bfe2b8c0dab8eb4b79688a0c84bc/desktop/app/src/dispatcher/metroDevice.tsx#L37). This PR ensures that the string is present in the manifest. 

- https://twitter.com/Baconbrix/status/1412921581542658049?s=20

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- `expod start` then opened flipper with `METRO_SERVER_PORT=19000 open -a flipper.app`, React Native section was enabled and available.
- `expod start --dev-client` then opened flipper normally, React Native section was enabled.