### PR TITLE
[webpack config] reduce font loading complexity

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@babel/core": "7.9.0",
     "@expo/config": "5.0.6",
+    "debug": "^4.3.2",
     "babel-loader": "8.1.0",
     "chalk": "^4.0.0",
     "clean-webpack-plugin": "^3.0.0",
@@ -75,6 +76,7 @@
     "@types/react-dev-utils": "~9.0.4",
     "@types/terser-webpack-plugin": "~3.0.0",
     "@types/webpack": "4.41.18",
+    "@types/debug": "^4.1.7",
     "@types/webpack-dev-server": "3.11.0",
     "@types/webpack-manifest-plugin": "~2.1.0",
     "jest-puppeteer": "^4.4.0",

--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -106,8 +106,7 @@ Object {
           Object {
             "include": Array [
               "packages/webpack-config/e2e/basic",
-              "packages/webpack-config/e2e/basic/node_modules/react-native-vector-icons",
-              "packages/webpack-config/e2e/basic/node_modules/@expo/vector-icons",
+              "node_modules/@expo/vector-icons/build",
             ],
             "test": /\\\\\\.\\(woff2\\?\\|eot\\|ttf\\|otf\\)\\$/,
             "use": Array [
@@ -275,8 +274,7 @@ Object {
           Object {
             "include": Array [
               "packages/webpack-config/e2e/basic",
-              "packages/webpack-config/e2e/basic/node_modules/react-native-vector-icons",
-              "packages/webpack-config/e2e/basic/node_modules/@expo/vector-icons",
+              "node_modules/@expo/vector-icons/build",
             ],
             "test": /\\\\\\.\\(woff2\\?\\|eot\\|ttf\\|otf\\)\\$/,
             "use": Array [
@@ -551,8 +549,7 @@ Object {
           Object {
             "include": Array [
               "packages/webpack-config/e2e/basic",
-              "packages/webpack-config/e2e/basic/node_modules/react-native-vector-icons",
-              "packages/webpack-config/e2e/basic/node_modules/@expo/vector-icons",
+              "node_modules/@expo/vector-icons/build",
             ],
             "test": /\\\\\\.\\(woff2\\?\\|eot\\|ttf\\|otf\\)\\$/,
             "use": Array [
@@ -733,8 +730,7 @@ Object {
           Object {
             "include": Array [
               "packages/webpack-config/e2e/basic",
-              "packages/webpack-config/e2e/basic/node_modules/react-native-vector-icons",
-              "packages/webpack-config/e2e/basic/node_modules/@expo/vector-icons",
+              "node_modules/@expo/vector-icons/build",
             ],
             "test": /\\\\\\.\\(woff2\\?\\|eot\\|ttf\\|otf\\)\\$/,
             "use": Array [

--- a/packages/webpack-config/src/addons/withUnimodules.ts
+++ b/packages/webpack-config/src/addons/withUnimodules.ts
@@ -136,7 +136,7 @@ export default function withUnimodules(
     // Process application code with Babel.
     babelLoader,
 
-    supportsFontLoading && createFontLoader(locations.root, locations.includeModule),
+    supportsFontLoading && createFontLoader(locations.root),
   ].filter(Boolean);
 
   webpackConfig.module = {

--- a/packages/webpack-config/src/env/__tests__/__snapshots__/paths-test.js.snap
+++ b/packages/webpack-config/src/env/__tests__/__snapshots__/paths-test.js.snap
@@ -4,7 +4,6 @@ exports[`has consistent defaults 1`] = `
 Object {
   "absolute": [Function],
   "appMain": "e2e/basic/index.js",
-  "includeModule": [Function],
   "modules": "e2e/basic/node_modules",
   "packageJson": "e2e/basic/package.json",
   "production": Object {
@@ -34,7 +33,6 @@ exports[`works with no app.json 1`] = `
 Object {
   "absolute": [Function],
   "appMain": "e2e/minimum/index.js",
-  "includeModule": [Function],
   "modules": "e2e/minimum/node_modules",
   "packageJson": "e2e/minimum/package.json",
   "production": Object {

--- a/packages/webpack-config/src/env/paths.ts
+++ b/packages/webpack-config/src/env/paths.ts
@@ -61,10 +61,6 @@ function parsePaths(
     return path.resolve(productionPath, ...props);
   }
 
-  function getIncludeModule(...props: string[]): string {
-    return path.resolve(modulesPath, ...props);
-  }
-
   let appMain: string | null = null;
   try {
     appMain = getEntryPoint(
@@ -78,7 +74,6 @@ function parsePaths(
 
   return {
     absolute,
-    includeModule: getIncludeModule,
     packageJson: packageJsonPath,
     root: path.resolve(inputProjectRoot),
     appMain,

--- a/packages/webpack-config/src/loaders/createAllLoaders.ts
+++ b/packages/webpack-config/src/loaders/createAllLoaders.ts
@@ -1,5 +1,5 @@
 import { getPossibleProjectRoot } from '@expo/config/paths';
-import { Rule } from 'webpack';
+import { RuleSetRule } from 'webpack';
 
 import { getConfig, getPaths } from '../env';
 import { Environment } from '../types';
@@ -24,7 +24,7 @@ const imageInlineSizeLimit = parseInt(process.env.IMAGE_INLINE_SIZE_LIMIT || '10
  * @category loaders
  */
 // TODO: Bacon: Move SVG
-export const imageLoaderRule: Rule = {
+export const imageLoaderRule: RuleSetRule = {
   test: /\.(gif|jpe?g|png|svg)$/,
   use: {
     loader: require.resolve('url-loader'),
@@ -46,7 +46,7 @@ export const imageLoaderRule: Rule = {
  *
  * @category loaders
  */
-export const fallbackLoaderRule: Rule = {
+export const fallbackLoaderRule: RuleSetRule = {
   loader: require.resolve('file-loader'),
   // Exclude `js` files to keep "css" loader working as it injects
   // its runtime that would otherwise be processed through "file" loader.
@@ -67,7 +67,7 @@ export const fallbackLoaderRule: Rule = {
  *
  * @category loaders
  */
-export const styleLoaderRule: Rule = {
+export const styleLoaderRule: RuleSetRule = {
   test: /\.(css)$/,
   use: [require.resolve('style-loader'), require.resolve('css-loader')],
 };
@@ -80,20 +80,20 @@ export const styleLoaderRule: Rule = {
  */
 export default function createAllLoaders(
   env: Pick<Environment, 'projectRoot' | 'locations' | 'mode' | 'config' | 'platform' | 'babel'>
-): Rule[] {
+): RuleSetRule[] {
   env.projectRoot = env.projectRoot || getPossibleProjectRoot();
   // @ts-ignore
   env.config = env.config || getConfig(env);
   // @ts-ignore
   env.locations = env.locations || getPaths(env.projectRoot, env);
 
-  const { root, includeModule, template } = env.locations;
+  const { root, template } = env.locations;
 
   return [
     getHtmlLoaderRule(template.folder),
     imageLoaderRule,
     getBabelLoaderRule(env),
-    createFontLoader(root, includeModule),
+    createFontLoader(root),
     styleLoaderRule,
     // This needs to be the last loader
     fallbackLoaderRule,
@@ -109,7 +109,7 @@ export default function createAllLoaders(
  */
 export function getBabelLoaderRule(
   env: Pick<Environment, 'projectRoot' | 'config' | 'locations' | 'mode' | 'platform' | 'babel'>
-): Rule {
+): RuleSetRule {
   env.projectRoot = env.projectRoot || getPossibleProjectRoot();
   // @ts-ignore
   env.config = env.config || getConfig(env);
@@ -139,7 +139,7 @@ export function getBabelLoaderRule(
  * @param exclude
  * @category loaders
  */
-export function getHtmlLoaderRule(exclude: string): Rule {
+export function getHtmlLoaderRule(exclude: string): RuleSetRule {
   return {
     test: /\.html$/,
     use: [require.resolve('html-loader')],

--- a/packages/webpack-config/src/loaders/createBabelLoader.ts
+++ b/packages/webpack-config/src/loaders/createBabelLoader.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import { boolish } from 'getenv';
 import path from 'path';
 import resolveFrom from 'resolve-from';
-import { Rule } from 'webpack';
+import { RuleSetRule } from 'webpack';
 
 import { getConfig, getMode, getPaths } from '../env';
 import { Environment, Mode } from '../types';
@@ -89,7 +89,7 @@ function generateCacheIdentifier(projectRoot: string, version: string = '1'): st
  */
 export function createBabelLoaderFromEnvironment(
   env: Pick<Environment, 'babel' | 'locations' | 'projectRoot' | 'config' | 'mode' | 'platform'>
-): Rule {
+): RuleSetRule {
   const mode = getMode(env);
   const locations = env.locations || getPaths(env.projectRoot, env);
   const appConfig = env.config || getConfig(env);
@@ -132,7 +132,7 @@ export default function createBabelLoader({
   include?: string[];
   verbose?: boolean;
   [key: string]: any;
-} = {}): Rule {
+} = {}): RuleSetRule {
   const ensuredProjectRoot = ensureRoot(babelProjectRoot);
   const modules = [...includeModulesThatContainPaths, ...include];
   const customUse = options.use || {};

--- a/packages/webpack-config/src/plugins/ExpoAppManifestWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoAppManifestWebpackPlugin.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from '@expo/config';
+import type { ExpoConfig } from '@expo/config';
 
 import PwaManifestWebpackPlugin, { PwaManifestOptions } from './PwaManifestWebpackPlugin';
 

--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from '@expo/config';
+import type { ExpoConfig } from '@expo/config';
 import { boolish } from 'getenv';
 import semver from 'semver';
 import { DefinePlugin as OriginalDefinePlugin } from 'webpack';

--- a/packages/webpack-config/src/plugins/ExpoPwaManifestWebpackPlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoPwaManifestWebpackPlugin.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from '@expo/config';
+import type { ExpoConfig } from '@expo/config';
 import chalk from 'chalk';
 import { generateManifestJson } from 'expo-pwa';
 import fs from 'fs-extra';

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -98,7 +98,6 @@ export interface FilePathsFolder {
 }
 export interface FilePaths {
   absolute: PathResolver;
-  includeModule: PathResolver;
   template: FilePathsFolder;
   production: FilePathsFolder;
   packageJson: string;

--- a/packages/webpack-config/src/utils/search.ts
+++ b/packages/webpack-config/src/utils/search.ts
@@ -7,7 +7,6 @@ import {
   Configuration,
   Entry,
   Plugin,
-  Rule,
   RuleSetCondition,
   RuleSetLoader,
   RuleSetRule,
@@ -88,7 +87,7 @@ export function getRules(config: AnyConfiguration): RuleItem[] {
  * @param config
  * @category utils
  */
-export function getExpoBabelLoader(config: AnyConfiguration): Rule | null {
+export function getExpoBabelLoader(config: AnyConfiguration): RuleSetRule | null {
   const { rules = [] } = config.module || {};
   const currentRules = getRulesAsItems(getRulesFromRules(rules));
   for (const ruleItem of currentRules) {


### PR DESCRIPTION
# Why

Don't attempt to load fonts from packages that don't exist. Use node module resolution to determine where a package is located.

