### PR TITLE
[ENG-1600][metro-config] add function checking for metro config existence

### DIFF
--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -217,13 +217,14 @@ export interface LoadOptions {
   reporter?: Reporter;
   resetCache?: boolean;
   target?: ProjectTarget;
+  withoutDefaults?: boolean;
 }
 
 export async function loadAsync(
   projectRoot: string,
-  { reporter, target, ...metroOptions }: LoadOptions = {}
+  { reporter, target, withoutDefaults = false, ...metroOptions }: LoadOptions = {}
 ): Promise<MetroConfig.ConfigT> {
-  let defaultConfig = getDefaultConfig(projectRoot, { target });
+  let defaultConfig = withoutDefaults ? {} : getDefaultConfig(projectRoot, { target });
   if (reporter) {
     defaultConfig = { ...defaultConfig, reporter };
   }
@@ -232,6 +233,12 @@ export async function loadAsync(
     { cwd: projectRoot, projectRoot, ...metroOptions },
     defaultConfig
   );
+}
+
+export async function existsAsync(projectRoot: string): Promise<boolean> {
+  const MetroConfig = importMetroConfigFromProject(projectRoot);
+  const result = await MetroConfig.resolveConfig(undefined, projectRoot);
+  return !result.isEmpty;
 }
 
 function importMetroConfigFromProject(projectRoot: string): typeof MetroConfig {


### PR DESCRIPTION
# Why

From https://linear.app/expo/issue/ENG-1600/validate-metroconfigjs-if-it-exists-for-managed-apps

> A bunch of developers have run into an issue that they describe as something like "assets aren't working in production" - they build their app, upload it to TestFlight, then load it on their phone and don't see any images. With EAS Build for managed apps, this usually means they have a metro.config.js that doesn't extend expo/metro-config and is therefore missing the hashAssetFIles asset plugin.

# How

- I need a function that checks for metro config existence. The `metro-config` package exports `resolveConfig` which returns a boolean indicating whether a custom config exists. https://github.com/facebook/metro/blob/master/packages/metro-config/src/loadConfig.js#L92
- I also need to check whether the custom config has the `hashAssetFiles` plugin - I added the `withoutDefaults` flag to `loadAsync` so it's possible to load the metro config without Expo defaults.

# Test Plan

Tested with changes in https://github.com/expo/eas-cli/pull/534