### PR TITLE
[xdl][webpack] simplified API

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -366,10 +366,8 @@ Please reload the project in Expo Go for the change to take effect.`
       case 'r':
         if (options.isRemoteReloadingEnabled) {
           Log.log(`${BLT} Reloading apps`);
-          // Send reload requests over the metro dev server
+          // Send reload requests over the dev servers
           Project.broadcastMessage('reload');
-          // Send reload requests over the webpack dev server
-          Webpack.broadcastMessage('content-changed');
         } else if (!options.webOnly) {
           // [SDK 40]: Restart bundler
           Log.clear();


### PR DESCRIPTION
# Why

Make the bundler interface for webpack similar to that of metro & expo/dev-server. 

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- drop deprecated and unused values
- remove unused exports 
- make the return values of startAsync similar to that of expo/dev-server.
- Make the main interface functions: startAsync, bundleAsync

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Run `expo web`

