### PR TITLE
Remove shared monorepo deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "dependencies": {
+    "@babel/cli": "^7.8.4",
     "@expo/spawn-async": "^1.5.0",
     "@types/jest": "^26.0.8",
     "@types/node": "^12",
@@ -41,6 +42,8 @@
     "lerna": "3.4.1",
     "lint-staged": "^8.0.4",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
+    "memfs": "^2.15.5",
     "typescript": "^4.2.4",
     "yarn-deduplicate": "^3.1.0"
   },

--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -50,9 +50,7 @@
     "@types/debug": "^4.1.5",
     "@types/find-up": "^4.0.0",
     "@types/fs-extra": "^9.0.1",
-    "@types/xml2js": "^0.4.5",
-    "memfs": "^2.15.5",
-    "rimraf": "^3.0.2"
+    "@types/xml2js": "^0.4.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -46,10 +46,6 @@
     "semver": "7.3.2",
     "slugify": "^1.3.4"
   },
-  "devDependencies": {
-    "memfs": "^2.15.5",
-    "rimraf": "^3.0.2"
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -47,11 +47,9 @@
     "temp-dir": "^2.0.0"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/connect": "^3.4.33",
     "connect": "^3.7.0",
-    "node-fetch": "^2.6.0",
-    "rimraf": "^3.0.2"
+    "node-fetch": "^2.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.8.3",
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/react": "^16.9.56",
     "anser": "^1.4.7",
     "apollo-cache-inmemory": "^1.1.12",
@@ -61,7 +60,6 @@
     "react-redux": "^5.0.7",
     "react-textarea-autosize": "^6.1.0",
     "redux": "^3.7.2",
-    "rimraf": "^3.0.2",
     "slugify": "^1.0.2",
     "ts-node": "^9.1.1",
     "velocity-react": "^1.4.1",

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -42,9 +42,7 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/command-exists": "^1.2.0",
     "@types/dateformat": "^3.0.0",
     "@types/form-data": "^2.2.0",
@@ -63,8 +61,7 @@
     "@types/wrap-ansi": "^3.0.0",
     "klaw-sync": "6.0.0",
     "memfs": "^3.2.0",
-    "pretty-bytes": "^5.3.0",
-    "rimraf": "^3.0.2"
+    "pretty-bytes": "^5.3.0"
   },
   "dependencies": {
     "@expo/apple-utils": "0.0.0-alpha.20",

--- a/packages/expo-codemod/package.json
+++ b/packages/expo-codemod/package.json
@@ -34,11 +34,9 @@
     "yargs-parser": "^13.1.0"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/jscodeshift": "^0.11.0",
     "@types/multimatch": "^2.1.3",
     "@types/yargs-parser": "^13.0.0",
-    "ast-types": "^0.14.2",
-    "rimraf": "^3.0.2"
+    "ast-types": "^0.14.2"
   }
 }

--- a/packages/expo-optimize/package.json
+++ b/packages/expo-optimize/package.json
@@ -33,7 +33,6 @@
     "clean": "rimraf ./build/"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@expo/config": "5.0.5",
     "@expo/image-utils": "0.3.15",
     "@expo/json-file": "8.2.31",
@@ -42,7 +41,6 @@
     "cross-spawn": "6.0.5",
     "glob": "7.1.6",
     "pretty-bytes": "5.2.0",
-    "rimraf": "2.6.3",
     "tempy": "0.3.0",
     "update-check": "1.5.3"
   }

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -40,11 +40,9 @@
     "tempy": "0.3.0"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/fs-extra": "^9.0.1",
     "@types/getenv": "^0.7.0",
-    "@types/semver": "^6.0.0",
-    "rimraf": "^3.0.2"
+    "@types/semver": "^6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/json-file/package.json
+++ b/packages/json-file/package.json
@@ -33,11 +33,9 @@
     "write-file-atomic": "^2.3.0"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/babel__code-frame": "^7.0.1",
     "@types/json5": "^0.0.30",
-    "@types/write-file-atomic": "^2.1.1",
-    "rimraf": "^3.0.2"
+    "@types/write-file-atomic": "^2.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -39,12 +39,10 @@
     "metro-react-native-babel-transformer": "^0.59.0"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "expo": "37",
     "metro": "^0.59.0",
     "metro-config": "^0.59.0",
