### PR TITLE
Added better default splash screen on iOS

### DIFF
--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/getIosSplashConfig.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/getIosSplashConfig.ts
@@ -62,7 +62,12 @@ export function getIosSplashConfig(config: ExpoConfig): IOSSplashConfig | null {
     };
   }
 
-  return null;
+  return {
+    backgroundColor: '#ffffff',
+    resizeMode: 'contain',
+    tabletImage: null,
+    tabletBackgroundColor: null,
+  };
 }
 
 export function warnUnsupportedSplashProperties(config: ExpoConfig) {


### PR DESCRIPTION
# Why

Currently, the plugin is so good at removing the splash screen that it causes the app to shrink vertically, so instead of defaulting to removing the splash, we'll default to a blank white splash screen on iOS.

<img width="564" alt="Screen Shot 2021-07-15 at 1 18 25 PM" src="https://user-images.githubusercontent.com/9664363/125855257-3c6f7ee9-9aef-48b2-9f74-ef9a91648439.png">
