### PR TITLE
[expo-cli] Don't print escaped message

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -237,7 +237,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
             shouldPrompt,
             devClient: options.devClient ?? false,
           });
-          if (!results.success) {
+          if (!results.success && results.error !== 'escaped') {
             Log.nestedError(
               typeof results.error === 'string' ? results.error : results.error.message
             );
@@ -263,7 +263,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
             shouldPrompt,
             devClient: options.devClient ?? false,
           });
-          if (!results.success) {
+          if (!results.success && results.error !== 'escaped') {
             Log.nestedError(results.error);
           }
         }


### PR DESCRIPTION
# Why

Pressing <kbd>shift+i</kbd> then <kbd>ctrl+c</kbd> should silently return to the menu in terminal UI, currently it prints "escaped".

