### PR TITLE
[webpack] Drop support for worker-loader

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -72,8 +72,7 @@
     "webpack-deep-scope-plugin": "1.6.0",
     "webpack-manifest-plugin": "~2.2.0",
     "webpackbar": "^4.0.0",
-    "workbox-webpack-plugin": "^6.1.5",
-    "worker-loader": "^2.0.0"
+    "workbox-webpack-plugin": "^6.1.5"
   },
   "devDependencies": {
     "@expo/babel-preset-cli": "0.2.21",

--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -104,12 +104,6 @@ Object {
             },
           },
           Object {
-            "test": /\\\\\\.worker\\\\\\.\\(js\\|mjs\\|ts\\)\\$/,
-            "use": Object {
-              "loader": "node_modules/worker-loader/dist/cjs.js",
-            },
-          },
-          Object {
             "include": Array [
               "packages/webpack-config/e2e/basic",
               "packages/webpack-config/e2e/basic/node_modules/react-native-vector-icons",
@@ -276,12 +270,6 @@ Object {
                 "sourceMaps": true,
                 "sourceType": "unambiguous",
               },
-            },
-          },
-          Object {
-            "test": /\\\\\\.worker\\\\\\.\\(js\\|mjs\\|ts\\)\\$/,
-            "use": Object {
-              "loader": "node_modules/worker-loader/dist/cjs.js",
             },
           },
           Object {
@@ -561,12 +549,6 @@ Object {
             },
           },
           Object {
-            "test": /\\\\\\.worker\\\\\\.\\(js\\|mjs\\|ts\\)\\$/,
-            "use": Object {
-              "loader": "node_modules/worker-loader/dist/cjs.js",
-            },
-          },
-          Object {
             "include": Array [
               "packages/webpack-config/e2e/basic",
               "packages/webpack-config/e2e/basic/node_modules/react-native-vector-icons",
@@ -749,12 +731,6 @@ Object {
                 "sourceMaps": true,
                 "sourceType": "unambiguous",
               },
-            },
-          },
-          Object {
-            "test": /\\\\\\.worker\\\\\\.\\(js\\|mjs\\|ts\\)\\$/,
-            "use": Object {
-              "loader": "node_modules/worker-loader/dist/cjs.js",
             },
           },
           Object {

--- a/packages/webpack-config/src/loaders/createAllLoaders.ts
+++ b/packages/webpack-config/src/loaders/createAllLoaders.ts
@@ -5,7 +5,6 @@ import { getConfig, getPaths } from '../env';
 import { Environment } from '../types';
 import createBabelLoader from './createBabelLoader';
 import createFontLoader from './createFontLoader';
-import createWorkerLoader from './createWorkerLoader';
 
 // Inline resources as Base64 when there is less reason to parallelize their download. The
 // heuristic we use is whether the resource would fit within a TCP/IP packet that we would
@@ -94,7 +93,6 @@ export default function createAllLoaders(
     getHtmlLoaderRule(template.folder),
     imageLoaderRule,
     getBabelLoaderRule(env),
-    createWorkerLoader(),
     createFontLoader(root, includeModule),
     styleLoaderRule,
     // This needs to be the last loader

--- a/packages/webpack-config/src/loaders/createWorkerLoader.ts
+++ b/packages/webpack-config/src/loaders/createWorkerLoader.ts
@@ -1,7 +1,0 @@
-import { Rule } from 'webpack';
-
-export default (): Rule => ({
-  // Cannot exclude any node modules yet but in the future we should just target a select few.
-  test: /\.worker\.(js|mjs|ts)$/,
-  use: { loader: require.resolve('worker-loader') },
-});

--- a/packages/webpack-config/src/loaders/index.ts
+++ b/packages/webpack-config/src/loaders/index.ts
@@ -9,4 +9,3 @@ export {
 export { default as createBabelLoader } from './createBabelLoader';
 export * from './createBabelLoader';
 export { default as createFontLoader } from './createFontLoader';
-export { default as createWorkerLoader } from './createWorkerLoader';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12508,7 +12508,7 @@ loader-utils@2.0.0, loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^1.0.0, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -16992,14 +16992,6 @@ schema-utils@2.7.1, schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
-schema-utils@^0.4.0:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
-  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -19776,14 +19768,6 @@ worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
-
-worker-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
-  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
-  dependencies:
-    loader-utils "^1.0.0"
-    schema-utils "^0.4.0"
 
 worker-rpc@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
# Why

We added this experimentally to see if it would help with packages that required worker functionality. It didn't prove helpful, dropping as it's non-standard, undocumented, and adds bloat.

