### PR TITLE
[plist] Update xmldom to account for security vulnerability

### DIFF
--- a/packages/plist/package.json
+++ b/packages/plist/package.json
@@ -28,11 +28,10 @@
   "dependencies": {
     "base64-js": "^1.2.3",
     "xmlbuilder": "^14.0.0",
-    "xmldom": "~0.5.0"
+    "@xmldom/xmldom": "~0.7.0"
   },
   "devDependencies": {
-    "@types/base64-js": "^1.2.5",
-    "@types/xmldom": "^0.1.29"
+    "@types/base64-js": "^1.2.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plist/src/parse.ts
+++ b/packages/plist/src/parse.ts
@@ -24,8 +24,8 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE. */
 
+import { DOMParser } from '@xmldom/xmldom';
 import assert from 'assert';
-import { DOMParser } from 'xmldom';
 
 const TEXT_NODE = 3;
 const CDATA_NODE = 4;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3757,11 +3757,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/xmldom@^0.1.29":
-  version "0.1.29"
-  resolved "https://registry.yarnpkg.com/@types/xmldom/-/xmldom-0.1.29.tgz#c4428b0ca86d3b881475726fd94980b38a27c381"
-  integrity sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E=
-
 "@types/yargs-parser@*", "@types/yargs-parser@^13.0.0":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
@@ -4036,6 +4031,11 @@
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
   dependencies:
     tslib "^1.9.3"
+
+"@xmldom/xmldom@~0.7.0":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.2.tgz#d920079e66806b2626b5311955f6a7c4bed1cba8"
+  integrity sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -19366,11 +19366,6 @@ xmldom@0.1.x:
   version "0.1.31"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
   integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
-
-xmldom@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
-  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xpipe@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
# Why

Security vulnerability reported by a partner, see https://www.npmjs.com/advisories/1769

# How

this package is now published under the namespace, see https://github.com/xmldom/xmldom/issues/271

# Test Plan

`yarn tsc` and `yarn test`