### PR TITLE
Remove fs-extra from json-file

### DIFF
--- a/packages/json-file/__tests__/JsonFile-test.ts
+++ b/packages/json-file/__tests__/JsonFile-test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -8,8 +8,8 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 20 * 1000;
 
 const FIXTURES = path.join(os.tmpdir(), 'json-file-fixtures');
 
-beforeAll(() => fs.ensureDir(FIXTURES));
-afterAll(() => fs.remove(FIXTURES));
+beforeAll(() => fs.promises.mkdir(FIXTURES, { recursive: true }));
+afterAll(() => fs.promises.rmdir(FIXTURES, { recursive: true }));
 
 it(`is a class`, () => {
   const file = new JsonFile(path.join(__dirname, '../package.json'));
@@ -132,7 +132,7 @@ it('adds a new line at the eof', async () => {
   const file = new JsonFile(filename, { json5: true });
   await file.writeAsync(obj1);
   expect(fs.existsSync(filename)).toBe(true);
-  const data = await fs.readFile(filename, 'utf-8');
+  const data = await fs.promises.readFile(filename, 'utf-8');
   const lastChar = data[data.length - 1];
   expect(lastChar).toEqual('\n');
 });

--- a/packages/json-file/package.json
+++ b/packages/json-file/package.json
@@ -29,14 +29,12 @@
   ],
   "dependencies": {
     "@babel/code-frame": "~7.10.4",
-    "fs-extra": "9.0.0",
     "json5": "^1.0.1",
     "write-file-atomic": "^2.3.0"
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.20",
     "@types/babel__code-frame": "^7.0.1",
-    "@types/fs-extra": "^9.0.1",
     "@types/json5": "^0.0.30",
     "@types/write-file-atomic": "^2.1.1",
     "rimraf": "^3.0.2"

--- a/packages/json-file/src/JsonFile.ts
+++ b/packages/json-file/src/JsonFile.ts
@@ -1,5 +1,5 @@
 import { codeFrameColumns } from '@babel/code-frame';
-import { mkdirp, readFile, readFileSync } from 'fs-extra';
+import fs from 'fs';
 import JSON5 from 'json5';
 import path from 'path';
 import { promisify } from 'util';
@@ -131,7 +131,7 @@ function read<TJSONObject extends JSONObject>(
 ): TJSONObject {
   let json;
   try {
-    json = readFileSync(file, 'utf8');
+    json = fs.readFileSync(file, 'utf8');
   } catch (error) {
     assertEmptyJsonString(json, file);
     const defaultValue = cantReadFileDefault(options);
@@ -150,7 +150,7 @@ async function readAsync<TJSONObject extends JSONObject>(
 ): Promise<TJSONObject> {
   let json;
   try {
-    json = await readFile(file, 'utf8');
+    json = await fs.promises.readFile(file, 'utf8');
   } catch (error) {
     assertEmptyJsonString(json, file);
     const defaultValue = cantReadFileDefault(options);
@@ -213,7 +213,7 @@ async function writeAsync<TJSONObject extends JSONObject>(
   options?: Options<TJSONObject>
 ): Promise<TJSONObject> {
   if (options?.ensureDir) {
-    await mkdirp(path.dirname(file));
+    await fs.promises.mkdir(path.dirname(file), { recursive: true });
   }
   const space = _getOption(options, 'space');
   const json5 = _getOption(options, 'json5');


### PR DESCRIPTION
# Why

We no longer support node 10, and can freely use the new `fs` features.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

Hoping the unit tests work well enough to catch these changes.
