### PR TITLE
[config-plugins] Improved warnings system in config plugins

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -44,7 +44,8 @@
     "semver": "^7.3.5",
     "slash": "^3.0.0",
     "xcode": "^3.0.1",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.4.23",
+    "chalk": "^4.1.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/config-plugins/src/android/GoogleServices.ts
+++ b/packages/config-plugins/src/android/GoogleServices.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path';
 import { ConfigPlugin } from '../Plugin.types';
 import { withAppBuildGradle, withProjectBuildGradle } from '../plugins/android-plugins';
 import { withDangerousMod } from '../plugins/withDangerousMod';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningAndroid } from '../utils/warnings';
 
 const DEFAULT_TARGET_PATH = './android/app/google-services.json';
 
@@ -20,8 +20,8 @@ export const withClassPath: ConfigPlugin = config => {
     if (config.modResults.language === 'groovy') {
       config.modResults.contents = setClassPath(config, config.modResults.contents);
     } else {
-      WarningAggregator.addWarningAndroid(
-        'android-google-services',
+      addWarningAndroid(
+        'android.googleServicesFile',
         `Cannot automatically configure project build.gradle if it's not groovy`
       );
     }
@@ -34,8 +34,8 @@ export const withApplyPlugin: ConfigPlugin = config => {
     if (config.modResults.language === 'groovy') {
       config.modResults.contents = applyPlugin(config, config.modResults.contents);
     } else {
-      WarningAggregator.addWarningAndroid(
-        'android-google-services',
+      addWarningAndroid(
+        'android.googleServicesFile',
         `Cannot automatically configure app build.gradle if it's not groovy`
       );
     }

--- a/packages/config-plugins/src/android/Name.ts
+++ b/packages/config-plugins/src/android/Name.ts
@@ -26,7 +26,7 @@ export const withNameSettingsGradle: ConfigPlugin = config => {
       config.modResults.contents = applyNameSettingsGradle(config, config.modResults.contents);
     } else {
       addWarningAndroid(
-        'android-name-settings-gradle',
+        'name',
         `Cannot automatically configure settings.gradle if it's not groovy`
       );
     }

--- a/packages/config-plugins/src/android/NavigationBar.ts
+++ b/packages/config-plugins/src/android/NavigationBar.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidColors, withAndroidStyles } from '../plugins/android-plugins';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningAndroid } from '../utils/warnings';
 import { setColorItem } from './Colors';
 import { buildResourceItem, ResourceXML } from './Resources';
 import { assignStylesValue, getAppThemeLightNoActionBarGroup } from './Styles';
@@ -14,9 +14,10 @@ export const withNavigationBar: ConfigPlugin = config => {
   if (immersiveMode) {
     // Immersive mode needs to be set programmatically
     // TODO: Resolve
-    WarningAggregator.addWarningAndroid(
+    addWarningAndroid(
       'androidNavigationBar.visible',
-      'Hiding the navigation bar must be done programmatically. Refer to the Android documentation - https://developer.android.com/training/system-ui/immersive - for instructions.'
+      'Hiding the navigation bar must be done programmatically',
+      'https://developer.android.com/training/system-ui/immersive'
     );
   }
 

--- a/packages/config-plugins/src/android/Package.ts
+++ b/packages/config-plugins/src/android/Package.ts
@@ -8,7 +8,7 @@ import { ConfigPlugin } from '../Plugin.types';
 import { createAndroidManifestPlugin, withAppBuildGradle } from '../plugins/android-plugins';
 import { withDangerousMod } from '../plugins/withDangerousMod';
 import { directoryExistsAsync } from '../utils/modules';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningAndroid } from '../utils/warnings';
 import { AndroidManifest } from './Manifest';
 import { getAppBuildGradleFilePath, getProjectFilePath } from './Paths';
 
@@ -24,8 +24,8 @@ export const withPackageGradle: ConfigPlugin = config => {
     if (config.modResults.language === 'groovy') {
       config.modResults.contents = setPackageInBuildGradle(config, config.modResults.contents);
     } else {
-      WarningAggregator.addWarningAndroid(
-        'android-package',
+      addWarningAndroid(
+        'android.package',
         `Cannot automatically configure app build.gradle if it's not groovy`
       );
     }

--- a/packages/config-plugins/src/android/Scheme.ts
+++ b/packages/config-plugins/src/android/Scheme.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig } from '@expo/config-types';
 
 import { createAndroidManifestPlugin } from '../plugins/android-plugins';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningAndroid } from '../utils/warnings';
 import { AndroidManifest, ManifestActivity } from './Manifest';
 
 export type IntentFilterProps = {
@@ -44,9 +44,10 @@ export function setScheme(
   }
 
   if (!ensureManifestHasValidIntentFilter(androidManifest)) {
-    WarningAggregator.addWarningAndroid(
+    addWarningAndroid(
       'scheme',
-      `Cannot add schemes because the provided manifest does not have a valid Activity with \`android:launchMode="singleTask"\`.\nThis guide can help you get setup properly https://expo.fyi/setup-android-uri-scheme`
+      `Cannot add schemes because the provided manifest does not have a valid Activity with \`android:launchMode="singleTask"\``,
+      'https://expo.fyi/setup-android-uri-scheme'
     );
     return androidManifest;
   }

--- a/packages/config-plugins/src/android/UserInterfaceStyle.ts
+++ b/packages/config-plugins/src/android/UserInterfaceStyle.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { createAndroidManifestPlugin, withMainActivity } from '../plugins/android-plugins';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningAndroid } from '../utils/warnings';
 import { AndroidManifest, getMainActivityOrThrow } from './Manifest';
 
 export const CONFIG_CHANGES_ATTRIBUTE = 'android:configChanges';
@@ -33,8 +33,8 @@ export const withUiModeMainActivity: ConfigPlugin = config => {
         config.modResults.contents
       );
     } else {
-      WarningAggregator.addWarningAndroid(
-        'android-userInterfaceStyle',
+      addWarningAndroid(
+        'android.userInterfaceStyle',
         `Cannot automatically configure MainActivity if it's not java`
       );
     }

--- a/packages/config-plugins/src/android/Version.ts
+++ b/packages/config-plugins/src/android/Version.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAppBuildGradle } from '../plugins/android-plugins';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningAndroid } from '../utils/warnings';
 
 export const withVersion: ConfigPlugin = config => {
   return withAppBuildGradle(config, config => {
@@ -10,8 +10,8 @@ export const withVersion: ConfigPlugin = config => {
       config.modResults.contents = setVersionCode(config, config.modResults.contents);
       config.modResults.contents = setVersionName(config, config.modResults.contents);
     } else {
-      WarningAggregator.addWarningAndroid(
-        'android-version',
+      addWarningAndroid(
+        'android.versionCode',
         `Cannot automatically configure app build.gradle if it's not groovy`
       );
     }

--- a/packages/config-plugins/src/ios/DeviceFamily.ts
+++ b/packages/config-plugins/src/ios/DeviceFamily.ts
@@ -3,7 +3,7 @@ import { XcodeProject } from 'xcode';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withXcodeProject } from '../plugins/ios-plugins';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningIOS } from '../utils/warnings';
 
 export const withDeviceFamily: ConfigPlugin = config => {
   return withXcodeProject(config, async config => {
@@ -27,8 +27,8 @@ export function getDeviceFamilies(config: Pick<ExpoConfig, 'ios'>): number[] {
   const isTabletOnly = getIsTabletOnly(config);
 
   if (isTabletOnly && config.ios?.supportsTablet === false) {
-    WarningAggregator.addWarningIOS(
-      'device-family',
+    addWarningIOS(
+      'ios.supportsTablet',
       `Found contradictory values: \`{ ios: { isTabletOnly: true, supportsTablet: false } }\`. Using \`{ isTabletOnly: true }\`.`
     );
   }

--- a/packages/config-plugins/src/ios/Locales.ts
+++ b/packages/config-plugins/src/ios/Locales.ts
@@ -6,7 +6,7 @@ import { XcodeProject } from 'xcode';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withXcodeProject } from '../plugins/ios-plugins';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningIOS } from '../utils/warnings';
 import { addResourceFileToGroup, ensureGroupRecursively, getProjectName } from './utils/Xcodeproj';
 
 type LocaleJson = Record<string, string>;
@@ -87,8 +87,8 @@ export async function getResolvedLocalesAsync(
         locales[lang] = await JsonFile.readAsync(join(projectRoot, localeJsonPath));
       } catch (e) {
         // Add a warning when a json file cannot be parsed.
-        WarningAggregator.addWarningIOS(
-          `locales-${lang}`,
+        addWarningIOS(
+          `locales.${lang}`,
           `Failed to parse JSON of locale file for language: ${lang}`,
           'https://docs.expo.dev/distribution/app-stores/#localizing-your-ios-app'
         );

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -3,7 +3,7 @@ import { sync as globSync } from 'glob';
 import * as path from 'path';
 
 import { UnexpectedError } from '../utils/errors';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningIOS } from '../utils/warnings';
 
 const ignoredPaths = ['**/@(Carthage|Pods|vendor|node_modules)/**'];
 
@@ -235,7 +235,7 @@ function warnMultipleFiles({
 }) {
   const usingPath = projectRoot ? path.relative(projectRoot, using) : using;
   const extraPaths = projectRoot ? extra.map(v => path.relative(projectRoot, v)) : extra;
-  WarningAggregator.addWarningIOS(
+  addWarningIOS(
     `paths-${tag}`,
     `Found multiple ${fileName} file paths, using "${usingPath}". Ignored paths: ${JSON.stringify(
       extraPaths

--- a/packages/config-plugins/src/ios/RequiresFullScreen.ts
+++ b/packages/config-plugins/src/ios/RequiresFullScreen.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { createInfoPlistPlugin } from '../plugins/ios-plugins';
 import { gteSdkVersion } from '../utils/versions';
-import * as WarningAggregator from '../utils/warnings';
+import { addWarningIOS } from '../utils/warnings';
 import { InfoPlist } from './IosConfig.types';
 
 export const withRequiresFullScreen = createInfoPlistPlugin(
@@ -66,7 +66,7 @@ function resolveExistingIpadInterfaceOrientations(interfaceOrientations: any): s
     !hasMinimumOrientations(interfaceOrientations)
   ) {
     const existingList = interfaceOrientations!.join(', ');
-    WarningAggregator.addWarningIOS(
+    addWarningIOS(
       'ios.requireFullScreen',
       `iPad multitasking requires all \`${iPadInterfaceKey}\` orientations to be defined in the Info.plist. The Info.plist currently defines values that are incompatible with multitasking, these will be overwritten to prevent submission failure. Existing: ${existingList}`
     );

--- a/packages/config-plugins/src/ios/__tests__/DeviceFamily-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/DeviceFamily-test.ts
@@ -26,7 +26,7 @@ describe(getDeviceFamilies, () => {
   it(`warns about invalid config`, () => {
     getDeviceFamilies({ ios: { isTabletOnly: true, supportsTablet: false } } as any);
     expect(WarningAggregator.addWarningIOS).toHaveBeenLastCalledWith(
-      'device-family',
+      'ios.supportsTablet',
       'Found contradictory values: `{ ios: { isTabletOnly: true, supportsTablet: false } }`. Using `{ isTabletOnly: true }`.'
     );
   });

--- a/packages/config-plugins/src/ios/__tests__/Locales-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Locales-test.ts
@@ -75,7 +75,7 @@ describe('e2e: iOS locales', () => {
     expect(after[locales[1]]).toMatch(/spanish-name/);
     // Test a warning is thrown for an invalid locale JSON file.
     expect(WarningAggregator.addWarningIOS).toHaveBeenCalledWith(
-      'locales-xx',
+      'locales.xx',
       'Failed to parse JSON of locale file for language: xx',
       'https://docs.expo.dev/distribution/app-stores/#localizing-your-ios-app'
     );

--- a/packages/config-plugins/src/utils/warnings.ts
+++ b/packages/config-plugins/src/utils/warnings.ts
@@ -1,46 +1,48 @@
+import chalk from 'chalk';
+
 import { ModPlatform } from '../Plugin.types';
 
-type WarningArray = [string, string, string | undefined];
-let _warningsIOS: WarningArray[] = [];
-let _warningsAndroid: WarningArray[] = [];
-
-export function hasWarningsIOS() {
-  return !!_warningsIOS.length;
+/**
+ * Log a warning that doesn't disrupt the spinners.
+ *
+ * ```sh
+ * » android: android.package: property is invalid https://expo.fyi/android-package
+ * ```
+ *
+ * @param property Name of the config property that triggered the warning (best-effort)
+ * @param text Main warning message
+ * @param link Useful link to resources related to the warning
+ */
+export function addWarningAndroid(property: string, text: string, link?: string) {
+  console.warn(formatWarning('android', property, text, link));
 }
 
-export function hasWarningsAndroid() {
-  return !!_warningsAndroid.length;
-}
-
-export function addWarningAndroid(tag: string, text: string, link?: string) {
-  _warningsAndroid = [..._warningsAndroid, [tag, text, link]];
-}
-
-export function addWarningIOS(tag: string, text: string, link?: string) {
-  _warningsIOS = [..._warningsIOS, [tag, text, link]];
+/**
+ * Log a warning that doesn't disrupt the spinners.
+ *
+ * ```sh
+ * » ios: ios.bundleIdentifier: property is invalid https://expo.fyi/bundle-identifier
+ * ```
+ *
+ * @param property Name of the config property that triggered the warning (best-effort)
+ * @param text Main warning message
+ * @param link Useful link to resources related to the warning
+ */
+export function addWarningIOS(property: string, text: string, link?: string) {
+  console.warn(formatWarning('ios', property, text, link));
 }
 
 export function addWarningForPlatform(
   platform: ModPlatform,
-  tag: string,
+  property: string,
   text: string,
   link?: string
 ) {
-  if (platform === 'ios') {
-    addWarningIOS(tag, text, link);
-  } else {
-    addWarningAndroid(tag, text, link);
-  }
+  console.warn(formatWarning(platform, property, text, link));
 }
 
-export function flushWarningsAndroid() {
-  const result = _warningsAndroid;
-  _warningsAndroid = [];
-  return result;
-}
-
-export function flushWarningsIOS() {
-  const result = _warningsIOS;
-  _warningsIOS = [];
-  return result;
+function formatWarning(platform: string, property: string, warning: string, link?: string) {
+  return chalk.yellow`${'» ' + chalk.bold(platform)}: ${property}: ${warning}${
+    link ? chalk.gray(' ' + link) : ''
+  }`;
 }

--- a/packages/expo-cli/__mocks__/ora.js
+++ b/packages/expo-cli/__mocks__/ora.js
@@ -4,6 +4,7 @@ const ora = jest.fn(() => {
       return { stop: jest.fn(), succeed: jest.fn(), fail: jest.fn() };
     }),
     stop: jest.fn(),
+    stopAndPersist: jest.fn(),
     succeed: jest.fn(),
     fail: jest.fn(),
   };

--- a/packages/expo-cli/src/commands/eject/logNextSteps.ts
+++ b/packages/expo-cli/src/commands/eject/logNextSteps.ts
@@ -1,4 +1,3 @@
-import { WarningAggregator } from '@expo/config-plugins';
 import chalk from 'chalk';
 import terminalLink from 'terminal-link';
 
@@ -17,12 +16,6 @@ export function logNextSteps({
 }: PrebuildResults) {
   Log.newLine();
   Log.nested(`➡️  ${chalk.bold('Next steps')}`);
-
-  if (WarningAggregator.hasWarningsIOS() || WarningAggregator.hasWarningsAndroid()) {
-    Log.nested(
-      `\u203A 👆 Review the logs above and look for any warnings (⚠️ ) that might need follow-up.`
-    );
-  }
 
   // Log a warning about needing to install node modules
   if (nodeInstall) {

--- a/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
@@ -1,30 +1,7 @@
-import { WarningAggregator } from '@expo/config-plugins';
 import chalk from 'chalk';
 
 import Log from '../../log';
 import * as TerminalLink from './TerminalLink';
-
-export function logConfigWarningsIOS() {
-  const warningsIOS = WarningAggregator.flushWarningsIOS();
-  if (warningsIOS.length) {
-    warningsIOS.forEach(([property, warning, link]) => {
-      Log.nested(formatNamedWarning(property, warning, link));
-    });
-  }
-
-  return !!warningsIOS;
-}
-
-export function logConfigWarningsAndroid() {
-  const warningsAndroid = WarningAggregator.flushWarningsAndroid();
-  if (warningsAndroid.length) {
-    warningsAndroid.forEach(([property, warning, link]) => {
-      Log.nested(formatNamedWarning(property, warning, link));
-    });
-  }
-
-  return !!warningsAndroid;
-}
 
 export function formatNamedWarning(property: string, warning: string, link?: string) {
   return `- ${chalk.bold(property)}: ${warning}${

--- a/packages/expo-cli/src/utils/ora.ts
+++ b/packages/expo-cli/src/utils/ora.ts
@@ -21,6 +21,57 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
     ...inputOptions,
   });
 
+  // eslint-disable-next-line no-console
+  const logReal = console.log;
+  // eslint-disable-next-line no-console
+  const infoReal = console.info;
+  // eslint-disable-next-line no-console
+  const warnReal = console.warn;
+  // eslint-disable-next-line no-console
+  const errorReal = console.error;
+
+  const oraStop = ora.stop.bind(ora);
+
+  const origStopAndPersist = ora.stopAndPersist.bind(ora);
+
+  const logWrap = (method: any, args: any[]) => {
+    oraStop();
+    method(...args);
+    ora!.start();
+  };
+
+  // eslint-disable-next-line no-console
+  console.log = (...args: any) => logWrap(logReal, args);
+  // eslint-disable-next-line no-console
+  console.info = (...args: any) => logWrap(infoReal, args);
+  // eslint-disable-next-line no-console
+  console.warn = (...args: any) => logWrap(warnReal, args);
+  // eslint-disable-next-line no-console
+  console.error = (...args: any) => logWrap(errorReal, args);
+
+  const resetNativeLogs = () => {
+    // eslint-disable-next-line no-console
+    console.log = logReal;
+    // eslint-disable-next-line no-console
+    console.info = logReal;
+    // eslint-disable-next-line no-console
+    console.warn = warnReal;
+    // eslint-disable-next-line no-console
+    console.error = errorReal;
+  };
+
+  ora.stopAndPersist = (): oraReal.Ora => {
+    origStopAndPersist();
+    resetNativeLogs();
+    return ora!;
+  };
+
+  ora.stop = (): oraReal.Ora => {
+    oraStop();
+    resetNativeLogs();
+    return ora!;
+  };
+
   // Always make the central logging module aware of the current spinner
   Log.setSpinner(ora);
 

--- a/packages/prebuild-config/src/plugins/unversioned/expo-document-picker.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-document-picker.ts
@@ -6,7 +6,6 @@ export default createLegacyPlugin({
   packageName: 'expo-document-picker',
   fallback(config) {
     if (config.ios?.usesIcloudStorage) {
-      // TODO: need access to the appleTeamId for this one!
       WarningAggregator.addWarningIOS(
         'ios.usesIcloudStorage',
         'Install expo-document-picker to enable the ios.usesIcloudStorage feature'

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/getIosSplashConfig-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/getIosSplashConfig-test.ts
@@ -48,7 +48,7 @@ describe(warnUnsupportedSplashProperties, () => {
     warnUnsupportedSplashProperties(config);
 
     expect(WarningAggregator.addWarningIOS).toHaveBeenCalledWith(
-      'splash',
+      'ios.splash.xib',
       'ios.splash.xib is not supported in prebuild. Please use ios.splash.image instead.'
     );
   });

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/getIosSplashConfig-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/getIosSplashConfig-test.ts
@@ -49,7 +49,7 @@ describe(warnUnsupportedSplashProperties, () => {
 
     expect(WarningAggregator.addWarningIOS).toHaveBeenCalledWith(
       'ios.splash.xib',
-      'ios.splash.xib is not supported in prebuild. Please use ios.splash.image instead.'
+      'property is not supported in prebuild. Please use ios.splash.image instead.'
     );
   });
 });

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withIosSplashInfoPlist-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withIosSplashInfoPlist-test.ts
@@ -53,7 +53,7 @@ describe(setSplashInfoPlist, () => {
 
     // Check if the warning was thrown
     expect(WarningAggregator.addWarningIOS).toHaveBeenCalledWith(
-      'splash',
+      'userInterfaceStyle',
       'The existing `userInterfaceStyle` property is preventing splash screen from working properly. Please remove it or disable dark mode splash screens.'
     );
 

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/getIosSplashConfig.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/getIosSplashConfig.ts
@@ -73,8 +73,8 @@ export function getIosSplashConfig(config: ExpoConfig): IOSSplashConfig | null {
 export function warnUnsupportedSplashProperties(config: ExpoConfig) {
   if (config.ios?.splash?.xib) {
     WarningAggregator.addWarningIOS(
-      'splash',
-      'ios.splash.xib is not supported in prebuild. Please use ios.splash.image instead.'
+      'ios.splash.xib',
+      'property is not supported in prebuild. Please use ios.splash.image instead.'
     );
   }
 }

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashScreen.ts
@@ -18,7 +18,7 @@ export const withAndroidSplashScreen: ConfigPlugin = config => {
     ) {
       WarningAggregator.addWarningAndroid(
         'androidStatusBar.backgroundColor',
-        'The androidStatusBar.backgroundColor color conflicts with the splash backgroundColor on Android'
+        'Color conflicts with the splash.backgroundColor'
       );
     }
   } else {

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withIosSplashInfoPlist.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withIosSplashInfoPlist.ts
@@ -33,7 +33,7 @@ export function setSplashInfoPlist(
     // Add a warning to prevent the dark mode splash screen from not being shown -- this was learned the hard way.
     if (existing && existing !== 'automatic') {
       WarningAggregator.addWarningIOS(
-        'splash',
+        'userInterfaceStyle',
         'The existing `userInterfaceStyle` property is preventing splash screen from working properly. Please remove it or disable dark mode splash screens.'
       );
     }


### PR DESCRIPTION
# Why

- resolve https://github.com/expo/expo-cli/issues/3757
- change `WarningAggregator` to just be a wrapper around `console.warn`
- make our spinners support arbitrary console logs during prebuild so plugins can easily log to the terminal.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
