### PR TITLE
[expo cli] prompt to remove malformed projects

### DIFF
--- a/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
+++ b/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
@@ -68,10 +68,15 @@ async function isIOSProjectValidAsync(projectRoot: string) {
   return hasRequiredIOSFilesAsync(projectRoot);
 }
 
-export async function promptToClearMalformedNativeProjectsAsync(projectRoot: string) {
+export async function promptToClearMalformedNativeProjectsAsync(
+  projectRoot: string,
+  checkPlatforms: string[]
+) {
   const [isAndroidValid, isIOSValid] = await Promise.all([
-    isAndroidProjectValidAsync(projectRoot),
-    isIOSProjectValidAsync(projectRoot),
+    checkPlatforms.includes('android')
+      ? isAndroidProjectValidAsync(projectRoot)
+      : Promise.resolve(true),
+    checkPlatforms.includes('ios') ? isIOSProjectValidAsync(projectRoot) : Promise.resolve(true),
   ]);
 
   if (isAndroidValid && isIOSValid) {

--- a/packages/expo-cli/src/commands/eject/ejectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/ejectAsync.ts
@@ -18,7 +18,7 @@ export async function ejectAsync(
   assertPlatforms(platforms);
 
   if (await maybeBailOnGitStatusAsync()) return;
-  await promptToClearMalformedNativeProjectsAsync(projectRoot);
+  await promptToClearMalformedNativeProjectsAsync(projectRoot, platforms);
 
   const results = await prebuildAsync(projectRoot, { platforms, ...options });
   logNextSteps(results);

--- a/packages/expo-cli/src/commands/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/prebuildAsync.ts
@@ -31,7 +31,7 @@ export async function actionAsync(
     // Clear the native folders before syncing
     await clearNativeFolder(projectRoot, platforms);
   } else {
-    await promptToClearMalformedNativeProjectsAsync(projectRoot);
+    await promptToClearMalformedNativeProjectsAsync(projectRoot, platforms);
   }
 
   await prebuildAsync(projectRoot, {

--- a/packages/expo-cli/src/commands/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/prebuildAsync.ts
@@ -1,4 +1,7 @@
-import { clearNativeFolder } from './eject/clearNativeFolder';
+import {
+  clearNativeFolder,
+  promptToClearMalformedNativeProjectsAsync,
+} from './eject/clearNativeFolder';
 import { platformsFromPlatform } from './eject/platformOptions';
 import { EjectAsyncOptions, prebuildAsync } from './eject/prebuildAsync';
 import maybeBailOnGitStatusAsync from './utils/maybeBailOnGitStatusAsync';
@@ -27,6 +30,8 @@ export async function actionAsync(
     if (await maybeBailOnGitStatusAsync()) return;
     // Clear the native folders before syncing
     await clearNativeFolder(projectRoot, platforms);
+  } else {
+    await promptToClearMalformedNativeProjectsAsync(projectRoot);
   }
 
   await prebuildAsync(projectRoot, {

--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -10,8 +10,10 @@ import StatusEventEmitter from '../../../StatusEventEmitter';
 import getDevClientProperties from '../../../analytics/getDevClientProperties';
 import Log from '../../../log';
 import { getSchemesForAndroidAsync } from '../../../schemes';
+import { promptToClearMalformedNativeProjectsAsync } from '../../eject/clearNativeFolder';
 import { prebuildAsync } from '../../eject/prebuildAsync';
 import { installCustomExitHook } from '../../start/installExitHooks';
+import { profileMethod } from '../../utils/profileMethod';
 import { startBundlerAsync } from '../ios/startBundlerAsync';
 import { isDevMenuInstalled } from '../utils/isDevMenuInstalled';
 import { resolvePortAsync } from '../utils/resolvePortAsync';
@@ -98,6 +100,10 @@ async function resolveOptionsAsync(
 }
 
 export async function actionAsync(projectRoot: string, options: Options) {
+  // If the user has an empty android folder then the project won't build, this can happen when they delete the prebuild files in git.
+  // Check to ensure most of the core files are in place, and prompt to remove the folder if they aren't.
+  await profileMethod(promptToClearMalformedNativeProjectsAsync)(projectRoot, ['android']);
+
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   track(projectRoot, exp);
 

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -9,6 +9,7 @@ import StatusEventEmitter from '../../../StatusEventEmitter';
 import getDevClientProperties from '../../../analytics/getDevClientProperties';
 import Log from '../../../log';
 import { getSchemesForIosAsync } from '../../../schemes';
+import { promptToClearMalformedNativeProjectsAsync } from '../../eject/clearNativeFolder';
 import { EjectAsyncOptions, prebuildAsync } from '../../eject/prebuildAsync';
 import { installCustomExitHook } from '../../start/installExitHooks';
 import { profileMethod } from '../../utils/profileMethod';
@@ -23,6 +24,10 @@ import { startBundlerAsync } from './startBundlerAsync';
 const isMac = process.platform === 'darwin';
 
 export async function actionAsync(projectRoot: string, options: Options) {
+  // If the user has an empty ios folder then the project won't build, this can happen when they delete the prebuild files in git.
+  // Check to ensure most of the core files are in place, and prompt to remove the folder if they aren't.
+  await profileMethod(promptToClearMalformedNativeProjectsAsync)(projectRoot, ['ios']);
+
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   track(projectRoot, exp);
 


### PR DESCRIPTION
# Why

Resolve https://github.com/expo/expo-cli/issues/3772

# How

- Added malformed project check to run commands and prebuild.
- Added platform specifier to malformed project check.

# Test Plan

revert the contents of a binary folder and run `expo prebuild`