### PR TITLE
[expo-cli] Disable update check in non-interactive mode

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -332,7 +332,7 @@ export type Action = (...args: any[]) => void;
 // parsing the command input
 Command.prototype.asyncAction = function (asyncFn: Action) {
   return this.action(async (...args: any[]) => {
-    if (!getenv.boolish('EAS_BUILD', false)) {
+    if (!getenv.boolish('EAS_BUILD', false) && !program.nonInteractive) {
       try {
         await profileMethod(checkCliVersionAsync)();
       } catch (e) {}


### PR DESCRIPTION
# Why

- resolve https://github.com/expo/expo-cli/issues/3160
- I'm not really sure this is a great idea since the update info is still relevant.