### PR TITLE
[expo-cli] generate smaller QR codes

### DIFF
--- a/packages/expo-cli/src/urlOpts.ts
+++ b/packages/expo-cli/src/urlOpts.ts
@@ -87,7 +87,7 @@ async function optsAsync(projectRoot: string, options: any) {
 }
 
 function printQRCode(url: string) {
-  qrcodeTerminal.generate(url, code => Log.log(`${indentString(code, 1)}\n`));
+  qrcodeTerminal.generate(url, { small: true }, code => Log.log(`${indentString(code, 1)}\n`));
 }
 
 async function handleMobileOptsAsync(

--- a/ts-declarations/qrcode-terminal/index.d.ts
+++ b/ts-declarations/qrcode-terminal/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'qrcode-terminal' {
-  export function generate(url: string, cb: (code: string) => void): void;
+  export function generate(url: string, opts: { small: boolean }, cb: (code: string) => void): void;
 }


### PR DESCRIPTION
# Why

The QR code for the dev client can be too big to fit in the terminal. We recently made the QR codes in `eas-cli` smaller: https://github.com/expo/eas-cli/pull/573 and @esamelson suggested to do this in `expo-cli` too.

# How

- Used `qrcode-terminal` small option: https://github.com/gtanner/qrcode-terminal/commit/c6327e52ca7681631c898ea94c519fc77db8b59c

# Test Plan

- Run `expo start --dev-client` and compare with `expo_dev start --dev-client` (here is a before / after):
<img width="1616" alt="Screenshot 2021-08-26 at 18 16 23" src="https://user-images.githubusercontent.com/10477267/130999959-c3ec7fa6-a969-4130-b0b8-be59c351709c.png">
<img width="1616" alt="Screenshot 2021-08-26 at 18 17 26" src="https://user-images.githubusercontent.com/10477267/130999978-f886c2ff-57e2-4345-bf58-cd6bdcf38e91.png">
