### PR TITLE
[image-utils] Allow any size or resize mode for jimp

### DIFF
--- a/packages/image-utils/src/Image.ts
+++ b/packages/image-utils/src/Image.ts
@@ -126,6 +126,11 @@ async function ensureImageOptionsAsync(imageOptions: ImageOptions): Promise<Imag
     src: await Download.downloadOrUseCachedImage(imageOptions.src),
   };
 
+  // Default to contain
+  if (!icon.resizeMode) {
+    icon.resizeMode = 'contain';
+  }
+
   const mimeType = mime.getType(icon.src);
 
   if (!mimeType) {

--- a/packages/image-utils/src/jimp.ts
+++ b/packages/image-utils/src/jimp.ts
@@ -119,9 +119,19 @@ export async function getJimpImageAsync(input: string | Buffer | Jimp): Promise<
 
 export async function resize(
   { input, quality = 100 }: JimpGlobalOptions,
-  { background, position, fit, width, height = Jimp.AUTO }: Omit<ResizeOptions, 'operation'>
+  { background, position, fit, width, height }: Omit<ResizeOptions, 'operation'>
 ): Promise<Jimp> {
   let initialImage = await getJimpImageAsync(input);
+
+  if (width && !height) {
+    height = Jimp.AUTO;
+  } else if (!width && height) {
+    width = Jimp.AUTO;
+  } else {
+    width = initialImage.bitmap.width;
+    height = initialImage.bitmap.height;
+  }
+
   const jimpPosition = convertPosition(position);
   const jimpQuality = typeof quality !== 'number' ? 100 : quality;
   if (fit === 'cover') {


### PR DESCRIPTION
# Why

Sharp allows for passing undefined width, height, resizeMode, but jimp does not.
