### PR TITLE
[webpack] Drop support for deep-scope plugin 

### DIFF
--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -32,7 +32,7 @@ Running `expo customize:web` will generate this default config in your project.
 ```js
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
-module.exports = async function (env, argv) {
+module.exports = async function(env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
   // Customize the config before returning it.
   return config;
@@ -45,16 +45,14 @@ module.exports = async function (env, argv) {
 
 The main options used to configure how `@expo/webpack-config` works.
 
-| name                        | type                                    | default     | description                                                          |
-| --------------------------- | --------------------------------------- | ----------- | -------------------------------------------------------------------- |
-| `projectRoot`               | `string`                                | required    | Root of the Expo project.                                            |
-| `https`                     | `boolean`                               | `false`     | Should the dev server use https protocol.                            |
-| `offline`                   | `boolean`                               | `false`     | Passing `true` will enable offline support and add a service worker. |
-| `mode`                      | `Mode`                                  | required    | The Webpack mode to bundle the project in.                           |
-| `platform`                  | [`ExpoPlatform`](#ExpoPlatform)         | required    | The target platform to bundle for.                                   |
-| `pwa`                       | `boolean`                               | `true`      | Generate the PWA image assets in production mode.                    |
-| `babel`                     | [`ExpoBabelOptions`](#ExpoBabelOptions) | `undefined` | Control how the default Babel loader is configured.                  |
-| `removeUnusedImportExports` | `boolean`                               | `false`     | Enables advanced tree-shaking with deep scope analysis.              |
+| name          | type                                    | default     | description                                         |
+| ------------- | --------------------------------------- | ----------- | --------------------------------------------------- |
+| `projectRoot` | `string`                                | required    | Root of the Expo project.                           |
+| `https`       | `boolean`                               | `false`     | Should the dev server use https protocol.           |
+| `mode`        | `Mode`                                  | required    | The Webpack mode to bundle the project in.          |
+| `platform`    | [`ExpoPlatform`](#ExpoPlatform)         | required    | The target platform to bundle for.                  |
+| `pwa`         | `boolean`                               | `true`      | Generate the PWA image assets in production mode.   |
+| `babel`       | [`ExpoBabelOptions`](#ExpoBabelOptions) | `undefined` | Control how the default Babel loader is configured. |
 
 ### `Environment` internal
 
@@ -242,7 +240,7 @@ You may find that you want to include universal modules that aren't part of the 
 ```ts
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
-module.exports = async function (env, argv) {
+module.exports = async function(env, argv) {
   const config = await createExpoWebpackConfigAsync(
     {
       ...env,
@@ -266,7 +264,7 @@ If you're adding support to some other Webpack config like in Storybook or Gatsb
 ```ts
 const { withUnimodules } = require('@expo/webpack-config/addons');
 
-module.exports = function () {
+module.exports = function() {
   const someWebpackConfig = {
     /* Your custom Webpack config */
   };
@@ -296,7 +294,7 @@ If you want to modify the babel loader further, you can retrieve it using the he
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 const { getExpoBabelLoader } = require('@expo/webpack-config/utils');
 
-module.exports = async function (env, argv) {
+module.exports = async function(env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
   const loader = getExpoBabelLoader(config);
   if (loader) {
@@ -308,7 +306,7 @@ module.exports = async function (env, argv) {
 
 ### Service workers
 
-Service workers are great for emulating native functionality, but they can also lead to a lot of confusion so they are opt-in only (starting in Expo SDK 39 and greater) in this Webpack config. To enable the default workbox plugin pass the options `{ offline: true }` to the creator method.
+Service workers are great for emulating native functionality, but they can also lead to a lot of confusion so they are opt-in only (starting in Expo SDK 42 and greater) in this Webpack config. To enable the default workbox plugin pass the options `{ offline: true }` to the creator method.
 
 #### How Expo service workers ... work
 
@@ -335,7 +333,7 @@ This can have some unfortunate side-effects as application libraries like expo-n
 ```js
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
-module.exports = async function (env, argv) {
+module.exports = async function(env, argv) {
   // Set offline to `false`
   const config = await createExpoWebpackConfigAsync({ ...env, offline: false }, argv);
   return config;

--- a/packages/webpack-config/jest/build-project.js
+++ b/packages/webpack-config/jest/build-project.js
@@ -12,9 +12,6 @@ async function main(args) {
       pwa: false,
       verbose: true,
       mode: 'production',
-      webpackEnv: {
-        removeUnusedImportExports: true,
-      },
     });
     process.exit(0);
   } catch (error) {

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -67,7 +67,6 @@
     "terser-webpack-plugin": "^3.0.6",
     "url-loader": "~4.1.0",
     "webpack": "4.43.0",
-    "webpack-deep-scope-plugin": "1.6.0",
     "webpack-manifest-plugin": "~2.2.0",
     "webpackbar": "^4.0.0",
     "workbox-webpack-plugin": "^6.1.5",

--- a/packages/webpack-config/src/env/__tests__/__snapshots__/validate-test.js.snap
+++ b/packages/webpack-config/src/env/__tests__/__snapshots__/validate-test.js.snap
@@ -5,7 +5,6 @@ Object {
   "https": false,
   "mode": "development",
   "platform": "web",
-  "removeUnusedImportExports": false,
 }
 `;
 
@@ -14,6 +13,5 @@ Object {
   "https": false,
   "mode": "development",
   "platform": "web",
-  "removeUnusedImportExports": false,
 }
 `;

--- a/packages/webpack-config/src/env/validate.ts
+++ b/packages/webpack-config/src/env/validate.ts
@@ -35,10 +35,6 @@ export function validateEnvironment(env: InputEnvironment): Environment {
   if (typeof env.https === 'undefined') {
     env.https = false;
   }
-  // This is experimental and might be removed in the future.
-  if (typeof env.removeUnusedImportExports === 'undefined') {
-    env.removeUnusedImportExports = false;
-  }
 
   // Ensure the locations are defined.
   if (!env.locations) {

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -24,7 +24,6 @@ export type InputEnvironment = {
   config?: AnyObject;
   locations?: FilePaths;
   mode?: Mode;
-  removeUnusedImportExports?: boolean;
   pwa?: boolean;
   offline?: boolean;
   babel?: {
@@ -67,12 +66,6 @@ export type Environment = {
    * The target platform to bundle for. Currently only `web` and `electron` are supported.
    */
   platform: ExpoPlatform;
-  /**
-   * Enables advanced tree-shaking with deep scope analysis.
-   *
-   * @default false
-   */
-  removeUnusedImportExports?: boolean;
   /**
    * Generate the PWA image assets in production mode.
    *

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -20,7 +20,6 @@ import ModuleNotFoundPlugin from 'react-dev-utils/ModuleNotFoundPlugin';
 import WatchMissingNodeModulesPlugin from 'react-dev-utils/WatchMissingNodeModulesPlugin';
 import resolveFrom from 'resolve-from';
 import webpack, { Configuration, HotModuleReplacementPlugin, Options, Output } from 'webpack';
-import WebpackDeepScopeAnalysisPlugin from 'webpack-deep-scope-plugin';
 import ManifestPlugin from 'webpack-manifest-plugin';
 
 import {
@@ -53,7 +52,6 @@ import {
 import ExpoAppManifestWebpackPlugin from './plugins/ExpoAppManifestWebpackPlugin';
 import { HTMLLinkNode } from './plugins/ModifyHtmlWebpackPlugin';
 import { Arguments, DevConfiguration, Environment, FilePaths, Mode } from './types';
-import { overrideWithPropertyOrConfig } from './utils';
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = boolish('GENERATE_SOURCEMAP', true);
@@ -158,15 +156,6 @@ export default async function (
   // Because the native React runtime is different to the browser we need to make
   // some core modifications to webpack.
   const isNative = ['ios', 'android'].includes(env.platform);
-
-  // Enables deep scope analysis in production mode.
-  // Remove unused import/exports
-  // override: `env.removeUnusedImportExports`
-  const deepScopeAnalysisEnabled = overrideWithPropertyOrConfig(
-    env.removeUnusedImportExports,
-    false
-    // isProd
-  );
 
   const locations = env.locations || (await getPathsAsync(env.projectRoot));
 
@@ -484,8 +473,6 @@ export default async function (
             };
           },
         }),
-
-      deepScopeAnalysisEnabled && new WebpackDeepScopeAnalysisPlugin(),
 
       // Skip using a progress bar in CI
       !isCI && new ExpoProgressBarPlugin(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7617,14 +7617,6 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deep-scope-analyser@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/deep-scope-analyser/-/deep-scope-analyser-1.7.0.tgz#23015b3a1d23181b1d9cebd25b783a7378ead8da"
-  integrity sha512-rl5Dmt2IZkFpZo6XbEY1zG8st2Wpq8Pi/dV2gz8ZF6BDYt3fnor2JNxHwdO1WLo0k6JbmYp0x8MNy8kE4l1NtA==
-  dependencies:
-    esrecurse "^4.2.1"
-    estraverse "^4.2.0"
-
 deepmerge@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
@@ -8543,7 +8535,7 @@ esquery@^1.4.0:
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0, esrecurse@^4.2.1, esrecurse@^4.3.0:
+esrecurse@^4.1.0, esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
@@ -19290,13 +19282,6 @@ webidl-conversions@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
-
-webpack-deep-scope-plugin@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/webpack-deep-scope-plugin/-/webpack-deep-scope-plugin-1.6.0.tgz#5a3a26dc8a40863c7c362840df1fb63f5ca4c441"
-  integrity sha512-ZYldKNeWQtk9SoV70x7Eb2NRmvHMtNBOjscs0wUdg/pfymntiF+0W/D9v2o76ztufjND6RNFjNVnyFQww25AZg==
-  dependencies:
-    deep-scope-analyser "^1.6.0"
 
 webpack-dev-middleware@^3.7.2:
   version "3.7.2"


### PR DESCRIPTION
# Why

We added this experimentally to see if it would help to reduce native code passed in expo packages, but we've removed most of the need for this by migrating all expo packages to support web. Drops `removeUnusedImportExports` option.

