### PR TITLE
Added port option to expo start

### DIFF
--- a/packages/expo-cli/src/commands/run/utils/resolvePortAsync.ts
+++ b/packages/expo-cli/src/commands/run/utils/resolvePortAsync.ts
@@ -8,9 +8,11 @@ export async function resolvePortAsync(
   {
     reuseExistingPort,
     defaultPort,
+    fallbackPort,
   }: {
     reuseExistingPort?: boolean;
     defaultPort?: string | number;
+    fallbackPort?: number;
   } = {}
 ): Promise<number | null> {
   let port: number;
@@ -19,7 +21,7 @@ export async function resolvePortAsync(
   } else if (typeof defaultPort === 'number') {
     port = defaultPort;
   } else {
-    port = getenv.int('RCT_METRO_PORT', 8081);
+    port = getenv.int('RCT_METRO_PORT', fallbackPort || 8081);
   }
 
   // Only check the port when the bundler is running.

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -177,7 +177,7 @@ export default (program: any) => {
     .option('--no-minify', 'Do not minify code')
     .option('--https', 'To start webpack with https protocol')
     .option('--no-https', 'To start webpack with http protocol')
-    .option('--port', 'To start webpack with http protocol')
+    .option('-p, --port <port>', 'Port to start the Webpack bundler on. Default: 19006')
     .option('-s, --send-to [dest]', 'An email address to send a link to')
     .urlOpts()
     .allowOffline()

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -152,6 +152,10 @@ export default (program: any) => {
     .option('--minify', 'Minify code')
     .option('--no-minify', 'Do not minify code')
     .option('--https', 'To start webpack with https protocol')
+    .option(
+      '-p, --port <port>',
+      'Port to start the native Metro bundler on (does not apply to web or tunnel). Default: 19000'
+    )
     .option('--no-https', 'To start webpack with http protocol')
     .urlOpts()
     .allowOffline()
@@ -173,6 +177,7 @@ export default (program: any) => {
     .option('--no-minify', 'Do not minify code')
     .option('--https', 'To start webpack with https protocol')
     .option('--no-https', 'To start webpack with http protocol')
+    .option('--port', 'To start webpack with http protocol')
     .option('-s, --send-to [dest]', 'An email address to send a link to')
     .urlOpts()
     .allowOffline()

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -23,6 +23,7 @@ export type NormalizedOptions = URLOptions & {
 };
 
 export type RawStartOptions = NormalizedOptions & {
+  port?: number;
   parent?: { nonInteractive: boolean; rawArgs: string[] };
 };
 
@@ -63,13 +64,14 @@ export async function normalizeOptionsAsync(
 
   const opts = parseRawArguments(options, rawArgs);
 
-  if (opts.devClient) {
-    const metroPort = await resolvePortAsync(projectRoot);
-    if (!metroPort) {
-      throw new AbortCommandError();
-    }
-    opts.metroPort = metroPort;
+  const metroPort = await resolvePortAsync(projectRoot, {
+    defaultPort: options.port,
+    fallbackPort: options.devClient ? 8081 : 19000,
+  });
+  if (!metroPort) {
+    throw new AbortCommandError();
   }
+  opts.metroPort = metroPort;
 
   // Side-effect
   await cacheOptionsAsync(projectRoot, opts);

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -54,6 +54,7 @@ type CLIWebOptions = {
 type BundlingOptions = {
   dev?: boolean;
   clear?: boolean;
+  port?: number;
   pwa?: boolean;
   isImageEditingEnabled?: boolean;
   webpackEnv?: object;

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -61,7 +61,10 @@ export async function startAsync(
   watchBabelConfigForProject(projectRoot);
 
   if (options.webOnly) {
-    await Webpack.restartAsync(projectRoot, options);
+    await Webpack.restartAsync(projectRoot, {
+      ...options,
+      port: options.webpackPort,
+    });
     DevSession.startSession(projectRoot, exp, 'web');
     return exp;
   } else if (Env.shouldUseDevServer(exp) || options.devClient) {

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -11,6 +11,7 @@ import {
 
 export type StartOptions = {
   metroPort?: number;
+  webpackPort?: number;
   isWebSocketsEnabled?: boolean;
   isRemoteReloadingEnabled?: boolean;
   devClient?: boolean;

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -33,7 +33,7 @@ export async function startDevServerAsync(projectRoot: string, startOptions: Sta
   } else {
     port = startOptions.devClient
       ? Number(process.env.RCT_METRO_PORT) || 8081
-      : await getFreePortAsync(19000);
+      : await getFreePortAsync(startOptions.metroPort || 19000);
   }
   await ProjectSettings.setPackagerInfoAsync(projectRoot, {
     expoServerPort: port,


### PR DESCRIPTION
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Added `--port` option to `expo start` and `expo start --dev-client`
- default port for Expo Go: 19000
- default port for Expo dev client: 8081

Doesn't apply to tunnel (ngrok) or web (webpack). `expo web --port` exists for webpack control.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `expo start --port 8081`, should reuse the port selection prompt that we use across the CLI.
- `expo start --dev-client --port 8089`, should reuse the port selection prompt that we use across the CLI.

## Combos

- `expod start` -> 19000 (metro)
  - `w` -> 19006 (webpack)
- `expod start --dev-client` -> 8081 (metro)
  - `w` -> 19006 (webpack)
- `WEB_PORT=3000 expod web --port 8081` -> 8081 (webpack)
- `WEB_PORT=3000 expod web` -> 3000 (webpack)
- `expod start --port 8081` -> 8081 (metro)
  - `w` -> 19006 (webpack)


