### PR TITLE
[dev-server] Refactor project imports

### DIFF
--- a/packages/dev-server/src/metro/importMetroFromProject.ts
+++ b/packages/dev-server/src/metro/importMetroFromProject.ts
@@ -15,12 +15,16 @@ class MetroImportError extends Error {
   }
 }
 
-function importFromProject(projectRoot: string, moduleId: string) {
+function resolveFromProject(projectRoot: string, moduleId: string) {
   const resolvedPath = resolveFrom.silent(projectRoot, moduleId);
   if (!resolvedPath) {
     throw new MetroImportError(projectRoot, moduleId);
   }
-  return require(resolvedPath);
+  return resolvedPath;
+}
+
+function importFromProject(projectRoot: string, moduleId: string) {
+  return require(resolveFromProject(projectRoot, moduleId));
 }
 
 export function importMetroSourceMapComposeSourceMapsFromProject(
@@ -57,7 +61,7 @@ export function importInspectorProxyServerFromProject(
 
 export function importHermesCommandFromProject(projectRoot: string): string {
   const platformExecutable = getHermesCommandPlatform();
-  return importFromProject(projectRoot, `hermes-engine/${platformExecutable}`);
+  return resolveFromProject(projectRoot, `hermes-engine/${platformExecutable}`);
 }
 
 function getHermesCommandPlatform(): string {

--- a/packages/dev-server/src/metro/importMetroFromProject.ts
+++ b/packages/dev-server/src/metro/importMetroFromProject.ts
@@ -1,5 +1,7 @@
 import type Metro from 'metro';
 import type MetroConfig from 'metro-config';
+import type { composeSourceMaps } from 'metro-source-map';
+import os from 'os';
 import resolveFrom from 'resolve-from';
 
 class MetroImportError extends Error {
@@ -19,6 +21,12 @@ function importFromProject(projectRoot: string, moduleId: string) {
     throw new MetroImportError(projectRoot, moduleId);
   }
   return require(resolvedPath);
+}
+
+export function importMetroSourceMapComposeSourceMapsFromProject(
+  projectRoot: string
+): typeof composeSourceMaps {
+  return importFromProject(projectRoot, 'metro-source-map/src/composeSourceMaps');
 }
 
 export function importMetroConfigFromProject(projectRoot: string): typeof MetroConfig {
@@ -45,4 +53,22 @@ export function importInspectorProxyServerFromProject(
   projectRoot: string
 ): { InspectorProxy: any } {
   return importFromProject(projectRoot, 'metro-inspector-proxy');
+}
+
+export function importHermesCommandFromProject(projectRoot: string): string {
+  const platformExecutable = getHermesCommandPlatform();
+  return importFromProject(projectRoot, `hermes-engine/${platformExecutable}`);
+}
+
+function getHermesCommandPlatform(): string {
+  switch (os.platform()) {
+    case 'darwin':
+      return 'osx-bin/hermesc';
+    case 'linux':
+      return 'linux64-bin/hermesc';
+    case 'win32':
+      return 'win64-bin/hermesc.exe';
+    default:
+      throw new Error(`Unsupported host platform for Hermes compiler: ${os.platform()}`);
+  }
 }


### PR DESCRIPTION
# Why

Follow up #3759 collecting up functions that perform dynamic metro imports so we can target them when bundling expo-cli with webpack.

