### PR TITLE
[prebuild-config] Also set CFBundleName

### DIFF
--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -157,7 +157,7 @@ Object {
       "CFBundleExecutable": "$(EXECUTABLE_NAME)",
       "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
       "CFBundleInfoDictionaryVersion": "6.0",
-      "CFBundleName": "$(PRODUCT_NAME)",
+      "CFBundleName": "my cool app",
       "CFBundlePackageType": "APPL",
       "CFBundleShortVersionString": "1.0.0",
       "CFBundleSignature": "????",
@@ -840,7 +840,7 @@ Object {
           "CFBundleExecutable": "$(EXECUTABLE_NAME)",
           "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
           "CFBundleInfoDictionaryVersion": "6.0",
-          "CFBundleName": "$(PRODUCT_NAME)",
+          "CFBundleName": "my cool app",
           "CFBundlePackageType": "APPL",
           "CFBundleShortVersionString": "1.0.0",
           "CFBundleSignature": "????",
@@ -1064,7 +1064,7 @@ Object {
       "CFBundleExecutable": "$(EXECUTABLE_NAME)",
       "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
       "CFBundleInfoDictionaryVersion": "6.0",
-      "CFBundleName": "$(PRODUCT_NAME)",
+      "CFBundleName": "my cool app",
       "CFBundlePackageType": "APPL",
       "CFBundleShortVersionString": "1.0.0",
       "CFBundleSignature": "????",
@@ -1656,6 +1656,7 @@ Object {
         },
         "infoPlist": Object {
           "CFBundleDisplayName": "my cool app",
+          "CFBundleName": "my cool app",
           "CFBundleShortVersionString": "1.0.0",
           "CFBundleURLTypes": Array [
             Object {
@@ -1859,6 +1860,7 @@ Object {
     "googleServicesFile": "./config/GoogleService-Info.plist",
     "infoPlist": Object {
       "CFBundleDisplayName": "my cool app",
+      "CFBundleName": "my cool app",
       "CFBundleShortVersionString": "1.0.0",
       "CFBundleURLTypes": Array [
         Object {

--- a/packages/prebuild-config/src/plugins/withDefaultPlugins.ts
+++ b/packages/prebuild-config/src/plugins/withDefaultPlugins.ts
@@ -41,6 +41,7 @@ export const withIosExpoPlugins: ConfigPlugin<{
     IOSConfig.Swift.withNoopSwiftFile,
     IOSConfig.Google.withGoogle,
     IOSConfig.Name.withDisplayName,
+    IOSConfig.Name.withName,
     IOSConfig.Orientation.withOrientation,
     IOSConfig.RequiresFullScreen.withRequiresFullScreen,
     IOSConfig.Scheme.withScheme,


### PR DESCRIPTION
# Why

<img width="650" alt="Screen Shot 2021-07-17 at 9 13 33 AM" src="https://user-images.githubusercontent.com/90494/126043169-53f3736d-628d-409f-82ff-00322628c099.png">

# How

Use existing `withName` plugin

# Test Plan

Snapshots looked good