### PR TITLE
[expo cli] Refactor TerminalUI commands

### DIFF
--- a/packages/expo-cli/src/commands/run/android/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/android/resolveDeviceAsync.ts
@@ -18,9 +18,7 @@ async function ensureEmulatorOpenAsync(device?: Android.Device): Promise<Android
   return bootedDevice;
 }
 
-export async function resolveDeviceAsync(
-  device: string | boolean | undefined
-): Promise<Android.Device> {
+export async function resolveDeviceAsync(device?: string | boolean): Promise<Android.Device> {
   if (!device) {
     return await ensureEmulatorOpenAsync();
   }

--- a/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
@@ -30,7 +30,7 @@ async function getBuildDestinationsAsync({ osType }: { osType?: string } = {}) {
 }
 
 export async function resolveDeviceAsync(
-  device: string | boolean | undefined,
+  device?: string | boolean,
   { osType }: { osType?: string } = {}
 ): Promise<SimControl.SimulatorDevice | SimControl.XCTraceDevice> {
   if (!(await profileMethod(Simulator.ensureXcodeCommandLineToolsInstalledAsync)())) {

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -18,7 +18,6 @@ import Log from '../../log';
 import { selectAsync } from '../../prompts';
 import urlOpts from '../../urlOpts';
 import { openInEditorAsync } from '../utils/openInEditorAsync';
-import { profileMethod } from '../utils/profileMethod';
 
 const CTRL_C = '\u0003';
 const CTRL_D = '\u0004';

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -215,89 +215,61 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
   await printServerInfo(projectRoot, options);
 
   async function handleKeypress(key: string) {
-    if (options.webOnly) {
-      switch (key) {
-        case 'A':
-        case 'a':
-          if (key === 'A') {
-            Log.clear();
-          }
+    const shouldPrompt = !options.nonInteractive && ['I', 'A'].includes(key);
+    if (shouldPrompt) {
+      Log.clear();
+    }
+    switch (key) {
+      case 'A':
+      case 'a':
+        if (options.webOnly) {
           Log.log(`${BLT} Opening the web project in Chrome on Android...`);
-          await Android.openWebProjectAsync({
+          const results = await Android.openWebProjectAsync({
             projectRoot,
-            shouldPrompt: !options.nonInteractive && key === 'A',
+            shouldPrompt,
           });
-          printHelp();
-          break;
-        case 'i':
-        case 'I':
-          if (key === 'I') {
-            Log.clear();
+          if (!results.success) {
+            Log.nestedError(results.error);
           }
-          Log.log(`${BLT} Opening the web project in Safari on iOS...`);
-          await Simulator.openWebProjectAsync({
-            projectRoot,
-            shouldPrompt: !options.nonInteractive && key === 'I',
-            // note(brentvatne): temporarily remove logic for picking the
-            // simulator until we have parity for Android. this also ensures that we
-            // don't interfere with the default user flow until more users have tested
-            // this out.
-            //
-            // If no simulator is booted, then prompt which simulator to use.
-            // (key === 'I' || !(await Simulator.isSimulatorBootedAsync())),
-          });
-          printHelp();
-          break;
-      }
-    } else {
-      switch (key) {
-        case 'A':
-          Log.clear();
-          await Android.openProjectAsync({
-            projectRoot,
-            shouldPrompt: true,
-            devClient: options.devClient ?? false,
-          });
-          printHelp();
-          break;
-        case 'a': {
+        } else {
           Log.log(`${BLT} Opening on Android...`);
-          await Android.openProjectAsync({ projectRoot, devClient: options.devClient ?? false });
-          printHelp();
-          break;
-        }
-        case 'I':
-          Log.clear();
-          await Simulator.openProjectAsync({
+          const results = await Android.openProjectAsync({
             projectRoot,
-            shouldPrompt: true,
+            shouldPrompt,
             devClient: options.devClient ?? false,
           });
-          printHelp();
-          break;
-        case 'i': {
-          // note(brentvatne): temporarily remove logic for picking the
-          // simulator until we have parity for Android. this also ensures that we
-          // don't interfere with the default user flow until more users have tested
-          // this out.
-          //
-          // If no simulator is booted, then prompt for which simulator to use.
-          // const shouldPrompt =
-          //   !options.nonInteractive && (key === 'I' || !(await Simulator.isSimulatorBootedAsync()));
-
+          if (!results.success) {
+            Log.nestedError(
+              typeof results.error === 'string' ? results.error : results.error.message
+            );
+          }
+        }
+        printHelp();
+        break;
+      case 'I':
+      case 'i':
+        if (options.webOnly) {
+          Log.log(`${BLT} Opening the web project in Safari on iOS...`);
+          const results = await Simulator.openWebProjectAsync({
+            projectRoot,
+            shouldPrompt,
+          });
+          if (!results.success) {
+            Log.nestedError(results.error);
+          }
+        } else {
           Log.log(`${BLT} Opening on iOS...`);
-          await profileMethod(
-            Simulator.openProjectAsync,
-            'Simulator.openProjectAsync'
-          )({
+          const results = await Simulator.openProjectAsync({
             projectRoot,
-            shouldPrompt: false,
+            shouldPrompt,
             devClient: options.devClient ?? false,
           });
-          printHelp();
-          break;
+          if (!results.success) {
+            Log.nestedError(results.error);
+          }
         }
-      }
+        printHelp();
+        break;
     }
 
     switch (key) {

--- a/packages/expo-cli/src/commands/start/startAsync.ts
+++ b/packages/expo-cli/src/commands/start/startAsync.ts
@@ -23,18 +23,20 @@ export async function actionAsync(projectRoot: string, options: NormalizedOption
   // Add clean up hooks
   installExitHooks(projectRoot);
 
-  // Find expo binary in project/workspace node_modules
-  const hasExpoInstalled = resolveFrom.silent(projectRoot, 'expo');
-
-  if (!hasExpoInstalled) {
-    throw new ConfigError(
-      `Unable to find expo in this project - have you run yarn / npm install yet?`,
-      'MODULE_NOT_FOUND'
-    );
+  // Only validate expo in Expo Go contexts
+  if (!options.devClient) {
+    // Find expo binary in project/workspace node_modules
+    const hasExpoInstalled = resolveFrom.silent(projectRoot, 'expo');
+    if (!hasExpoInstalled) {
+      throw new ConfigError(
+        `Unable to find expo in this project - have you run yarn / npm install yet?`,
+        'MODULE_NOT_FOUND'
+      );
+    }
   }
 
   const { exp, pkg } = profileMethod(getConfig)(projectRoot, {
-    skipSDKVersionRequirement: options.webOnly,
+    skipSDKVersionRequirement: options.webOnly || options.devClient,
   });
 
   if (options.devClient) {


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo-cli/pull/3737
- Only validate expo package in Expo Go contexts 
- Combine TerminalUI commands
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- `expo start` press i, I, a, A

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->