### PR TITLE
[config-plugins] Fix addJavaImports broken for kotlin files

### DIFF
--- a/packages/config-plugins/src/android/UserInterfaceStyle.ts
+++ b/packages/config-plugins/src/android/UserInterfaceStyle.ts
@@ -92,7 +92,7 @@ export function addOnConfigurationChangedMainActivity(
 // TODO: we should have a generic utility for doing this
 export function addJavaImports(javaSource: string, javaImports: string[], isJava: boolean): string {
   const lines = javaSource.split('\n');
-  const lineIndexWithPackageDeclaration = lines.findIndex(line => line.match(/^package .*;$/));
+  const lineIndexWithPackageDeclaration = lines.findIndex(line => line.match(/^package .*;?$/));
   for (const javaImport of javaImports) {
     if (!javaSource.includes(javaImport)) {
       const importStatement = `import ${javaImport}${isJava ? ';' : ''}`;


### PR DESCRIPTION
# Why

`addJavaImports` does not add imports after package line for kotlin files. kotlin does not end lines with semicolon.

# How

for the package regular expression, the semicolon is optional.

# Test Plan

Test splash-screen config-plugins with MainActvivity.kt 