### PR TITLE
[expo-cli][xdl] Removes Segment

### DIFF
--- a/packages/expo-cli/jest/setup.ts
+++ b/packages/expo-cli/jest/setup.ts
@@ -17,4 +17,3 @@ afterAll(() => {
 });
 
 jest.mock('@expo/rudder-sdk-node');
-jest.mock('analytics-node');

--- a/packages/expo-cli/src/__tests__/exp-test.ts
+++ b/packages/expo-cli/src/__tests__/exp-test.ts
@@ -11,12 +11,6 @@ Command.prototype.asyncAction = jest.fn().mockImplementation(_ => program);
 Command.prototype.allowOffline = jest.fn().mockImplementation(_ => program);
 Command.prototype.urlOpts = jest.fn().mockImplementation(_ => program);
 
-jest.mock('xdl', () => {
-  const actual = jest.requireActual('xdl');
-  actual.Env.shouldDisableAnalytics = jest.fn().mockImplementation(() => false);
-  return actual;
-});
-
 describe(bootstrapAnalyticsAsync.name, () => {
   const spy = jest.spyOn(UnifiedAnalytics, 'identifyUser');
 

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -659,25 +659,15 @@ Command.prototype.asyncActionProjectDir = function (
 };
 
 export async function bootstrapAnalyticsAsync(): Promise<void> {
-  if (Env.shouldDisableAnalytics()) {
-    return; // do not allow E2E to fire events
-  }
-
   Analytics.initializeClient(
-    'vGu92cdmVaggGA26s3lBX6Y5fILm8SQ7',
-    {
-      apiKey: '1wHTzmVgmZvNjCalKL45chlc2VN',
-      dataPlaneUrl: 'https://cdp.expo.dev',
-    },
+    '1wHTzmVgmZvNjCalKL45chlc2VN',
+    'https://cdp.expo.dev',
     packageJSON.version
   );
 
   UnifiedAnalytics.initializeClient(
-    'u4e9dmCiNpwIZTXuyZPOJE7KjCMowdx5',
-    {
-      apiKey: '1wabJGd5IiuF9Q8SGlcI90v8WTs',
-      dataPlaneUrl: 'https://cdp.expo.dev',
-    },
+    '1wabJGd5IiuF9Q8SGlcI90v8WTs',
+    'https://cdp.expo.dev',
     packageJSON.version
   );
 
@@ -714,7 +704,10 @@ async function runAsync(programName: string) {
   try {
     _registerLogs();
 
-    await bootstrapAnalyticsAsync();
+    if (Env.shouldEnableAnalytics()) {
+      await bootstrapAnalyticsAsync();
+    }
+
     UserManager.setInteractiveAuthenticationCallback(loginOrRegisterAsync);
 
     if (process.env.SERVER_URL) {

--- a/packages/xdl/jest/fs-mock-setup.ts
+++ b/packages/xdl/jest/fs-mock-setup.ts
@@ -1,6 +1,5 @@
 jest.mock('@expo/image-utils');
 jest.mock('@expo/rudder-sdk-node');
-jest.mock('analytics-node');
 jest.mock('dtrace-provider');
 jest.mock('fs');
 jest.mock('os');

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -45,7 +45,6 @@
     "@expo/sdk-runtime-versions": "^1.0.0",
     "@expo/spawn-async": "1.5.0",
     "@expo/webpack-config": "0.15.0",
-    "analytics-node": "3.5.0",
     "axios": "0.21.1",
     "boxen": "^5.0.1",
     "bplist-parser": "^0.3.0",
@@ -100,7 +99,6 @@
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@expo/ngrok": "4.1.0",
-    "@types/analytics-node": "^3.1.4",
     "@types/concat-stream": "^1.6.0",
     "@types/form-data": "^2.2.0",
     "@types/fs-extra": "^9.0.1",

--- a/packages/xdl/src/Analytics.ts
+++ b/packages/xdl/src/Analytics.ts
@@ -1,6 +1,6 @@
 import RudderAnalytics from '@expo/rudder-sdk-node';
-import SegmentAnalytics from 'analytics-node';
 import os from 'os';
+import { URL } from 'url';
 
 import { ip } from './internal';
 
@@ -10,15 +10,9 @@ const PLATFORM_TO_ANALYTICS_PLATFORM: { [platform: string]: string } = {
   linux: 'Linux',
 };
 
-type RudderAnalyticsConfig = {
-  apiKey: string;
-  dataPlaneUrl: string;
-};
-
 export class AnalyticsClient {
   private userTraits?: { [key: string]: any };
   private rudderstackClient?: RudderAnalytics;
-  private segmentClient?: SegmentAnalytics; // should be removed when we've confirmed rudder client works as expected
   private _userId?: string;
   private _version?: string;
 
@@ -34,29 +28,22 @@ export class AnalyticsClient {
     if (this.rudderstackClient) {
       this.rudderstackClient.flush();
     }
-
-    if (this.segmentClient) {
-      this.segmentClient.flush();
-    }
   }
 
   public initializeClient(
-    segmentWriteKey: string,
-    rudderConfig: RudderAnalyticsConfig,
+    rudderstackWriteKey: string,
+    rudderstackDataPlaneURL: string,
     packageVersion: string
   ) {
     // Do not wait before flushing, we want node to close immediately if the programs ends
     this.rudderstackClient = new RudderAnalytics(
-      rudderConfig.apiKey,
-      `${rudderConfig.dataPlaneUrl}/v1/batch`,
+      rudderstackWriteKey,
+      new URL('/v1/batch', rudderstackDataPlaneURL).toString(),
       {
         flushInterval: 300,
       }
     );
     this.rudderstackClient.logger.silent = true;
-    this.segmentClient = new SegmentAnalytics(segmentWriteKey, {
-      flushInterval: 300,
-    });
     this._version = packageVersion;
   }
 
@@ -71,27 +58,11 @@ export class AnalyticsClient {
         context: this.getContext(),
       });
     }
-    if (this.segmentClient) {
-      this.segmentClient.identify({
-        userId: this._userId,
-        traits: this.userTraits,
-        context: this.getContext(),
-      });
-    }
   }
 
   public logEvent(name: string, properties: any = {}) {
     if (this.rudderstackClient && this._userId) {
       this.rudderstackClient.track({
-        userId: this._userId,
-        event: name,
-        properties,
-        context: this.getContext(),
-      });
-    }
-
-    if (this.segmentClient && this._userId) {
-      this.segmentClient.track({
         userId: this._userId,
         event: name,
         properties,

--- a/packages/xdl/src/Env.ts
+++ b/packages/xdl/src/Env.ts
@@ -28,6 +28,7 @@ export function shouldUseDevServer(exp: Pick<ExpoConfig, 'sdkVersion'>) {
   return !Versions.lteSdkVersion(exp, '39.0.0') || getenv.boolish('EXPO_USE_DEV_SERVER', false);
 }
 
-export function shouldDisableAnalytics() {
-  return getenv.boolish('E2E', false) || getenv.boolish('CI', false);
+// do not allow E2E to fire events
+export function shouldEnableAnalytics() {
+  return !getenv.boolish('E2E', false) && !getenv.boolish('CI', false);
 }

--- a/packages/xdl/src/__tests__/tools/FsCache-test.js
+++ b/packages/xdl/src/__tests__/tools/FsCache-test.js
@@ -1,6 +1,6 @@
 import { FsCache } from '../../internal';
 
-jest.mock('analytics-node');
+jest.mock('@expo/rudder-sdk-node');
 
 const fs = require('fs-extra');
 const path = require('path');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3055,11 +3055,6 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.7.tgz#677bd9117e8164dc319987dd6ff5fc1ba6fbf18b"
   integrity sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==
 
-"@types/analytics-node@^3.1.4":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@types/analytics-node/-/analytics-node-3.1.5.tgz#4fe00efc08aefc5211c8b8e6a8cb4145892c10e5"
-  integrity sha512-zSqNpyzF3hcweslf7ttqB03iZvxtymUh820SAXaFhox5Y5Qa7bYmrdOi4IW050OHrKmtq4SE4kE1XeE1mK+zrQ==
-
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -4260,20 +4255,6 @@ alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
-
-analytics-node@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/analytics-node/-/analytics-node-3.5.0.tgz#b33ff92195f006b20f1c4e28af86d975c98e4636"
-  integrity sha512-XgQq6ejZHCehUSnZS4V7QJPLIP7S9OAWwQDYl4WTLtsRvc5fCxIwzK/yihzmIW51v9PnyBmrl9dMcqvwfOE8WA==
-  dependencies:
-    "@segment/loosely-validate-event" "^2.0.0"
-    axios "^0.21.1"
-    axios-retry "^3.0.2"
-    lodash.isstring "^4.0.1"
-    md5 "^2.2.1"
-    ms "^2.0.0"
-    remove-trailing-slash "^0.1.0"
-    uuid "^3.2.1"
 
 anser@1.4.9:
   version "1.4.9"


### PR DESCRIPTION
# Why

Volumes are look even between Segment and RudderStack. Removing Segment to finish the migration to RudderStack.

# How

Removed Segment from xdl and expo-cli. 

Slight refactor to the `Env.shouldDisableAnalytics` method  => `Env.shouldEnableAnalytics`. This way I could pull it out of `boostrapAnalyticsAsync` and remove the mock for it inside `exp.ts`. It's a bit simpler and cleaner, imo.

# Test Plan

Tested locally to confirm events fired outside of tests.