### PR TITLE
[webpack] Add all native middleware to webpack

### DIFF
--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -1,11 +1,6 @@
 import type Log from '@expo/bunyan';
 import { ExpoConfig, getConfigFilePaths } from '@expo/config';
 import * as ExpoMetroConfig from '@expo/metro-config';
-import {
-  createDevServerMiddleware,
-  securityHeadersMiddleware,
-} from '@react-native-community/cli-server-api';
-import bodyParser from 'body-parser';
 import type { Server as ConnectServer } from 'connect';
 import http from 'http';
 import type Metro from 'metro';
@@ -20,14 +15,11 @@ import {
 import LogReporter from './LogReporter';
 import { createDevServerAsync } from './metro/createDevServerAsync';
 import {
+  importInspectorProxyServerFromProject,
   importMetroFromProject,
   importMetroServerFromProject,
 } from './metro/importMetroFromProject';
-import clientLogsMiddleware from './middleware/clientLogsMiddleware';
-import createJsInspectorMiddleware from './middleware/createJsInspectorMiddleware';
-import { remoteDevtoolsCorsMiddleware } from './middleware/remoteDevtoolsCorsMiddleware';
-import { remoteDevtoolsSecurityHeadersMiddleware } from './middleware/remoteDevtoolsSecurityHeadersMiddleware';
-import { replaceMiddlewareWith } from './middleware/replaceMiddlewareWith';
+import { createDevServerMiddleware } from './middleware/devServerMiddleware';
 
 export type MetroDevServerOptions = ExpoMetroConfig.LoadOptions & {
   logger: Log;
@@ -69,20 +61,8 @@ export async function runMetroDevServerAsync(
   const { middleware, attachToServer } = createDevServerMiddleware({
     port: metroConfig.server.port,
     watchFolders: metroConfig.watchFolders,
+    logger: options.logger,
   });
-
-  // securityHeadersMiddleware does not support cross-origin requests for remote devtools to get the sourcemap.
-  // We replace with the enhanced version.
-  replaceMiddlewareWith(
-    middleware as ConnectServer,
-    securityHeadersMiddleware,
-    remoteDevtoolsSecurityHeadersMiddleware
-  );
-  middleware.use(remoteDevtoolsCorsMiddleware);
-
-  middleware.use(bodyParser.json());
-  middleware.use('/logs', clientLogsMiddleware(options.logger));
-  middleware.use('/inspector', createJsInspectorMiddleware());
 
   const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;
   // @ts-ignore can't mutate readonly config
@@ -251,3 +231,26 @@ function gteSdkVersion(expJson: Pick<ExpoConfig, 'sdkVersion'>, sdkVersion: stri
     throw new Error(`${expJson.sdkVersion} is not a valid version. Must be in the form of x.y.z`);
   }
 }
+
+export function connectInspectorProxy(
+  projectRoot: string,
+  { server, connect }: { server: http.Server; connect: ConnectServer }
+) {
+  const { InspectorProxy } = importInspectorProxyServerFromProject(projectRoot);
+  const inspectorProxy = new InspectorProxy(projectRoot);
+  if ('addWebSocketListener' in inspectorProxy) {
+    // metro@0.59.0
+    inspectorProxy.addWebSocketListener(server);
+  } else if ('createWebSocketListeners' in inspectorProxy) {
+    // metro@0.66.0
+    // TODO: This isn't properly support without a ws router.
+    inspectorProxy.createWebSocketListeners(server);
+  }
+  // TODO(hypuk): Refactor inspectorProxy.processRequest into separate request handlers
+  // so that we could provide routes (/json/list and /json/version) here.
+  // Currently this causes Metro to give warning about T31407894.
+  // $FlowFixMe[method-unbinding] added when improving typing for this parameters
+  connect.use(inspectorProxy.processRequest.bind(inspectorProxy));
+}
+
+export { LogReporter, createDevServerMiddleware };

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -232,9 +232,20 @@ function gteSdkVersion(expJson: Pick<ExpoConfig, 'sdkVersion'>, sdkVersion: stri
   }
 }
 
-export function connectInspectorProxy(
+/**
+ * Attach the inspector proxy to a development server.
+ * Inspector proxy is used for viewing the JS context in a browser.
+ * This must be attached after the server is listening.
+ * Attaching consists of pushing custom middleware and appending WebSockets to the server.
+ *
+ *
+ * @param projectRoot
+ * @param props.server dev server to add WebSockets to
+ * @param props.middleware dev server middleware to add extra middleware to
+ */
+export function attachInspectorProxy(
   projectRoot: string,
-  { server, connect }: { server: http.Server; connect: ConnectServer }
+  { server, middleware }: { server: http.Server; middleware: ConnectServer }
 ) {
   const { InspectorProxy } = importInspectorProxyServerFromProject(projectRoot);
   const inspectorProxy = new InspectorProxy(projectRoot);
@@ -250,7 +261,9 @@ export function connectInspectorProxy(
   // so that we could provide routes (/json/list and /json/version) here.
   // Currently this causes Metro to give warning about T31407894.
   // $FlowFixMe[method-unbinding] added when improving typing for this parameters
-  connect.use(inspectorProxy.processRequest.bind(inspectorProxy));
+  middleware.use(inspectorProxy.processRequest.bind(inspectorProxy));
+
+  return { inspectorProxy };
 }
 
 export { LogReporter, createDevServerMiddleware };

--- a/packages/dev-server/src/middleware/devServerMiddleware.ts
+++ b/packages/dev-server/src/middleware/devServerMiddleware.ts
@@ -1,0 +1,63 @@
+import type Log from '@expo/bunyan';
+import {
+  createDevServerMiddleware as createReactNativeDevServerMiddleware,
+  securityHeadersMiddleware,
+} from '@react-native-community/cli-server-api';
+import bodyParser from 'body-parser';
+import type { Server as ConnectServer } from 'connect';
+
+import clientLogsMiddleware from './clientLogsMiddleware';
+import createJsInspectorMiddleware from './createJsInspectorMiddleware';
+import { remoteDevtoolsCorsMiddleware } from './remoteDevtoolsCorsMiddleware';
+import { remoteDevtoolsSecurityHeadersMiddleware } from './remoteDevtoolsSecurityHeadersMiddleware';
+import { replaceMiddlewareWith } from './replaceMiddlewareWith';
+
+export type AttachToServerFunction = ReturnType<
+  typeof createReactNativeDevServerMiddleware
+>['attachToServer'];
+
+/**
+ * Extends the default `createDevServerMiddleware` and adds some Expo CLI-specific dev middleware
+ * with exception for the manifest middleware which is currently in `xdl`.
+ *
+ * Adds:
+ * - `/logs`: pipe runtime `console` logs to the `props.logger` object.
+ * - `/inspector`: launch hermes inspector proxy in chrome.
+ * - CORS support for remote devtools
+ * - body parser middleware
+ *
+ * @param props.watchFolders array of directory paths to use with watchman
+ * @param props.port port that the dev server will run on
+ * @param props.logger bunyan instance that all runtime `console` logs will be piped through.
+ *
+ * @returns
+ */
+export function createDevServerMiddleware({
+  watchFolders,
+  port,
+  logger,
+}: {
+  watchFolders: readonly string[];
+  port: number;
+  logger: Log;
+}): { middleware: ConnectServer; attachToServer: AttachToServerFunction; logger: Log } {
+  const { middleware, attachToServer } = createReactNativeDevServerMiddleware({
+    port,
+    watchFolders,
+  });
+
+  // securityHeadersMiddleware does not support cross-origin requests for remote devtools to get the sourcemap.
+  // We replace with the enhanced version.
+  replaceMiddlewareWith(
+    middleware as ConnectServer,
+    securityHeadersMiddleware,
+    remoteDevtoolsSecurityHeadersMiddleware
+  );
+  middleware.use(remoteDevtoolsCorsMiddleware);
+
+  middleware.use(bodyParser.json());
+  middleware.use('/logs', clientLogsMiddleware(logger));
+  middleware.use('/inspector', createJsInspectorMiddleware());
+
+  return { middleware, attachToServer, logger };
+}

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -1,8 +1,7 @@
 import { getConfig, getNameFromConfig } from '@expo/config';
-import { MessageSocket } from '@expo/dev-server';
+import { createDevServerMiddleware, LogReporter, MessageSocket } from '@expo/dev-server';
 import * as devcert from '@expo/devcert';
 import { isUsingYarn } from '@expo/package-manager';
-import { createDevServerMiddleware } from '@react-native-community/cli-server-api';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import getenv from 'getenv';
@@ -149,6 +148,47 @@ export async function broadcastMessage(message: 'reload' | string, data?: any) {
   webpackDevServerInstance.sockWrite(webpackDevServerInstance.sockets, hackyConvertedMessage, data);
 }
 
+function createNativeDevServerMiddleware(projectRoot: string, { port }: { port: number }) {
+  if (!isTargetingNative()) {
+    return null;
+  }
+  const nativeMiddleware = createDevServerMiddleware({
+    logger: ProjectUtils.getLogger(projectRoot),
+    port,
+    watchFolders: [projectRoot],
+  });
+  // Add manifest middleware to the other middleware.
+  // TODO: Move this in to expo/dev-server.
+  nativeMiddleware.middleware
+    .use(ManifestHandler.getManifestHandler(projectRoot))
+    .use(ExpoUpdatesManifestHandler.getManifestHandler(projectRoot));
+
+  return nativeMiddleware;
+}
+
+function attachNativeDevServerMiddlewareToDevServer(
+  server: http.Server,
+  nativeMiddleware: ReturnType<typeof createNativeDevServerMiddleware>
+) {
+  if (!nativeMiddleware) {
+    return null;
+  }
+  // Hook up the React Native WebSockets to the Webpack dev server.
+  const { messageSocket, debuggerProxy, eventsSocket } = nativeMiddleware.attachToServer(server);
+
+  customMessageSocketBroadcaster = messageSocket.broadcast;
+
+  const logReporter = new LogReporter(nativeMiddleware.logger);
+  logReporter.reportEvent = eventsSocket.reportEvent;
+
+  return {
+    messageSocket,
+    eventsSocket,
+    debuggerProxy,
+    logReporter,
+  };
+}
+
 export async function startAsync(
   projectRoot: string,
   options: CLIWebOptions = {}
@@ -242,36 +282,23 @@ export async function startAsync(
       onFinished: () => resolve(server),
     });
 
-    let nativeMiddleware: any;
-    if (isTargetingNative()) {
-      nativeMiddleware = createDevServerMiddleware({
-        port,
-        watchFolders: [projectRoot],
-      });
-      // Inject the Expo Go manifest middleware.
-      const originalBefore = config.devServer!.before!.bind(config.devServer!.before);
-      config.devServer!.before = (app, server, compiler) => {
-        originalBefore(app, server, compiler);
+    // Create the middleware required for interacting with a native runtime (Expo Go, or Expo Dev Client).
+    const nativeMiddleware = createNativeDevServerMiddleware(projectRoot, { port });
+    // Inject the native manifest middleware.
+    const originalBefore = config.devServer!.before!.bind(config.devServer!.before);
+    config.devServer!.before = (app, server, compiler) => {
+      originalBefore(app, server, compiler);
 
+      if (nativeMiddleware?.middleware) {
         app.use(nativeMiddleware.middleware);
-        app.use(ManifestHandler.getManifestHandler(projectRoot));
-        app.use(ExpoUpdatesManifestHandler.getManifestHandler(projectRoot));
-      };
-    }
+      }
+    };
 
     const server = new WebpackDevServer(compiler, config.devServer);
 
     // Launch WebpackDevServer.
     server.listen(port, WebpackEnvironment.HOST, function (this: http.Server, error) {
-      if (nativeMiddleware) {
-        // Hook up the React Native WebSockets to the Webpack dev server.
-        const {
-          messageSocket,
-          // eventsSocket
-        } = nativeMiddleware.attachToServer(this);
-
-        customMessageSocketBroadcaster = messageSocket.broadcast;
-      }
+      attachNativeDevServerMiddlewareToDevServer(this, nativeMiddleware);
 
       if (error) {
         ProjectUtils.logError(projectRoot, WEBPACK_LOG_TAG, error.message);


### PR DESCRIPTION
# Why

- Adds support for piping logs to the terminal via the `/logs` endpoint by adding all middleware to the webpack dev server.
- Also attaches any extra features that we'd expect when using Metro bundler.
- Adds support for inspecting the JS context from a browser.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan


- `EXPO_WEBPACK_PLATFORM=ios expod web`
- Open the project with `i` (reloads with `r` since HMR isn't done).
- `console.log` should show up in the terminal
- Open Safari > Develop > [Simulator name] > JSContext: breakpoints and other inspection works

<img width="1772" alt="Screen Shot 2021-08-30 at 1 42 24 PM" src="https://user-images.githubusercontent.com/9664363/131396091-6cac21d6-34e9-4ced-ac12-d206cab34827.png">

