### PR TITLE
Added device selection to `expo client:install:android`

### DIFF
--- a/packages/expo-cli/src/commands/client/clientInstallAndroidAsync.ts
+++ b/packages/expo-cli/src/commands/client/clientInstallAndroidAsync.ts
@@ -3,13 +3,16 @@ import { Android, Versions } from 'xdl';
 
 import Log from '../../log';
 import { confirmAsync } from '../../prompts';
+import { resolveDeviceAsync } from '../run/android/resolveDeviceAsync';
 import * as ClientUpgradeUtils from '../utils/ClientUpgradeUtils';
 
 type Options = {
   latest?: boolean;
+  device?: boolean | string;
 };
 
 export async function actionAsync(options: Options) {
+  const device = await resolveDeviceAsync(options.device);
   const forceLatest = !!options.latest;
   const currentSdkConfig = await ClientUpgradeUtils.getExpoSdkConfig(process.cwd());
   const currentSdkVersion = currentSdkConfig ? currentSdkConfig.sdkVersion : undefined;
@@ -29,7 +32,13 @@ export async function actionAsync(options: Options) {
       return;
     }
 
-    if (await Android.upgradeExpoAsync({ url: latestClient.url, version: latestClient.version })) {
+    if (
+      await Android.upgradeExpoAsync({
+        device,
+        url: latestClient.url,
+        version: latestClient.version,
+      })
+    ) {
       Log.log('Done!');
     } else {
       Log.error(`Unable to install Expo Go ${latestClient.version} for Android.`);
@@ -57,6 +66,7 @@ export async function actionAsync(options: Options) {
     });
     if (answer) {
       await Android.upgradeExpoAsync({
+        device,
         url: recommendedClient.url,
         version: recommendedClient.version,
       });
@@ -71,6 +81,7 @@ export async function actionAsync(options: Options) {
     });
     if (answer) {
       await Android.upgradeExpoAsync({
+        device,
         url: latestClient?.url,
         version: latestClient?.version,
       });
@@ -93,6 +104,7 @@ export async function actionAsync(options: Options) {
     });
     if (answer) {
       await Android.upgradeExpoAsync({
+        device,
         url: latestClient?.url,
         version: latestClient?.version,
       });
@@ -109,7 +121,7 @@ export async function actionAsync(options: Options) {
     clients: availableClients,
   });
 
-  if (await Android.upgradeExpoAsync({ url: targetClient.clientUrl })) {
+  if (await Android.upgradeExpoAsync({ device, url: targetClient.clientUrl })) {
     Log.log('Done!');
   }
 }

--- a/packages/expo-cli/src/commands/client/index.ts
+++ b/packages/expo-cli/src/commands/client/index.ts
@@ -36,6 +36,7 @@ export default function (program: Command) {
     program
       .command('client:install:android')
       .description('Install Expo Go for Android on a connected device or emulator')
+      .option('-d, --device [device]', 'Device name to install the client on')
       .option(
         '--latest',
         `Install the latest version of Expo Go, ignore the current project version.`

--- a/packages/expo-cli/src/commands/run/android/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/android/resolveDeviceAsync.ts
@@ -29,7 +29,7 @@ export async function resolveDeviceAsync(device?: string | boolean): Promise<And
     // --device with no props after
     const device = await Android.promptForDeviceAsync(devices);
     if (!device) {
-      throw new CommandError('Select a device to run on');
+      throw new CommandError('Select a device to use');
     }
     Log.log(chalk.dim`\u203A Using --device ${device.name}`);
     return device;

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -483,19 +483,23 @@ export async function uninstallExpoAsync(device: Device): Promise<string | undef
   }
 }
 
-export async function upgradeExpoAsync(options?: {
+export async function upgradeExpoAsync({
+  url,
+  version,
+  device,
+}: {
   url?: string;
   version?: string;
-}): Promise<boolean> {
-  const { url, version } = options || {};
-
+  device?: Device | null;
+} = {}): Promise<boolean> {
   try {
-    const devices = await getAttachedDevicesAsync();
-    if (!devices.length) {
-      throw new Error('no devices connected');
+    if (!device) {
+      device = (await getAttachedDevicesAsync())[0];
+      if (!device) {
+        throw new Error('no devices connected');
+      }
     }
-
-    const device = await attemptToStartEmulatorOrAssertAsync(devices[0]);
+    device = await attemptToStartEmulatorOrAssertAsync(device);
     if (!device) {
       return false;
     }


### PR DESCRIPTION
# Why

- Resolve https://github.com/expo/expo-cli/issues/2991

- Auto opens an emulator (best-effort) if no device is connected and no emulator is open.
- Provide `--device` or `-d` to get a device picker.
- Pass `--device "Pixel_4_XL_API_30"` to automatically open a specific device (basically the same as `expo run:android`).
