### PR TITLE
[expo-cli] display correct manifest link after publish

### DIFF
--- a/packages/expo-cli/src/commands/publishAsync.ts
+++ b/packages/expo-cli/src/commands/publishAsync.ts
@@ -39,7 +39,7 @@ export async function actionAsync(
   const { exp, pkg } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
-  const { sdkVersion } = exp;
+  const { sdkVersion, runtimeVersion } = exp;
 
   const target = options.target ?? getDefaultTarget(projectRoot);
 
@@ -51,9 +51,10 @@ export async function actionAsync(
 
   // Log building info before building.
   // This gives the user sometime to bail out if the info is unexpected.
-
-  if (sdkVersion) {
-    Log.log(`\u203A Expo SDK: ${Log.chalk.bold(exp.sdkVersion)}`);
+  if (runtimeVersion) {
+    Log.log(`\u203A Runtime version: ${Log.chalk.bold(runtimeVersion)}`);
+  } else if (sdkVersion) {
+    Log.log(`\u203A Expo SDK: ${Log.chalk.bold(sdkVersion)}`);
   }
   Log.log(`\u203A Release channel: ${Log.chalk.bold(options.releaseChannel)}`);
   Log.log(`\u203A Workflow: ${Log.chalk.bold(target.replace(/\b\w/g, l => l.toUpperCase()))}`);
@@ -101,7 +102,7 @@ export async function actionAsync(
   Log.log('Publish complete');
   Log.newLine();
 
-  logManifestUrl({ url, sdkVersion: exp.sdkVersion });
+  logManifestUrl({ url, sdkVersion, runtimeVersion });
 
   if (target === 'managed' && projectPageUrl) {
     // note(brentvatne): disable copy to clipboard functionality for now, need to think more about
@@ -142,8 +143,16 @@ function assertValidReleaseChannel(releaseChannel?: string): void {
  * @example 📝  Manifest: https://exp.host/@bacon/my-app/index.exp?sdkVersion=38.0.0 Learn more: https://expo.fyi/manifest-url
  * @param options
  */
-function logManifestUrl({ url, sdkVersion }: { url: string; sdkVersion?: string }) {
-  const manifestUrl = getExampleManifestUrl(url, sdkVersion) ?? url;
+function logManifestUrl({
+  url,
+  sdkVersion,
+  runtimeVersion,
+}: {
+  url: string;
+  sdkVersion?: string;
+  runtimeVersion?: string;
+}) {
+  const manifestUrl = getExampleManifestUrl(url, { sdkVersion, runtimeVersion }) ?? url;
   Log.log(
     `📝  Manifest: ${Log.chalk.bold(TerminalLink.fallbackToUrl(url, manifestUrl))} ${Log.chalk.dim(
       TerminalLink.learnMore('https://expo.fyi/manifest-url')
@@ -175,22 +184,28 @@ function logProjectPageUrl({
   Log.log(productionMessage);
 }
 
-function getExampleManifestUrl(url: string, sdkVersion: string | undefined): string | null {
-  if (!sdkVersion) {
+function getExampleManifestUrl(
+  url: string,
+  { sdkVersion, runtimeVersion }: { sdkVersion?: string; runtimeVersion?: string }
+): string | null {
+  if (!(sdkVersion || runtimeVersion)) {
     return null;
   }
 
   if (url.includes('release-channel') && url.includes('?release-channel')) {
-    return (
-      url.replace('?release-channel', '/index.exp?release-channel') + `&sdkVersion=${sdkVersion}`
-    );
+    const urlWithIndexSuffix = url.replace('?release-channel', '/index.exp?release-channel');
+    return runtimeVersion
+      ? urlWithIndexSuffix + `&runtimeVersion=${runtimeVersion}`
+      : urlWithIndexSuffix + `&sdkVersion=${sdkVersion}`;
   } else if (url.includes('?') && !url.includes('release-channel')) {
     // This is the only relevant url query param we are aware of at the time of
     // writing this code, so if there is some other param included we don't know
     // how to deal with it and log nothing.
     return null;
   } else {
-    return `${url}/index.exp?sdkVersion=${sdkVersion}`;
+    return runtimeVersion
+      ? `${url}/index.exp?runtimeVersion=${runtimeVersion}`
+      : `${url}/index.exp?sdkVersion=${sdkVersion}`;
   }
 }
 


### PR DESCRIPTION
# Why

@tcdavis noticed that the manifest link displayed after a publish ignored the runtimeVersion and displayed the associated SDK version:

<img width="730" alt="Screen Shot 2021-07-26 at 6 52 12 AM" src="https://user-images.githubusercontent.com/1220444/127000457-a5fb75c2-5c8c-49f6-9570-81ecd513e372.png">

Further we display the SDK instead of the runtime version in the informational log:

<img width="387" alt="Screen Shot 2021-07-26 at 6 51 40 AM" src="https://user-images.githubusercontent.com/1220444/127000520-7c2c9eaa-f471-45fc-9a16-580f29ebc014.png">


# How

override SDK and use runtimeVersion if it is present.

# Test Plan

confirmed with test publish in demo project:

<img width="602" alt="Screen Shot 2021-07-26 at 6 48 30 AM" src="https://user-images.githubusercontent.com/1220444/127000637-a76cba2f-c5b4-468e-8ac2-f012591d4816.png">
<img width="771" alt="Screen Shot 2021-07-26 at 6 48 49 AM" src="https://user-images.githubusercontent.com/1220444/127000651-7e4faaf0-0068-4c5f-95c2-f32a2d871c36.png">
and double checked the backend directed a url with runtime version query parameter to a runtimeVersion manifest
<img width="366" alt="Screen Shot 2021-07-26 at 6 49 23 AM" src="https://user-images.githubusercontent.com/1220444/127000728-87702a58-dcfe-435f-96f0-b848eb9d822b.png">
:
