### PR TITLE
[xdl] Upgrade uuid

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -90,7 +90,7 @@
     "text-table": "^0.2.0",
     "tree-kill": "1.2.2",
     "url-join": "4.0.0",
-    "uuid": "3.3.2",
+    "uuid": "^8.0.0",
     "webpack": "4.43.0",
     "webpack-dev-server": "3.11.0",
     "wrap-ansi": "^7.0.0"
@@ -114,7 +114,7 @@
     "@types/tar": "^4.0.1",
     "@types/text-table": "^0.2.1",
     "@types/url-join": "^4.0.0",
-    "@types/uuid": "^3.4.4",
+    "@types/uuid": "^8.3.1",
     "@types/webpack": "4.41.18",
     "@types/webpack-dev-server": "3.11.0",
     "@types/wrap-ansi": "^3.0.0",

--- a/packages/xdl/src/Session.ts
+++ b/packages/xdl/src/Session.ts
@@ -1,9 +1,9 @@
-import { v4 } from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 import { UserSettings } from './internal';
 
 function _newIdentifier(type = 'c') {
-  const bytes = v4(null, Buffer.alloc(16));
+  const bytes = uuidv4(null, Buffer.alloc(16));
   const base64 = bytes.toString('base64');
   const slug = base64
     // Replace + with - (see RFC 4648, sec. 5)

--- a/packages/xdl/src/UserSettings.ts
+++ b/packages/xdl/src/UserSettings.ts
@@ -2,7 +2,7 @@ import JsonFile from '@expo/json-file';
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 import { ConnectionType, Env } from './internal';
 
@@ -68,7 +68,7 @@ async function getAnonymousIdentifierAsync(): Promise<string> {
   let id = await settings.getAsync('uuid', null);
 
   if (!id) {
-    id = uuid.v4();
+    id = uuidv4();
     await settings.setAsync('uuid', id);
   }
 

--- a/packages/xdl/src/__integration_tests__/UserManager-test.ts
+++ b/packages/xdl/src/__integration_tests__/UserManager-test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import HashIds from 'hashids';
 import path from 'path';
-import uuid from 'uuid';
+import { v1 as uuidv1 } from 'uuid';
 
 import { ApiV2 as ApiV2Client, User, UserManagerInstance } from '../internal';
 
@@ -20,13 +20,13 @@ describe.skip('UserManager', () => {
     process.env.__UNSAFE_EXPO_HOME_DIRECTORY = path.join(
       '/',
       'tmp',
-      `.expo-${_makeShortId(uuid.v1())}`
+      `.expo-${_makeShortId(uuidv1())}`
     );
 
     const UserManager = _newTestUserManager();
 
-    const username = `xdl-test-${_makeShortId(uuid.v1())}`;
-    const password = uuid.v1();
+    const username = `xdl-test-${_makeShortId(uuidv1())}`;
+    const password = uuidv1();
 
     // Register a new user that we can use for this test run
     const newUser = await UserManager.registerAsync({

--- a/packages/xdl/src/__integration_tests__/UserSessions-test.ts
+++ b/packages/xdl/src/__integration_tests__/UserSessions-test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import HashIds from 'hashids';
-import uuid from 'uuid';
+import { v1 as uuidv1 } from 'uuid';
 
 import { ApiV2 as ApiV2Client, User, UserManagerInstance, UserSettings } from '../internal';
 
@@ -20,8 +20,8 @@ describe.skip('User Sessions', () => {
 
     const UserManager = _newTestUserManager();
 
-    const username = `xdl-test-${_makeShortId(uuid.v1())}`;
-    const password = uuid.v1();
+    const username = `xdl-test-${_makeShortId(uuidv1())}`;
+    const password = uuidv1();
 
     // Register a new user that we can use for this test run
     const newUser = await UserManager.registerAsync({

--- a/packages/xdl/src/credentials/AndroidCredentials.ts
+++ b/packages/xdl/src/credentials/AndroidCredentials.ts
@@ -1,7 +1,7 @@
 import spawnAsync, { SpawnResult } from '@expo/spawn-async';
 import crypto from 'crypto';
 import fs from 'fs-extra';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 
 import { Logger as logger } from '../internal';
 

--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -3,7 +3,7 @@ import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
 import express from 'express';
 import http from 'http';
 import { parse } from 'url';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   Analytics,
@@ -89,7 +89,7 @@ export async function getManifestResponseAsync({
   );
 
   const expoUpdatesManifest = {
-    id: uuid.v4(),
+    id: uuidv4(),
     createdAt: new Date().toISOString(),
     runtimeVersion,
     launchAsset: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3742,12 +3742,10 @@
   resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.0.tgz#72eff71648a429c7d4acf94e03780e06671369bd"
   integrity sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==
 
-"@types/uuid@^3.4.4":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.6.tgz#d2c4c48eb85a757bf2927f75f939942d521e3016"
-  integrity sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==
-  dependencies:
-    "@types/node" "*"
+"@types/uuid@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
+  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
 
 "@types/webpack-dev-server@*", "@types/webpack-dev-server@3.11.0":
   version "3.11.0"
@@ -9769,10 +9767,10 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@0.0.0, hermes-engine@~0.5.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
-  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
+hermes-engine@~0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.5.1.tgz#601115e4b1e0a17d9aa91243b96277de4e926e09"
+  integrity sha512-hLwqh8dejHayjlpvZY40e1aDCDvyP98cWx/L5DhAjSJLH8g4z9Tp08D7y4+3vErDsncPOdf1bxm+zUWpx0/Fxg==
 
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"
@@ -18586,11 +18584,6 @@ uuid@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
   integrity sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg=
-
-uuid@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
# Why

Drops install warning:

```
npm WARN deprecated uuid@3.3.2: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```

# Test Plan

- [ ] TBD