### PR TITLE
[xdl] pass appropriate headers when making getManifestCall

### DIFF
--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -133,15 +133,21 @@ export async function publishAsync(
     exp.android?.publishManifestPath ||
     EmbeddedAssets.shouldEmbedAssetsForExpoUpdates(projectRoot, exp, pkg, target)
   ) {
+    const sdkOrRuntimeVersion = exp.runtimeVersion
+      ? {
+          'expo-runtime-version': exp.runtimeVersion,
+        }
+      : { 'expo-sdk-version': exp.sdkVersion };
+
     [androidManifest, iosManifest] = await Promise.all([
       ExponentTools.getManifestAsync(response.url, {
-        'Exponent-SDK-Version': exp.sdkVersion,
+        ...sdkOrRuntimeVersion,
         'Exponent-Platform': 'android',
         'Expo-Release-Channel': options.releaseChannel,
         Accept: 'application/expo+json,application/json',
       }),
       ExponentTools.getManifestAsync(response.url, {
-        'Exponent-SDK-Version': exp.sdkVersion,
+        ...sdkOrRuntimeVersion,
         'Exponent-Platform': 'ios',
         'Expo-Release-Channel': options.releaseChannel,
         Accept: 'application/expo+json,application/json',
@@ -264,10 +270,15 @@ async function _handleKernelPublishedAsync({
     kernelBundleUrl = `${kernelBundleUrl}:${Config.api.port}`;
   }
   kernelBundleUrl = `${kernelBundleUrl}/@${user.username}/${exp.slug}/bundle`;
+  const sdkOrRuntimeVersion = exp.runtimeVersion
+    ? {
+        'expo-runtime-version': exp.runtimeVersion,
+      }
+    : { 'expo-sdk-version': exp.sdkVersion };
 
   if (exp.kernel?.androidManifestPath) {
     const manifest = await ExponentTools.getManifestAsync(url, {
-      'Exponent-SDK-Version': exp.sdkVersion,
+      ...sdkOrRuntimeVersion,
       'Exponent-Platform': 'android',
       Accept: 'application/expo+json,application/json',
     });
@@ -281,7 +292,7 @@ async function _handleKernelPublishedAsync({
 
   if (exp.kernel?.iosManifestPath) {
     const manifest = await ExponentTools.getManifestAsync(url, {
-      'Exponent-SDK-Version': exp.sdkVersion,
+      ...sdkOrRuntimeVersion,
       'Exponent-Platform': 'ios',
       Accept: 'application/expo+json,application/json',
     });


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

`expo publish` with a runtime version was failing for the project described here:

https://exponent-internal.slack.com/archives/C020VQQ8WAE/p1628129369013400

# How

Pass the correct runtime headers when making a `getManifestAsync` call.

I'm unfamiliar with how this part of classic publishing works, but it seems safe to assume that where we were requesting an sdk runtime manifest, we should now be getting a runtime OR sdk manifest.

`grep -i` for other instances of `expo-sdk-version` and `exponenet-sdk-version` and found none.

# Test Plan

Repro'd error
Confirmed publish works with rtv.
Confirmed publish still works without rtv.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->