### PR TITLE
[dev server] extract metro run layer into dev server

### DIFF
--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@types/connect": "^3.4.33",
     "connect": "^3.7.0",
+    "metro-inspector-proxy": "^0.59.0",
     "node-fetch": "^2.6.0"
   },
   "publishConfig": {

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -7,10 +7,9 @@ import {
 } from '@react-native-community/cli-server-api';
 import bodyParser from 'body-parser';
 import type { Server as ConnectServer } from 'connect';
-import type http from 'http';
+import http from 'http';
 import type Metro from 'metro';
 import path from 'path';
-import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
 import {
@@ -19,6 +18,11 @@ import {
   maybeInconsistentEngineAsync,
 } from './HermesBundler';
 import LogReporter from './LogReporter';
+import { createDevServerAsync } from './metro/createDevServerAsync';
+import {
+  importMetroFromProject,
+  importMetroServerFromProject,
+} from './metro/importMetroFromProject';
 import clientLogsMiddleware from './middleware/clientLogsMiddleware';
 import createJsInspectorMiddleware from './middleware/createJsInspectorMiddleware';
 import { remoteDevtoolsCorsMiddleware } from './middleware/remoteDevtoolsCorsMiddleware';
@@ -58,8 +62,6 @@ export async function runMetroDevServerAsync(
   middleware: any;
   messageSocket: MessageSocket;
 }> {
-  const Metro = importMetroFromProject(projectRoot);
-
   const reporter = new LogReporter(options.logger);
 
   const metroConfig = await ExpoMetroConfig.loadAsync(projectRoot, { reporter, ...options });
@@ -91,13 +93,16 @@ export async function runMetroDevServerAsync(
     return middleware.use(metroMiddleware);
   };
 
-  const serverInstance = await Metro.runServer(metroConfig, { hmrEnabled: true });
+  const { server } = await createDevServerAsync(projectRoot, {
+    config: metroConfig,
+    logger: options.logger,
+  });
 
-  const { messageSocket, eventsSocket } = attachToServer(serverInstance);
+  const { messageSocket, eventsSocket } = attachToServer(server);
   reporter.reportEvent = eventsSocket.reportEvent;
 
   return {
-    server: serverInstance,
+    server,
     middleware,
     messageSocket,
   };
@@ -228,34 +233,6 @@ export async function bundleAsync(
   } finally {
     metroServer.end();
   }
-}
-
-function importMetroFromProject(projectRoot: string): typeof Metro {
-  const resolvedPath = resolveFrom.silent(projectRoot, 'metro');
-  if (!resolvedPath) {
-    throw new Error(
-      'Missing package "metro" in the project at ' +
-        projectRoot +
-        '. ' +
-        'This usually means `react-native` is not installed. ' +
-        'Please verify that dependencies in package.json include "react-native" ' +
-        'and run `yarn` or `npm install`.'
-    );
-  }
-  return require(resolvedPath);
-}
-
-function importMetroServerFromProject(projectRoot: string): typeof Metro.Server {
-  const resolvedPath = resolveFrom.silent(projectRoot, 'metro/src/Server');
-  if (!resolvedPath) {
-    throw new Error(
-      'Missing module "metro/src/Server" in the project. ' +
-        'This usually means React Native is not installed. ' +
-        'Please verify that dependencies in package.json include "react-native" ' +
-        'and run `yarn` or `npm install`.'
-    );
-  }
-  return require(resolvedPath);
 }
 
 // Cloned from xdl/src/Versions.ts, we cannot use that because of circular dependency

--- a/packages/dev-server/src/metro/createDevServerAsync.ts
+++ b/packages/dev-server/src/metro/createDevServerAsync.ts
@@ -1,0 +1,132 @@
+import type Log from '@expo/bunyan';
+import connect from 'connect';
+import http from 'http';
+import type MetroConfig from 'metro-config';
+
+import {
+  importInspectorProxyServerFromProject,
+  importMetroConfigFromProject,
+  importMetroHmrServerFromProject,
+  importMetroLibAttachWebsocketServerFromProject,
+  importMetroServerFromProject,
+} from './importMetroFromProject';
+
+async function getConfig(
+  projectRoot: string,
+  config: MetroConfig.InputConfigT
+): Promise<MetroConfig.ConfigT> {
+  const { getDefaultConfig, mergeConfig } = importMetroConfigFromProject(projectRoot);
+  const defaultConfig = await getDefaultConfig(config.projectRoot || projectRoot);
+  return mergeConfig(defaultConfig, config);
+}
+
+/**
+ * Send the initial load event to our logger.
+ * @param config loaded metro config
+ */
+function reportInitializeStarted(config: MetroConfig.ConfigT) {
+  config.reporter.update({
+    hasReducedPerformance: false,
+    port: config.server.port,
+    type: 'initialize_started',
+  });
+}
+
+async function runMetro(projectRoot: string, config: MetroConfig.InputConfigT) {
+  const MetroServer = importMetroServerFromProject(projectRoot);
+
+  const mergedConfig = await getConfig(projectRoot, config);
+
+  reportInitializeStarted(mergedConfig);
+
+  return new MetroServer(mergedConfig);
+}
+
+type RunServerProps = {
+  config: MetroConfig.ConfigT;
+  logger: Log;
+  onReady?: (server: http.Server) => void;
+};
+
+export async function createDevServerAsync(
+  projectRoot: string,
+  { config, logger, onReady }: RunServerProps
+): Promise<{
+  server: http.Server;
+}> {
+  const serverApp = connect();
+
+  const metroServer = await runMetro(projectRoot, config);
+
+  const { InspectorProxy } = importInspectorProxyServerFromProject(projectRoot);
+  const MetroHmrServer = importMetroHmrServerFromProject(projectRoot);
+  const attachWebsocketServer = importMetroLibAttachWebsocketServerFromProject(projectRoot);
+
+  let middleware = metroServer.processRequest;
+
+  // Enhance the resulting middleware using the config options
+  if (config.server.enhanceMiddleware) {
+    middleware = config.server.enhanceMiddleware(middleware, metroServer);
+  }
+
+  serverApp.use(middleware);
+
+  let inspectorProxy: typeof InspectorProxy | null = null;
+  if (config.server.runInspectorProxy) {
+    inspectorProxy = new InspectorProxy(config.projectRoot);
+  }
+
+  const httpServer = http.createServer(serverApp);
+
+  // Disable any kind of automatic timeout behavior for incoming
+  // requests in case it takes the packager more than the default
+  // timeout of 120 seconds to respond to a request.
+  httpServer.timeout = 0;
+
+  return new Promise((resolve, reject) => {
+    httpServer.listen(config.server.port, () => {
+      if (onReady) {
+        onReady(httpServer);
+      }
+
+      // Create a new HMR Server
+      // TODO: Replace with a metro-agnostic HMR server and share with Webpack.
+      const websocketServer = new MetroHmrServer(
+        metroServer.getBundler(),
+        metroServer.getCreateModuleId(),
+        config
+      );
+
+      // attachHmrServer
+      // TODO: Extract this function into expo/dev-server
+      attachWebsocketServer({
+        httpServer,
+        path: '/hot',
+        websocketServer,
+      });
+
+      if (inspectorProxy) {
+        inspectorProxy.addWebSocketListener(httpServer);
+
+        // TODO(hypuk): Refactor inspectorProxy.processRequest into separate request handlers
+        // so that we could provide routes (/json/list and /json/version) here.
+        // Currently this causes Metro to give warning about T31407894.
+        // $FlowFixMe[method-unbinding] added when improving typing for this parameters
+        serverApp.use(inspectorProxy.processRequest.bind(inspectorProxy));
+      }
+
+      resolve({ server: httpServer });
+    });
+
+    httpServer.on('error', error => {
+      // Send a custom log to inform our system that the server has had an unexpected error.
+      logger.error({ tag: 'metro' }, `Server error: ${error.message}`);
+      metroServer.end();
+      reject(error);
+    });
+
+    httpServer.on('close', () => {
+      metroServer.end();
+    });
+  });
+}

--- a/packages/dev-server/src/metro/importMetroFromProject.ts
+++ b/packages/dev-server/src/metro/importMetroFromProject.ts
@@ -1,0 +1,48 @@
+import type Metro from 'metro';
+import type MetroConfig from 'metro-config';
+import resolveFrom from 'resolve-from';
+
+class MetroImportError extends Error {
+  constructor(projectRoot: string, moduleId: string) {
+    super(
+      `Missing package "${moduleId}" in the project at: ${projectRoot}\n` +
+        'This usually means `react-native` is not installed. ' +
+        'Please verify that dependencies in package.json include "react-native" ' +
+        'and run `yarn` or `npm install`.'
+    );
+  }
+}
+
+function importFromProject(projectRoot: string, moduleId: string) {
+  const resolvedPath = resolveFrom.silent(projectRoot, moduleId);
+  if (!resolvedPath) {
+    throw new MetroImportError(projectRoot, moduleId);
+  }
+  return require(resolvedPath);
+}
+
+export function importMetroConfigFromProject(projectRoot: string): typeof MetroConfig {
+  return importFromProject(projectRoot, 'metro-config');
+}
+
+export function importMetroFromProject(projectRoot: string): typeof Metro {
+  return importFromProject(projectRoot, 'metro');
+}
+
+export function importMetroHmrServerFromProject(projectRoot: string): any {
+  return importFromProject(projectRoot, 'metro/src/HmrServer');
+}
+
+export function importMetroLibAttachWebsocketServerFromProject(projectRoot: string): any {
+  return importFromProject(projectRoot, 'metro/src/lib/attachWebsocketServer');
+}
+
+export function importMetroServerFromProject(projectRoot: string): typeof Metro.Server {
+  return importFromProject(projectRoot, 'metro/src/Server');
+}
+
+export function importInspectorProxyServerFromProject(
+  projectRoot: string
+): { InspectorProxy: any } {
+  return importFromProject(projectRoot, 'metro-inspector-proxy');
+}


### PR DESCRIPTION
# Why

Extract code for creating the server instance into expo/dev-server so we can start replacing metro dev server features with bundler agnostic versions that can be applied across platforms and bundlers.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Extract `Metro.runServer` into `createDevServerAsync`. This gives us the ability to replace `MetroHmrServer`, `MetroServer`, and `attachWebsocketServer` with bundler agnostic versions in a set of future PRs.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `expo start`
  - open in sim (bundle middleware) 
  - `console.log`
  - throw error (symbolication)
  - press `r` -- sends reload event (websockets)
  - make a change and save (hmr)