### PR TITLE
[expo cli] lazy load install, eject, prebuild, run:ios, run:android

### DIFF
--- a/packages/expo-cli/e2e/__tests__/eject-test.ts
+++ b/packages/expo-cli/e2e/__tests__/eject-test.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import temporary from 'tempy';
 
-import { actionAsync } from '../../src/commands/eject';
+import { actionAsync } from '../../src/commands/ejectAsync';
 import {
   createMinimalProjectAsync,
   EXPO_CLI,

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -1,70 +1,25 @@
-import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 import type { Command } from 'commander';
-import { Versions } from 'xdl';
 
-import CommandError from '../CommandError';
-import Log from '../log';
-import { confirmAsync } from '../prompts';
-import { ejectAsync } from './eject/ejectAsync';
-import { platformsFromPlatform } from './eject/platformOptions';
-import { EjectAsyncOptions } from './eject/prebuildAsync';
 import { learnMore } from './utils/TerminalLink';
-
-async function userWantsToEjectWithoutUpgradingAsync() {
-  const answer = await confirmAsync({
-    message: `We recommend upgrading to the latest SDK version before ejecting. SDK 37 introduces support for OTA updates and notifications in ejected projects, and includes many features that make ejecting your project easier. Would you like to continue ejecting anyways?`,
-  });
-
-  return answer;
-}
-
-export async function actionAsync(
-  projectRoot: string,
-  {
-    platform,
-    ...options
-  }: Omit<EjectAsyncOptions, 'platforms'> & {
-    npm?: boolean;
-    platform?: string;
-  }
-) {
-  const { exp } = getConfig(projectRoot);
-
-  if (options.npm) {
-    options.packageManager = 'npm';
-  }
-
-  // Set EXPO_VIEW_DIR to universe/exponent to pull expo view code locally instead of from S3 for ExpoKit
-  if (Versions.lteSdkVersion(exp, '36.0.0')) {
-    if (options.force || (await userWantsToEjectWithoutUpgradingAsync())) {
-      throw new CommandError(
-        `Ejecting to ExpoKit is now deprecated. Upgrade to Expo SDK +37 or downgrade to expo-cli@4.1.3`
-      );
-    }
-  } else {
-    Log.debug('Eject Mode: Latest');
-    await ejectAsync(projectRoot, {
-      ...options,
-      platforms: platformsFromPlatform(platform),
-    } as EjectAsyncOptions);
-  }
-}
+import { applyAsyncActionProjectDir } from './utils/applyAsyncAction';
 
 export default function (program: Command) {
-  program
-    .command('eject [path]')
-    .description(
-      `Create native iOS and Android project files. ${chalk.dim(
-        learnMore('https://docs.expo.io/workflow/customizing/')
-      )}`
-    )
-    .longDescription(
-      'Create Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.'
-    )
-    .helpGroup('eject')
-    .option('--no-install', 'Skip installing npm packages and CocoaPods.')
-    .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
-    .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
-    .asyncActionProjectDir(actionAsync);
+  applyAsyncActionProjectDir(
+    program
+      .command('eject [path]')
+      .description(
+        `Create native iOS and Android project files. ${chalk.dim(
+          learnMore('https://docs.expo.io/workflow/customizing/')
+        )}`
+      )
+      .longDescription(
+        'Create Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.'
+      )
+      .helpGroup('eject')
+      .option('--no-install', 'Skip installing npm packages and CocoaPods.')
+      .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
+      .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all'),
+    () => import('./ejectAsync')
+  );
 }

--- a/packages/expo-cli/src/commands/ejectAsync.ts
+++ b/packages/expo-cli/src/commands/ejectAsync.ts
@@ -1,0 +1,49 @@
+import { getConfig } from '@expo/config';
+import { Versions } from 'xdl';
+
+import CommandError from '../CommandError';
+import Log from '../log';
+import { confirmAsync } from '../prompts';
+import { ejectAsync } from './eject/ejectAsync';
+import { platformsFromPlatform } from './eject/platformOptions';
+import { EjectAsyncOptions } from './eject/prebuildAsync';
+
+async function userWantsToEjectWithoutUpgradingAsync() {
+  const answer = await confirmAsync({
+    message: `We recommend upgrading to the latest SDK version before ejecting. SDK 37 introduces support for OTA updates and notifications in ejected projects, and includes many features that make ejecting your project easier. Would you like to continue ejecting anyways?`,
+  });
+
+  return answer;
+}
+
+export async function actionAsync(
+  projectRoot: string,
+  {
+    platform,
+    ...options
+  }: Omit<EjectAsyncOptions, 'platforms'> & {
+    npm?: boolean;
+    platform?: string;
+  }
+) {
+  const { exp } = getConfig(projectRoot);
+
+  if (options.npm) {
+    options.packageManager = 'npm';
+  }
+
+  // Set EXPO_VIEW_DIR to universe/exponent to pull expo view code locally instead of from S3 for ExpoKit
+  if (Versions.lteSdkVersion(exp, '36.0.0')) {
+    if (options.force || (await userWantsToEjectWithoutUpgradingAsync())) {
+      throw new CommandError(
+        `Ejecting to ExpoKit is now deprecated. Upgrade to Expo SDK +37 or downgrade to expo-cli@4.1.3`
+      );
+    }
+  } else {
+    Log.debug('Eject Mode: Latest');
+    await ejectAsync(projectRoot, {
+      ...options,
+      platforms: platformsFromPlatform(platform),
+    } as EjectAsyncOptions);
+  }
+}

--- a/packages/expo-cli/src/commands/install.ts
+++ b/packages/expo-cli/src/commands/install.ts
@@ -1,149 +1,16 @@
-import { getConfig } from '@expo/config';
-import * as PackageManager from '@expo/package-manager';
 import type { Command } from 'commander';
-import npmPackageArg from 'npm-package-arg';
-import resolveFrom from 'resolve-from';
-import { Versions } from 'xdl';
 
-import CommandError, { SilentError } from '../CommandError';
-import Log from '../log';
-import { findProjectRootAsync } from './utils/ProjectUtils';
-import { autoAddConfigPluginsAsync } from './utils/autoAddConfigPluginsAsync';
-import { getBundledNativeModulesAsync } from './utils/bundledNativeModules';
+import { applyAsyncAction } from './utils/applyAsyncAction';
 
-async function resolveExpoProjectRootAsync() {
-  try {
-    const info = await findProjectRootAsync(process.cwd());
-    return info.projectRoot;
-  } catch (error) {
-    if (error.code !== 'NO_PROJECT') {
-      // An unknown error occurred.
-      throw error;
-    }
-    // This happens when an app.config exists but a package.json is not present.
-    Log.addNewLineIfNone();
-    Log.error(error.message);
-    Log.newLine();
-    Log.log(Log.chalk.cyan(`You can create a new project with ${Log.chalk.bold(`expo init`)}`));
-    Log.newLine();
-    throw new SilentError(error);
-  }
-}
-
-async function installAsync(packages: string[], options: PackageManager.CreateForProjectOptions) {
-  const projectRoot = await resolveExpoProjectRootAsync();
-
-  const packageManager = PackageManager.createForProject(projectRoot, {
-    npm: options.npm,
-    yarn: options.yarn,
-    log: Log.log,
-  });
-
-  let { exp, pkg } = getConfig(projectRoot, {
-    skipSDKVersionRequirement: true,
-    // Sometimes users will add a plugin to the config before installing the library,
-    // this wouldn't work unless we dangerously disable plugin serialization.
-    skipPlugins: true,
-  });
-
-  // If using `expo install` in a project without the expo package even listed
-  // in package.json, just fall through to npm/yarn.
-  //
-  if (!pkg.dependencies['expo']) {
-    return await packageManager.addAsync(...packages);
-  }
-
-  if (!exp.sdkVersion) {
-    Log.addNewLineIfNone();
-    throw new CommandError(
-      `The ${Log.chalk.bold(`expo`)} package was found in your ${Log.chalk.bold(
-        `package.json`
-      )} but we couldn't resolve the Expo SDK version. Run ${Log.chalk.bold(
-        `${packageManager.name.toLowerCase()} install`
-      )} and then try this command again.\n`
-    );
-  }
-
-  if (!Versions.gteSdkVersion(exp, '33.0.0')) {
-    const message = `${Log.chalk.bold(
-      `expo install`
-    )} is only available for Expo SDK version 33 or higher.`;
-    Log.addNewLineIfNone();
-    Log.error(message);
-    Log.newLine();
-    Log.log(Log.chalk.cyan(`Current version: ${Log.chalk.bold(exp.sdkVersion)}`));
-    Log.newLine();
-    throw new SilentError(message);
-  }
-
-  // This shouldn't be invoked because `findProjectRootAsync` will throw if node_modules are missing.
-  // Every React project should have react installed...
-  if (!resolveFrom.silent(projectRoot, 'react')) {
-    Log.addNewLineIfNone();
-    Log.log(
-      Log.chalk.cyan(`node_modules not found, running ${packageManager.name} install command.`)
-    );
-    Log.newLine();
-    await packageManager.installAsync();
-  }
-
-  const bundledNativeModules = await getBundledNativeModulesAsync(projectRoot, exp.sdkVersion);
-  const nativeModules = [];
-  const others = [];
-  const versionedPackages = packages.map(arg => {
-    const spec = npmPackageArg(arg);
-    const { name } = spec;
-    if (['tag', 'version', 'range'].includes(spec.type) && name && bundledNativeModules[name]) {
-      // Unimodule packages from npm registry are modified to use the bundled version.
-      const version = bundledNativeModules[name];
-      const modifiedSpec = `${name}@${version}`;
-      nativeModules.push(modifiedSpec);
-      return modifiedSpec;
-    } else {
-      // Other packages are passed through unmodified.
-      others.push(spec.raw);
-      return spec.raw;
-    }
-  });
-  const messages = [];
-  if (nativeModules.length > 0) {
-    messages.push(
-      `${nativeModules.length} SDK ${exp.sdkVersion} compatible native ${
-        nativeModules.length === 1 ? 'module' : 'modules'
-      }`
-    );
-  }
-  if (others.length > 0) {
-    messages.push(`${others.length} other ${others.length === 1 ? 'package' : 'packages'}`);
-  }
-  Log.log(`Installing ${messages.join(' and ')} using ${packageManager.name}.`);
-  await packageManager.addAsync(...versionedPackages);
-
-  try {
-    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp;
-
-    // Only auto add plugins if the plugins array is defined or if the project is using SDK +42.
-    await autoAddConfigPluginsAsync(
-      projectRoot,
-      exp,
-      versionedPackages.map(pkg => pkg.split('@')[0]).filter(Boolean)
-    );
-  } catch (error) {
-    if (error.isPluginError) {
-      Log.error(`Skipping plugin check: ` + error.message);
-      return;
-    }
-    throw error;
-  }
-}
-
-export default function install(program: Command) {
-  program
-    .command('install [packages...]')
-    .alias('add')
-    .helpGroup('core')
-    .option('--npm', 'Use npm to install dependencies. (default when package-lock.json exists)')
-    .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
-    .description('Install a unimodule or other package to a project')
-    .asyncAction(installAsync);
+export default function (program: Command) {
+  applyAsyncAction(
+    program
+      .command('install [packages...]')
+      .alias('add')
+      .helpGroup('core')
+      .option('--npm', 'Use npm to install dependencies. (default when package-lock.json exists)')
+      .option('--yarn', 'Use Yarn to install dependencies. (default when yarn.lock exists)')
+      .description('Install a unimodule or other package to a project'),
+    () => import('./installAsync')
+  );
 }

--- a/packages/expo-cli/src/commands/installAsync.ts
+++ b/packages/expo-cli/src/commands/installAsync.ts
@@ -1,0 +1,140 @@
+import { getConfig } from '@expo/config';
+import * as PackageManager from '@expo/package-manager';
+import npmPackageArg from 'npm-package-arg';
+import resolveFrom from 'resolve-from';
+import { Versions } from 'xdl';
+
+import CommandError, { SilentError } from '../CommandError';
+import Log from '../log';
+import { findProjectRootAsync } from './utils/ProjectUtils';
+import { autoAddConfigPluginsAsync } from './utils/autoAddConfigPluginsAsync';
+import { getBundledNativeModulesAsync } from './utils/bundledNativeModules';
+
+async function resolveExpoProjectRootAsync() {
+  try {
+    const info = await findProjectRootAsync(process.cwd());
+    return info.projectRoot;
+  } catch (error) {
+    if (error.code !== 'NO_PROJECT') {
+      // An unknown error occurred.
+      throw error;
+    }
+    // This happens when an app.config exists but a package.json is not present.
+    Log.addNewLineIfNone();
+    Log.error(error.message);
+    Log.newLine();
+    Log.log(Log.chalk.cyan(`You can create a new project with ${Log.chalk.bold(`expo init`)}`));
+    Log.newLine();
+    throw new SilentError(error);
+  }
+}
+
+export async function actionAsync(
+  packages: string[],
+  options: PackageManager.CreateForProjectOptions
+) {
+  const projectRoot = await resolveExpoProjectRootAsync();
+
+  const packageManager = PackageManager.createForProject(projectRoot, {
+    npm: options.npm,
+    yarn: options.yarn,
+    log: Log.log,
+  });
+
+  let { exp, pkg } = getConfig(projectRoot, {
+    skipSDKVersionRequirement: true,
+    // Sometimes users will add a plugin to the config before installing the library,
+    // this wouldn't work unless we dangerously disable plugin serialization.
+    skipPlugins: true,
+  });
+
+  // If using `expo install` in a project without the expo package even listed
+  // in package.json, just fall through to npm/yarn.
+  //
+  if (!pkg.dependencies['expo']) {
+    return await packageManager.addAsync(...packages);
+  }
+
+  if (!exp.sdkVersion) {
+    Log.addNewLineIfNone();
+    throw new CommandError(
+      `The ${Log.chalk.bold(`expo`)} package was found in your ${Log.chalk.bold(
+        `package.json`
+      )} but we couldn't resolve the Expo SDK version. Run ${Log.chalk.bold(
+        `${packageManager.name.toLowerCase()} install`
+      )} and then try this command again.\n`
+    );
+  }
+
+  if (!Versions.gteSdkVersion(exp, '33.0.0')) {
+    const message = `${Log.chalk.bold(
+      `expo install`
+    )} is only available for Expo SDK version 33 or higher.`;
+    Log.addNewLineIfNone();
+    Log.error(message);
+    Log.newLine();
+    Log.log(Log.chalk.cyan(`Current version: ${Log.chalk.bold(exp.sdkVersion)}`));
+    Log.newLine();
+    throw new SilentError(message);
+  }
+
+  // This shouldn't be invoked because `findProjectRootAsync` will throw if node_modules are missing.
+  // Every React project should have react installed...
+  if (!resolveFrom.silent(projectRoot, 'react')) {
+    Log.addNewLineIfNone();
+    Log.log(
+      Log.chalk.cyan(`node_modules not found, running ${packageManager.name} install command.`)
+    );
+    Log.newLine();
+    await packageManager.installAsync();
+  }
+
+  const bundledNativeModules = await getBundledNativeModulesAsync(projectRoot, exp.sdkVersion);
+  const nativeModules = [];
+  const others = [];
+  const versionedPackages = packages.map(arg => {
+    const spec = npmPackageArg(arg);
+    const { name } = spec;
+    if (['tag', 'version', 'range'].includes(spec.type) && name && bundledNativeModules[name]) {
+      // Unimodule packages from npm registry are modified to use the bundled version.
+      const version = bundledNativeModules[name];
+      const modifiedSpec = `${name}@${version}`;
+      nativeModules.push(modifiedSpec);
+      return modifiedSpec;
+    } else {
+      // Other packages are passed through unmodified.
+      others.push(spec.raw);
+      return spec.raw;
+    }
+  });
+  const messages = [];
+  if (nativeModules.length > 0) {
+    messages.push(
+      `${nativeModules.length} SDK ${exp.sdkVersion} compatible native ${
+        nativeModules.length === 1 ? 'module' : 'modules'
+      }`
+    );
+  }
+  if (others.length > 0) {
+    messages.push(`${others.length} other ${others.length === 1 ? 'package' : 'packages'}`);
+  }
+  Log.log(`Installing ${messages.join(' and ')} using ${packageManager.name}.`);
+  await packageManager.addAsync(...versionedPackages);
+
+  try {
+    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp;
+
+    // Only auto add plugins if the plugins array is defined or if the project is using SDK +42.
+    await autoAddConfigPluginsAsync(
+      projectRoot,
+      exp,
+      versionedPackages.map(pkg => pkg.split('@')[0]).filter(Boolean)
+    );
+  } catch (error) {
+    if (error.isPluginError) {
+      Log.error(`Skipping plugin check: ` + error.message);
+      return;
+    }
+    throw error;
+  }
+}

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -1,68 +1,34 @@
 import chalk from 'chalk';
 import type { Command } from 'commander';
 
-import { clearNativeFolder } from './eject/clearNativeFolder';
-import { platformsFromPlatform } from './eject/platformOptions';
-import { EjectAsyncOptions, prebuildAsync } from './eject/prebuildAsync';
 import { learnMore } from './utils/TerminalLink';
-import maybeBailOnGitStatusAsync from './utils/maybeBailOnGitStatusAsync';
-
-export async function actionAsync(
-  projectRoot: string,
-  {
-    platform,
-    clean,
-    skipDependencyUpdate,
-    ...options
-  }: EjectAsyncOptions & {
-    npm?: boolean;
-    platform?: string;
-    clean?: boolean;
-    skipDependencyUpdate?: string;
-  }
-) {
-  if (options.npm) {
-    options.packageManager = 'npm';
-  }
-
-  const platforms = platformsFromPlatform(platform);
-
-  if (clean) {
-    if (await maybeBailOnGitStatusAsync()) return;
-    // Clear the native folders before syncing
-    await clearNativeFolder(projectRoot, platforms);
-  }
-
-  await prebuildAsync(projectRoot, {
-    ...options,
-    skipDependencyUpdate: skipDependencyUpdate ? skipDependencyUpdate.split(',') : [],
-    platforms,
-  } as EjectAsyncOptions);
-}
+import { applyAsyncActionProjectDir } from './utils/applyAsyncAction';
 
 export default function (program: Command) {
-  program
-    .command('prebuild [path]')
-    .description(
-      `Experimental: Create native iOS and Android project files before building natively. ${chalk.dim(
-        learnMore('https://docs.expo.io/workflow/customizing/')
-      )}`
-    )
-    .longDescription(
-      'Generate the native iOS and Android projects for your app before building them. The generated code should not be modified directly, instead config plugins should be used to make modifications.'
-    )
-    .helpGroup('eject')
-    .option('--no-install', 'Skip installing npm packages and CocoaPods.')
-    .option('--clean', 'Delete the native folders and regenerate them before applying changes')
-    .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
-    .option(
-      '--template <template>',
-      'Project template to clone from. File path pointing to a local tar file or a github repo'
-    )
-    .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
-    .option(
-      '--skip-dependency-update <dependencies>',
-      'Preserves versions of listed packages in package.json (comma separated list)'
-    )
-    .asyncActionProjectDir(actionAsync);
+  applyAsyncActionProjectDir(
+    program
+      .command('prebuild [path]')
+      .description(
+        `Experimental: Create native iOS and Android project files before building natively. ${chalk.dim(
+          learnMore('https://docs.expo.io/workflow/customizing/')
+        )}`
+      )
+      .longDescription(
+        'Generate the native iOS and Android projects for your app before building them. The generated code should not be modified directly, instead config plugins should be used to make modifications.'
+      )
+      .helpGroup('eject')
+      .option('--no-install', 'Skip installing npm packages and CocoaPods.')
+      .option('--clean', 'Delete the native folders and regenerate them before applying changes')
+      .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
+      .option(
+        '--template <template>',
+        'Project template to clone from. File path pointing to a local tar file or a github repo'
+      )
+      .option('-p, --platform [platform]', 'Platforms to sync: ios, android, all. Default: all')
+      .option(
+        '--skip-dependency-update <dependencies>',
+        'Preserves versions of listed packages in package.json (comma separated list)'
+      ),
+    () => import('./prebuildAsync')
+  );
 }

--- a/packages/expo-cli/src/commands/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/prebuildAsync.ts
@@ -1,0 +1,37 @@
+import { clearNativeFolder } from './eject/clearNativeFolder';
+import { platformsFromPlatform } from './eject/platformOptions';
+import { EjectAsyncOptions, prebuildAsync } from './eject/prebuildAsync';
+import maybeBailOnGitStatusAsync from './utils/maybeBailOnGitStatusAsync';
+
+export async function actionAsync(
+  projectRoot: string,
+  {
+    platform,
+    clean,
+    skipDependencyUpdate,
+    ...options
+  }: EjectAsyncOptions & {
+    npm?: boolean;
+    platform?: string;
+    clean?: boolean;
+    skipDependencyUpdate?: string;
+  }
+) {
+  if (options.npm) {
+    options.packageManager = 'npm';
+  }
+
+  const platforms = platformsFromPlatform(platform);
+
+  if (clean) {
+    if (await maybeBailOnGitStatusAsync()) return;
+    // Clear the native folders before syncing
+    await clearNativeFolder(projectRoot, platforms);
+  }
+
+  await prebuildAsync(projectRoot, {
+    ...options,
+    skipDependencyUpdate: skipDependencyUpdate ? skipDependencyUpdate.split(',') : [],
+    platforms,
+  } as EjectAsyncOptions);
+}

--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -97,7 +97,7 @@ async function resolveOptionsAsync(
   };
 }
 
-export async function runAndroidActionAsync(projectRoot: string, options: Options) {
+export async function actionAsync(projectRoot: string, options: Options) {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   track(projectRoot, exp);
 

--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -1,29 +1,34 @@
 import type { Command } from 'commander';
 
-import { runAndroidActionAsync } from './android/runAndroid';
-import { runIosActionAsync } from './ios/runIos';
+import { applyAsyncActionProjectDir } from '../utils/applyAsyncAction';
 
 export default function (program: Command) {
-  program
-    .command('run:android [path]')
-    .description('Run the Android app binary locally')
-    .helpGroup('core')
-    .option('--no-bundler', 'Skip starting the Metro bundler')
-    .option('-d, --device [device]', 'Device name to build the app on')
-    .option('-p, --port <port>', 'Port to start the Metro bundler on. Default: 8081')
-    .option('--variant [name]', '(Android) build variant', 'debug')
-    .asyncActionProjectDir(runAndroidActionAsync);
-  program
-    .command('run:ios [path]')
-    .description('Run the iOS app binary locally')
-    .helpGroup('core')
-    .option('--no-bundler', 'Skip starting the Metro bundler')
-    .option('-d, --device [device]', 'Device name or UDID to build the app on')
-    .option('-p, --port <port>', 'Port to start the Metro bundler on. Default: 8081')
-    .option('--scheme [scheme]', 'Scheme to build')
-    .option(
-      '--configuration <configuration>',
-      'Xcode configuration to use. Debug or Release. Default: Debug'
-    )
-    .asyncActionProjectDir(runIosActionAsync, { checkConfig: false });
+  applyAsyncActionProjectDir(
+    program
+      .command('run:android [path]')
+      .description('Run the Android app binary locally')
+      .helpGroup('core')
+      .option('--no-bundler', 'Skip starting the Metro bundler')
+      .option('-d, --device [device]', 'Device name to build the app on')
+      .option('-p, --port <port>', 'Port to start the Metro bundler on. Default: 8081')
+      .option('--variant [name]', '(Android) build variant', 'debug'),
+    () => import('./android/runAndroid')
+  );
+
+  applyAsyncActionProjectDir(
+    program
+      .command('run:ios [path]')
+      .description('Run the iOS app binary locally')
+      .helpGroup('core')
+      .option('--no-bundler', 'Skip starting the Metro bundler')
+      .option('-d, --device [device]', 'Device name or UDID to build the app on')
+      .option('-p, --port <port>', 'Port to start the Metro bundler on. Default: 8081')
+      .option('--scheme [scheme]', 'Scheme to build')
+      .option(
+        '--configuration <configuration>',
+        'Xcode configuration to use. Debug or Release. Default: Debug'
+      ),
+    () => import('./ios/runIos'),
+    { checkConfig: false }
+  );
 }

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -22,7 +22,7 @@ import { startBundlerAsync } from './startBundlerAsync';
 
 const isMac = process.platform === 'darwin';
 
-export async function runIosActionAsync(projectRoot: string, options: Options) {
+export async function actionAsync(projectRoot: string, options: Options) {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   track(projectRoot, exp);
 


### PR DESCRIPTION
# Why

- related https://github.com/expo/expo-cli/pull/3672
- lazy load contents of: install, eject, prebuild, run:ios, run:android


# Test Plan

- Ran each command