### PR TITLE
fix: only show supported platforms in dev tools and terminal UIs

### DIFF
--- a/packages/dev-tools/components/ProjectManager.js
+++ b/packages/dev-tools/components/ProjectManager.js
@@ -189,6 +189,7 @@ class ProjectManager extends React.Component {
         isPublishing={this.props.isPublishing}
         isActiveDeviceIOS={this.props.isActiveDeviceIOS}
         isActiveDeviceAndroid={this.props.isActiveDeviceAndroid}
+        config={this.props.project.config}
       />
     );
 

--- a/packages/dev-tools/components/ProjectManagerSidebarOptions.js
+++ b/packages/dev-tools/components/ProjectManagerSidebarOptions.js
@@ -123,6 +123,7 @@ export default class ProjectManagerSidebarOptions extends React.Component {
   render() {
     const { showCopiedMessage, isSendFormVisible } = this.state;
     const isDisabled = !this.props.url;
+    const { platforms } = this.props.config;
 
     const sendHeader = (
       <div className={STYLES_CONTENT_GROUP} onClick={this._handleSendHeaderClick}>
@@ -132,16 +133,21 @@ export default class ProjectManagerSidebarOptions extends React.Component {
 
     return (
       <div>
-        <div className={STYLES_CONTENT_GROUP} onClick={this.props.onSimulatorClickAndroid}>
-          <span className={STYLES_CONTENT_GROUP_LEFT}>Run on Android device/emulator</span>
-        </div>
-        <div className={STYLES_CONTENT_GROUP} onClick={this.props.onSimulatorClickIOS}>
-          <span className={STYLES_CONTENT_GROUP_LEFT}>Run on iOS simulator</span>
-        </div>
-
-        <a className={STYLES_CONTENT_GROUP} onClick={this.props.onStartWebClick}>
-          <span className={STYLES_CONTENT_GROUP_LEFT}>Run in web browser</span>
-        </a>
+        {platforms.includes('android') && (
+          <div className={STYLES_CONTENT_GROUP} onClick={this.props.onSimulatorClickAndroid}>
+            <span className={STYLES_CONTENT_GROUP_LEFT}>Run on Android device/emulator</span>
+          </div>
+        )}
+        {platforms.includes('ios') && (
+          <div className={STYLES_CONTENT_GROUP} onClick={this.props.onSimulatorClickIOS}>
+            <span className={STYLES_CONTENT_GROUP_LEFT}>Run on iOS simulator</span>
+          </div>
+        )}
+        {platforms.includes('web') && (
+          <a className={STYLES_CONTENT_GROUP} onClick={this.props.onStartWebClick}>
+            <span className={STYLES_CONTENT_GROUP_LEFT}>Run in web browser</span>
+          </a>
+        )}
 
         <ContentGroup header={sendHeader} isActive={isSendFormVisible}>
           <InputWithButton

--- a/packages/dev-tools/pages/index.js
+++ b/packages/dev-tools/pages/index.js
@@ -38,6 +38,7 @@ const query = gql`
         description
         slug
         githubUrl
+        platforms
       }
       sources {
         id

--- a/packages/dev-tools/server/graphql/GraphQLSchema.ts
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.ts
@@ -71,6 +71,7 @@ const typeDefs = graphql`
     description: String
     slug: String
     githubUrl: String
+    platforms: [String]
   }
 
   input ProjectConfigInput {

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -35,6 +35,7 @@ type StartOptions = {
   nonPersistent?: boolean;
   maxWorkers?: number;
   webOnly?: boolean;
+  platforms?: ('android' | 'ios' | 'web')[];
 };
 
 const printHelp = (): void => {
@@ -56,23 +57,24 @@ const printUsageAsync = async (
   projectRoot: string,
   options: Pick<
     StartOptions,
-    'webOnly' | 'devClient' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled'
+    'webOnly' | 'devClient' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled' | 'platforms'
   > = {}
 ) => {
   const { dev } = await ProjectSettings.readAsync(projectRoot);
   const openDevToolsAtStartup = await shouldOpenDevToolsOnStartupAsync();
   const devMode = dev ? 'development' : 'production';
   const currentToggle = openDevToolsAtStartup ? 'enabled' : 'disabled';
+  const { platforms = ['android', 'ios', 'web'] } = options;
 
   const isMac = process.platform === 'darwin';
 
   logCommandsTable([
     [],
-    ['a', `open Android`],
-    ['shift+a', `select a device or emulator`],
-    isMac && ['i', `open iOS simulator`],
-    isMac && ['shift+i', `select a simulator`],
-    ['w', `open web`],
+    platforms.includes('android') && ['a', `open Android`],
+    platforms.includes('android') && ['shift+a', `select a device or emulator`],
+    platforms.includes('ios') && isMac && ['i', `open iOS simulator`],
+    platforms.includes('ios') && isMac && ['shift+i', `select a simulator`],
+    platforms.includes('web') && ['w', `open web`],
     [],
     !!options.isRemoteReloadingEnabled && ['r', `reload app`],
     !!options.isWebSocketsEnabled && ['m', `toggle menu`],
@@ -91,17 +93,21 @@ const printUsageAsync = async (
 };
 
 const printBasicUsageAsync = async (
-  options: Pick<StartOptions, 'webOnly' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled'> = {}
+  options: Pick<
+    StartOptions,
+    'webOnly' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled' | 'platforms'
+  > = {}
 ) => {
   const isMac = process.platform === 'darwin';
   const openDevToolsAtStartup = await shouldOpenDevToolsOnStartupAsync();
   const currentToggle = openDevToolsAtStartup ? 'enabled' : 'disabled';
+  const { platforms = ['android', 'ios', 'web'] } = options;
 
   logCommandsTable([
     [],
-    ['a', `open Android`],
-    isMac && ['i', `open iOS simulator`],
-    ['w', `open web`],
+    platforms.includes('android') && ['a', `open Android`],
+    platforms.includes('ios') && isMac && ['i', `open iOS simulator`],
+    platforms.includes('web') && ['w', `open web`],
     [],
     !!options.isRemoteReloadingEnabled && ['r', `reload app`],
     !!options.isWebSocketsEnabled && ['m', `toggle menu`],

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -163,6 +163,9 @@ export function parseStartOptions(
 
   if (options.webOnly) {
     startOpts.webOnly = true;
+    startOpts.platforms = ['web'];
+  } else {
+    startOpts.platforms = exp.platforms;
   }
 
   if (options.maxWorkers) {

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -23,6 +23,7 @@ export type StartOptions = {
   maxWorkers?: number;
   webOnly?: boolean;
   target?: ProjectTarget;
+  platforms?: ('ios' | 'android' | 'web')[];
 };
 
 export async function startDevServerAsync(


### PR DESCRIPTION
# Why

Got a request to hide the option to open in web, since if you're using `@expo/next-adapter` you need to use `yarn next dev` instead. Seems like we should hide any options that is excluded from `platforms` 

# How

put all the 'open in X platform' behind a flag that depends on the `platforms` key of your app config

# Test Plan

`expod start`