### PR TITLE
[ENG-1601][config-plugins] use default value for android version code

### DIFF
--- a/packages/config-plugins/src/android/Version.ts
+++ b/packages/config-plugins/src/android/Version.ts
@@ -34,7 +34,7 @@ export function setVersionName(config: Pick<ExpoConfig, 'version'>, buildGradle:
 }
 
 export function getVersionCode(config: Pick<ExpoConfig, 'android'>) {
-  return config.android?.versionCode ?? null;
+  return config.android?.versionCode ?? 1;
 }
 
 export function setVersionCode(config: Pick<ExpoConfig, 'android'>, buildGradle: string) {

--- a/packages/config-plugins/src/android/__tests__/Version-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Version-test.ts
@@ -55,8 +55,8 @@ describe('versionName', () => {
 });
 
 describe('versionCode', () => {
-  it(`returns null if no version code is provided`, () => {
-    expect(getVersionCode({})).toBe(null);
+  it(`returns 1 if no version code is provided`, () => {
+    expect(getVersionCode({})).toBe(1);
   });
 
   it(`returns the version code if provided`, () => {


### PR DESCRIPTION
# Why

Version code is the Android equivalent of the build number. In the case when the build number is not defined, we use a default value - `1.0.0` (https://github.com/expo/expo-cli/blob/master/packages/config-plugins/src/ios/Version.ts#L22). However, for 
the version code, we don't fall back to `null`.

We've noticed that because we record the version code / build number as the app build version in EAS Build build metadata (https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/build/metadata.ts#L68). We should make the build version consistent across platforms.

# How

I updated `getVersionCode` so that it returns `1` if `android.versionCode` is not defined.

# Test Plan

I updated the unit test.