### PR TITLE
[webpack] Add metro runtime shim

### DIFF
--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -112,6 +112,7 @@ Object {
     "ModuleNotFoundPlugin",
     "DefinePlugin",
     "LimitChunkCountPlugin",
+    "NormalModuleReplacementPlugin",
     "WatchMissingNodeModulesPlugin",
     "SourceMapDevToolPlugin",
   ],
@@ -321,6 +322,7 @@ Object {
     "ModuleNotFoundPlugin",
     "DefinePlugin",
     "LimitChunkCountPlugin",
+    "NormalModuleReplacementPlugin",
     "SourceMapDevToolPlugin",
   ],
   "resolve": Object {

--- a/packages/webpack-config/src/runtime/metro-runtime-shim.ts
+++ b/packages/webpack-config/src/runtime/metro-runtime-shim.ts
@@ -1,0 +1,11 @@
+// A shim for `react-native/Libraries/Utilities/HMRClient.js` which uses Metro specific code.
+module.exports = {
+  setup() {},
+  enable() {},
+  disable() {},
+  registerBundle() {},
+  log(level: string, data: any[]) {
+    // no-op: we use a log reporter in the expo package which is retrieved by `/logs` middleware from `@expo/dev-server`:
+    // https://github.com/expo/expo/blob/50661f5c77b26c1192492496b17ed251d4965ff0/packages/expo/src/logs/RemoteLogging.ts#L122-L126
+  },
+};

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -460,6 +460,14 @@ export default async function (
       // This is necessary to emit hot updates (currently CSS only):
       !isNative && isDev && new HotModuleReplacementPlugin(),
 
+      // Replace the Metro specific HMR code in `react-native` with
+      // a shim.
+      isNative &&
+        new webpack.NormalModuleReplacementPlugin(
+          /react-native\/Libraries\/Utilities\/HMRClient\.js$/,
+          require.resolve('./runtime/metro-runtime-shim')
+        ),
+
       // If you require a missing module and then `npm install` it, you still have
       // to restart the development server for Webpack to discover it. This plugin
       // makes the discovery automatic so you don't have to restart.


### PR DESCRIPTION
# Why

react-native `HMRClient` runtime code adds the following:
- event hooks (for web sockets) that map to `metro-runtime` (`metro` in the current version 0.55) HMR features.
- socket code for piping logs to metro -- we currently ignore these in favor of the `expo` [RemoteLogging](https://github.com/expo/expo/blob/50661f5c77b26c1192492496b17ed251d4965ff0/packages/expo/src/logs/RemoteLogging.ts#L122-L126) code.

# Test Plan

- cherry-picked onto https://github.com/expo/expo-cli/pull/3808 to test that logs still worked.
- HMR shouldn't change because it isn't implemented.