### PR TITLE
[next-adapter] update template to transpile `react-native-web`

### DIFF
--- a/packages/next-adapter/src/customize/manifest.ts
+++ b/packages/next-adapter/src/customize/manifest.ts
@@ -69,9 +69,12 @@ function getDependencies(
   const dependencies = ['react-native-web', 'next'].filter(
     dependency => !resolveFrom.silent(projectRoot, dependency)
   );
-  const devDependencies = ['@expo/next-adapter', 'babel-preset-expo'].filter(
-    dependency => !resolveFrom.silent(projectRoot, dependency)
-  );
+  const devDependencies = [
+    '@expo/next-adapter',
+    'babel-preset-expo',
+    'next-compose-plugins',
+    'next-transpile-modules',
+  ].filter(dependency => !resolveFrom.silent(projectRoot, dependency));
 
   return { dependencies, devDependencies };
 }

--- a/packages/next-adapter/template/next.config.js
+++ b/packages/next-adapter/template/next.config.js
@@ -1,7 +1,9 @@
 // Learn more: https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/guides/using-nextjs.md#withexpo
 
 const { withExpo } = require('@expo/next-adapter');
+const withPlugins = require('next-compose-plugins');
+const withTM = require('next-transpile-modules')(['react-native-web']);
 
-module.exports = withExpo({
-  projectRoot: __dirname,
-});
+const nextConfig = {};
+
+module.exports = withPlugins([withTM, [withExpo, { projectRoot: __dirname }]], nextConfig);


### PR DESCRIPTION
# Why

We added support for Next.js 11 and Webpack since `@expo/next-adapter@3.0.0`

# How

Updated the required `next.config.js` to transpile `react-native-web`

# Test Plan

Use the next-adapter generated template and make sure that it's working