### PR TITLE
Added fallback support for complex characters in prebuild

### DIFF
--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -1,6 +1,7 @@
 import { ExpoConfig } from '@expo/config-types';
 import assert from 'assert';
 import path from 'path';
+import slugify from 'slugify';
 import xcode, {
   PBXFile,
   PBXGroup,
@@ -47,7 +48,12 @@ export function resolvePathOrProject(
 }
 
 // TODO: come up with a better solution for using app.json expo.name in various places
-function sanitizedName(name: string) {
+export function sanitizedName(name: string) {
+  // Default to the name `app` when every safe character has been sanitized
+  return sanitizedNameForProjects(name) || sanitizedNameForProjects(slugify(name)) || 'app';
+}
+
+function sanitizedNameForProjects(name: string) {
   return name
     .replace(/[\W_]+/g, '')
     .normalize('NFD')

--- a/packages/config-plugins/src/ios/utils/__tests__/Xcodeproj-test.ts
+++ b/packages/config-plugins/src/ios/utils/__tests__/Xcodeproj-test.ts
@@ -1,0 +1,13 @@
+import { sanitizedName } from '../Xcodeproj';
+
+describe(sanitizedName, () => {
+  it(`formats basic name`, () => {
+    expect(sanitizedName('bacon')).toBe('bacon');
+  });
+  it(`formats android/xcode unsupported name`, () => {
+    expect(sanitizedName('あいう')).toBe('app');
+  });
+  it(`uses slugify for better name support`, () => {
+    expect(sanitizedName('\u2665')).toBe('love');
+  });
+});

--- a/packages/expo-cli/src/utils/extractTemplateAppAsync.ts
+++ b/packages/expo-cli/src/utils/extractTemplateAppAsync.ts
@@ -1,4 +1,5 @@
 import { BareAppConfig, ExpoConfig } from '@expo/config';
+import { IOSConfig } from '@expo/config-plugins';
 import JsonFile from '@expo/json-file';
 import fs from 'fs-extra';
 import merge from 'lodash/merge';
@@ -11,13 +12,6 @@ import { UserSettings } from 'xdl';
 
 type AppJsonInput = { expo: Partial<ExpoConfig> & { name: string } };
 type TemplateConfig = { name: string };
-
-function sanitizedName(name: string) {
-  return name
-    .replace(/[\W_]+/g, '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
-}
 
 function escapeXMLCharacters(original: string): string {
   const noAmps = original.replace('&', '&amp;');
@@ -50,8 +44,8 @@ class Transformer extends Minipass {
     const name = this.getNormalizedName();
     const replaced = this.data
       .replace(/Hello App Display Name/g, name)
-      .replace(/HelloWorld/g, sanitizedName(name))
-      .replace(/helloworld/g, sanitizedName(name.toLowerCase()));
+      .replace(/HelloWorld/g, IOSConfig.XcodeUtils.sanitizedName(name))
+      .replace(/helloworld/g, IOSConfig.XcodeUtils.sanitizedName(name.toLowerCase()));
     super.write(replaced);
     return super.end();
   }
@@ -145,9 +139,11 @@ export function createEntryResolver(name: string) {
       entry.path = entry.path
         .replace(
           /HelloWorld/g,
-          entry.path.includes('android') ? sanitizedName(name.toLowerCase()) : sanitizedName(name)
+          entry.path.includes('android')
+            ? IOSConfig.XcodeUtils.sanitizedName(name.toLowerCase())
+            : IOSConfig.XcodeUtils.sanitizedName(name)
         )
-        .replace(/helloworld/g, sanitizedName(name).toLowerCase());
+        .replace(/helloworld/g, IOSConfig.XcodeUtils.sanitizedName(name).toLowerCase());
     }
     if (entry.type && /^file$/i.test(entry.type) && path.basename(entry.path) === 'gitignore') {
       // Rename `gitignore` because npm ignores files named `.gitignore` when publishing.

--- a/packages/xdl/src/EmbeddedAssets.ts
+++ b/packages/xdl/src/EmbeddedAssets.ts
@@ -1,4 +1,5 @@
 import { ExpoAppManifest, getConfig, PackageJSONConfig, ProjectTarget } from '@expo/config';
+import { IOSConfig } from '@expo/config-plugins';
 import fs from 'fs-extra';
 import path from 'path';
 import semver from 'semver';
@@ -345,14 +346,6 @@ async function _maybeConfigureExpoUpdatesEmbeddedAssetsAsync(config: EmbeddedAss
 
 /** The code below here is duplicated from expo-cli currently **/
 
-// TODO: come up with a better solution for using app.json expo.name in various places
-function sanitizedName(name: string) {
-  return name
-    .replace(/[\W_]+/g, '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
-}
-
 // TODO: it's silly and kind of fragile that we look at app config to determine
 // the ios project paths. Overall this function needs to be revamped, just a
 // placeholder for now! Make this more robust when we support applying config
@@ -365,11 +358,15 @@ export function getIOSPaths(projectRoot: string) {
     throw new Error('Your project needs a name in app.json/app.config.js.');
   }
 
-  const iosProjectDirectory = path.join(projectRoot, 'ios', sanitizedName(projectName));
+  const iosProjectDirectory = path.join(
+    projectRoot,
+    'ios',
+    IOSConfig.XcodeUtils.sanitizedName(projectName)
+  );
   const iosSupportingDirectory = path.join(
     projectRoot,
     'ios',
-    sanitizedName(projectName),
+    IOSConfig.XcodeUtils.sanitizedName(projectName),
     'Supporting'
   );
   const iconPath = path.join(iosProjectDirectory, 'Assets.xcassets', 'AppIcon.appiconset');


### PR DESCRIPTION
# Why

- resolve https://github.com/expo/eas-cli/issues/458 
- When name sanitization strips all characters from a name, fallback to "app".
- I've also added a step to use slugify if all characters are stripped, this would attempt to add extra diversity to project names.
- Unified name sanitization across the repo.

# How


# Test Plan

- `expo prebuild` in an app named: `あいう`