### PR TITLE
Skip cleaning node modules for yarn users

### DIFF
--- a/packages/expo-cli/src/commands/eject/installNodeDependenciesAsync.ts
+++ b/packages/expo-cli/src/commands/eject/installNodeDependenciesAsync.ts
@@ -15,21 +15,26 @@ export async function installNodeDependenciesAsync(
   packageManager: 'yarn' | 'npm',
   { clean = true }: { clean: boolean }
 ) {
-  if (clean) {
+  if (clean && packageManager !== 'yarn') {
     // This step can take a couple seconds, if the installation logs are enabled (with EXPO_DEBUG) then it
     // ends up looking odd to see "Installing JavaScript dependencies" for ~5 seconds before the logs start showing up.
-    const cleanJsDepsStep = logNewSection('Cleaning JavaScript dependencies.');
+    const cleanJsDepsStep = logNewSection('Cleaning JavaScript dependencies');
+    const time = Date.now();
     // nuke the node modules
     // TODO: this is substantially slower, we should find a better alternative to ensuring the modules are installed.
     await fs.remove('node_modules');
-    cleanJsDepsStep.succeed('Cleaned JavaScript dependencies.');
+    cleanJsDepsStep.succeed(
+      `Cleaned JavaScript dependencies ${chalk.gray(Date.now() - time + 'ms')}`
+    );
   }
 
-  const installJsDepsStep = logNewSection('Installing JavaScript dependencies.');
-
+  const installJsDepsStep = logNewSection('Installing JavaScript dependencies');
   try {
+    const time = Date.now();
     await CreateApp.installNodeDependenciesAsync(projectRoot, packageManager);
-    installJsDepsStep.succeed('Installed JavaScript dependencies.');
+    installJsDepsStep.succeed(
+      `Installed JavaScript dependencies ${chalk.gray(Date.now() - time + 'ms')}`
+    );
   } catch {
     const message = `Something went wrong installing JavaScript dependencies, check your ${packageManager} logfile or run ${chalk.bold(
       `${packageManager} install`

--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -50,13 +50,13 @@ export async function updatePackageJSONAsync({
   );
 
   updatingPackageJsonStep.succeed(
-    'Updated package.json and added index.js entry point for iOS and Android.'
+    'Updated package.json and added index.js entry point for iOS and Android'
   );
   if (removedPkgMain) {
     Log.log(
       `\u203A Removed ${chalk.bold(
         `"main": "${removedPkgMain}"`
-      )} from package.json because we recommend using index.js as main instead.`
+      )} from package.json because we recommend using index.js as main instead`
     );
     Log.newLine();
   }

--- a/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
+++ b/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
@@ -50,7 +50,7 @@ export function writeMetroConfig({
     }
 
     fs.copySync(sourceConfigPath, targetConfigPath);
-    updatingMetroConfigStep.succeed('Added Metro config.');
+    updatingMetroConfigStep.succeed('Added Metro config');
   } catch (e) {
     updatingMetroConfigStep.stopAndPersist({
       symbol: '⚠️ ',


### PR DESCRIPTION
# Why

We currently clean the node modules before installing after running prebuild/eject, I guess this is supposed to prevent issues when changing the react-native fork to the upstream react-native. I haven't encountered this error in the latest Expo SDK (I only use yarn), so this PR proposes we skip that step and go straight to relying on yarn to work as expected. 

In blank projects, this reduces prebuild time by over 30% (~6 seconds), this metric would only grow as the project adds more dependencies (also wifi conditions vary). 

# Test Plan

- On a clean blank project: `expo run:android`
- On a clean blank project: `expo run:ios`