### PR TITLE
Remove types hapi joi dependency

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -49,7 +49,6 @@
     "@types/dateformat": "^3.0.0",
     "@types/form-data": "^2.2.0",
     "@types/fs-extra": "^9.0.1",
-    "@types/hapi__joi": "^17.1.2",
     "@types/hashids": "^1.0.30",
     "@types/js-yaml": "^3.12.2",
     "@types/klaw-sync": "^6.0.0",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -105,7 +105,6 @@
     "@types/form-data": "^2.2.0",
     "@types/fs-extra": "^9.0.1",
     "@types/getenv": "^0.7.0",
-    "@types/hapi__joi": "^17.1.2",
     "@types/hashids": "^1.0.30",
     "@types/node-forge": "^0.9.7",
     "@types/raven": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,11 +3699,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hapi__joi@^17.1.2":
-  version "17.1.2"
-  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-17.1.2.tgz#f547d45b5d33677d1807ec217aeee832dc7e6334"
-  integrity sha512-2S6+hBISRQ5Ca6/9zfQi7zPueWMGyZxox6xicqJuW1/aC/6ambLyh+gDqY5fi8JBuHmGKMHldSfEpIXJtTmGKQ==
-
 "@types/hashids@^1.0.30":
   version "1.0.30"
   resolved "https://registry.yarnpkg.com/@types/hashids/-/hashids-1.0.30.tgz#c0a056b25c5b13c80bf330fb8d379ac4d4049999"
@@ -19286,10 +19281,8 @@ watchpack@^1.6.1, watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
# Why

After the removal of hapi/joi in https://github.com/expo/expo-cli/pull/3639, `@types/hapi__joi` can be removed. Joi already contains built-in package definitions, so the package can be removed altogether.

# How

Remove all instances of `@types/hapi__joi` and run `yarn install`. 

# Test Plan

Run `yarn build` and no compilation error should occur. 

![image](https://user-images.githubusercontent.com/21222656/125641963-856b7463-f610-4658-bbc3-6546d9a4b869.png)

(This is my first PR, sorry if I'm doing any wrong).