### PR TITLE
[config-plugins] Fix multitasking ipad orientations

### DIFF
--- a/packages/config-plugins/src/ios/RequiresFullScreen.ts
+++ b/packages/config-plugins/src/ios/RequiresFullScreen.ts
@@ -30,12 +30,50 @@ export function getRequiresFullScreen(config: Pick<ExpoConfig, 'ios' | 'sdkVersi
   }
 }
 
+const iPadInterfaceKey = 'UISupportedInterfaceOrientations~ipad';
+
 const requiredIPadInterface = [
   'UIInterfaceOrientationPortrait',
   'UIInterfaceOrientationPortraitUpsideDown',
   'UIInterfaceOrientationLandscapeLeft',
   'UIInterfaceOrientationLandscapeRight',
 ];
+
+function isStringArray(value: any): value is string[] {
+  return Array.isArray(value) && value.every(value => typeof value === 'string');
+}
+
+function hasMinimumOrientations(masks: string[]): boolean {
+  return requiredIPadInterface.every(mask => masks.includes(mask));
+}
+
+/**
+ * Require full screen being disabled requires all ipad interfaces to to be added,
+ * otherwise submissions to the iOS App Store will fail.
+ *
+ * ERROR ITMS-90474: "Invalid Bundle. iPad Multitasking support requires these orientations: 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight'. Found 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown' in bundle 'com.bacon.app'."
+ *
+ * @param interfaceOrientations
+ * @returns
+ */
+function resolveExistingIpadInterfaceOrientations(interfaceOrientations: any): string[] {
+  if (
+    // Ensure type.
+    isStringArray(interfaceOrientations) &&
+    // Don't warn if it's an empty array, this is invalid regardless.
+    interfaceOrientations.length &&
+    // Check if the minimum requirements are met.
+    !hasMinimumOrientations(interfaceOrientations)
+  ) {
+    const existingList = interfaceOrientations!.join(', ');
+    WarningAggregator.addWarningIOS(
+      'ios.requireFullScreen',
+      `iPad multitasking requires all \`${iPadInterfaceKey}\` orientations to be defined in the Info.plist. Currently, the plist defines an insufficient set of values that will be overwritten to prevent submission failure. Existing: ${existingList}`
+    );
+    return interfaceOrientations;
+  }
+  return [];
+}
 
 // Whether requires full screen on iPad
 export function setRequiresFullScreen(
@@ -44,26 +82,14 @@ export function setRequiresFullScreen(
 ): InfoPlist {
   const requiresFullScreen = getRequiresFullScreen(config);
   if (!requiresFullScreen) {
-    if (Array.isArray(infoPlist['UISupportedInterfaceOrientations~ipad'])) {
-      if (
-        !(infoPlist['UISupportedInterfaceOrientations~ipad'] as string[]).every(mask =>
-          requiredIPadInterface.includes(mask)
-        )
-      ) {
-        WarningAggregator.addWarningIOS(
-          'ios.requireFullScreen',
-          `iPad multitasking requires all UISupportedInterfaceOrientations~ipad to be defined. The Info.plist currently defines insufficient values that will be overwritten. Existing: ${infoPlist[
-            'UISupportedInterfaceOrientations~ipad'
-          ].join(', ')}`
-        );
-      }
-    }
-    // Require full screen being disabled requires all ipad interfaces to to be added, otherwise submissions to the store will fail.
-    // For issue searching:
-    // ERROR ITMS-90474: "Invalid Bundle. iPad Multitasking support requires these orientations: 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight'. Found 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown' in bundle 'com.bacon.app'."
-    infoPlist['UISupportedInterfaceOrientations~ipad'] = requiredIPadInterface;
+    const existing = resolveExistingIpadInterfaceOrientations(infoPlist[iPadInterfaceKey]);
 
-    // There currently exists no mechanism to safely undo this feature.
+    // There currently exists no mechanism to safely undo this feature besides `expo prebuild --clear`,
+    // this seems ok though because anyone using `UISupportedInterfaceOrientations~ipad` probably
+    // wants them to be defined to this value anyways. This is also the default value used in the Xcode iOS template.
+
+    // Merge any previous interfaces with the required interfaces.
+    infoPlist[iPadInterfaceKey] = [...new Set(existing.concat(requiredIPadInterface))];
   }
 
   return {

--- a/packages/config-plugins/src/ios/RequiresFullScreen.ts
+++ b/packages/config-plugins/src/ios/RequiresFullScreen.ts
@@ -68,7 +68,7 @@ function resolveExistingIpadInterfaceOrientations(interfaceOrientations: any): s
     const existingList = interfaceOrientations!.join(', ');
     WarningAggregator.addWarningIOS(
       'ios.requireFullScreen',
-      `iPad multitasking requires all \`${iPadInterfaceKey}\` orientations to be defined in the Info.plist. Currently, the plist defines an insufficient set of values that will be overwritten to prevent submission failure. Existing: ${existingList}`
+      `iPad multitasking requires all \`${iPadInterfaceKey}\` orientations to be defined in the Info.plist. The Info.plist currently defines values that are incompatible with multitasking, these will be overwritten to prevent submission failure. Existing: ${existingList}`
     );
     return interfaceOrientations;
   }

--- a/packages/config-plugins/src/ios/__tests__/RequiresFullScreen-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/RequiresFullScreen-test.ts
@@ -1,29 +1,99 @@
+import * as WarningAggregator from '../../utils/warnings';
 import { getRequiresFullScreen, setRequiresFullScreen } from '../RequiresFullScreen';
 
-describe('requires full screen', () => {
-  it(`returns true if nothing provided`, () => {
-    expect(getRequiresFullScreen({ ios: {} })).toBe(true);
-  });
-  it(`returns false if nothing provided after 43`, () => {
-    expect(getRequiresFullScreen({ ios: {}, sdkVersion: '43.0.0' })).toBe(false);
-    expect(getRequiresFullScreen({ ios: {}, sdkVersion: 'UNVERSIONED' })).toBe(false);
-  });
-  it(`asserts invalid SDK version`, () => {
-    expect(() => getRequiresFullScreen({ ios: {}, sdkVersion: '43.0' })).toThrow(/version/);
+it(`returns true if nothing provided`, () => {
+  expect(getRequiresFullScreen({ ios: {} })).toBe(true);
+});
+it(`returns false if nothing provided after 43`, () => {
+  expect(getRequiresFullScreen({ ios: {}, sdkVersion: '43.0.0' })).toBe(false);
+  expect(getRequiresFullScreen({ ios: {}, sdkVersion: 'UNVERSIONED' })).toBe(false);
+});
+it(`asserts invalid SDK version`, () => {
+  expect(() => getRequiresFullScreen({ ios: {}, sdkVersion: '43.0' })).toThrow(/version/);
+});
+
+it(`returns the given value if provided`, () => {
+  expect(getRequiresFullScreen({ ios: { requireFullScreen: false } })).toBe(false);
+  expect(getRequiresFullScreen({ ios: { requireFullScreen: true } })).toBe(true);
+});
+
+it(`sets UIRequiresFullScreen value`, () => {
+  expect(setRequiresFullScreen({ ios: { requireFullScreen: false } }, {})).toMatchObject({
+    UIRequiresFullScreen: false,
   });
 
-  it(`returns the given value if provided`, () => {
-    expect(getRequiresFullScreen({ ios: { requireFullScreen: false } })).toBe(false);
-    expect(getRequiresFullScreen({ ios: { requireFullScreen: true } })).toBe(true);
+  expect(setRequiresFullScreen({}, {})).toMatchObject({
+    UIRequiresFullScreen: true,
+  });
+});
+
+beforeEach(() => {
+  // @ts-ignore: jest
+  // eslint-disable-next-line import/namespace
+  WarningAggregator.addWarningIOS = jest.fn();
+});
+
+it(`updates the UISupportedInterfaceOrientations~ipad values to support iPad multi-tasking`, () => {
+  expect(setRequiresFullScreen({ ios: { requireFullScreen: false } }, {})).toMatchObject({
+    UIRequiresFullScreen: false,
+    'UISupportedInterfaceOrientations~ipad': [
+      'UIInterfaceOrientationPortrait',
+      'UIInterfaceOrientationPortraitUpsideDown',
+      'UIInterfaceOrientationLandscapeLeft',
+      'UIInterfaceOrientationLandscapeRight',
+    ],
   });
 
-  it(`sets UIRequiresFullScreen value`, () => {
-    expect(setRequiresFullScreen({ ios: { requireFullScreen: false } }, {})).toMatchObject({
-      UIRequiresFullScreen: false,
-    });
+  expect(WarningAggregator.addWarningIOS).not.toBeCalled();
+});
 
-    expect(setRequiresFullScreen({}, {})).toMatchObject({
-      UIRequiresFullScreen: true,
-    });
-  });
+it(`warns when the predefined UISupportedInterfaceOrientations~ipad values are invalid`, () => {
+  setRequiresFullScreen(
+    { ios: { requireFullScreen: false } },
+    {
+      'UISupportedInterfaceOrientations~ipad': [
+        'UIInterfaceOrientationPortrait',
+        'UIInterfaceOrientationPortraitUpsideDown',
+        'UIInterfaceOrientationLandscapeRight',
+      ],
+    }
+  );
+
+  expect(WarningAggregator.addWarningIOS).toBeCalledTimes(1);
+});
+
+it(`does not warn when predefined orientation mask matches required values`, () => {
+  setRequiresFullScreen(
+    { ios: { requireFullScreen: false } },
+    {
+      'UISupportedInterfaceOrientations~ipad': [
+        'UIInterfaceOrientationPortrait',
+        'UIInterfaceOrientationPortraitUpsideDown',
+        'UIInterfaceOrientationLandscapeLeft',
+        'UIInterfaceOrientationLandscapeRight',
+      ],
+    }
+  );
+
+  expect(WarningAggregator.addWarningIOS).not.toBeCalled();
+});
+
+it(`does not warn when predefined orientation mask is empty`, () => {
+  setRequiresFullScreen(
+    { ios: { requireFullScreen: false } },
+    {
+      'UISupportedInterfaceOrientations~ipad': [],
+    }
+  );
+
+  expect(WarningAggregator.addWarningIOS).not.toBeCalled();
+});
+
+it(`cannot remove predefined orientation mask`, () => {
+  let plist = {};
+  plist = setRequiresFullScreen({ ios: { requireFullScreen: false } }, plist);
+  expect(plist['UISupportedInterfaceOrientations~ipad']?.length).toBe(4);
+  plist = setRequiresFullScreen({ ios: { requireFullScreen: true } }, plist);
+  expect(plist['UISupportedInterfaceOrientations~ipad']?.length).toBe(4);
+  expect(WarningAggregator.addWarningIOS).not.toBeCalled();
 });


### PR DESCRIPTION
# Why

If you build an app with SDK 43, requireFullScreen will be false, after the build is successfully compiled, Transporter will fail with:

```
ERROR ITMS-90474: "Invalid Bundle. iPad Multitasking support requires these orientations: 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight'. Found 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown' in bundle 'com.bacon.app'."
```

Xcode bootstraps a project with:

```js
{
  'UISupportedInterfaceOrientations~ipad': {
   'UIInterfaceOrientationPortrait',
    'UIInterfaceOrientationPortraitUpsideDown',
    'UIInterfaceOrientationLandscapeLeft',
    'UIInterfaceOrientationLandscapeRight',
  }
}
```

This PR proposes that we inject these values when requireFullScreen is false. There is currently no way to undo adding these after they've been added, but it seems that we should mostly just default to users having these. 

# Test Plan


- [x] Unit test
- [x] Build and submit an app using `ios.requireFullScreen: false` without any issues