### PR TITLE
[dev-server] support building hermes bytecode bundle for ios

### DIFF
--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -39,6 +39,7 @@
     "@expo/metro-config": "0.1.84",
     "@react-native-community/cli-server-api": "^5.0.1",
     "body-parser": "1.19.0",
+    "chalk": "^4.0.0",
     "fs-extra": "9.0.0",
     "open": "^8.2.0",
     "resolve-from": "^5.0.0",

--- a/packages/dev-server/src/HermesBundler.ts
+++ b/packages/dev-server/src/HermesBundler.ts
@@ -191,13 +191,11 @@ export async function maybeInconsistentEngineIosAsync(
   // Check Podfile.properties.json from prebuild template
   const podfilePropertiesPath = path.join(projectRoot, 'ios', 'Podfile.properties.json');
   if (fs.existsSync(podfilePropertiesPath)) {
-    try {
-      const props = JSON.parse(await fs.readFile(podfilePropertiesPath, 'utf8'));
-      const isHermesBare = props['expo.jsEngine'] === 'hermes';
-      if (isHermesManaged !== isHermesBare) {
-        return true;
-      }
-    } catch (e) {}
+    const props = await parsePodfilePropertiesAsync(podfilePropertiesPath);
+    const isHermesBare = props['expo.jsEngine'] === 'hermes';
+    if (isHermesManaged !== isHermesBare) {
+      return true;
+    }
   }
 
   return false;
@@ -241,5 +239,15 @@ function gteSdkVersion(expJson: Pick<ExpoConfig, 'sdkVersion'>, sdkVersion: stri
     return semver.gte(expJson.sdkVersion, sdkVersion);
   } catch (e) {
     throw new Error(`${expJson.sdkVersion} is not a valid version. Must be in the form of x.y.z`);
+  }
+}
+
+async function parsePodfilePropertiesAsync(
+  podfilePropertiesPath: string
+): Promise<Record<string, string>> {
+  try {
+    return JSON.parse(await fs.readFile(podfilePropertiesPath, 'utf8'));
+  } catch (e) {
+    return {};
   }
 }

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -1,6 +1,7 @@
 import type Log from '@expo/bunyan';
 import { ExpoConfig, getConfigFilePaths } from '@expo/config';
 import * as ExpoMetroConfig from '@expo/metro-config';
+import chalk from 'chalk';
 import type { Server as ConnectServer } from 'connect';
 import http from 'http';
 import type Metro from 'metro';
@@ -167,9 +168,12 @@ export async function bundleAsync(
     );
 
     if (isHermesManaged) {
+      const platformTag = chalk.bold(
+        { ios: 'iOS', android: 'Android', web: 'Web' }[platform] || platform
+      );
       options.logger.info(
         { tag: 'expo' },
-        `💿 Building Hermes bytecode for the bundle - platform[${platform}]`
+        `💿 ${platformTag} Building Hermes bytecode for the bundle`
       );
       const hermesBundleOutput = await buildHermesBundleAsync(
         projectRoot,
@@ -180,10 +184,10 @@ export async function bundleAsync(
       bundleOutput.hermesBytecodeBundle = hermesBundleOutput.hbc;
       bundleOutput.hermesSourcemap = hermesBundleOutput.sourcemap;
 
-      if (platform) {
+      if (platform === 'ios') {
         options.logger.warn(
           { tag: 'expo' },
-          '❗️ Over-the-Air updates with Hermes engine may violate App Store Review Guideline. Publish with your own risk.'
+          `❗️ ${platformTag} Over-the-Air updates with Hermes engine may violate App Store Review Guidelines. Publish the bundle at risk.`
         );
       }
     }

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -183,15 +183,7 @@ export async function bundleAsync(
       );
       bundleOutput.hermesBytecodeBundle = hermesBundleOutput.hbc;
       bundleOutput.hermesSourcemap = hermesBundleOutput.sourcemap;
-
-      if (platform === 'ios') {
-        options.logger.warn(
-          { tag: 'expo' },
-          `❗️ ${platformTag} Over-the-Air updates with Hermes engine may violate App Store Review Guidelines. Publish the bundle at risk.`
-        );
-      }
     }
-
     return bundleOutput;
   };
 


### PR DESCRIPTION
# Why

support building hermes bytecode bundle for ios

# How

- add ios and shared `jsEngine` support to `isEnableHermesManaged` 
- some refactoring to make `maybeAddHermesBundleAsync` clear
  = move sdk check into HermesBundler.ts
  = move throwing error of `maybeInconsistentEngine*` into HermesBundler.ts
- add `maybeInconsistentEngineIosAsync` to support Podfile.properties.json

# Test Plan

### new unit tests

```
 PASS   @expo/dev-server  src/__tests__/HermesBundler-test.ts
  isEnableHermesManaged
    ✓ should support shared jsEngine key
    ✓ platform jsEngine should override shared jsEngine
    ✓ should exclude old SDK (18 ms)
  maybeThrowFromInconsistentEngineAsync - ios
    ✓ should resolve if ":hermes_enabled => true" in Podfile and "jsEngine: 'hermes'" in app.json (1 ms)
    ✓ should throw if ":hermes_enabled => true" in Podfile but no "jsEngine: 'hermes'" in app.json
    ✓ should throw if (":hermes_enabled => false" or not existed in Podfile) and "jsEngine: 'hermes'" in app.json (1 ms)
    ✓ should resolve if "expo.jsEngine": 'hermes' in Podfile.properties.json and "jsEngine: 'hermes'" in app.json
    ✓ should handle the inconsistency between Podfile and Podfile.properties.json
```

### updated unit tests (mostly for `maybeThrowFromInconsistentEngineAsync` interface change)

```
  maybeThrowFromInconsistentEngineAsync - common
    ✓ should resolve for managed project
  maybeThrowFromInconsistentEngineAsync - android
    ✓ should resolve if "enableHermes: true" in app/build.gradle and "jsEngine: 'hermes'" in app.json (3 ms)
    ✓ should throw if "enableHermes: false" in app/build.gradle and "jsEngine: 'hermes'" in app.json (1 ms)
    ✓ should resolve if "expo.jsEngine=hermes" in gradle.properties and "jsEngine: 'hermes'" in app.json (1 ms)
    ✓ should resolve if "expo.jsEngine=hermes" in gradle.properties but no "jsEngine: 'hermes'" in app.json
    ✓ should resolve for old sdk bare project
    ✓ should handle the inconsistency between app/build.gradle and gradle.properties
```

### manually test

```sh
$ expo init extest # select managed
# add `jsEngine: "hermes"` and `sdkVersion: "UNVERSIONED"` to app.json
$ EXPO_SKIP_MANIFEST_VALIDATION_TOKEN=1 /path/to/expo-cli/packages/expo-cli/bin/expo.js export -p https://example.com/
```
