### PR TITLE
[metro-config] automatically polyfill expo modules

### DIFF
--- a/packages/metro-config/README.md
+++ b/packages/metro-config/README.md
@@ -1,3 +1,27 @@
 # expo-metro-config
 
 A Metro config for running React Native projects with the Metro bundler.
+
+## Side Effects
+
+This config ensures that the required side-effects for certain packages are applied when needed. This currently includes `react-native-gesture-handler` and `expo-dev-client`.
+
+If you have any of the following side-effect imports, you can now remove them:
+
+```js
+import 'react-native-gesture-handler';
+
+// or
+
+import 'expo-dev-client';
+```
+
+## Babel
+
+This config uses Babel to transpile JavaScript. By default, if your project does not have a `babel.config.js`, `.babelrc`, or `.babelrc.js`, a default Babel preset will be used. The default is [`babel-preset-expo`](https://www.npmjs.com/package/babel-preset-expo) which extends the default Metro preset for React Native and adds other features for more optimal tree-shaking (smaller production bundles).
+
+## Debugging
+
+You can see some of the resolved settings by using the envar `EXPO_DEBUG=1` before running any command that uses the Metro Bundler.
+
+You can debug the internals of Metro by using the envar `DEBUG=*`.

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -36,9 +36,11 @@
     "@expo/config": "5.0.7",
     "chalk": "^4.1.0",
     "getenv": "^1.0.0",
-    "metro-react-native-babel-transformer": "^0.59.0"
+    "metro-react-native-babel-transformer": "^0.59.0",
+    "resolve": "^1.20.0"
   },
   "devDependencies": {
+    "@types/resolve": "^1.20.1",
     "expo": "37",
     "metro": "^0.59.0",
     "metro-config": "^0.59.0",

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -92,8 +92,8 @@ export function getDefaultConfig(
     // it is not needed
   }
 
-  const isLegacy = readIsLegacyImportsEnabled(projectRoot);
   // Deprecated -- SDK 41 --
+  const isLegacy = readIsLegacyImportsEnabled(projectRoot);
   if (options.target) {
     if (!isLegacy) {
       console.warn(

--- a/packages/metro-config/src/metro-expo-babel-transformer.ts
+++ b/packages/metro-config/src/metro-expo-babel-transformer.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { readFileSync } from 'fs';
-import resolveFrom from 'resolve-from';
+
+import { resolveSilent } from './resolve';
 
 const cacheKeyParts = [
   readFileSync(__filename),
@@ -16,7 +17,7 @@ function resolveTransformer(projectRoot: string) {
   if (transformer) {
     return transformer;
   }
-  const resolvedPath = resolveFrom.silent(projectRoot, 'metro-react-native-babel-transformer');
+  const resolvedPath = resolveSilent(projectRoot, 'metro-react-native-babel-transformer');
   if (!resolvedPath) {
     throw new Error(
       'Missing package "metro-react-native-babel-transformer" in the project. ' +
@@ -49,7 +50,7 @@ function transform(props: {
   src: string;
 }) {
   // Use babel-preset-expo by default if available...
-  props.options.extendsBabelConfigPath = resolveFrom.silent(
+  props.options.extendsBabelConfigPath = resolveSilent(
     props.options.projectRoot,
     'babel-preset-expo'
   );

--- a/packages/metro-config/src/resolve.ts
+++ b/packages/metro-config/src/resolve.ts
@@ -1,0 +1,31 @@
+import { Opts, sync } from 'resolve';
+
+// Resolves modules in the same way metro bundler would.
+export function resolveAsBundler(projectRoot: string, id: string, opts: Opts = {}): string | null {
+  return resolveSilent(projectRoot, id, {
+    extensions: ['.ts', '.js'],
+    packageFilter: pkg => ({
+      ...pkg,
+      main: pkg['react-native'] || pkg['browser'] || pkg['main'],
+    }),
+    ...opts,
+  });
+}
+
+export function resolveSilent(projectRoot: string, id: string, opts: Opts = {}): string | null {
+  try {
+    return resolveFrom(projectRoot, id, opts);
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export function resolveFrom(projectRoot: string, id: string, opts: Opts = {}): string {
+  return sync(id, {
+    ...opts,
+    basedir: projectRoot,
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3569,6 +3569,11 @@
   resolved "https://registry.yarnpkg.com/@types/require-from-string/-/require-from-string-1.2.1.tgz#50292d824e2244628c0b961c6a1a583fdc494554"
   integrity sha512-mIDK7lTHc0uW67SxPIqkwCrxmdKBV5aAET560hyZnT8c6Ekp9Aah3GPqe8Pl1Yzn/i2NMYmYv+HiMLwjGDCIAQ==
 
+"@types/resolve@^1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.1.tgz#3727e48042fda81e374f5d5cf2fa92288bf698f8"
+  integrity sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==
+
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
@@ -9800,10 +9805,10 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@0.0.0, hermes-engine@~0.5.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
-  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
+hermes-engine@~0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.5.1.tgz#601115e4b1e0a17d9aa91243b96277de4e926e09"
+  integrity sha512-hLwqh8dejHayjlpvZY40e1aDCDvyP98cWx/L5DhAjSJLH8g4z9Tp08D7y4+3vErDsncPOdf1bxm+zUWpx0/Fxg==
 
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"
@@ -16292,7 +16297,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==


### PR DESCRIPTION
# Why

We currently require people to import these packages when installed in the project, this PR automatically finds the required packages and links them before loading the app.

I added a new resolution library which can resolve packages based on specific main fields (required for RNGH). It'd be good to add our new monorepo resolution too.

The idea here being that you could essentially, automatically add the required side effects to every project, and lower the chances of misconfiguration:

```ts
import 'expo-dev-client'
import 'react-native-gesture-handler'
```

We could even add the `expo` side-effects too which would enable people to skip over using `registerRootComponent` and still have features like logging fully enabled.


# Test Plan

- [ ] Continuous: TBD
- [x] Manual: `EXPO_DEBUG=1 expo start` (in a project without a local metro config): Should see just RNGH, if you install dev client, you'll see that too.
