### PR TITLE
Fix legacy dev server port selection

### DIFF
--- a/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
+++ b/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
@@ -134,7 +134,7 @@ export async function startReactNativeServerAsync({
   await Watchman.addToPathAsync(); // Attempt to fix watchman if it's hanging
   await Watchman.unblockAndGetVersionAsync(projectRoot);
 
-  let packagerPort = options.metroPort ?? (await getFreePortAsync(19001)); // Create packager options
+  let packagerPort = await getFreePortAsync(options.metroPort || 19001); // Create packager options
 
   const customLogReporterPath: string = require.resolve(
     path.join(__dirname, '../../build/reporter')


### PR DESCRIPTION
# Why

- Resolve https://github.com/expo/expo-cli/issues/3687
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Port selection won't work in the legacy dev server since it uses react-native-community cli under the hood. This PR ensures that a free port be used for the legacy server.

# Test Plan

- `expo start` in a project using SDK 39 or less.