### PR TITLE
Support ios projects with numeric names

### DIFF
--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -413,5 +413,9 @@ export function isNotComment([key]:
 
 // Remove surrounding double quotes if they exist.
 export function unquote(value: string): string {
+  // projects with numeric names will fail due to a bug in the xcode package.
+  if (typeof value === 'number') {
+    value = String(value);
+  }
   return value.match(/^"(.*)"$/)?.[1] ?? value;
 }


### PR DESCRIPTION
# Why

iOS projects that have fully numeric names currently fail to build with run:ios due to a bug in the ascii plist parser used by the xcode npm package. This PR adds a check to ensure we convert the numeric value to string when needed.

# Test Plan

- `expo init`
- Change `name` in app.json to `3` or some other stringified name
- Run `expo run:ios` -- this will work now