-    "react-native": "~0.63.4",
-    "rimraf": "^3.0.2"
+    "react-native": "~0.63.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/next-adapter/package.json
+++ b/packages/next-adapter/package.json
@@ -44,11 +44,9 @@
     "service-worker.js"
   ],
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/fs-extra": "^9.0.1",
     "@types/node-fetch": "^2.5.8",
-    "@types/prompts": "^2.0.6",
-    "rimraf": "^3.0.2"
+    "@types/prompts": "^2.0.6"
   },
   "peerDependencies": {
     "next": "^11",

--- a/packages/osascript/package.json
+++ b/packages/osascript/package.json
@@ -33,10 +33,6 @@
     "@expo/spawn-async": "^1.5.0",
     "exec-async": "^2.2.0"
   },
-  "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
-    "rimraf": "^3.0.2"
-  },
   "files": [
     "build"
   ],

--- a/packages/package-manager/package.json
+++ b/packages/package-manager/package.json
@@ -44,7 +44,6 @@
     "sudo-prompt": "9.1.1"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/npm-package-arg": "^6.1.0",
     "@types/rimraf": "^3.0.0",
     "@types/split": "^1.0.0"

--- a/packages/pod-install/package.json
+++ b/packages/pod-install/package.json
@@ -32,11 +32,9 @@
     "clean": "rimraf ./build/"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@expo/package-manager": "0.0.44",
     "chalk": "^4.0.0",
     "commander": "2.20.0",
-    "rimraf": "^3.0.2",
     "update-check": "1.5.3"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -31,9 +31,6 @@
     "build": "tsc",
     "clean": "rimraf build ./tsconfig.tsbuildinfo"
   },
-  "devDependencies": {
-    "rimraf": "^3.0.2"
-  },
   "dependencies": {
     "@expo/config": "5.0.5",
     "@expo/image-utils": "0.3.15",

--- a/packages/schemer/package.json
+++ b/packages/schemer/package.json
@@ -23,9 +23,6 @@
   "files": [
     "build"
   ],
-  "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21"
-  },
   "dependencies": {
     "ajv": "^5.2.2",
     "json-schema-traverse": "0.3.1",

--- a/packages/uri-scheme/package.json
+++ b/packages/uri-scheme/package.json
@@ -34,7 +34,6 @@
     "clean": "rimraf ./build/"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@expo/config-plugins": "3.0.5",
     "@expo/plist": "0.0.13",
     "@expo/spawn-async": "1.5.0",
@@ -43,7 +42,6 @@
     "commander": "2.20.0",
     "glob": "7.1.6",
     "prompts": "^2.3.2",
-    "rimraf": "2.6.3",
     "update-check": "1.5.3"
   }
 }

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -74,7 +74,6 @@
     "worker-loader": "^2.0.0"
   },
   "devDependencies": {
-    "@expo/babel-preset-cli": "0.2.21",
     "@types/copy-webpack-plugin": "~6.0.0",
     "@types/html-webpack-plugin": "~3.2.3",
     "@types/optimize-css-assets-webpack-plugin": "^5.0.0",
@@ -85,8 +84,6 @@
     "@types/webpack-manifest-plugin": "~2.1.0",
     "@types/workbox-webpack-plugin": "^5.1.8",
     "jest-puppeteer": "^4.4.0",
-    "prettier": "^1.16.4",
-    "rimraf": "^3.0.2",
     "serve": "^11.1.0"
   },
   "browserslist": {

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -97,7 +97,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
-    "@expo/babel-preset-cli": "0.2.21",
     "@expo/ngrok": "2.4.3",
     "@types/analytics-node": "^3.1.1",
     "@types/concat-stream": "^1.6.0",
@@ -120,8 +119,6 @@
     "@types/webpack-dev-server": "3.11.0",
     "@types/wrap-ansi": "^3.0.0",
     "hashids": "1.1.4",
-    "memfs": "^3.2.0",
-    "rimraf": "^3.0.2",
     "tempy": "^0.7.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15574,11 +15574,6 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.16.4:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
 prettier@^2.2.0, prettier@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
@@ -16784,13 +16779,6 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.
   dependencies:
     glob "^7.1.3"
 
-rimraf@2.6.3, rimraf@~2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -16809,6 +16797,13 @@ rimraf@~2.4.0:
   integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
   dependencies:
     glob "^6.0.1"
+
+rimraf@~2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
# Why

- Removing shared deps help make update diffs smaller. 
- Removed extra prettier copy.
- Moved memfs and rimraf to the base package.json since almost all packages use them.