### PR TITLE
[config-plugins] add vendor paths used by Bundlers to ignoredPaths

### DIFF
--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { UnexpectedError } from '../utils/errors';
 import * as WarningAggregator from '../utils/warnings';
 
-const ignoredPaths = ['**/@(Carthage|Pods|node_modules)/**'];
+const ignoredPaths = ['**/@(Carthage|Pods|vendor|node_modules)/**'];
 
 interface ProjectFile<L extends string = string> {
   path: string;

--- a/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
@@ -26,7 +26,7 @@ export type ProjectInfo = {
   name: string;
 };
 
-const ignoredPaths = ['**/@(Carthage|Pods|node_modules)/**'];
+const ignoredPaths = ['**/@(Carthage|Pods|vendor|node_modules)/**'];
 
 function findXcodeProjectPaths(
   projectRoot: string,

--- a/packages/uri-scheme/src/Ios.ts
+++ b/packages/uri-scheme/src/Ios.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 
 import { CommandError, Options } from './Options';
 
-const ignoredPaths = ['**/@(Carthage|Pods|node_modules)/**'];
+const ignoredPaths = ['**/@(Carthage|Pods|vendor|node_modules)/**'];
 
 export function isAvailable(projectRoot: string): boolean {
   const reactNativeIos = globSync('ios/*.xcodeproj', {

--- a/unlinked-packages/configure-splash-screen/src/ios/Paths.ts
+++ b/unlinked-packages/configure-splash-screen/src/ios/Paths.ts
@@ -5,7 +5,7 @@ import { sync as globSync } from 'glob';
 import * as path from 'path';
 import { XcodeProject } from 'xcode';
 
-const ignoredPaths = ['**/@(Carthage|Pods|node_modules)/**'];
+const ignoredPaths = ['**/@(Carthage|Pods|vendor|node_modules)/**'];
 
 export function getAllXcodeProjectPaths(projectRoot: string): string[] {
   const iosFolder = 'ios';


### PR DESCRIPTION
# Why
`expo run:ios` may fail on projects that use Bundler to manage CocoaPods and Fastlane versions.


With `Gemfile` at ios project root:
```
source 'https://rubygems.org'

gem 'cocoapods'
gem 'cocoapods-keys'

gem 'fui', '~> 0.3.0'
gem 'xcpretty'
gem 'second_curtain', '~> 0.2.3'
gem 'fastlane'
```
When you run `cd ios && bundle exec pod install`, Bundler saves files to `vendor/bundle` paths such as `ios/vendor/bundle` and `android/vendor/bundle`, which may have unrelated xcodeproj files.

For example, after `bundle exec pod install`, my project end up having files like below:

```
  'XXXX/android/vendor/bundle/ruby/2.5.0/gems/fastlane-2.157.2/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj',
  'XXXX/ios/ExampleApp.xcodeproj',
  'XXXX/ios/Pods/Pods.xcodeproj',
  'XXXX/ios/vendor/bundle/ruby/2.5.0/gems/fastlane-2.157.2/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj',
```
These cause `expo run:ios` to fail because it picks up the first xcodeproj found.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

I added `vendor` to ignoredPaths.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan
`expo run:ios` successfully builds on projects that uses Bundler after this change.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->