### PR TITLE
[webpack] Use proper project context

### DIFF
--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -458,7 +458,7 @@ Object {
 exports[`web web development 1`] = `
 Object {
   "bail": false,
-  "context": "packages/webpack-config/src",
+  "context": "packages/webpack-config/e2e/basic",
   "devServer": Object {
     "after": [Function],
     "before": [Function],
@@ -670,7 +670,7 @@ Object {
 exports[`web web production 1`] = `
 Object {
   "bail": true,
-  "context": "packages/webpack-config/src",
+  "context": "packages/webpack-config/e2e/basic",
   "devtool": "source-map",
   "entry": Object {
     "app": Array [

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -318,8 +318,9 @@ export default async function (
     // Fail out on the first error instead of tolerating it.
     bail: isProd,
     devtool,
-    // TODO(Bacon): Simplify this while ensuring gatsby support continues to work.
-    context: isNative ? env.projectRoot ?? __dirname : __dirname,
+    // This must point to the project root (where the webpack.config.js would normally be located).
+    // If this is anywhere else, the source maps and errors won't show correct paths.
+    context: env.projectRoot ?? __dirname,
     // configures where the build ends up
     output: getOutput(locations, mode, publicPath, env.platform),
     plugins: [


### PR DESCRIPTION


# Why

Webpack config's context property must point to the project root (where the webpack.config.js would normally be located). If this is anywhere else, the source maps and errors won't show correct paths.