### PR TITLE
[expo-cli][run:ios] Auto detect device type for scheme

### DIFF
--- a/packages/config-plugins/src/ios/Target.ts
+++ b/packages/config-plugins/src/ios/Target.ts
@@ -11,6 +11,7 @@ import {
 export enum TargetType {
   APPLICATION = 'com.apple.product-type.application',
   EXTENSION = 'com.apple.product-type.app-extension',
+  WATCH = 'com.apple.product-type.application.watchapp',
   STICKER_PACK_EXTENSION = 'com.apple.product-type.app-extension.messages-sticker-pack',
   OTHER = 'other',
 }
@@ -85,6 +86,7 @@ export function findSignableTargets(project: XcodeProject): NativeTargetSectionE
     ([, target]) =>
       isTargetOfType(target, TargetType.APPLICATION) ||
       isTargetOfType(target, TargetType.EXTENSION) ||
+      isTargetOfType(target, TargetType.WATCH) ||
       isTargetOfType(target, TargetType.STICKER_PACK_EXTENSION)
   );
   if (applicationTargets.length === 0) {

--- a/packages/config-plugins/src/ios/__tests__/BuildScheme-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/BuildScheme-test.ts
@@ -5,11 +5,37 @@ import path from 'path';
 import {
   getApplicationTargetNameForSchemeAsync,
   getArchiveBuildConfigurationForSchemeAsync,
+  getRunnableSchemesFromXcodeproj,
 } from '../BuildScheme';
 
 const fsReal = jest.requireActual('fs') as typeof fs;
 
 jest.mock('fs');
+
+describe(getRunnableSchemesFromXcodeproj, () => {
+  beforeAll(async () => {
+    vol.fromJSON(
+      {
+        'ios/project.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project-multitarget.pbxproj'),
+          'utf-8'
+        ),
+      },
+      '/app'
+    );
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+  it(`parses for runnable schemes`, async () => {
+    const schemes = getRunnableSchemesFromXcodeproj('/app');
+    expect(schemes).toStrictEqual([
+      { name: 'multitarget', osType: 'iOS', type: 'com.apple.product-type.application' },
+      { name: 'shareextension', osType: 'iOS', type: 'com.apple.product-type.app-extension' },
+    ]);
+  });
+});
 
 describe(getApplicationTargetNameForSchemeAsync, () => {
   describe('single build action entry', () => {

--- a/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
-import ora from 'ora';
 import { SimControl, Simulator } from 'xdl';
 
 import CommandError from '../../../CommandError';
 import Log from '../../../log';
 import prompt from '../../../prompts';
+import { ora } from '../../../utils/ora';
 import { profileMethod } from '../../utils/profileMethod';
 
 async function getSimulatorsAsync(): Promise<SimControl.SimulatorDevice[]> {
@@ -14,7 +14,7 @@ async function getSimulatorsAsync(): Promise<SimControl.SimulatorDevice[]> {
   }, []);
 }
 
-async function getBuildDestinationsAsync() {
+async function getBuildDestinationsAsync({ osType }: { osType?: string } = {}) {
   const devices = (
     await profileMethod(SimControl.listDevicesAsync, 'SimControl.listDevicesAsync')()
   ).filter(device => {
@@ -22,35 +22,53 @@ async function getBuildDestinationsAsync() {
   });
 
   const simulators = await Simulator.sortDefaultDeviceToBeginningAsync(
-    await profileMethod(getSimulatorsAsync)()
+    await profileMethod(getSimulatorsAsync)(),
+    osType
   );
 
   return [...devices, ...simulators];
 }
 
 export async function resolveDeviceAsync(
-  device: string | boolean | undefined
+  device: string | boolean | undefined,
+  { osType }: { osType?: string } = {}
 ): Promise<SimControl.SimulatorDevice | SimControl.XCTraceDevice> {
   if (!(await profileMethod(Simulator.ensureXcodeCommandLineToolsInstalledAsync)())) {
     throw new CommandError('Unable to verify Xcode and Simulator installation.');
   }
+
   if (!device) {
-    return await profileMethod(
+    const simulator = await profileMethod(
       Simulator.ensureSimulatorOpenAsync,
       'Simulator.ensureSimulatorOpenAsync'
-    )();
+    )({ osType });
+    Log.debug(`Resolved default (${osType}) device:`, simulator.name, simulator.udid);
+    return simulator;
   }
 
   const spinner = ora(
     `🔍 Finding ${device === true ? 'devices' : `device ${chalk.cyan(device)}`}`
   ).start();
-  const devices: (
+  let devices: (
     | SimControl.SimulatorDevice
     | SimControl.XCTraceDevice
-  )[] = await getBuildDestinationsAsync().catch(() => []);
+  )[] = await getBuildDestinationsAsync({ osType }).catch(() => []);
+
   spinner.stop();
 
   if (device === true) {
+    // If osType is defined, then filter out ineligible simulators.
+    // Only do this inside of the device selection so users who pass the entire device udid can attempt to select any simulator (even if it's invalid).
+    if (osType) {
+      devices = devices.filter(device => {
+        // connected device
+        if (!('osType' in device)) {
+          return true;
+        }
+        return device.osType === osType;
+      });
+    }
+
     // --device with no props after
     const { value } = await prompt({
       type: 'autocomplete',

--- a/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import CommandError from '../../../CommandError';
 import Log from '../../../log';
 import { selectAsync } from '../../../prompts';
+import { profileMethod } from '../../utils/profileMethod';
 import { resolvePortAsync } from '../utils/resolvePortAsync';
 import * as XcodeBuild from './XcodeBuild';
 import { resolveDeviceAsync } from './resolveDeviceAsync';
@@ -136,9 +137,12 @@ export async function resolveOptionsAsync(
     port = 8081;
   }
 
-  const resolvedScheme = (await resolveNativeSchemeAsync(projectRoot, options)) ?? {
-    name: path.basename(xcodeProject.name, path.extname(xcodeProject.name)),
-  };
+  const resolvedScheme = (await resolveNativeSchemeAsync(projectRoot, options)) ??
+    profileMethod(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj)(projectRoot, {
+      configuration: options.configuration,
+    })[0] ?? {
+      name: path.basename(xcodeProject.name, path.extname(xcodeProject.name)),
+    };
 
   const device = await resolveDeviceAsync(options.device, { osType: resolvedScheme.osType });
 

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -786,7 +786,8 @@ any interaction with Expo servers may result in unexpected behaviour.`
 }
 
 function _registerLogs() {
-  const stream = {
+  const stream: bunyan.Stream = {
+    level: Log.isDebug ? 'debug' : 'info',
     stream: {
       write: (chunk: any) => {
         if (chunk.code) {
@@ -835,6 +836,8 @@ function _registerLogs() {
           Log.log(chunk.msg);
         } else if (chunk.level === bunyan.WARN) {
           Log.warn(chunk.msg);
+        } else if (chunk.level === bunyan.DEBUG) {
+          Log.debug(chunk.msg);
         } else if (chunk.level >= bunyan.ERROR) {
           Log.error(chunk.msg);
         }

--- a/packages/xdl/src/Logger.ts
+++ b/packages/xdl/src/Logger.ts
@@ -2,7 +2,9 @@ import bunyan from '@expo/bunyan';
 
 class ConsoleRawStream {
   write(record: any) {
-    if (record.level < bunyan.INFO) {
+    if (record.level < bunyan.DEBUG) {
+      console.debug(record);
+    } else if (record.level < bunyan.INFO) {
       console.log(record);
     } else if (record.level < bunyan.WARN) {
       console.info(record);

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -333,16 +333,6 @@ function _getDefaultSimulatorDeviceUDID() {
   }
 }
 
-async function getFirstAvailableDeviceAsync({ osType = 'iOS' }: { osType?: string } = {}) {
-  const simulators = await getSelectableSimulatorsAsync({ osType });
-
-  if (!simulators.length) {
-    // TODO: Prompt to install the simulators
-    throw new Error(`No ${osType} devices available in Simulator.app`);
-  }
-  return simulators[0];
-}
-
 async function waitForActionAsync<T>({
   action,
   interval = 100,
@@ -914,7 +904,6 @@ export async function sortDefaultDeviceToBeginningAsync(
   osType?: string
 ): Promise<SimControl.SimulatorDevice[]> {
   const defaultUdid = await getBestSimulatorAsync({ osType });
-  // _getDefaultSimulatorDeviceUDID() ?? (await getFirstAvailableDeviceAsync()).udid;
   if (defaultUdid) {
     let iterations = 0;
     while (devices[0].udid !== defaultUdid && iterations < devices.length) {

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -211,7 +211,7 @@ export async function isSimulatorInstalledAsync(): Promise<boolean> {
  * This is where any timeout related error handling should live.
  */
 export async function ensureSimulatorOpenAsync(
-  { udid }: { udid?: string } = {},
+  { udid, osType }: { udid?: string; osType?: string } = {},
   tryAgain: boolean = true
 ): Promise<SimControl.SimulatorDevice> {
   // Yes, simulators can be booted even if the app isn't running, obviously we'd never want this.
@@ -230,14 +230,7 @@ export async function ensureSimulatorOpenAsync(
 
   // Use a default simulator if none was specified
   if (!udid) {
-    const simulatorOpenedByApp = await isSimulatorBootedAsync({ udid });
-    // This should prevent opening a second simulator in the chance that default
-    // simulator doesn't match what the Simulator app would open by default.
-    if (simulatorOpenedByApp?.udid) {
-      udid = simulatorOpenedByApp.udid;
-    } else {
-      udid = _getDefaultSimulatorDeviceUDID() ?? (await getFirstAvailableDeviceAsync()).udid;
-    }
+    udid = await getBestSimulatorAsync({ osType });
   }
 
   const bootedDevice = await waitForDeviceToBootAsync({ udid });
@@ -245,7 +238,7 @@ export async function ensureSimulatorOpenAsync(
   if (!bootedDevice) {
     // Give it a second chance, this might not be needed but it could potentially lead to a better UX on slower devices.
     if (tryAgain) {
-      return await ensureSimulatorOpenAsync({ udid }, false);
+      return await ensureSimulatorOpenAsync({ udid, osType }, false);
     }
     // TODO: We should eliminate all needs for a timeout error, it's bad UX to get an error about the simulator not starting while the user can clearly see it starting on their slow computer.
     throw new TimeoutError(
@@ -255,12 +248,51 @@ export async function ensureSimulatorOpenAsync(
   return bootedDevice;
 }
 
+async function getBestSimulatorAsync({ osType }: { osType?: string }): Promise<string> {
+  const simulatorOpenedByApp = await isSimulatorBootedAsync();
+
+  // This should prevent opening a second simulator in the chance that default
+  // simulator doesn't match what the Simulator app would open by default.
+  if (
+    simulatorOpenedByApp?.udid &&
+    (!osType || (osType && simulatorOpenedByApp.osType === osType))
+  ) {
+    return simulatorOpenedByApp.udid;
+  }
+
+  const defaultUdid = _getDefaultSimulatorDeviceUDID();
+
+  if (defaultUdid && !osType) {
+    return defaultUdid;
+  }
+
+  const simulators = await getSelectableSimulatorsAsync({ osType });
+
+  if (!simulators.length) {
+    // TODO: Prompt to install the simulators
+    throw new Error(`No ${osType || 'iOS'} devices available in Simulator.app`);
+  }
+
+  // If the default udid is defined, then check to ensure its osType matches the required os.
+  if (defaultUdid) {
+    const defaultSimulator = simulators.find(device => device.udid === defaultUdid);
+    if (defaultSimulator?.osType === osType) {
+      return defaultUdid;
+    }
+  }
+
+  // Return first selectable device.
+  return simulators[0].udid;
+}
+
 /**
  * Get all simulators supported by Expo (iOS only).
  */
-async function getSelectableSimulatorsAsync(): Promise<SimControl.SimulatorDevice[]> {
+async function getSelectableSimulatorsAsync({ osType = 'iOS' }: { osType?: string } = {}): Promise<
+  SimControl.SimulatorDevice[]
+> {
   const simulators = await getSimulatorsAsync();
-  return simulators.filter(device => device.isAvailable && device.osType === 'iOS');
+  return simulators.filter(device => device.isAvailable && device.osType === osType);
 }
 
 async function getSimulatorsAsync(): Promise<SimControl.SimulatorDevice[]> {
@@ -301,11 +333,12 @@ function _getDefaultSimulatorDeviceUDID() {
   }
 }
 
-async function getFirstAvailableDeviceAsync() {
-  const simulators = await getSelectableSimulatorsAsync();
+async function getFirstAvailableDeviceAsync({ osType = 'iOS' }: { osType?: string } = {}) {
+  const simulators = await getSelectableSimulatorsAsync({ osType });
+
   if (!simulators.length) {
     // TODO: Prompt to install the simulators
-    throw new Error('No iPhone devices available in Simulator.');
+    throw new Error(`No ${osType} devices available in Simulator.app`);
   }
   return simulators[0];
 }
@@ -877,10 +910,11 @@ export async function openWebProjectAsync({
  * @param devices
  */
 export async function sortDefaultDeviceToBeginningAsync(
-  devices: SimControl.SimulatorDevice[]
+  devices: SimControl.SimulatorDevice[],
+  osType?: string
 ): Promise<SimControl.SimulatorDevice[]> {
-  const defaultUdid =
-    _getDefaultSimulatorDeviceUDID() ?? (await getFirstAvailableDeviceAsync()).udid;
+  const defaultUdid = await getBestSimulatorAsync({ osType });
+  // _getDefaultSimulatorDeviceUDID() ?? (await getFirstAvailableDeviceAsync()).udid;
   if (defaultUdid) {
     let iterations = 0;
     while (devices[0].udid !== defaultUdid && iterations < devices.length) {
@@ -892,9 +926,10 @@ export async function sortDefaultDeviceToBeginningAsync(
 }
 
 export async function promptForSimulatorAsync(
-  devices: SimControl.SimulatorDevice[]
+  devices: SimControl.SimulatorDevice[],
+  osType?: string
 ): Promise<SimControl.SimulatorDevice | null> {
-  devices = await sortDefaultDeviceToBeginningAsync(devices);
+  devices = await sortDefaultDeviceToBeginningAsync(devices, osType);
   // TODO: Bail on non-interactive
   const results = await promptForDeviceAsync(devices);
 

--- a/packages/xdl/src/__tests__/SimControl-test.ts
+++ b/packages/xdl/src/__tests__/SimControl-test.ts
@@ -1,0 +1,36 @@
+import { parseXcrunError } from '../SimControl';
+
+describe(parseXcrunError, () => {
+  it(`parses exit code 2`, () => {
+    // Test that a useful error message is created.
+
+    expect(
+      parseXcrunError({
+        message: 'xcrun exited with non-zero code: 2',
+        pid: 8887,
+        output: [
+          '',
+          'An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):\n' +
+            'Unable to boot device because we cannot determine the runtime bundle.\n' +
+            'No such file or directory\n',
+        ],
+        stdout: '',
+        stderr:
+          'An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):\n' +
+          'Unable to boot device because we cannot determine the runtime bundle.\n' +
+          'No such file or directory\n',
+        status: 2,
+        signal: null,
+      }).message
+    ).toBe(
+      [
+        // The standard error
+        'xcrun exited with non-zero code: 2',
+        // Extra input added on in the wrapper method
+        'An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):',
+        'Unable to boot device because we cannot determine the runtime bundle.',
+        'No such file or directory',
+      ].join('\n')
+    );
+  });
+});


### PR DESCRIPTION
# Why

When running a project that supports different OSs, automatically detect which simulator should be opened. This enables users to run projects with something like tvOS support by simply doing `expo run:ios --scheme` and choosing the TV scheme. A best effort approach will be used to find the ideal simulator and open it before building. This prevents unexpected build errors related to using the incorrect target.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Move scheme resolution before device resolution.
- Filter devices based on selected scheme.
- Fix debug logging in XDL.
- Added improved xcrun error handling.
- Added detection for tvOS since is uses the same application type as iOS.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Testing on this project: https://github.com/react-native-tvos/TVReanimated
- Run `expo run:ios --scheme` -- should show you a list of schemes: 
  - `TVReanimated (app)`
  - `TVReanimated-tvOS`
- Selecting `TVReanimated-tvOS` should automatically open a TV device and build the project as expected. 


- Run `expo run:ios --scheme --device` -- should show you a list of schemes, select the tvOS one.
- Devices list should only show Apple TV simulators (no watches or phones), with the exception of connected devices which are always shown.
- Performing the same test again but selecting the default scheme should show only iOS devices.