### PR TITLE
[expo-cli] Remove eas sort group

### DIFF
--- a/packages/expo-cli/scripts/introspect.ts
+++ b/packages/expo-cli/scripts/introspect.ts
@@ -128,7 +128,7 @@ function formatCommandsAsMarkdown(commands: CommandData[]) {
   return Object.entries(grouped)
     .map(([groupName, commands]) => {
       // Omit internal and eas commands from the docs
-      if (['eas', 'internal'].includes(groupName)) {
+      if (['internal'].includes(groupName)) {
         return '';
       }
 

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -103,7 +103,7 @@ Command.prototype.prepareCommands = function () {
       if (getenv.boolish('EXPO_DEBUG', false)) {
         return true;
       }
-      return !['internal', 'eas'].includes(cmd.__helpGroup);
+      return !['internal'].includes(cmd.__helpGroup);
     })
     .map(function (cmd: Command, i: number) {
       const args = cmd._args.map(humanReadableArgName).join(' ');
@@ -201,7 +201,6 @@ export const helpGroupOrder = [
   'publish',
   'build',
   'credentials',
-  'eas',
   'notifications',
   'url',
   'webhooks',
@@ -222,7 +221,6 @@ function sortHelpGroups(helpGroups: Record<string, string[][]>): Record<string, 
 
   const subGroupOrder: Record<string, string[]> = {
     core: ['init', 'start', 'start:web', 'publish', 'export'],
-    eas: ['eas:credentials'],
   };
 
   const sortSubGroupWithOrder = (groupName: string, group: string[][]): string[][] => {


### PR DESCRIPTION
This was used to sort and hide eas commands back when we were testing them in expo-cli.