### PR TITLE
Split up e2e tests so they're only run when the user specifies

### DIFF
--- a/packages/expo-cli/jest.config.js
+++ b/packages/expo-cli/jest.config.js
@@ -1,9 +1,17 @@
 const path = require('path');
 
+const enableE2E = process.env.CI || process.env.E2E;
+
+const roots = ['__mocks__', 'src'];
+
+if (enableE2E) {
+  roots.push('e2e');
+}
+
 module.exports = {
   preset: '../../jest/unit-test-config',
   rootDir: path.resolve(__dirname),
   displayName: require('./package').name,
-  roots: ['__mocks__', 'src', 'e2e'],
+  roots,
   setupFilesAfterEnv: ['<rootDir>/jest/setup.ts'],
 };

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -17,6 +17,7 @@
     "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "preversion": "node ./scripts/preversion.js",
     "test": "jest",
+    "test:e2e": "cross-env E2E=1 jest",
     "test:watch": "jest --watch"
   },
   "bin": {


### PR DESCRIPTION
# Why

expo-cli e2e tests are long and a bit poorly written atm (i.e. cleanup has issues). All tests currently run when the user does `yarn test` in expo-cli, I found that this often leads to me writing less tests for expo-cli. Now they'll only be run with `yarn test:e2e` or in CI.

