### PR TITLE
Bump apple-utils to v25

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.9.0",
-    "@expo/apple-utils": "0.0.0-alpha.20",
+    "@expo/apple-utils": "0.0.0-alpha.25",
     "@expo/bunyan": "4.0.0",
     "@expo/config": "5.0.8",
     "@expo/config-plugins": "3.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,10 +1524,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@expo/apple-utils@0.0.0-alpha.20":
-  version "0.0.0-alpha.20"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.20.tgz#cbc92e4c7e8754b051b7293af60a55a550fb6583"
-  integrity sha512-L/M9NPNlT1e38whA3M4QdnIDCClj6Y2GPXFOxBxuwzlmh847RHwZ/ojJpVP8sLVC+is54DS1hU9vtDkiPHGPRw==
+"@expo/apple-utils@0.0.0-alpha.25":
+  version "0.0.0-alpha.25"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-0.0.0-alpha.25.tgz#fea4f5a409cc1bf79a0d2acec3eca52dbd8443c1"
+  integrity sha512-meyCJ/5jHJsgZNBMwlAugqD5Z0bcazCLgAyYQCw8O1/sXh4gWf0IiWJGnkevdxnA3g1R9nmJFmjkFuLoGOt+Bw==
 
 "@expo/bunyan@4.0.0":
   version "4.0.0"


### PR DESCRIPTION
# Why

Adds improved error handling for the new Apple server errors that have been showing up for users that use ASC API with cookies auth https://github.com/fastlane/fastlane/pull/19273 https://github.com/expo/third-party/pull/63

# Test Plan

- one user says this works for them https://github.com/expo/expo-cli/issues/3788#issuecomment-904943841