### PR TITLE
[metro-config] Restrict [native code] in stack traces

### DIFF
--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -26,6 +26,8 @@ export const INTERNAL_CALLSITES_REGEX = new RegExp(
     '/metro/.*/polyfills/require.js$',
     // Hide frames related to a fast refresh.
     '/metro/.*/lib/bundle-modules/.+\\.js$',
+    '/metro/.*/lib/bundle-modules/.+\\.js$',
+    'node_modules/react-native/Libraries/Utilities/HMRClient.js$',
     'node_modules/eventemitter3/index.js',
     'node_modules/event-target-shim/dist/.+\\.js$',
     // Ignore the log forwarder used in the Expo Go app
@@ -39,6 +41,8 @@ export const INTERNAL_CALLSITES_REGEX = new RegExp(
     'node_modules/promise/setimmediate/.+\\.js$',
     // Babel helpers that implement language features
     'node_modules/@babel/runtime/.+\\.js$',
+    // Block native code invocations
+    `\\[native code\\]`,
   ].join('|')
 );
 


### PR DESCRIPTION
# Why

Reduce useless traces coming from HMR:

```
TransformError SyntaxError: /Users/evanbacon/Documents/GitHub/lab/yolo39/App.js: Expected corresponding JSX closing tag for <Text2>. (10:38)

   8 | export default () => (
   9 |   <View>
> 10 |     <Text2>hey {String(haveRemoteDev)}</Text>
     |                                       ^
  11 |   </View>
  12 | );
  13 |
at node_modules/react-native/Libraries/Utilities/HMRClient.js:320:31 in showCompileError
at node_modules/react-native/Libraries/Utilities/HMRClient.js:227:26 in client.on$argument_1
at node_modules/react-native/Libraries/WebSocket/WebSocket.js:231:8 in _eventEmitter.addListener$argument_1
at node_modules/react-native/Libraries/vendor/emitter/EventEmitter.js:189:10 in emit
at [native code]:null in callFunctionReturnFlushedQueue
```


Down to

```
TransformError SyntaxError: /Users/evanbacon/Documents/GitHub/lab/yolo39/App.js: Expected corresponding JSX closing tag for <Text2>. (10:38)

   8 | export default () => (
   9 |   <View>
> 10 |     <Text2>hey {String(haveRemoteDev)}</Text>
     |                                       ^
  11 |   </View>
  12 | );
  13 |
at node_modules/react-native/Libraries/WebSocket/WebSocket.js:231:8 in _eventEmitter.addListener$argument_1
at node_modules/react-native/Libraries/vendor/emitter/EventEmitter.js:189:10 in emit
```


