### PR TITLE
[run][android] fix cannot connect metro in a pure managed app

### DIFF
--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -146,6 +146,7 @@ export async function runAndroidActionAsync(projectRoot: string, options: Option
   } else {
     Log.debug('Opening app on device via package name: ' + props.device.name);
     // For now, just open the app with a matching package name
+    await Android.startAdbReverseAsync(projectRoot);
     await Android.openAppAsync(props.device, props);
   }
 


### PR DESCRIPTION
# Why

`expo run:android` cannot connect metro server because reverse tunnel not setting up.

# How

Add adb reverse

# Test Plan

```sh
expo init testapp
# select the managed blank template

expo run:android
# app should start without metro connection failures.
```