### PR TITLE
Added skipPlugins prop to getConfig to support expo install better

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -122,7 +122,10 @@ export function getConfig(projectRoot: string, options: GetConfigOptions = {}): 
     }
 
     // Apply static json plugins, should be done after _internal
-    configWithDefaultValues.exp = withConfigPlugins(configWithDefaultValues.exp);
+    configWithDefaultValues.exp = withConfigPlugins(
+      configWithDefaultValues.exp,
+      !!options.skipPlugins
+    );
 
     if (!options.isModdedConfig) {
       // @ts-ignore: Delete mods added by static plugins when they won't have a chance to be evaluated

--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -155,6 +155,10 @@ export type GetConfigOptions = {
    */
   isModdedConfig?: boolean;
   skipSDKVersionRequirement?: boolean;
+  /**
+   * Dangerously skip resolving plugins.
+   */
+  skipPlugins?: boolean;
   strict?: boolean;
 };
 

--- a/packages/config/src/plugins/withConfigPlugins.ts
+++ b/packages/config/src/plugins/withConfigPlugins.ts
@@ -8,14 +8,19 @@ import { serializeAfterStaticPlugins } from '../Serialize';
  * @param config
  * @param projectRoot
  */
-export const withConfigPlugins: ConfigPlugin = config => {
+export const withConfigPlugins: ConfigPlugin<boolean> = (config, skipPlugins) => {
   // @ts-ignore: plugins not on config type yet -- TODO
   if (!Array.isArray(config.plugins) || !config.plugins?.length) {
     return config;
   }
-  // Resolve and evaluate plugins
-  // @ts-ignore: TODO: add plugins to the config schema
-  config = withPlugins(config, config.plugins);
+  if (!skipPlugins) {
+    // Resolve and evaluate plugins
+    // @ts-ignore: TODO: add plugins to the config schema
+    config = withPlugins(config, config.plugins);
+  } else {
+    // Delete the plugins array in case someone added functions or other values which cannot be automatically serialized.
+    delete config.plugins;
+  }
   // plugins aren't serialized by default, serialize the plugins after resolving them.
   return serializeAfterStaticPlugins(config);
 };

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -356,7 +356,7 @@ Command.prototype.asyncAction = function (asyncFn: Action) {
       // TODO: Find better ways to consolidate error messages
       if (err instanceof AbortCommandError || err instanceof SilentError) {
         // Do nothing when a prompt is cancelled or the error is logged in a pretty way.
-      } else if (err.isCommandError) {
+      } else if (err.isCommandError || err.isPluginError) {
         Log.error(err.message);
       } else if (err._isApiError) {
         Log.error(chalk.red(err.message));


### PR DESCRIPTION
# Why

If a user incorrectly adds a plugin to their app.json plugins array before installing the plugin, the `expo install` command will fail. This PR dangerously allows for deleting the plugins array so expo install can just read the sdkVersion and package.json. 

# Test Plan

Add an invalid plugin and run `expo install lodash` or somn. It should install the package and fail to resolve the plugins for auto plugin adding.