### PR TITLE
[config] Improve missing file errors

### DIFF
--- a/packages/config/src/evalConfig.ts
+++ b/packages/config/src/evalConfig.ts
@@ -33,6 +33,8 @@ export function evalConfig(
     ignore: [/node_modules/],
     filename: 'unknown',
     presets: [getBabelPreset()],
+    // Retain lines for improved error reporting.
+    retainLines: true,
   });
 
   const result = requireString(code, configFile);


### PR DESCRIPTION
# Why

- Make things like this easier to debug in the future https://github.com/expo/expo/issues/13577

# Test Plan

- `app.json` - `expo config` should still work
- `app.config.js` - `expo config` should still work
- `app.config.ts` - `expo config` should still work

- import a missing file in the app.config.js -- the error message should point to the exact issue.
- import a file with a missing file, the stack trace should point to the exact location.

