### PR TITLE
[webpack] added manifest middleware

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -221,7 +221,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
     switch (key) {
       case 'A':
       case 'a':
-        if (options.webOnly) {
+        if (options.webOnly && !Webpack.isTargetingNative()) {
           Log.log(`${BLT} Opening the web project in Chrome on Android...`);
           const results = await Android.openWebProjectAsync({
             projectRoot,
@@ -247,7 +247,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         break;
       case 'I':
       case 'i':
-        if (options.webOnly) {
+        if (options.webOnly && !Webpack.isTargetingNative()) {
           Log.log(`${BLT} Opening the web project in Safari on iOS...`);
           const results = await Simulator.openWebProjectAsync({
             projectRoot,

--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -40,7 +40,7 @@ Object {
     "transportMode": "ws",
     "watchContentBase": true,
   },
-  "devtool": "cheap-module-source-map",
+  "devtool": false,
   "entry": Object {
     "app": Array [
       "node_modules/react-native/Libraries/polyfills/console.js",
@@ -68,17 +68,6 @@ Object {
             ],
           },
           Object {
-            "test": /\\\\\\.\\(gif\\|jpe\\?g\\|png\\|svg\\)\\$/,
-            "use": Object {
-              "loader": "node_modules/url-loader/dist/cjs.js",
-              "options": Object {
-                "esModule": false,
-                "limit": 1000,
-                "name": "static/media/[name].[hash:8].[ext]",
-              },
-            },
-          },
-          Object {
             "include": [Function],
             "test": /\\\\\\.\\(mjs\\|\\[jt\\]sx\\?\\)\\$/,
             "use": Object {
@@ -103,43 +92,6 @@ Object {
               },
             },
           },
-          Object {
-            "include": Array [
-              "packages/webpack-config/e2e/basic",
-              "packages/webpack-config/e2e/basic/node_modules/react-native-vector-icons",
-              "packages/webpack-config/e2e/basic/node_modules/@expo/vector-icons",
-            ],
-            "test": /\\\\\\.\\(woff2\\?\\|eot\\|ttf\\|otf\\)\\$/,
-            "use": Array [
-              Object {
-                "loader": "node_modules/url-loader/dist/cjs.js",
-                "options": Object {
-                  "esModule": false,
-                  "limit": 50000,
-                  "name": "./fonts/[name].[ext]",
-                },
-              },
-            ],
-          },
-          Object {
-            "test": /\\\\\\.\\(css\\)\\$/,
-            "use": Array [
-              "node_modules/style-loader/dist/cjs.js",
-              "node_modules/css-loader/dist/cjs.js",
-            ],
-          },
-          Object {
-            "exclude": Array [
-              /\\\\\\.\\(mjs\\|\\[jt\\]sx\\?\\)\\$/,
-              /\\\\\\.html\\$/,
-              /\\\\\\.json\\$/,
-            ],
-            "loader": "node_modules/file-loader/dist/cjs.js",
-            "options": Object {
-              "esModule": false,
-              "name": "static/media/[name].[hash:8].[ext]",
-            },
-          },
         ],
       },
     ],
@@ -148,7 +100,7 @@ Object {
   "output": Object {
     "chunkFilename": "static/js/[name].chunk.js",
     "devtoolModuleFilenameTemplate": [Function],
-    "filename": "static/js/bundle.js",
+    "filename": "index.bundle",
     "globalObject": "this",
     "path": "packages/webpack-config/e2e/basic/web-build",
     "pathinfo": true,
@@ -162,8 +114,14 @@ Object {
     "DefinePlugin",
     "LimitChunkCountPlugin",
     "WatchMissingNodeModulesPlugin",
+    "SourceMapDevToolPlugin",
   ],
   "resolve": Object {
+    "aliasFields": Array [
+      "react-native",
+      "browser",
+      "main",
+    ],
     "extensions": Array [
       ".ios.ts",
       ".ios.tsx",
@@ -178,6 +136,11 @@ Object {
       ".js",
       ".jsx",
       ".json",
+    ],
+    "mainFields": Array [
+      "react-native",
+      "browser",
+      "main",
     ],
     "plugins": Array [
       Object {
@@ -209,7 +172,7 @@ exports[`ios ios production 1`] = `
 Object {
   "bail": true,
   "context": "packages/webpack-config/e2e/basic",
-  "devtool": "source-map",
+  "devtool": false,
   "entry": Object {
     "app": Array [
       "node_modules/react-native/Libraries/polyfills/console.js",
@@ -237,17 +200,6 @@ Object {
             ],
           },
           Object {
-            "test": /\\\\\\.\\(gif\\|jpe\\?g\\|png\\|svg\\)\\$/,
-            "use": Object {
-              "loader": "node_modules/url-loader/dist/cjs.js",
-              "options": Object {
-                "esModule": false,
-                "limit": 1000,
-                "name": "static/media/[name].[hash:8].[ext]",
-              },
-            },
-          },
-          Object {
             "include": [Function],
             "test": /\\\\\\.\\(mjs\\|\\[jt\\]sx\\?\\)\\$/,
             "use": Object {
@@ -272,43 +224,6 @@ Object {
               },
             },
           },
-          Object {
-            "include": Array [
-              "packages/webpack-config/e2e/basic",
-              "packages/webpack-config/e2e/basic/node_modules/react-native-vector-icons",
-              "packages/webpack-config/e2e/basic/node_modules/@expo/vector-icons",
-            ],
-            "test": /\\\\\\.\\(woff2\\?\\|eot\\|ttf\\|otf\\)\\$/,
-            "use": Array [
-              Object {
-                "loader": "node_modules/url-loader/dist/cjs.js",
-                "options": Object {
-                  "esModule": false,
-                  "limit": 50000,
-                  "name": "./fonts/[name].[ext]",
-                },
-              },
-            ],
-          },
-          Object {
-            "test": /\\\\\\.\\(css\\)\\$/,
-            "use": Array [
-              "node_modules/style-loader/dist/cjs.js",
-              "node_modules/css-loader/dist/cjs.js",
-            ],
-          },
-          Object {
-            "exclude": Array [
-              /\\\\\\.\\(mjs\\|\\[jt\\]sx\\?\\)\\$/,
-              /\\\\\\.html\\$/,
-              /\\\\\\.json\\$/,
-            ],
-            "loader": "node_modules/file-loader/dist/cjs.js",
-            "options": Object {
-              "esModule": false,
-              "name": "static/media/[name].[hash:8].[ext]",
-            },
-          },
         ],
       },
     ],
@@ -326,7 +241,7 @@ Object {
           "include": undefined,
           "minify": undefined,
           "parallel": true,
-          "sourceMap": true,
+          "sourceMap": false,
           "terserOptions": Object {
             "compress": Object {
               "comparisons": false,
@@ -363,10 +278,7 @@ Object {
           "canPrint": undefined,
           "cssProcessor": [Function],
           "cssProcessorOptions": Object {
-            "map": Object {
-              "annotation": true,
-              "inline": false,
-            },
+            "map": false,
             "parser": [Function],
           },
           "cssProcessorPluginOptions": Object {},
@@ -398,7 +310,7 @@ Object {
   "output": Object {
     "chunkFilename": "static/js/[name].[contenthash:8].chunk.js",
     "devtoolModuleFilenameTemplate": [Function],
-    "filename": "static/js/[name].[contenthash:8].js",
+    "filename": "index.bundle",
     "globalObject": "this",
     "path": "packages/webpack-config/e2e/basic/web-build",
     "publicPath": "/",
@@ -412,8 +324,14 @@ Object {
     "ModuleNotFoundPlugin",
     "DefinePlugin",
     "LimitChunkCountPlugin",
+    "SourceMapDevToolPlugin",
   ],
   "resolve": Object {
+    "aliasFields": Array [
+      "react-native",
+      "browser",
+      "main",
+    ],
     "extensions": Array [
       ".ios.ts",
       ".ios.tsx",
@@ -428,6 +346,11 @@ Object {
       ".js",
       ".jsx",
       ".json",
+    ],
+    "mainFields": Array [
+      "react-native",
+      "browser",
+      "main",
     ],
     "plugins": Array [
       Object {
@@ -628,6 +551,7 @@ Object {
       "react-native/Libraries/vendor/emitter/EventEmitter$": "react-native-web/dist/vendor/react-native/emitter/EventEmitter",
       "react-native/Libraries/vendor/emitter/EventSubscriptionVendor$": "react-native-web/dist/vendor/react-native/emitter/EventSubscriptionVendor",
     },
+    "aliasFields": undefined,
     "extensions": Array [
       ".web.ts",
       ".web.tsx",
@@ -642,6 +566,7 @@ Object {
       ".json",
       ".wasm",
     ],
+    "mainFields": undefined,
     "plugins": Array [
       Object {
         "apply": [Function],
@@ -893,6 +818,7 @@ Object {
       "react-native/Libraries/vendor/emitter/EventEmitter$": "react-native-web/dist/vendor/react-native/emitter/EventEmitter",
       "react-native/Libraries/vendor/emitter/EventSubscriptionVendor$": "react-native-web/dist/vendor/react-native/emitter/EventSubscriptionVendor",
     },
+    "aliasFields": undefined,
     "extensions": Array [
       ".web.ts",
       ".web.tsx",
@@ -907,6 +833,7 @@ Object {
       ".json",
       ".wasm",
     ],
+    "mainFields": undefined,
     "plugins": Array [
       Object {
         "apply": [Function],

--- a/packages/webpack-config/src/addons/withSourceMaps.ts
+++ b/packages/webpack-config/src/addons/withSourceMaps.ts
@@ -8,7 +8,7 @@ function isNative(env: Pick<InputEnvironment, 'platform'>): boolean {
 
 function createSourceMapPlugin(
   webpackConfig: AnyConfiguration,
-  env: Pick<InputEnvironment, 'mode'> = {}
+  env: Pick<InputEnvironment, 'mode' | 'platform'> = {}
 ) {
   const mode = env.mode ?? webpackConfig.mode;
   const isDev = mode !== 'production';
@@ -19,13 +19,15 @@ function createSourceMapPlugin(
     // This doesn't support inline source maps.
     new SourceMapDevToolPlugin({
       test: /\.(js|tsx?|(js)?bundle)($|\?)/i,
-      filename: webpackConfig.output?.sourceMapFilename,
+      exclude: /\.chunk\.(js)?bundle$/,
+      filename: webpackConfig.output?.sourceMapFilename ?? '[file].map',
+      append: `//# sourceMappingURL=[url]?platform=${env.platform!}`,
       // @ts-ignore: this is how webpack works internally
       moduleFilenameTemplate: webpackConfig.output?.devtoolModuleFilenameTemplate,
       // Emulate the `devtool` settings based on CRA defaults
       ...(isDev
         ? {
-            // cheap-module-source-map
+            // cheap-module-source-map -- less accurate but faster
             module: true,
             columns: false,
           }

--- a/packages/webpack-config/src/loaders/createAllLoaders.ts
+++ b/packages/webpack-config/src/loaders/createAllLoaders.ts
@@ -88,6 +88,12 @@ export default function createAllLoaders(
   env.locations = env.locations || getPaths(env.projectRoot, env);
 
   const { root, includeModule, template } = env.locations;
+  const isNative = ['ios', 'android'].includes(env.platform);
+
+  if (isNative) {
+    // TODO: Support fallback loader + assets
+    return [getHtmlLoaderRule(template.folder), getBabelLoaderRule(env)];
+  }
 
   return [
     getHtmlLoaderRule(template.folder),
@@ -97,7 +103,7 @@ export default function createAllLoaders(
     styleLoaderRule,
     // This needs to be the last loader
     fallbackLoaderRule,
-  ].filter(Boolean);
+  ].filter(Boolean) as Rule[];
 }
 
 /**

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -55,7 +55,7 @@ import { Arguments, DevConfiguration, Environment, FilePaths, Mode } from './typ
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = boolish('GENERATE_SOURCEMAP', true);
-const shouldUseNativeCodeLoading = boolish('EXPO_WEBPACK_USE_NATIVE_CODE_LOADING', true);
+const shouldUseNativeCodeLoading = boolish('EXPO_WEBPACK_USE_NATIVE_CODE_LOADING', false);
 
 const isCI = boolish('CI', false);
 
@@ -335,9 +335,10 @@ export default async function (
       isProd && new CopyWebpackPlugin({ patterns: filesToCopy }),
 
       // Generate the `index.html`
-      new ExpoHtmlWebpackPlugin(env, templateIndex),
+      (!isNative || !shouldUseNativeCodeLoading) && new ExpoHtmlWebpackPlugin(env, templateIndex),
 
-      ExpoInterpolateHtmlPlugin.fromEnv(env, ExpoHtmlWebpackPlugin),
+      (!isNative || !shouldUseNativeCodeLoading) &&
+        ExpoInterpolateHtmlPlugin.fromEnv(env, ExpoHtmlWebpackPlugin),
 
       isNative &&
         new ExpoAppManifestWebpackPlugin(

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -487,6 +487,8 @@ export default async function (
       ],
     },
     resolve: {
+      mainFields: isNative ? ['react-native', 'browser', 'main'] : undefined,
+      aliasFields: isNative ? ['react-native', 'browser', 'main'] : undefined,
       extensions: getPlatformsExtensions(env.platform),
       plugins: [
         // Adds support for installing with Plug'n'Play, leading to faster installs and adding

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -106,6 +106,11 @@ async function clearWebCacheAsync(projectRoot: string, mode: string): Promise<vo
   } catch {}
 }
 
+// Temporary hack while we implement multi-bundler dev server proxy.
+export function isTargetingNative() {
+  return ['ios', 'android'].includes(process.env.EXPO_WEBPACK_PLATFORM || '');
+}
+
 export type WebpackDevServerResults = {
   server: DevServer;
   location: Omit<WebpackSettings, 'server'>;
@@ -205,8 +210,8 @@ export async function startAsync(
 
   // This is a temporary hack since we need to serve the expo manifest JSON on `/` for Expo Go support.
   // In the future, if we support HTML links to manifests we can get rid of this platform specific code.
-  const isNative = ['ios', 'android'].includes(process.env.EXPO_WEBPACK_PLATFORM || '');
-  if (isNative) {
+
+  if (isTargetingNative()) {
     await ProjectSettings.setPackagerInfoAsync(projectRoot, {
       expoServerPort: webpackServerPort,
       packagerPort: webpackServerPort,
@@ -225,7 +230,7 @@ export async function startAsync(
       onFinished: () => resolve(server),
     });
 
-    if (isNative) {
+    if (isTargetingNative()) {
       // Inject the Expo Go manifest middleware.
       const originalBefore = config.devServer!.before!.bind(config.devServer!.before);
       config.devServer!.before = (app, server, compiler) => {

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -122,6 +122,12 @@ export async function broadcastMessage(message: 'reload' | string, data?: any) {
     return;
   }
 
+  // Allow any message on native
+  if (isTargetingNative()) {
+    webpackDevServerInstance.sockWrite(webpackDevServerInstance.sockets, message, data);
+    return;
+  }
+
   if (message !== 'reload') {
     // TODO:
     // Webpack currently only supports reloading the client (browser),

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -68,8 +68,7 @@ export async function startAsync(
     });
 
     // This is used to make Expo Go open the project in either Expo Go, or the web browser.
-    const isNative = ['ios', 'android'].includes(process.env.EXPO_WEBPACK_PLATFORM || '');
-    DevSession.startSession(projectRoot, exp, isNative ? 'native' : 'web');
+    DevSession.startSession(projectRoot, exp, Webpack.isTargetingNative() ? 'native' : 'web');
     return exp;
   } else if (Env.shouldUseDevServer(exp) || options.devClient) {
     [serverInstance, , messageSocket] = await startDevServerAsync(projectRoot, options);

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -66,7 +66,10 @@ export async function startAsync(
       ...options,
       port: options.webpackPort,
     });
-    DevSession.startSession(projectRoot, exp, 'web');
+
+    // This is used to make Expo Go open the project in either Expo Go, or the web browser.
+    const isNative = ['ios', 'android'].includes(process.env.EXPO_WEBPACK_PLATFORM || '');
+    DevSession.startSession(projectRoot, exp, isNative ? 'native' : 'web');
     return exp;
   } else if (Env.shouldUseDevServer(exp) || options.devClient) {
     [serverInstance, , messageSocket] = await startDevServerAsync(projectRoot, options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5173,7 +5173,7 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
-big-integer@^1.6.44:
+big-integer@1.6.x, big-integer@^1.6.44:
   version "1.6.48"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
@@ -5297,6 +5297,13 @@ bplist-parser@0.2.0:
   integrity sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==
   dependencies:
     big-integer "^1.6.44"
+
+bplist-parser@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.3.0.tgz#ba50666370f61bbf94881636cd9f7d23c5286090"
+  integrity sha512-zgmaRvT6AN1JpPPV+S0a1/FAtoxSreYDccZGIqEMSvZl9DMe70mJ7MFzpxa1X+gHVdkToE2haRUHHMiW1OdejA==
+  dependencies:
+    big-integer "1.6.x"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -12513,7 +12520,7 @@ metro-core@0.59.0, metro-core@^0.59.0:
     metro-resolver "0.59.0"
     wordwrap "^1.0.0"
 
-metro-inspector-proxy@0.59.0:
+metro-inspector-proxy@0.59.0, metro-inspector-proxy@^0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.59.0.tgz#39d1390772d13767fc595be9a1a7074e2425cf8e"
   integrity sha512-hPeAuQcofTOH0F+2GEZqWkvkVY1/skezSSlMocDQDaqds+Kw6JgdA7FlZXxnKmQ/jYrWUzff/pl8SUCDwuYthQ==


### PR DESCRIPTION
# Why

Currently webpack can be used to load native projects, but only if they support code loading from index.html which hasn't been implemented in any public package yet. This PR makes native webpack work like a regular project by hosting a manifest from `/` so it can be loaded in Expo Go. This PR also adds support for Expo Go opening the project and Terminal UI support.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `EXPO_WEBPACK_PLATFORM=ios expo web`
  - pressing `i` should open in the simulator
  - pressing `a` should open in the emulator
  - Expo Go should show the project in the project's page
 