### PR TITLE
expo.io -> expo.dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,7 +4,7 @@ description: 'You want to report a reproducible bug or regression in Expo CLI or
 body:
   - type: markdown
     attributes:
-      value: "We're looking to keep questions on our forums and bug reports on the GitHub repo. For questions and help using Expo CLI, post in our [community forums](https://forums.expo.io/c/expo-cli) (log in with your Expo developer account)."
+      value: "We're looking to keep questions on our forums and bug reports on the GitHub repo. For questions and help using Expo CLI, post in our [community forums](https://forums.expo.dev/c/expo-cli) (log in with your Expo developer account)."
   - type: markdown
     attributes:
       value: Found a bug in the Expo SDK? Open a bug report [here](https://github.com/expo/expo/issues/new?assignees=&labels=needs+review&template=bug_report.yml) instead.
@@ -13,7 +13,7 @@ body:
       value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
   - type: markdown
     attributes:
-      value: If you leave out sections there is a high likelihood your issue will be closed. If you have a question, not a bug report, please post it on our [forums](https://forums.expo.io/) instead.
+      value: If you leave out sections there is a high likelihood your issue will be closed. If you have a question, not a bug report, please post it on our [forums](https://forums.expo.dev/) instead.
   - type: textarea
     validations:
       required: true
@@ -43,7 +43,7 @@ body:
       required: true
     attributes:
       label: Reproducible demo or steps to reproduce from a blank project
-      description: 'This should include as little code as possible, do not simply link your entire project. Sharing a link to a [Snack](https://snack.expo.io/) is a GREAT way to provide a reproducible demo :) If a reproducible demo, or a complete list of steps from blank project to bug, are not provided, it is very likely your issue will be closed. Read [here more guidance](https://stackoverflow.com/help/mcve).'
+      description: 'This should include as little code as possible, do not simply link your entire project. Sharing a link to a [Snack](https://snack.expo.dev/) is a GREAT way to provide a reproducible demo :) If a reproducible demo, or a complete list of steps from blank project to bug, are not provided, it is very likely your issue will be closed. Read [here more guidance](https://stackoverflow.com/help/mcve).'
   - type: markdown
     attributes:
       value: Please make sure contributors can follow the steps your provided in order to reproduce the bug.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,4 +4,4 @@ The Expo team is committed to fostering an open and welcoming environment.
 
 **Our Community Guidelines can be found here:**
 
-https://expo.io/guidelines
+https://expo.dev/guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ You can contribute to Expo development tools in various ways, including:
 
 - [Reporting bugs or issues](https://github.com/expo/expo-cli/issues/new) on GitHub. Please make sure to include fill in all the details in the issue template to make sure the issue can be addressed as quickly as possible.
 - [Submitting improvements to the documentation](https://github.com/expo/expo-docs). Updates, enhancements, new guides, spelling fixes...
-- Helping other people on the [forums](https://forums.expo.io).
+- Helping other people on the [forums](https://forums.expo.dev).
 - Looking at existing [issues](https://github.com/expo/expo-cli/issues) and adding more information, particularly helping to reproduce the issues.
 - [Submitting a pull request](#submitting-a-pull-request) with a bug fix or an improvement.
 
@@ -19,7 +19,7 @@ The [Expo CLI GitHub repository](https://github.com/expo/expo-cli) contains the 
 - `expo-cli`: Expo CLI is the command line interface for developing, building and sharing Expo apps.
 - `@expo/dev-tools`: the web-based graphical user interface included in Expo CLI for quickly viewing logs, connecting testing devices, deploying updates and more.
 - `xdl`: the Expo development library is a dependency of both the CLI and Dev Tools user interfaces, doing all the heavy lifting behind the scenes.
-- `@expo/schemer`: a library for validating [Expo configuration files](https://docs.expo.io/workflow/configuration/).
+- `@expo/schemer`: a library for validating [Expo configuration files](https://docs.expo.dev/workflow/configuration/).
 - `@expo/json-file`: a library for reading and writing JSON files.
 - `@expo/osascript`: a library for working with `osascript` which runs AppleScript code on macOS.
 - `@expo/traveling-fastlane-darwin`/`@expo/traveling-fastlane-linux`: JavaScript wrappers for managing iOS certs, based on [Fastlane](https://fastlane.tools), which is a Ruby based app automation tool.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- Title -->
 
 <p align="center">
-  <a href="https://expo.io/">
+  <a href="https://expo.dev/">
     <img alt="expo cli" src="./.gh-assets/banner.svg">
   </a>
 </p>
@@ -16,14 +16,14 @@
   <a aria-label="expo-cli downloads" href="http://www.npmtrends.com/expo-cli" target="_blank">
     <img alt="Downloads" src="https://img.shields.io/npm/dm/expo-cli.svg?style=flat-square&labelColor=000&color=000000&label=Downloads" />
 </a>
-  <a aria-label="Join our forums" href="https://forums.expo.io" target="_blank">
+  <a aria-label="Join our forums" href="https://forums.expo.dev" target="_blank">
     <img alt="" src="https://img.shields.io/badge/Ask%20Questions%20-000.svg?style=flat-square&logo=discourse&logoWidth=15&labelColor=000000&color=000000">
   </a>
 
 </p>
 
 <p align="center">
-  <a aria-label="expo documentation" href="https://docs.expo.io/workflow/expo-cli/">📚 Read the Documentation</a>
+  <a aria-label="expo documentation" href="https://docs.expo.dev/workflow/expo-cli/">📚 Read the Documentation</a>
   |
   <a aria-label="contribute to expo cli" href="https://github.com/expo/expo-cli/blob/master/CONTRIBUTING.md"><b>Contributing to Expo CLI</b></a>
 </p>
@@ -32,7 +32,7 @@
   <a aria-label="Follow @expo on Twitter" href="https://twitter.com/intent/follow?screen_name=expo" target="_blank">
     <img  alt="Twitter: expo" src="https://img.shields.io/twitter/follow/expo.svg?style=flat-square&label=Follow%20%40expo&logo=TWITTER&logoColor=FFFFFF&labelColor=00aced&logoWidth=15&color=lightgray" target="_blank" />
   </a>
-  <a aria-label="Follow Expo on Medium" href="https://blog.expo.io">
+  <a aria-label="Follow Expo on Medium" href="https://blog.expo.dev">
     <img align="right" alt="Medium: exposition" src="https://img.shields.io/badge/Learn%20more%20on%20our%20blog-lightgray.svg?style=flat-square" target="_blank" />
   </a>
 </p>
@@ -53,11 +53,11 @@
 
 ## 📚 Documentation
 
-<p>Learn about building and deploying universal apps <a aria-label="expo documentation" href="https://docs.expo.io">in our official docs!</a></p>
+<p>Learn about building and deploying universal apps <a aria-label="expo documentation" href="https://docs.expo.dev">in our official docs!</a></p>
 
-- [Using the CLI](https://docs.expo.io/workflow/expo-cli/)
-- [App.json Configuration](https://docs.expo.io/workflow/configuration/)
-- [Building and Deploying apps](https://docs.expo.io/introduction/walkthrough/#building-and-deploying)
+- [Using the CLI](https://docs.expo.dev/workflow/expo-cli/)
+- [App.json Configuration](https://docs.expo.dev/workflow/configuration/)
+- [Building and Deploying apps](https://docs.expo.dev/introduction/walkthrough/#building-and-deploying)
 
 ## 🗺 Project Layout
 
@@ -97,14 +97,14 @@
 Let everyone know your app can be run instantly in the _Expo Go_ app!
 <br/>
 
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.io/client)
+[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.io/client)
+[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 
 ```md
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.io/client)
+[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.io/client)
+[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 ```
 
 ## 👏 Contributing
@@ -113,13 +113,13 @@ If you like the Expo CLI and want to help make it better then check out our [con
 
 ## ❓ FAQ
 
-If you have questions about Expo and want answers, then check out our [Frequently Asked Questions](https://docs.expo.io/introduction/faq/)!
+If you have questions about Expo and want answers, then check out our [Frequently Asked Questions](https://docs.expo.dev/introduction/faq/)!
 
-If you still have questions you can ask them on our [forums](https://forums.expo.io) or on Twitter [@Expo](https://twitter.com/expo).
+If you still have questions you can ask them on our [forums](https://forums.expo.dev) or on Twitter [@Expo](https://twitter.com/expo).
 
 ## 💙 The Team
 
-Curious about who makes Expo? Here are our [team members](https://expo.io/about)!
+Curious about who makes Expo? Here are our [team members](https://expo.dev/about)!
 
 ## License
 

--- a/packages/babel-preset-cli/package.json
+++ b/packages/babel-preset-cli/package.json
@@ -14,7 +14,7 @@
   "keywords": [
     "babel-preset"
   ],
-  "author": "Expo <support@expo.io>",
+  "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/expo/expo-cli/issues"

--- a/packages/config-plugins/README.md
+++ b/packages/config-plugins/README.md
@@ -1,5 +1,5 @@
 # Expo Config Plugins
 
-The Expo config is a powerful tool for generating native app code from a unified JavaScript interface. Most basic functionality can be controlled by using the the [static Expo config](https://docs.expo.io/versions/latest/config/app/), but some features require manipulation of the native project files. To support complex behavior we've created config plugins, and mods (short for modifiers).
+The Expo config is a powerful tool for generating native app code from a unified JavaScript interface. Most basic functionality can be controlled by using the the [static Expo config](https://docs.expo.dev/versions/latest/config/app/), but some features require manipulation of the native project files. To support complex behavior we've created config plugins, and mods (short for modifiers).
 
-For more info, please refer to the official docs: [Config Plugins](https://docs.expo.io/guides/config-plugins/).
+For more info, please refer to the official docs: [Config Plugins](https://docs.expo.dev/guides/config-plugins/).

--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -26,7 +26,7 @@
   "bugs": {
     "url": "https://github.com/expo/expo-cli/issues"
   },
-  "homepage": "https://docs.expo.io/guides/config-plugins/",
+  "homepage": "https://docs.expo.dev/guides/config-plugins/",
   "files": [
     "build",
     "paths"

--- a/packages/config-plugins/src/android/AllowBackup.ts
+++ b/packages/config-plugins/src/android/AllowBackup.ts
@@ -7,7 +7,7 @@ export const withAllowBackup = createAndroidManifestPlugin(setAllowBackup, 'with
 
 export function getAllowBackup(config: Pick<ExpoConfig, 'android'>) {
   // Defaults to true.
-  // https://docs.expo.io/versions/latest/config/app/#allowbackup
+  // https://docs.expo.dev/versions/latest/config/app/#allowbackup
   return config.android?.allowBackup ?? true;
 }
 

--- a/packages/config-plugins/src/ios/Locales.ts
+++ b/packages/config-plugins/src/ios/Locales.ts
@@ -90,7 +90,7 @@ export async function getResolvedLocalesAsync(
         WarningAggregator.addWarningIOS(
           `locales-${lang}`,
           `Failed to parse JSON of locale file for language: ${lang}`,
-          'https://docs.expo.io/distribution/app-stores/#localizing-your-ios-app'
+          'https://docs.expo.dev/distribution/app-stores/#localizing-your-ios-app'
         );
       }
     } else {

--- a/packages/config-plugins/src/ios/__tests__/Locales-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Locales-test.ts
@@ -77,7 +77,7 @@ describe('e2e: iOS locales', () => {
     expect(WarningAggregator.addWarningIOS).toHaveBeenCalledWith(
       'locales-xx',
       'Failed to parse JSON of locale file for language: xx',
-      'https://docs.expo.io/distribution/app-stores/#localizing-your-ios-app'
+      'https://docs.expo.dev/distribution/app-stores/#localizing-your-ios-app'
     );
   });
 });

--- a/packages/config-plugins/src/utils/plugin-resolver.ts
+++ b/packages/config-plugins/src/utils/plugin-resolver.ts
@@ -113,7 +113,7 @@ export function resolveConfigPluginFunctionWithInfo(projectRoot: string, pluginR
     result = requirePluginFile(pluginFile);
   } catch (error) {
     if (error instanceof SyntaxError) {
-      const learnMoreLink = `Learn more: https://docs.expo.io/guides/config-plugins/#creating-a-plugin`;
+      const learnMoreLink = `Learn more: https://docs.expo.dev/guides/config-plugins/#creating-a-plugin`;
       // If the plugin reference is a node module, and that node module has a syntax error, then it probably doesn't have an official config plugin.
       if (!isPluginFile && !moduleNameIsDirectFileReference(pluginReference)) {
         const pluginError = new PluginError(
@@ -162,7 +162,7 @@ export function resolveConfigPluginExport({
     plugin = plugin.default;
   }
   if (typeof plugin !== 'function') {
-    const learnMoreLink = `Learn more: https://docs.expo.io/guides/config-plugins/#creating-a-plugin`;
+    const learnMoreLink = `Learn more: https://docs.expo.dev/guides/config-plugins/#creating-a-plugin`;
     // If the plugin reference is a node module, and that node module does not export a function then it probably doesn't have a config plugin.
     if (!isPluginFile && !moduleNameIsDirectFileReference(pluginReference)) {
       throw new PluginError(

--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -13,7 +13,7 @@ export interface ExpoConfig {
    */
   description?: string;
   /**
-   * The friendly URL name for publishing. For example, `myAppName` will refer to the `expo.io/@project-owner/myAppName` project.
+   * The friendly URL name for publishing. For example, `myAppName` will refer to the `expo.dev/@project-owner/myAppName` project.
    */
   slug: string;
   /**
@@ -43,7 +43,7 @@ export interface ExpoConfig {
    */
   runtimeVersion?: string;
   /**
-   * Your app version. In addition to this field, you'll also use `ios.buildNumber` and `android.versionCode` — read more about how to version your app [here](https://docs.expo.io/distribution/app-stores/#versioning-your-app). On iOS this corresponds to `CFBundleShortVersionString`, and on Android, this corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
+   * Your app version. In addition to this field, you'll also use `ios.buildNumber` and `android.versionCode` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). On iOS this corresponds to `CFBundleShortVersionString`, and on Android, this corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
    */
   version?: string;
   /**
@@ -87,7 +87,7 @@ export interface ExpoConfig {
      */
     color?: string;
     /**
-     * Whether or not to display notifications when the app is in the foreground on iOS. `_displayInForeground` option in the individual push notification message overrides this option. [Learn more.](https://docs.expo.io/push-notifications/receiving-notifications/#foreground-notification-behavior) Defaults to `false`.
+     * Whether or not to display notifications when the app is in the foreground on iOS. `_displayInForeground` option in the individual push notification message overrides this option. [Learn more.](https://docs.expo.dev/push-notifications/receiving-notifications/#foreground-notification-behavior) Defaults to `false`.
      */
     iosDisplayInForeground?: boolean;
     /**
@@ -104,7 +104,7 @@ export interface ExpoConfig {
    */
   appKey?: string;
   /**
-   * Configuration for the status bar on Android. For more details please navigate to [Configuring StatusBar](https://docs.expo.io/guides/configuring-statusbar/).
+   * Configuration for the status bar on Android. For more details please navigate to [Configuring StatusBar](https://docs.expo.dev/guides/configuring-statusbar/).
    */
   androidStatusBar?: {
     /**
@@ -165,13 +165,13 @@ export interface ExpoConfig {
    */
   entryPoint?: string;
   /**
-   * Any extra fields you want to pass to your experience. Values are accessible via `Expo.Constants.manifest.extra` ([Learn more](https://docs.expo.io/versions/latest/sdk/constants/#constantsmanifest))
+   * Any extra fields you want to pass to your experience. Values are accessible via `Expo.Constants.manifest.extra` ([Learn more](https://docs.expo.dev/versions/latest/sdk/constants/#constantsmanifest))
    */
   extra?: {
     [k: string]: any;
   };
   /**
-   * @deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.io/guides/customizing-metro/)
+   * @deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.dev/guides/customizing-metro/)
    */
   packagerOpts?: {
     [k: string]: any;
@@ -242,11 +242,11 @@ export interface ExpoConfig {
     [k: string]: any;
   };
   /**
-   * An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.io/guides/offline-support/)
+   * An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.dev/guides/offline-support/)
    */
   assetBundlePatterns?: string[];
   /**
-   * Config plugins for adding extra functionality to your project. [Learn more](https://docs.expo.io/guides/config-plugins/).
+   * Config plugins for adding extra functionality to your project. [Learn more](https://docs.expo.dev/guides/config-plugins/).
    */
   plugins?: (string | [] | [string] | [string, any])[];
   splash?: Splash;

--- a/packages/dev-tools/TESTING.md
+++ b/packages/dev-tools/TESTING.md
@@ -45,7 +45,7 @@
 - ✅ Editing app name should update the slug, if slug matches the name (e.g. "My App" and "my-app").
 - ✅ Should validate app name and slug.
 - ✅ Should show a toast after clicking "Publish"
-- ✅ Should replace the toast when published successfully and display the expo.io URL.
+- ✅ Should replace the toast when published successfully and display the expo.dev URL.
 - ✅ Should handle failed publish (e.g. machine not connected to internet).
 - ✅ Changes to fields should be persisted to `app.json` after publishing.
 - ✅ Publishing should be disabled when running with `expo start --offline`.

--- a/packages/dev-tools/components/ProjectManagerPublishingSection.js
+++ b/packages/dev-tools/components/ProjectManagerPublishingSection.js
@@ -283,7 +283,7 @@ export default class ProjectManagerPublishingSection extends React.Component {
         <p className={STYLES_PARAGRAPH}>
           Once you publish your project, you will be able to view it at&nbsp;
           <span className={STYLES_EMPHASIS}>
-            https://expo.io/@{this.props.user.username}/projects/{this.state.config.slug}
+            https://expo.dev/@{this.props.user.username}/projects/{this.state.config.slug}
           </span>
           .
         </p>

--- a/packages/dev-tools/server/graphql/GraphQLSchema.ts
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.ts
@@ -287,7 +287,7 @@ const typeDefs = graphql`
     openSimulator(platform: Platform!): OpenSimulatorResult
     # Starts WebPack server
     openWeb: OpenWebResult
-    # Publishes the current project to expo.dev
+    # Publishes the current project to expo.dev (classic updates)
     publishProject(releaseChannel: String): PublishProjectResult
     # Sends the project URL by email.
     sendProjectUrl(recipient: String!): SendProjectResult

--- a/packages/dev-tools/server/graphql/GraphQLSchema.ts
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.ts
@@ -287,7 +287,7 @@ const typeDefs = graphql`
     openSimulator(platform: Platform!): OpenSimulatorResult
     # Starts WebPack server
     openWeb: OpenWebResult
-    # Publishes the current project to expo.io
+    # Publishes the current project to expo.dev
     publishProject(releaseChannel: String): PublishProjectResult
     # Sends the project URL by email.
     sendProjectUrl(recipient: String!): SendProjectResult

--- a/packages/expo-cli/README.md
+++ b/packages/expo-cli/README.md
@@ -5,7 +5,7 @@ at https://github.com/expo/expo-cli. Thanks!
 
 ## Installation
 
-[Installation instructions and documentation here.](https://docs.expo.io/workflow/expo-cli/#installation)
+[Installation instructions and documentation here.](https://docs.expo.dev/workflow/expo-cli/#installation)
 
 ## Getting Started
 

--- a/packages/expo-cli/src/accounts.ts
+++ b/packages/expo-cli/src/accounts.ts
@@ -341,7 +341,7 @@ async function _usernamePasswordAuth(
   }
 }
 
-export const REGISTRATION_URL = `https://expo.io/signup`;
+export const REGISTRATION_URL = `https://expo.dev/signup`;
 
 export function openRegistrationInBrowser() {
   const spinner = ora(`Opening ${REGISTRATION_URL}...`).start();

--- a/packages/expo-cli/src/appleApi/resolveCredentials.ts
+++ b/packages/expo-cli/src/appleApi/resolveCredentials.ts
@@ -92,11 +92,11 @@ export async function promptPasswordAsync({
 
   if (cachedPassword) {
     Log.log(`\u203A Using password for ${username} from your local Keychain`);
-    Log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
+    Log.log(`  ${learnMore('https://docs.expo.dev/distribution/security#keychain')}`);
     return cachedPassword;
   }
 
-  // https://docs.expo.io/distribution/security/#apple-developer-account-credentials
+  // https://docs.expo.dev/distribution/security/#apple-developer-account-credentials
   Log.log(
     wrapAnsi(
       chalk.bold(
@@ -171,7 +171,7 @@ async function cachePasswordAsync({ username, password }: Auth.UserCredentials):
   }
 
   Log.log(`\u203A Saving Apple ID password to the local Keychain`);
-  Log.log(`  ${learnMore('https://docs.expo.io/distribution/security#keychain')}`);
+  Log.log(`  ${learnMore('https://docs.expo.dev/distribution/security#keychain')}`);
   const serviceName = getKeychainServiceName(username);
   return Keychain.setPasswordAsync({ username, password, serviceName });
 }

--- a/packages/expo-cli/src/commands/__tests__/export-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/export-test.ts
@@ -63,7 +63,7 @@ describe('ensurePublicUrlAsync', () => {
   it(`validates a URL`, async () => {
     const logWarnSpy = jest.spyOn(Log, 'nestedWarn').mockImplementation(() => {});
 
-    await expect(ensurePublicUrlAsync('https://expo.io', true)).resolves.toBe('https://expo.io');
+    await expect(ensurePublicUrlAsync('https://expo.dev', true)).resolves.toBe('https://expo.dev');
     // No warnings thrown
     expect(logWarnSpy).toBeCalledTimes(0);
 

--- a/packages/expo-cli/src/commands/__tests__/export-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/export-test.ts
@@ -83,7 +83,7 @@ describe('collectMergeSourceUrlsAsync', () => {
   });
 
   it(`downloads tar files`, async () => {
-    const directories = await collectMergeSourceUrlsAsync(projectRoot, ['expo.io/app.tar.gz']);
+    const directories = await collectMergeSourceUrlsAsync(projectRoot, ['expo.dev/app.tar.gz']);
     expect(directories.length).toBe(1);
     // Ensure the file was downloaded with the expected name
     expect(directories[0]).toMatch(/\/alpha\/\.tmp\/app_/);

--- a/packages/expo-cli/src/commands/build/BaseBuilder.ts
+++ b/packages/expo-cli/src/commands/build/BaseBuilder.ts
@@ -154,7 +154,7 @@ export default class BaseBuilder {
     if (reuseStatus.canReuse) {
       Log.warn(`Did you know that Expo provides over-the-air updates?
 Please see the docs (${chalk.underline(
-        'https://docs.expo.io/guides/configuring-ota-updates/'
+        'https://docs.expo.dev/guides/configuring-ota-updates/'
       )}) and check if you can use them instead of building your app binaries again.`);
 
       Log.warn(
@@ -215,7 +215,7 @@ Please see the docs (${chalk.underline(
           )}`;
           if (shouldShowUpgradeInfo) {
             status += `\nWant to wait less? Get priority builds at ${chalk.underline(
-              'https://expo.io/settings/billing'
+              'https://expo.dev/settings/billing'
             )}.`;
           }
           break;
@@ -226,7 +226,7 @@ Please see the docs (${chalk.underline(
           status = 'Build in progress...';
           if (shouldShowUpgradeInfo) {
             status += `\nWant to wait less? Get priority builds at ${chalk.underline(
-              'https://expo.io/settings/billing'
+              'https://expo.dev/settings/billing'
             )}.`;
           }
           break;
@@ -234,7 +234,7 @@ Please see the docs (${chalk.underline(
           status = 'Build finished.';
           if (shouldShowUpgradeInfo) {
             status += `\nLooks like this build could have been faster.\nRead more about priority builds at ${chalk.underline(
-              'https://expo.io/settings/billing'
+              'https://expo.dev/settings/billing'
             )}.`;
           }
           break;
@@ -378,7 +378,7 @@ ${job.id}
     );
     if (priority === 'normal' && canPurchasePriorityBuilds) {
       Log.log(
-        'You can make this faster. 🐢\nGet priority builds at: https://expo.io/settings/billing\n'
+        'You can make this faster. 🐢\nGet priority builds at: https://expo.dev/settings/billing\n'
       );
     }
 

--- a/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
+++ b/packages/expo-cli/src/commands/build/ios/IOSBuilder.ts
@@ -358,7 +358,7 @@ class IOSBuilder extends BaseBuilder {
     Log.log(
       `You can now publish to the App Store with ${TerminalLink.transporterAppLink()} or ${chalk.bold(
         'eas submit --platform ios'
-      )}. ${TerminalLink.learnMore('https://docs.expo.io/distribution/uploading-apps/')}`
+      )}. ${TerminalLink.learnMore('https://docs.expo.dev/distribution/uploading-apps/')}`
     );
   }
 

--- a/packages/expo-cli/src/commands/client/clientIosAsync.ts
+++ b/packages/expo-cli/src/commands/client/clientIosAsync.ts
@@ -180,7 +180,7 @@ export async function actionAsync(
     );
     Log.log(table.toString());
     Log.log(
-      'See https://docs.expo.io/guides/adhoc-builds/#optional-additional-configuration-steps for more details.'
+      'See https://docs.expo.dev/guides/adhoc-builds/#optional-additional-configuration-steps for more details.'
     );
   }
 

--- a/packages/expo-cli/src/commands/eject.ts
+++ b/packages/expo-cli/src/commands/eject.ts
@@ -10,7 +10,7 @@ export default function (program: Command) {
       .command('eject [path]')
       .description(
         `Create native iOS and Android project files. ${chalk.dim(
-          learnMore('https://docs.expo.io/workflow/customizing/')
+          learnMore('https://docs.expo.dev/workflow/customizing/')
         )}`
       )
       .longDescription(

--- a/packages/expo-cli/src/commands/eject/logNextSteps.ts
+++ b/packages/expo-cli/src/commands/eject/logNextSteps.ts
@@ -52,7 +52,7 @@ export function logNextSteps({
       `\u203A 📁 The property ${chalk.bold(
         `assetBundlePatterns`
       )} does not have the same effect in the bare workflow.\n  ${Log.chalk.dim(
-        learnMore('https://docs.expo.io/bare/updating-your-app/#embedding-assets')
+        learnMore('https://docs.expo.dev/bare/updating-your-app/#embedding-assets')
       )}`
     );
   }

--- a/packages/expo-cli/src/commands/eject/setupWarnings.ts
+++ b/packages/expo-cli/src/commands/eject/setupWarnings.ts
@@ -57,7 +57,7 @@ export function getSetupWarnings({
     )} is not available in the bare workflow. You should replace it with ${chalk.bold(
       'Updates.manifest'
     )}. ${Log.chalk.dim(
-      learnMore('https://docs.expo.io/versions/latest/sdk/updates/#updatesmanifest')
+      learnMore('https://docs.expo.dev/versions/latest/sdk/updates/#updatesmanifest')
     )}`;
   }
 

--- a/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
+++ b/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
@@ -61,7 +61,7 @@ export function writeMetroConfig({
       `\u203A You will need to extend the default ${chalk.bold(
         '@expo/metro-config'
       )} in your Metro config.\n  ${Log.chalk.dim(
-        learnMore('https://docs.expo.io/guides/customizing-metro')
+        learnMore('https://docs.expo.dev/guides/customizing-metro')
       )}`
     );
     Log.newLine();

--- a/packages/expo-cli/src/commands/prebuild.ts
+++ b/packages/expo-cli/src/commands/prebuild.ts
@@ -10,7 +10,7 @@ export default function (program: Command) {
       .command('prebuild [path]')
       .description(
         `Experimental: Create native iOS and Android project files before building natively. ${chalk.dim(
-          learnMore('https://docs.expo.io/workflow/customizing/')
+          learnMore('https://docs.expo.dev/workflow/customizing/')
         )}`
       )
       .longDescription(

--- a/packages/expo-cli/src/commands/publishAsync.ts
+++ b/packages/expo-cli/src/commands/publishAsync.ts
@@ -162,7 +162,7 @@ function logManifestUrl({
 
 /**
  *
- * @example ⚙️   Project page: https://expo.io/@bacon/projects/my-app [copied to clipboard] Learn more: https://expo.fyi/project-page
+ * @example ⚙️   Project page: https://expo.dev/@bacon/projects/my-app [copied to clipboard] Learn more: https://expo.fyi/project-page
  * @param options
  */
 function logProjectPageUrl({
@@ -242,7 +242,7 @@ export function logOptimizeWarnings({ projectRoot }: { projectRoot: string }): v
       `Project may contain uncompressed images. Optimizing image assets can improve app size and performance.\n  To fix this, run ${chalk.bold(
         `npx expo-optimize`
       )}`,
-      'https://docs.expo.io/distribution/optimizing-updates/#optimize-images'
+      'https://docs.expo.dev/distribution/optimizing-updates/#optimize-images'
     )
   );
 }

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -175,7 +175,7 @@ export function parseStartOptions(
 
   if (isLegacyImportsEnabled(exp)) {
     // For `expo start`, the default target is 'managed', for both managed *and* bare apps.
-    // See: https://docs.expo.io/bare/using-expo-client
+    // See: https://docs.expo.dev/bare/using-expo-client
     startOpts.target = options.devClient ? 'bare' : 'managed';
     Log.debug('Using target: ', startOpts.target);
   }

--- a/packages/expo-cli/src/commands/upgradeAsync.ts
+++ b/packages/expo-cli/src/commands/upgradeAsync.ts
@@ -346,7 +346,7 @@ async function shouldBailWhenUsingLatest(
     });
 
     if (!answer) {
-      Log.log('Follow the Expo blog at https://blog.expo.io for new release information!');
+      Log.log('Follow the Expo blog at https://blog.expo.dev for new release information!');
       Log.newLine();
       return true;
     }
@@ -818,7 +818,7 @@ export async function upgradeAsync(
       );
     } else {
       Log.gray(
-        `Unable to find release notes for ${targetSdkVersionString}, please try to find them on https://blog.expo.io to learn more about other potentially important upgrade steps and breaking changes.`
+        `Unable to find release notes for ${targetSdkVersionString}, please try to find them on https://blog.expo.dev to learn more about other potentially important upgrade steps and breaking changes.`
       );
     }
   }

--- a/packages/expo-cli/src/commands/upgradeAsync.ts
+++ b/packages/expo-cli/src/commands/upgradeAsync.ts
@@ -271,7 +271,7 @@ async function makeBreakingChangesToConfigAsync(
             text: chalk.red(
               `Please manually update "androidNavigationBar.visible" according to ${terminalLink(
                 'this documentation',
-                'https://docs.expo.io/versions/latest/config/app/#androidnavigationbar'
+                'https://docs.expo.dev/versions/latest/config/app/#androidnavigationbar'
               )}`
             ),
           });
@@ -302,7 +302,7 @@ async function maybeBailOnUnsafeFunctionalityAsync(
     }
 
     const answer = await confirmAsync({
-      message: `This command works best on SDK 33 and higher. We can try updating for you, but you will likely need to follow up with the instructions from https://docs.expo.io/workflow/upgrading-expo-sdk-walkthrough/. Continue anyways?`,
+      message: `This command works best on SDK 33 and higher. We can try updating for you, but you will likely need to follow up with the instructions from https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/. Continue anyways?`,
     });
 
     if (!answer) {
@@ -855,7 +855,7 @@ export async function upgradeAsync(
 async function maybeCleanNpmStateAsync(packageManager: any) {
   // We don't trust npm to properly handle deduping dependencies so we need to
   // clear the lockfile and node_modules.
-  // https://forums.expo.io/t/sdk-37-unrecognized-font-family/35201
+  // https://forums.expo.dev/t/sdk-37-unrecognized-font-family/35201
   // https://twitter.com/geoffreynyaga/status/1246170581109743617
   if (packageManager instanceof PackageManager.NpmPackageManager) {
     const cleaningNpmStateStep = logNewSection(

--- a/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/android/__tests__/AndroidSubmitCommand-test.ts
@@ -84,7 +84,7 @@ describe(AndroidSubmitCommand, () => {
       (ensureProjectExistsAsync as jest.Mock).mockImplementationOnce(() => projectId);
 
       const options: AndroidSubmitCommandOptions = {
-        url: 'http://expo.io/fake.apk',
+        url: 'http://expo.dev/fake.apk',
         type: 'apk',
         key: '/google-service-account.json',
         track: 'internal',
@@ -95,7 +95,7 @@ describe(AndroidSubmitCommand, () => {
       await command.runAsync();
 
       const androidSubmissionConfig: AndroidOnlineSubmissionConfig = {
-        archiveUrl: 'http://expo.io/fake.apk',
+        archiveUrl: 'http://expo.dev/fake.apk',
         archiveType: ArchiveType.apk,
         androidPackage: testProject.appJSON.expo.android?.package,
         serviceAccount: fakeFiles['/google-service-account.json'],

--- a/packages/expo-cli/src/commands/upload/submission-service/utils/__tests__/files-test.ts
+++ b/packages/expo-cli/src/commands/upload/submission-service/utils/__tests__/files-test.ts
@@ -44,11 +44,11 @@ afterAll(() => {
 
 describe('downloadAppArchiveAsync', () => {
   it(`downloads an apk to a file with the same name in a temporary directory`, async () => {
-    const path = await downloadAppArchiveAsync('http://fake.expo.io/app.apk');
+    const path = await downloadAppArchiveAsync('http://fake.expo.dev/app.apk');
     expect(path).toMatch(/app.apk$/);
   });
   it(`downloads and extracts a tar to a file with the correct extension in a temporary directory`, async () => {
-    const path = await downloadAppArchiveAsync('http://fake.expo.io/app.tar.gz');
+    const path = await downloadAppArchiveAsync('http://fake.expo.dev/app.tar.gz');
     expect(path).toMatch(/app.tar.gz.apk$/);
   });
 });

--- a/packages/expo-cli/src/commands/upload/uploadIosAsync.ts
+++ b/packages/expo-cli/src/commands/upload/uploadIosAsync.ts
@@ -12,7 +12,7 @@ export async function actionAsync() {
   Log.log(chalk.yellow('expo upload:ios is no longer supported'));
   Log.log('Please use one of the following');
   Log.newLine();
-  logItem(chalk.cyan.bold('eas submit'), 'https://docs.expo.io/submit/ios');
+  logItem(chalk.cyan.bold('eas submit'), 'https://docs.expo.dev/submit/ios');
   logItem('Transporter', 'https://apps.apple.com/us/app/transporter/id1450874784');
   logItem(
     'Fastlane deliver',

--- a/packages/expo-cli/src/commands/utils/TerminalLink.ts
+++ b/packages/expo-cli/src/commands/utils/TerminalLink.ts
@@ -6,8 +6,8 @@ import Log from '../../log';
  * When linking isn't available, fallback to displaying the URL beside the
  * text in parentheses.
  *
- * @example [Expo](https://expo.io)
- * @example Expo (https://expo.io)
+ * @example [Expo](https://expo.dev)
+ * @example Expo (https://expo.dev)
  *
  * @param value
  * @param url
@@ -19,8 +19,8 @@ export function fallbackToTextAndUrl(text: string, url: string) {
 /**
  * When linking isn't available, fallback to just displaying the URL.
  *
- * @example [value](https://expo.io)
- * @example https://expo.io
+ * @example [value](https://expo.dev)
+ * @example https://expo.dev
  *
  * @param text
  * @param url
@@ -34,8 +34,8 @@ export function fallbackToUrl(text: string, url: string): string {
 /**
  * When linking isn't available, format the learn more link better.
  *
- * @example [Learn more](https://expo.io)
- * @example Learn more: https://expo.io
+ * @example [Learn more](https://expo.dev)
+ * @example Learn more: https://expo.dev
  * @param url
  */
 export function learnMore(url: string): string {

--- a/packages/expo-cli/src/commands/utils/__tests__/url-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/url-test.ts
@@ -9,7 +9,7 @@ describe(constructBuildLogsUrl, () => {
     });
 
     expect(result).toBe(
-      'https://expo.io/accounts/test-username/projects/test-project-slug/builds/test-build-id'
+      'https://expo.dev/accounts/test-username/projects/test-project-slug/builds/test-build-id'
     );
   });
 
@@ -20,7 +20,7 @@ describe(constructBuildLogsUrl, () => {
       buildId: 'test-build-id',
     });
 
-    expect(result).toBe('https://expo.io/accounts/test-username/builds/test-build-id');
+    expect(result).toBe('https://expo.dev/accounts/test-username/builds/test-build-id');
   });
   it('returns URL without account or project slug', () => {
     const result = constructBuildLogsUrl({
@@ -29,6 +29,6 @@ describe(constructBuildLogsUrl, () => {
       buildId: 'test-build-id',
     });
 
-    expect(result).toBe('https://expo.io/builds/test-build-id');
+    expect(result).toBe('https://expo.dev/builds/test-build-id');
   });
 });

--- a/packages/expo-cli/src/commands/utils/url.ts
+++ b/packages/expo-cli/src/commands/utils/url.ts
@@ -2,11 +2,11 @@ import dns from 'dns';
 
 export function getExpoDomainUrl(): string {
   if (process.env.EXPO_STAGING) {
-    return `https://staging.expo.io`;
+    return `https://staging.expo.dev`;
   } else if (process.env.EXPO_LOCAL) {
     return `http://expo.test`;
   } else {
-    return `https://expo.io`;
+    return `https://expo.dev`;
   }
 }
 

--- a/packages/expo-cli/src/commands/webhooks/utils.ts
+++ b/packages/expo-cli/src/commands/webhooks/utils.ts
@@ -64,6 +64,6 @@ export async function setupAsync(projectRoot: string) {
 function projectNotFoundError(experienceName: string) {
   return new CommandError(
     ErrorCodes.PROJECT_NOT_FOUND,
-    `Project ${experienceName} not found. The project is created the first time you run \`expo publish\` or build the project (https://docs.expo.io/distribution/building-standalone-apps/).`
+    `Project ${experienceName} not found. The project is created the first time you run \`expo publish\` or build the project (https://docs.expo.dev/distribution/building-standalone-apps/).`
   );
 }

--- a/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
+++ b/packages/expo-cli/src/credentials/views/AndroidKeystore.ts
@@ -148,7 +148,7 @@ class RemoveKeystore implements IView {
       )
     );
     Log.warn(
-      'Please read https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android for more info before proceeding.'
+      'Please read https://docs.expo.dev/distribution/building-standalone-apps/#if-you-choose-to-build-for-android for more info before proceeding.'
     );
     Log.newLine();
     Log.warn(

--- a/packages/expo-cli/src/credentials/views/IosDistCert.ts
+++ b/packages/expo-cli/src/credentials/views/IosDistCert.ts
@@ -447,7 +447,7 @@ async function generateDistCert(ctx: Context, accountName: string): Promise<Dist
           {}
         );
 
-      // https://docs.expo.io/distribution/app-signing/#summary
+      // https://docs.expo.dev/distribution/app-signing/#summary
       const here = terminalLink('here', 'https://bit.ly/3cfJJkQ');
       Log.log(
         chalk.grey(`✅  Distribution Certificates can be revoked with no production side effects`)

--- a/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
+++ b/packages/expo-cli/src/credentials/views/IosPushCredentials.ts
@@ -530,7 +530,7 @@ async function generatePushKey(ctx: Context, accountName: string): Promise<PushK
           {}
         );
 
-      // https://docs.expo.io/distribution/app-signing/#summary
+      // https://docs.expo.dev/distribution/app-signing/#summary
       const here = terminalLink('here', 'https://bit.ly/3cfJJkQ');
       Log.log(chalk.grey(`⚠️  Revoking a Push Key will affect other apps that rely on it`));
       Log.log(chalk.grey(`ℹ️  Learn more ${here}`));

--- a/packages/expo-cli/src/projects.ts
+++ b/packages/expo-cli/src/projects.ts
@@ -59,7 +59,7 @@ function getProjectOwner(user: User | RobotUser, exp: ExpoConfig): string {
   if (user.kind === 'robot' && !exp.owner) {
     throw new CommandError(
       'ROBOT_OWNER_ERROR',
-      'The "owner" manifest property is required when using robot users. See: https://docs.expo.io/versions/latest/config/app/#owner'
+      'The "owner" manifest property is required when using robot users. See: https://docs.expo.dev/versions/latest/config/app/#owner'
     );
   }
 

--- a/packages/expo-optimize/README.md
+++ b/packages/expo-optimize/README.md
@@ -52,12 +52,12 @@ For more information run `npx expo-optimize --help` (or `-h`)
 
 ## 📚 Further Reading
 
-Read more about how this package works here: [Image compression in Expo projects](https://blog.expo.io/image-compression-with-expo-cli-d32d15cc8b73).
+Read more about how this package works here: [Image compression in Expo projects](https://blog.expo.dev/image-compression-with-expo-cli-d32d15cc8b73).
 
 ## Related
 
 - [sharp](https://sharp.pixelplumbing.com/) - native image editing library for node
-- [expo-cli](https://docs.expo.io/workflow/expo-cli/) - the original location for this command
+- [expo-cli](https://docs.expo.dev/workflow/expo-cli/) - the original location for this command
   <!-- - [react-native-cli optimize](https://github.com/react-native-community/cli/pull/419) - an alias for this command -->
 
 ## License
@@ -69,7 +69,7 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
 ---
 
 <p>
-    <a aria-label="sponsored by expo" href="http://expo.io">
+    <a aria-label="sponsored by expo" href="http://expo.dev">
         <img src="https://img.shields.io/badge/Sponsored_by-Expo-4630EB.svg?style=for-the-badge&logo=EXPO&labelColor=000&logoColor=fff" target="_blank" />
     </a>
     <a aria-label="expo-optimize is free to use" href="/LICENSE" target="_blank">
@@ -77,4 +77,4 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
     </a>
 </p>
 
-[abp]: https://docs.expo.io/versions/latest/config/app/#assetbundlepatterns
+[abp]: https://docs.expo.dev/versions/latest/config/app/#assetbundlepatterns

--- a/packages/expo-optimize/package.json
+++ b/packages/expo-optimize/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/expo/expo-cli.git",
     "directory": "packages/expo-optimize"
   },
-  "author": "Expo <support@expo.io>",
+  "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "bin": {
     "expo-optimize": "./build/index.js"

--- a/packages/next-adapter/README.md
+++ b/packages/next-adapter/README.md
@@ -35,7 +35,7 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
 ---
 
 <p>
-    <a aria-label="built by expo" href="http://expo.io">
+    <a aria-label="built by expo" href="http://expo.dev">
         <img src="https://img.shields.io/badge/Built_by-Expo-4630EB.svg?style=for-the-badge&logo=EXPO&labelColor=000&logoColor=fff" target="_blank" />
     </a>
     <a aria-label="expo next-adapter is free to use" href="/LICENSE" target="_blank">
@@ -43,7 +43,7 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
     </a>
 </p>
 
-[docs]: https://docs.expo.io/guides/using-nextjs/
+[docs]: https://docs.expo.dev/guides/using-nextjs/
 [nextjs]: https://nextjs.org/
 [next-docs]: https://nextjs.org/docs
 [custom-document]: https://nextjs.org/docs#custom-document

--- a/packages/package-manager/README.md
+++ b/packages/package-manager/README.md
@@ -48,7 +48,7 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
 ---
 
 <p>
-    <a aria-label="sponsored by expo" href="http://expo.io">
+    <a aria-label="sponsored by expo" href="http://expo.dev">
         <img src="https://img.shields.io/badge/SPONSORED%20BY%20EXPO-4630EB.svg?style=for-the-badge" target="_blank" />
     </a>
     <a aria-label="@expo/package-manager is free to use" href="/LICENSE" target="_blank">

--- a/packages/package-manager/src/utils/__tests__/isYarnOfflineAsync-test.ts
+++ b/packages/package-manager/src/utils/__tests__/isYarnOfflineAsync-test.ts
@@ -32,7 +32,7 @@ it(`allows an npm proxy`, async () => {
   jest.mock('child_process', () => {
     return {
       execSync() {
-        return 'https://expo.io';
+        return 'https://expo.dev';
       },
     };
   });

--- a/packages/pod-install/package.json
+++ b/packages/pod-install/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/expo/expo-cli.git"
   },
   "homepage": "https://github.com/expo/expo-cli/tree/master/packages/pod-install",
-  "author": "Expo <support@expo.io>",
+  "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "bin": {
     "pod-install": "./build/index.js"

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -74,7 +74,7 @@ Object {
           "DEFAULT",
         ],
         "data": Object {
-          "host": "*.expo.io",
+          "host": "*.expo.dev",
           "scheme": "https",
         },
       },
@@ -554,7 +554,7 @@ Object {
                         "data": Array [
                           Object {
                             "$": Object {
-                              "android:host": "*.expo.io",
+                              "android:host": "*.expo.dev",
                               "android:scheme": "https",
                             },
                           },
@@ -983,7 +983,7 @@ Object {
           "DEFAULT",
         ],
         "data": Object {
-          "host": "*.expo.io",
+          "host": "*.expo.dev",
           "scheme": "https",
         },
       },
@@ -1352,7 +1352,7 @@ Object {
                         "data": Array [
                           Object {
                             "$": Object {
-                              "android:host": "*.expo.io",
+                              "android:host": "*.expo.dev",
                               "android:scheme": "https",
                             },
                           },
@@ -1784,7 +1784,7 @@ Object {
           "DEFAULT",
         ],
         "data": Object {
-          "host": "*.expo.io",
+          "host": "*.expo.dev",
           "scheme": "https",
         },
       },

--- a/packages/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
+++ b/packages/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
@@ -166,7 +166,7 @@ function getLargeConfig(): ExportedConfig {
           action: 'VIEW',
           data: {
             scheme: 'https',
-            host: '*.expo.io',
+            host: '*.expo.dev',
           },
           category: ['BROWSABLE', 'DEFAULT'],
         },

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -107,7 +107,7 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
 ---
 
 <p>
-    <a aria-label="sponsored by expo" href="http://expo.io">
+    <a aria-label="sponsored by expo" href="http://expo.dev">
         <img src="https://img.shields.io/badge/Sponsored_by-Expo-4630EB.svg?style=for-the-badge&logo=EXPO&labelColor=000&logoColor=fff" target="_blank" />
     </a>
     <a aria-label="expo pwa is free to use" href="/LICENSE" target="_blank">
@@ -115,4 +115,4 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
     </a>
 </p>
 
-[abp]: https://docs.expo.io/workflow/configuration/#assetbundlepatterns
+[abp]: https://docs.expo.dev/workflow/configuration/#assetbundlepatterns

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/expo/expo-cli.git",
     "directory": "packages/pwa"
   },
-  "author": "Expo <support@expo.io>",
+  "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "bin": {
     "expo-pwa": "./build/cli.js"

--- a/packages/pwa/src/index.ts
+++ b/packages/pwa/src/index.ts
@@ -79,7 +79,7 @@ export async function generateSplashAsync(
     icons.map(
       async (icon: SplashIcon): Promise<HTMLOutput> => {
         // Ensure the default `splash.resizeMode` is used here:
-        // https://docs.expo.io/versions/latest/config/app/#splash
+        // https://docs.expo.dev/versions/latest/config/app/#splash
         if (!icon.resizeMode) {
           icon.resizeMode = 'contain';
         }

--- a/packages/uri-scheme/README.md
+++ b/packages/uri-scheme/README.md
@@ -51,7 +51,7 @@ In order to make this package fast with npx we don't ship types or doc-blocks.
 ```js
 import { Android, Ios } from 'uri-scheme';
 
-Ios.openAsync({ uri: 'http://expo.io/' });
+Ios.openAsync({ uri: 'http://expo.dev/' });
 ```
 
 ## ⚙️ Options
@@ -121,7 +121,7 @@ Open a URI scheme in a running simulator or emulator
 **Examples**
 
 - `uri-scheme open com.app://oauth --ios`
-- `uri-scheme open http://expo.io --android`
+- `uri-scheme open http://expo.dev --android`
 
 ### list
 
@@ -146,7 +146,7 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
 ---
 
 <p>
-    <a aria-label="sponsored by expo" href="http://expo.io">
+    <a aria-label="sponsored by expo" href="http://expo.dev">
         <img src="https://img.shields.io/badge/Sponsored_by-Expo-4630EB.svg?style=for-the-badge&logo=EXPO&labelColor=000&logoColor=fff" target="_blank" />
     </a>
     <a aria-label="uri-scheme is free to use" href="/LICENSE" target="_blank">

--- a/packages/uri-scheme/package.json
+++ b/packages/uri-scheme/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/expo/expo-cli.git",
     "directory": "packages/uri-scheme"
   },
-  "author": "Expo <support@expo.io>",
+  "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "bin": {
     "uri-scheme": "./cli.js"

--- a/packages/uri-scheme/src/CLI.ts
+++ b/packages/uri-scheme/src/CLI.ts
@@ -68,7 +68,7 @@ buildCommand('remove', ['com.app', 'myapp'])
     }
   });
 
-buildCommand('open', ['com.app://oauth', 'http://expo.io'])
+buildCommand('open', ['com.app://oauth', 'http://expo.dev'])
   .description('Open a URI scheme in a running simulator or emulator')
   .option('--package <string>', 'The Android package name to use when opening in an emulator')
   .action(async (uri: string, args: any) => {

--- a/packages/webpack-config/README.md
+++ b/packages/webpack-config/README.md
@@ -491,7 +491,7 @@ Custom versions of Webpack Plugins that are optimized for use with native React 
 import { ExpoDefinePlugin } from '@expo/webpack-config/plugins';
 ```
 
-Required for `expo-constants` https://docs.expo.io/versions/latest/sdk/constants/.
+Required for `expo-constants` https://docs.expo.dev/versions/latest/sdk/constants/.
 This surfaces the `app.json` (config) as an environment variable which is then parsed by `expo-constants`.
 
 #### `ExpoHtmlWebpackPlugin`
@@ -533,7 +533,7 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
 ---
 
 <p>
-    <a aria-label="sponsored by expo" href="http://expo.io">
+    <a aria-label="sponsored by expo" href="http://expo.dev">
         <img src="https://img.shields.io/badge/Sponsored_by-Expo-4630EB.svg?style=for-the-badge&logo=EXPO&labelColor=000&logoColor=fff" target="_blank" />
     </a>
     <a aria-label="expo webpack-config is free to use" href="/LICENSE" target="_blank">
@@ -541,5 +541,5 @@ The Expo source code is made available under the [MIT license](LICENSE). Some of
     </a>
 </p>
 
-[docs]: https://docs.expo.io/guides/customizing-webpack/
+[docs]: https://docs.expo.dev/guides/customizing-webpack/
 [docs-latest]: https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/guides/customizing-webpack.md

--- a/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
+++ b/packages/webpack-config/src/plugins/ExpoDefinePlugin.ts
@@ -93,7 +93,7 @@ export function createClientEnvironment(
 
         /**
          * Surfaces the `app.json` (config) as an environment variable which is then parsed by
-         * `expo-constants` https://docs.expo.io/versions/latest/sdk/constants/
+         * `expo-constants` https://docs.expo.dev/versions/latest/sdk/constants/
          */
         [`${prefix}APP_MANIFEST`]: JSON.stringify(nativeAppManifest),
       } as Record<string, string>
@@ -113,7 +113,7 @@ export function createClientEnvironment(
 }
 
 /**
- * Required for `expo-constants` https://docs.expo.io/versions/latest/sdk/constants/.
+ * Required for `expo-constants` https://docs.expo.dev/versions/latest/sdk/constants/.
  * This surfaces the `app.json` (config) as an environment variable which is then parsed by `expo-constants`.
  * @category plugins
  */

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -280,7 +280,7 @@ export default async function (
     // to our docs means they want to use a custom manifest.json instead of having a new one generated.
     //
     // Normalize the link (removing the beginning slash) so it can be resolved relative to the user's static folder.
-    // Ref: https://docs.expo.io/guides/progressive-web-apps/#manual-setup
+    // Ref: https://docs.expo.dev/guides/progressive-web-apps/#manual-setup
     if (manifestLink.href.startsWith('/')) {
       manifestLink.href = manifestLink.href.substring(1);
     }

--- a/packages/xdl/README.md
+++ b/packages/xdl/README.md
@@ -1,7 +1,7 @@
 # xdl
 
 The Expo Development Library.
-[Documentation](https://docs.expo.io/workflow/expo-cli/)
+[Documentation](https://docs.expo.dev/workflow/expo-cli/)
 
 If you have problems with the code in this repository, please file issues & bug reports
 at https://github.com/expo/expo. Thanks!

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -115,7 +115,7 @@ export async function getAllAvailableDevicesAsync(): Promise<Device[]> {
   if (!allDevices.length) {
     const genymotionMessage = `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`;
     throw new Error(
-      `No Android connected device found, and no emulators could be started automatically.\nPlease connect a device or create an emulator (https://docs.expo.io/workflow/android-studio-emulator).\nThen follow the instructions here to enable USB debugging:\n${genymotionMessage}`
+      `No Android connected device found, and no emulators could be started automatically.\nPlease connect a device or create an emulator (https://docs.expo.dev/workflow/android-studio-emulator).\nThen follow the instructions here to enable USB debugging:\n${genymotionMessage}`
     );
   }
 
@@ -370,7 +370,7 @@ async function ensureDevClientInstalledAsync(device: Device, applicationId: stri
     throw new Error(
       `The development client (${applicationId}) for this project is not installed. ` +
         `Please build and install the client on the simulator first.\n${learnMore(
-          'https://docs.expo.io/clients/distribution-for-android/'
+          'https://docs.expo.dev/clients/distribution-for-android/'
         )}`
     );
   }
@@ -415,7 +415,7 @@ export async function installExpoAsync({
     return setTimeout(() => {
       Logger.global.info('');
       Logger.global.info(
-        'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
+        'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.dev/tools'
       );
     }, INSTALL_WARNING_TIMEOUT);
   };
@@ -1087,7 +1087,7 @@ export async function checkSplashScreenImages(projectRoot: string): Promise<void
 Be aware that your splash image will be used as xxxhdpi asset and its ${chalk.bold(
       'actual size will be different'
     )} depending on device's DPI.
-See https://docs.expo.io/guides/splash-screens/#splash-screen-api-limitations-on-android for more information`);
+See https://docs.expo.dev/guides/splash-screens/#splash-screen-api-limitations-on-android for more information`);
     return;
   }
 
@@ -1100,7 +1100,7 @@ but their sizes mismatch expected ones: [dpi: provided (expected)] ${androidSpla
           `${dpi}: ${width}x${height} (${expectedWidth}x${expectedHeight})`
       )
       .join(', ')}
-See https://docs.expo.io/guides/splash-screens/#splash-screen-api-limitations-on-android for more information`);
+See https://docs.expo.dev/guides/splash-screens/#splash-screen-api-limitations-on-android for more information`);
   }
 }
 

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -486,7 +486,7 @@ export async function installExpoOnSimulatorAsync({
     return setTimeout(() => {
       Logger.global.info('');
       Logger.global.info(
-        'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.io/tools'
+        'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.dev/tools'
       );
     }, INSTALL_WARNING_TIMEOUT);
   };
@@ -693,7 +693,7 @@ async function assertDevClientInstalledAsync(
     throw new Error(
       `The development client (${bundleIdentifier}) for this project is not installed. ` +
         `Please build and install the client on the simulator first.\n${learnMore(
-          'https://docs.expo.io/clients/distribution-for-ios/#building-for-ios'
+          'https://docs.expo.dev/clients/distribution-for-ios/#building-for-ios'
         )}`
     );
   }

--- a/packages/xdl/src/__tests__/Project-publishAsync-test.ts
+++ b/packages/xdl/src/__tests__/Project-publishAsync-test.ts
@@ -78,7 +78,7 @@ jest.mock('axios', () => ({
         return mockApiV2Response(
           {
             url: 'https://test.exp.host/@testing/publish-test-app',
-            projectPageUrl: 'https://test.expo.io/@testing/projects/publish-test-app',
+            projectPageUrl: 'https://test.expo.dev/@testing/projects/publish-test-app',
             ids: ['1', '2'],
           },
           options
@@ -124,7 +124,7 @@ describe('publishAsync', () => {
     process.env.EXPO_USE_DEV_SERVER = 'true';
     const result = await publishAsync(projectRoot, { resetCache: true });
     expect(result.url).toBe('https://test.exp.host/@testing/publish-test-app');
-    expect(result.projectPageUrl).toBe('https://test.expo.io/@testing/projects/publish-test-app');
+    expect(result.projectPageUrl).toBe('https://test.expo.dev/@testing/projects/publish-test-app');
 
     process.env.EXPO_USE_DEV_SERVER = 'false';
     const resultOld = await publishAsync(projectRoot, { resetCache: true });

--- a/packages/xdl/src/__tests__/UrlUtils-test.ts
+++ b/packages/xdl/src/__tests__/UrlUtils-test.ts
@@ -243,7 +243,7 @@ describe(UrlUtils.isURL, () => {
     expect(
       UrlUtils.isURL('127.0.0.1:80', { protocols: ['https', 'http'], requireProtocol: true })
     ).toBe(false);
-    expect(UrlUtils.isURL('https://expo.io/', { protocols: ['https'] })).toBe(true);
+    expect(UrlUtils.isURL('https://expo.dev/', { protocols: ['https'] })).toBe(true);
     expect(UrlUtils.isURL('', { protocols: ['https'] })).toBe(false);
     expect(UrlUtils.isURL('hello', { protocols: ['https'] })).toBe(false);
   });

--- a/packages/xdl/src/logs/PackagerLogsStream.ts
+++ b/packages/xdl/src/logs/PackagerLogsStream.ts
@@ -422,7 +422,7 @@ export default class PackagerLogsStream {
     const relativePath = path.relative(this._projectRoot, originModulePath);
 
     const DOCS_PAGE_URL =
-      'https://docs.expo.io/workflow/using-libraries/#using-third-party-libraries';
+      'https://docs.expo.dev/workflow/using-libraries/#using-third-party-libraries';
 
     if (NODE_STDLIB_MODULES.includes(moduleName)) {
       if (originModulePath.includes('node_modules')) {

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -134,7 +134,7 @@ async function validateWithSchema(
       schemaErrorMessage = `Error: Problem${
         e.errors.length > 1 ? 's' : ''
       } validating fields in ${configName}. ${learnMore(
-        'https://docs.expo.io/workflow/configuration/'
+        'https://docs.expo.dev/workflow/configuration/'
       )}`;
       schemaErrorMessage += e.errors.map(formatValidationError).join('');
     }
@@ -147,7 +147,7 @@ async function validateWithSchema(
       if (e instanceof SchemerError) {
         assetsErrorMessage = `Error: Problem${
           e.errors.length > 1 ? '' : 's'
-        } validating asset fields in ${configName}. ${learnMore('https://docs.expo.io/')}`;
+        } validating asset fields in ${configName}. ${learnMore('https://docs.expo.dev/')}`;
         assetsErrorMessage += e.errors.map(formatValidationError).join('');
       }
     }
@@ -340,7 +340,7 @@ async function _validateReactNativeVersionAsync(
     ProjectUtils.logWarning(
       projectRoot,
       'expo',
-      `Warning: Not using the Expo fork of react-native. ${learnMore('https://docs.expo.io/')}`,
+      `Warning: Not using the Expo fork of react-native. ${learnMore('https://docs.expo.dev/')}`,
       'doctor-not-using-expo-fork'
     );
     return WARNING;

--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -291,7 +291,7 @@ export async function getManifestResponseAsync({
           `@${manifest.owner}`
         )} and you have not been granted the appropriate permissions.\n` +
           `Please request access from an admin of @${manifest.owner} or change the "owner" field to an account you belong to.\n` +
-          learnMore('https://docs.expo.io/versions/latest/config/app/#owner')
+          learnMore('https://docs.expo.dev/versions/latest/config/app/#owner')
       );
       ConnectionStatus.setIsOffline(true);
       manifestString = await getManifestStringAsync(manifest, hostInfo.host, acceptSignature);


### PR DESCRIPTION
# Why

We have a new domain, we should use it everywhere.

# How

Search and replace but careful not to clobber `expo.ios.xyz` strings. Also skipped over schemas, because that needs to be handled in universe.

# Test Plan

👀 