### PR TITLE
[prebuild-config] Support new expo-splash-screen to manage resizeMode in resource

### DIFF
--- a/packages/config-plugins/src/android/Resources.ts
+++ b/packages/config-plugins/src/android/Resources.ts
@@ -25,6 +25,7 @@ export type ResourceItemXML = {
   $: {
     name: string;
     'tools:targetApi'?: string;
+    translatable?: string;
   };
 };
 /**
@@ -87,14 +88,19 @@ export function buildResourceItem({
   name,
   value,
   targetApi,
+  translatable,
 }: {
   name: string;
   value: string;
   targetApi?: string;
+  translatable?: boolean;
 }): ResourceItemXML {
   const item: ResourceItemXML = { $: { name }, _: value };
   if (targetApi) {
     item.$['tools:targetApi'] = targetApi;
+  }
+  if (translatable !== undefined) {
+    item.$['translatable'] = String(translatable);
   }
   return item;
 }

--- a/packages/config-plugins/src/android/Strings.ts
+++ b/packages/config-plugins/src/android/Strings.ts
@@ -12,24 +12,27 @@ export function setStringItem(
   itemToAdd: ResourceItemXML[],
   stringFileContentsJSON: ResourceXML
 ): ResourceXML {
-  if (stringFileContentsJSON?.resources?.string) {
-    const stringNameExists = stringFileContentsJSON.resources.string.filter(
-      (e: ResourceItemXML) => e.$.name === itemToAdd[0].$.name
-    )[0];
-    if (stringNameExists) {
-      // replace the previous value
-      stringNameExists._ = itemToAdd[0]._;
-    } else {
-      stringFileContentsJSON.resources.string = stringFileContentsJSON.resources.string.concat(
-        itemToAdd
-      );
-    }
-  } else {
+  if (!stringFileContentsJSON?.resources?.string) {
     if (!stringFileContentsJSON.resources || typeof stringFileContentsJSON.resources === 'string') {
       // file was empty and JSON is `{resources : ''}`
       stringFileContentsJSON.resources = {};
     }
     stringFileContentsJSON.resources.string = itemToAdd;
+    return stringFileContentsJSON;
+  }
+
+  for (const newItem of itemToAdd) {
+    const stringNameExists = stringFileContentsJSON.resources.string.findIndex(
+      (e: ResourceItemXML) => e.$.name === newItem.$.name
+    );
+    if (stringNameExists > -1) {
+      // replace the previous item
+      stringFileContentsJSON.resources.string[stringNameExists] = newItem;
+    } else {
+      stringFileContentsJSON.resources.string = stringFileContentsJSON.resources.string.concat(
+        newItem
+      );
+    }
   }
   return stringFileContentsJSON;
 }

--- a/packages/config-plugins/src/android/__tests__/Strings-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Strings-test.ts
@@ -1,0 +1,45 @@
+import { buildResourceItem } from '../Resources';
+import { setStringItem } from '../Strings';
+
+describe(setStringItem, () => {
+  it('add item from empty xml', () => {
+    const results = setStringItem([buildResourceItem({ name: 'foo', value: 'foo' })], {
+      resources: {},
+    });
+    expect(results).toEqual({
+      resources: { string: [{ $: { name: 'foo' }, _: 'foo' }] },
+    });
+  });
+
+  it('support adding multiple items', () => {
+    const results = setStringItem(
+      [
+        buildResourceItem({ name: 'foo', value: 'foo' }),
+        buildResourceItem({ name: 'bar', value: 'bar' }),
+      ],
+      {
+        resources: {},
+      }
+    );
+    expect(results).toEqual({
+      resources: {
+        string: [
+          { $: { name: 'foo' }, _: 'foo' },
+          { $: { name: 'bar' }, _: 'bar' },
+        ],
+      },
+    });
+  });
+
+  it('override existing item', () => {
+    const results = setStringItem(
+      [buildResourceItem({ name: 'foo', value: 'bar', translatable: false })],
+      {
+        resources: { string: [{ $: { name: 'foo' }, _: 'foo' }] },
+      }
+    );
+    expect(results).toEqual({
+      resources: { string: [{ $: { name: 'foo', translatable: 'false' }, _: 'bar' }] },
+    });
+  });
+});

--- a/packages/prebuild-config/package.json
+++ b/packages/prebuild-config/package.json
@@ -41,7 +41,8 @@
     "@expo/json-file": "8.2.33",
     "debug": "^4.3.1",
     "fs-extra": "^9.0.0",
-    "resolve-from": "^5.0.0"
+    "resolve-from": "^5.0.0",
+    "semver": "7.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -736,6 +736,18 @@ Object {
               },
               Object {
                 "$": Object {
+                  "name": "expo_splash_screen_resize_mode",
+                },
+                "_": "contain",
+              },
+              Object {
+                "$": Object {
+                  "name": "expo_splash_screen_status_bar_translucent",
+                },
+                "_": "true",
+              },
+              Object {
+                "$": Object {
                   "name": "facebook_app_id",
                 },
                 "_": "1234567890",
@@ -1561,6 +1573,18 @@ Object {
                   "name": "app_name",
                 },
                 "_": "my cool app",
+              },
+              Object {
+                "$": Object {
+                  "name": "expo_splash_screen_resize_mode",
+                },
+                "_": "contain",
+              },
+              Object {
+                "$": Object {
+                  "name": "expo_splash_screen_status_bar_translucent",
+                },
+                "_": "true",
               },
               Object {
                 "$": Object {

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -737,12 +737,14 @@ Object {
               Object {
                 "$": Object {
                   "name": "expo_splash_screen_resize_mode",
+                  "translatable": "false",
                 },
                 "_": "contain",
               },
               Object {
                 "$": Object {
                   "name": "expo_splash_screen_status_bar_translucent",
+                  "translatable": "false",
                 },
                 "_": "true",
               },
@@ -1577,12 +1579,14 @@ Object {
               Object {
                 "$": Object {
                   "name": "expo_splash_screen_resize_mode",
+                  "translatable": "false",
                 },
                 "_": "contain",
               },
               Object {
                 "$": Object {
                   "name": "expo_splash_screen_status_bar_translucent",
+                  "translatable": "false",
                 },
                 "_": "true",
               },

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashLegacyMainActivity-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashLegacyMainActivity-test.ts
@@ -4,11 +4,11 @@ import fs from 'fs-extra';
 import { vol } from 'memfs';
 
 import fixtures from '../../../__tests__/fixtures/react-native-project';
-import { setSplashScreenMainActivity } from '../withAndroidSplashMainActivity';
+import { setSplashScreenLegacyMainActivity } from '../withAndroidSplashLegacyMainActivity';
 
 jest.mock('fs');
 
-describe(setSplashScreenMainActivity, () => {
+describe(setSplashScreenLegacyMainActivity, () => {
   beforeAll(async () => {
     vol.fromJSON(fixtures, '/app');
   });
@@ -29,12 +29,16 @@ describe(setSplashScreenMainActivity, () => {
     };
     const mainActivity = await AndroidConfig.Paths.getMainActivityAsync('/app');
     let contents = fs.readFileSync(mainActivity.path).toString();
-    contents = await setSplashScreenMainActivity(exp, contents, mainActivity.language);
+    contents = await setSplashScreenLegacyMainActivity(exp, contents, mainActivity.language);
     expect(contents).toMatch(
       /SplashScreen.show\(this, SplashScreenImageResizeMode\.NATIVE, ReactRootView\.class, false\);/
     );
     // Try it twice...
-    const nextContents = await setSplashScreenMainActivity(exp, contents, mainActivity.language);
+    const nextContents = await setSplashScreenLegacyMainActivity(
+      exp,
+      contents,
+      mainActivity.language
+    );
     expect(nextContents).toMatch(contents);
   });
 });

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashStrings-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashStrings-test.ts
@@ -1,0 +1,29 @@
+import { XML } from '@expo/config-plugins';
+
+import { setSplashStrings } from '../withAndroidSplashStrings';
+
+describe(setSplashStrings, () => {
+  it('add expo_splash_screen_strings', () => {
+    const results = setSplashStrings({ resources: {} }, 'cover', false);
+    const expectXML = `\
+<resources>
+  <string name="expo_splash_screen_resize_mode" translatable="false">cover</string>
+  <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+</resources>`;
+    expect(XML.format(results)).toEqual(expectXML);
+  });
+
+  it('override old expo_splash_screen_strings', () => {
+    const results = setSplashStrings(
+      { resources: { string: [{ $: { name: 'expo_splash_screen_resize_mode' }, _: 'contain' }] } },
+      'native',
+      false
+    );
+    const expectXML = `\
+<resources>
+  <string name="expo_splash_screen_resize_mode" translatable="false">native</string>
+  <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+</resources>`;
+    expect(XML.format(results)).toEqual(expectXML);
+  });
+});

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashLegacyMainActivity.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashLegacyMainActivity.ts
@@ -10,9 +10,9 @@ const debug = Debug('expo:prebuild-config:expo-splash-screen:android:mainActivit
 // DO NOT CHANGE
 const SHOW_SPLASH_ID = 'expo-splash-screen-mainActivity-onCreate-show-splash';
 
-export const withAndroidSplashMainActivity: ConfigPlugin = config => {
+export const withAndroidSplashLegacyMainActivity: ConfigPlugin = config => {
   return withMainActivity(config, config => {
-    config.modResults.contents = setSplashScreenMainActivity(
+    config.modResults.contents = setSplashScreenLegacyMainActivity(
       config,
       config.modResults.contents,
       config.modResults.language
@@ -21,7 +21,7 @@ export const withAndroidSplashMainActivity: ConfigPlugin = config => {
   });
 };
 
-export function setSplashScreenMainActivity(
+export function setSplashScreenLegacyMainActivity(
   config: Pick<ExpoConfig, 'android' | 'androidStatusBar' | 'userInterfaceStyle'>,
   mainActivity: string,
   language: 'java' | 'kt'

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
@@ -8,6 +8,7 @@ import { getAndroidSplashConfig } from './getAndroidSplashConfig';
 import { withAndroidSplashDrawables } from './withAndroidSplashDrawables';
 import { withAndroidSplashImages } from './withAndroidSplashImages';
 import { withAndroidSplashLegacyMainActivity } from './withAndroidSplashLegacyMainActivity';
+import { withAndroidSplashStrings } from './withAndroidSplashStrings';
 import { withAndroidSplashStyles } from './withAndroidSplashStyles';
 
 export const withAndroidSplashScreen: ConfigPlugin = config => {
@@ -35,6 +36,7 @@ export const withAndroidSplashScreen: ConfigPlugin = config => {
     [withAndroidSplashDrawables, splashConfig],
     ...(shouldUpdateLegacyMainActivity(config) ? [withAndroidSplashLegacyMainActivity] : []),
     withAndroidSplashStyles,
+    withAndroidSplashStrings,
   ]);
 };
 

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
@@ -44,8 +44,12 @@ function shouldUpdateLegacyMainActivity(config: ExpoConfig): boolean {
   try {
     const projectRoot = config._internal?.projectRoot;
     const packagePath = resolveFrom(projectRoot, 'expo-splash-screen/package.json');
-    const version = JsonFile.read(packagePath).version?.toString() ?? '';
-    return semver.lt(version, '0.12.0');
+    if (packagePath) {
+      const version = JsonFile.read(packagePath).version?.toString() ?? '';
+      return semver.lt(version, '0.12.0');
+    }
+    // If expo-splash-screen didn't be installed or included in template, we check the sdkVersion instead.
+    return !!(config.sdkVersion && semver.lt(config.sdkVersion, '43.0.0'));
   } catch {}
   return false;
 }

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashStrings.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashStrings.ts
@@ -1,0 +1,47 @@
+import { AndroidConfig, ConfigPlugin, withStringsXml } from '@expo/config-plugins';
+
+import { getAndroidSplashConfig } from './getAndroidSplashConfig';
+
+const RESIZE_MODE_KEY = 'expo_splash_screen_resize_mode';
+const STATUS_BAR_TRANSLUCENT_KEY = 'expo_splash_screen_status_bar_translucent';
+
+export const withAndroidSplashStrings: ConfigPlugin = config => {
+  config = withStringsXml(config, config => {
+    const splashConfig = getAndroidSplashConfig(config);
+    if (splashConfig) {
+      const { resizeMode } = splashConfig;
+      const statusBarTranslucent = !!config.androidStatusBar?.translucent;
+      config.modResults = setSplashStrings(config.modResults, resizeMode, statusBarTranslucent);
+    }
+    return config;
+  });
+  return config;
+};
+
+export function setSplashStrings(
+  strings: AndroidConfig.Resources.ResourceXML,
+  resizeMode: string,
+  statusBarTranslucent: boolean
+): AndroidConfig.Resources.ResourceXML {
+  let result = AndroidConfig.Strings.setStringItem(
+    [
+      AndroidConfig.Resources.buildResourceItem({
+        name: RESIZE_MODE_KEY,
+        value: resizeMode,
+      }),
+    ],
+    strings
+  );
+
+  result = AndroidConfig.Strings.setStringItem(
+    [
+      AndroidConfig.Resources.buildResourceItem({
+        name: STATUS_BAR_TRANSLUCENT_KEY,
+        value: String(statusBarTranslucent),
+      }),
+    ],
+    strings
+  );
+
+  return result;
+}

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashStrings.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashStrings.ts
@@ -6,7 +6,7 @@ const RESIZE_MODE_KEY = 'expo_splash_screen_resize_mode';
 const STATUS_BAR_TRANSLUCENT_KEY = 'expo_splash_screen_status_bar_translucent';
 
 export const withAndroidSplashStrings: ConfigPlugin = config => {
-  config = withStringsXml(config, config => {
+  return withStringsXml(config, config => {
     const splashConfig = getAndroidSplashConfig(config);
     if (splashConfig) {
       const { resizeMode } = splashConfig;
@@ -15,7 +15,6 @@ export const withAndroidSplashStrings: ConfigPlugin = config => {
     }
     return config;
   });
-  return config;
 };
 
 export function setSplashStrings(

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashStrings.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashStrings.ts
@@ -23,25 +23,19 @@ export function setSplashStrings(
   resizeMode: string,
   statusBarTranslucent: boolean
 ): AndroidConfig.Resources.ResourceXML {
-  let result = AndroidConfig.Strings.setStringItem(
+  return AndroidConfig.Strings.setStringItem(
     [
       AndroidConfig.Resources.buildResourceItem({
         name: RESIZE_MODE_KEY,
         value: resizeMode,
+        translatable: false,
       }),
-    ],
-    strings
-  );
-
-  result = AndroidConfig.Strings.setStringItem(
-    [
       AndroidConfig.Resources.buildResourceItem({
         name: STATUS_BAR_TRANSLUCENT_KEY,
         value: String(statusBarTranslucent),
+        translatable: false,
       }),
     ],
     strings
   );
-
-  return result;
 }


### PR DESCRIPTION
# Why

support https://github.com/expo/expo/pull/14061

# How

- add `withAndroidSplashStrings` to update `resizeMode` and `statusBarTranslucent`
- rename `withAndroidSplashMainActivity` as `withAndroidSplashLegacyMainActivity` and only process if expo-splash-screen version satisfies `< 0.12.0`

# Test Plan

## unit test

```
 PASS   @expo/prebuild-config  src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashStrings-test.ts
  setSplashStrings
    ✓ add expo_splash_screen_strings (148 ms)
    ✓ override old expo_splash_screen_strings

 PASS   @expo/config-plugins  src/android/__tests__/Strings-test.ts
  setStringItem
    ✓ add item from empty xml (2 ms)
    ✓ support adding multiple items (1 ms)
    ✓ override existing item
```

## manually test

```
expo init sdk42
cd sdk42 # select managed layout
expo prebuild -p android
cd node_modules/expo-splash-screen
# update expo-splash-screen version to 0.12.0
yarn add file:/path/to/expo-cli/packages/prebuild-config
cd ../..
rm -rf android
expo prebuild -p android
# verify MainActivity.java and strings.xml
```