### PR TITLE
Remove one instance of internal-ip

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -57,7 +57,6 @@
     "getenv": "^1.0.0",
     "glob": "7.1.6",
     "hasbin": "1.2.3",
-    "internal-ip": "4.3.0",
     "is-reachable": "^4.0.0",
     "is-root": "^2.1.0",
     "joi": "^17.4.0",

--- a/packages/xdl/src/index.ts
+++ b/packages/xdl/src/index.ts
@@ -3,6 +3,7 @@ import { install as installSourceMapSupport } from 'source-map-support';
 if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   installSourceMapSupport();
 }
+
 export {
   Analytics,
   Android,

--- a/packages/xdl/src/ip.ts
+++ b/packages/xdl/src/ip.ts
@@ -1,7 +1,16 @@
-import internalIp from 'internal-ip';
-
 export default {
   address() {
-    return internalIp.v4.sync() || '127.0.0.1';
+    // https://stackoverflow.com/a/15075395/4047926
+    const interfaces = require('os').networkInterfaces();
+    for (const devName in interfaces) {
+      const iface = interfaces[devName];
+
+      for (let i = 0; i < iface.length; i++) {
+        const alias = iface[i];
+        if (alias.family === 'IPv4' && alias.address !== '127.0.0.1' && !alias.internal)
+          return alias.address;
+      }
+    }
+    return '127.0.0.1';
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10212,7 +10212,7 @@ inquirer@^6.2.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-internal-ip@4.3.0, internal-ip@^4.3.0:
+internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
   integrity sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==


### PR DESCRIPTION
# Why

Webpack bundling doesn't work with default-gateway (presumably because of the dynamic require):

```
Module not found: Error: Can't resolve 'raw-loader' in '/Users/evanbacon/Documents/GitHub/cli/packages/expo-cli'
@ ../../node_modules/default-gateway/index.js 20:12-32
@ ../../node_modules/internal-ip/index.js 3:23-49
@ ../xdl/build/ip.js 7:38-60
```

Using the node.js `os` library instead. This problem will still persist though, as default-gateway is used in webpack-dev-server.

# Test Plan

Tested (on mac) that the results between the current method match the old method. I'd imagine that windows and linux also work as expected. Other platforms like linux-Android may run into some issues, hard to know for sure. 


