### PR TITLE
[xdl] support undefined SDK version cases

### DIFF
--- a/packages/xdl/__mocks__/resolve-from.ts
+++ b/packages/xdl/__mocks__/resolve-from.ts
@@ -1,6 +1,6 @@
-module.exports = require(require.resolve('resolve-from'));
+const resolveFrom = require(require.resolve('resolve-from'));
 
-module.exports.silent = (fromDirectory, request) => {
+const silent = (fromDirectory, request) => {
   const fs = require('fs');
   const path = require('path');
   try {
@@ -13,8 +13,24 @@ module.exports.silent = (fromDirectory, request) => {
     }
   }
 
-  const outputPath = path.join(fromDirectory, 'node_modules', request);
+  let outputPath = path.join(fromDirectory, 'node_modules', request);
+  if (fs.existsSync(outputPath)) {
+    return outputPath;
+  }
+  if (!path.extname(outputPath)) {
+    outputPath += '.js';
+  }
   if (fs.existsSync(outputPath)) {
     return outputPath;
   }
 };
+
+module.exports = (fromDirectory, request) => {
+  const path = silent(fromDirectory, request);
+  if (!path) {
+    return resolveFrom(fromDirectory, request);
+  }
+  return path;
+};
+
+module.exports.silent = silent;

--- a/packages/xdl/src/DevSession.ts
+++ b/packages/xdl/src/DevSession.ts
@@ -16,7 +16,7 @@ let keepUpdating = true;
 // TODO notify www when a project is started, and every N seconds afterwards
 export async function startSession(
   projectRoot: string,
-  exp: ExpoConfig,
+  exp: Pick<ExpoConfig, 'name' | 'description' | 'slug' | 'primaryColor'>,
   platform: 'native' | 'web',
   forceUpdate: boolean = false
 ): Promise<void> {

--- a/packages/xdl/src/Env.ts
+++ b/packages/xdl/src/Env.ts
@@ -24,6 +24,6 @@ export function maySkipManifestValidation(): boolean {
  * way), false if we should fall back to spawning it as a subprocess (supported for backwards
  * compatibility with SDK39 and older).
  */
-export function shouldUseDevServer(exp: ExpoConfig) {
-  return Versions.gteSdkVersion(exp, '40.0.0') || getenv.boolish('EXPO_USE_DEV_SERVER', false);
+export function shouldUseDevServer(exp: Pick<ExpoConfig, 'sdkVersion'>) {
+  return !Versions.lteSdkVersion(exp, '39.0.0') || getenv.boolish('EXPO_USE_DEV_SERVER', false);
 }

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -37,7 +37,7 @@ export async function constructDeepLinkAsync(
   projectRoot: string,
   opts?: Partial<URLOptions>,
   requestHostname?: string
-) {
+): Promise<string> {
   const { devClient } = await ProjectSettings.getPackagerOptsAsync(projectRoot);
 
   if (devClient) {
@@ -174,7 +174,8 @@ export async function constructDebuggerHostAsync(
 }
 
 export function constructBundleQueryParams(projectRoot: string, opts: MetroQueryOptions): string {
-  const { exp } = getConfig(projectRoot);
+  // No SDK Version will assume the latest requirements
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   return constructBundleQueryParamsWithConfig(projectRoot, opts, exp);
 }
 
@@ -197,26 +198,22 @@ export function constructBundleQueryParamsWithConfig(
     queryParams.minify = !!opts.minify;
   }
 
-  // No special requirements after SDK 33 (Jun 5 2019)
-  if (Versions.gteSdkVersion(exp, '33.0.0')) {
-    return QueryString.stringify(queryParams);
-  }
-
   // TODO: Remove this ...
 
   // SDK11 to SDK32 require us to inject hashAssetFiles through the params, but this is not
   // needed with SDK33+
-  const supportsAssetPlugins = Versions.gteSdkVersion(exp, '11.0.0');
-  const usesAssetPluginsQueryParam = supportsAssetPlugins && Versions.lteSdkVersion(exp, '32.0.0');
-  if (usesAssetPluginsQueryParam) {
-    // Use an absolute path here so that we can not worry about symlinks/relative requires
-    const pluginModule = resolveFrom(projectRoot, 'expo/tools/hashAssetFiles');
-    queryParams.assetPlugin = encodeURIComponent(pluginModule);
-  } else if (!supportsAssetPlugins) {
+  if (Versions.lteSdkVersion(exp, '10.0.0')) {
+    // SDK <=10
     // Only sdk-10.1.0+ supports the assetPlugin parameter. We use only the
     // major version in the sdkVersion field, so check for 11.0.0 to be sure.
     queryParams.includeAssetFileHashes = true;
+  } else if (Versions.lteSdkVersion(exp, '32.0.0')) {
+    // SDK 11-32
+    // Use an absolute path here so that we can not worry about symlinks/relative requires
+    const pluginModule = resolveFrom(projectRoot, 'expo/tools/hashAssetFiles');
+    queryParams.assetPlugin = encodeURIComponent(pluginModule);
   }
+  // Special requirements aren't needed after SDK 33 (Jun 5 2019)
 
   return QueryString.stringify(queryParams);
 }
@@ -293,7 +290,7 @@ function resolveProtocol(
   }
   let protocol = 'exp';
 
-  const { exp } = getConfig(projectRoot);
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
 
   // We only use these values from the config
   const { scheme, detach, sdkVersion } = exp;
@@ -305,7 +302,7 @@ function resolveProtocol(
     );
     // Get the first valid scheme.
     const firstScheme = schemes[0];
-    if (firstScheme && Versions.gteSdkVersion({ sdkVersion }, '27.0.0')) {
+    if (firstScheme && !Versions.lteSdkVersion({ sdkVersion }, '26.0.0')) {
       protocol = firstScheme;
     } else if (detach.scheme) {
       // must keep this fallback in place for older projects

--- a/packages/xdl/src/__tests__/Env-test.ts
+++ b/packages/xdl/src/__tests__/Env-test.ts
@@ -1,0 +1,25 @@
+import { shouldUseDevServer } from '../Env';
+
+describe(shouldUseDevServer, () => {
+  beforeEach(() => {
+    delete process.env.EXPO_USE_DEV_SERVER;
+  });
+  it(`defaults to true for projects without an SDK version`, () => {
+    expect(shouldUseDevServer({ sdkVersion: 'UNVERSIONED' })).toBe(true);
+    expect(shouldUseDevServer({ sdkVersion: undefined })).toBe(true);
+    expect(shouldUseDevServer({})).toBe(true);
+  });
+  it(`is true for projects in SDK +40`, () => {
+    expect(shouldUseDevServer({ sdkVersion: '40.0.0' })).toBe(true);
+    expect(shouldUseDevServer({ sdkVersion: '41.0.0' })).toBe(true);
+  });
+  it(`is false for projects in SDK 39`, () => {
+    expect(shouldUseDevServer({ sdkVersion: '39.0.0' })).toBe(false);
+    expect(shouldUseDevServer({ sdkVersion: '10.0.0' })).toBe(false);
+  });
+  it(`uses the env variable`, () => {
+    process.env.EXPO_USE_DEV_SERVER = String(true);
+    expect(shouldUseDevServer({ sdkVersion: '10.0.0' })).toBe(true);
+    expect(shouldUseDevServer({ sdkVersion: '41.0.0' })).toBe(true);
+  });
+});

--- a/packages/xdl/src/__tests__/UrlUtils-test.ts
+++ b/packages/xdl/src/__tests__/UrlUtils-test.ts
@@ -84,6 +84,17 @@ describe(UrlUtils.constructBundleQueryParamsWithConfig, () => {
       expect(
         UrlUtils.constructBundleQueryParamsWithConfig(projectRoot, {}, { sdkVersion: '33.0.0' })
       ).toBe('dev=false&hot=false');
+      // Defaults to highest SDK Support
+      expect(UrlUtils.constructBundleQueryParamsWithConfig(projectRoot, {}, {})).toBe(
+        'dev=false&hot=false'
+      );
+      expect(
+        UrlUtils.constructBundleQueryParamsWithConfig(
+          projectRoot,
+          {},
+          { sdkVersion: 'UNVERSIONED' }
+        )
+      ).toBe('dev=false&hot=false');
     });
     it(`creates a full query string`, async () => {
       expect(

--- a/packages/xdl/src/__tests__/UrlUtils-test.ts
+++ b/packages/xdl/src/__tests__/UrlUtils-test.ts
@@ -95,6 +95,29 @@ describe(UrlUtils.constructBundleQueryParamsWithConfig, () => {
       ).toBe('dev=true&hot=false&strict=true&minify=true');
     });
   });
+  describe('SDK -10', () => {
+    it(`adds includeAssetFileHashes`, async () => {
+      expect(
+        UrlUtils.constructBundleQueryParamsWithConfig(projectRoot, {}, { sdkVersion: '10.0.0' })
+      ).toBe('dev=false&hot=false&includeAssetFileHashes=true');
+    });
+  });
+  describe('SDK 11-32', () => {
+    it(`adds assetPlugin param`, async () => {
+      vol.fromJSON(
+        {
+          'node_modules/expo/tools/hashAssetFiles.js': 'foobar',
+        },
+        projectRoot
+      );
+
+      expect(
+        UrlUtils.constructBundleQueryParamsWithConfig(projectRoot, {}, { sdkVersion: '11.0.0' })
+      ).toBe(
+        'dev=false&hot=false&assetPlugin=%252Fapp%252Fnode_modules%252Fexpo%252Ftools%252FhashAssetFiles.js'
+      );
+    });
+  });
 });
 
 describe(UrlUtils.constructLogUrlAsync, () => {

--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -228,7 +228,11 @@ export async function getManifestResponseAsync({
   acceptSignature?: string | string[];
 }): Promise<{ exp: ExpoAppManifest; manifestString: string; hostInfo: HostInfo }> {
   // Read the config
-  const projectConfig = getConfig(projectRoot);
+  const projectConfig = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  // Opt towards newest functionality when expo isn't installed.
+  if (!projectConfig.exp.sdkVersion) {
+    projectConfig.exp.sdkVersion = 'UNVERSIONED';
+  }
   // Read from headers
   const hostname = stripPort(host);
 

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -46,7 +46,7 @@ export function broadcastMessage(
 export async function startAsync(
   projectRoot: string,
   {
-    exp = getConfig(projectRoot).exp,
+    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
     ...options
   }: StartDevServerOptions & { exp?: ExpoConfig } = {},
   verbose: boolean = true

--- a/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
+++ b/packages/xdl/src/start/startLegacyReactNativeServerAsync.ts
@@ -153,11 +153,14 @@ export async function startReactNativeServerAsync({
     sourceExts,
   };
 
-  if (options.nonPersistent && Versions.lteSdkVersion(exp, '32.0.0')) {
+  if (options.nonPersistent && !Versions.gteSdkVersion(exp, '33.0.0')) {
+    // Expo SDK -32 | React Native -57
     packagerOpts.nonPersistent = true;
   }
 
-  if (Versions.gteSdkVersion(exp, '33.0.0')) {
+  if (!Versions.lteSdkVersion(exp, '32.0.0')) {
+    // Expo SDK +33 | React Native +59.8 (hooks): Add asset plugins
+
     // starting with SDK 37, we bundle this plugin with the expo-asset package instead of expo,
     // so check there first and fall back to expo if we can't find it in expo-asset
     packagerOpts.assetPlugins = resolveFrom.silent(projectRoot, 'expo-asset/tools/hashAssetFiles');
@@ -175,7 +178,8 @@ export async function startReactNativeServerAsync({
     packagerOpts['max-workers'] = options.maxWorkers;
   }
 
-  if (!Versions.gteSdkVersion(exp, '16.0.0')) {
+  if (Versions.lteSdkVersion(exp, '15.0.0')) {
+    // Expo SDK -15 | React Native -42: customLogReporterPath is not supported
     delete packagerOpts.customLogReporterPath;
   }
   const userPackagerOpts = exp.packagerOpts;


### PR DESCRIPTION
# Why

Extracted from https://github.com/expo/expo-cli/pull/3737

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Flip sdkVersion checks so undefined or UNVERSIONED defaults to the latest sdkVersion behavior.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Added more tests