### PR TITLE
[expo-cli][xdl] Remove expo forked react-native from managed apps 

### DIFF
--- a/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
@@ -126,16 +126,18 @@ describe('getDependenciesFromBundledNativeModules', () => {
       });
     }
 
-    it(`upgrades react-native to fb version in bare workflow`, () => {
-      const deps = getDependenciesFromBundledNativeModules({
-        projectDependencies: { ...projectDependencies },
-        bundledNativeModules,
-        sdkVersion,
-        workflow: 'bare',
-        targetSdkVersion,
+    for (const workflow of ['bare', 'managed']) {
+      it(`upgrades react-native to fb version in ${workflow} workflow`, () => {
+        const deps = getDependenciesFromBundledNativeModules({
+          projectDependencies: { ...projectDependencies },
+          bundledNativeModules,
+          sdkVersion,
+          workflow: workflow as any,
+          targetSdkVersion,
+        });
+        expect(deps['react-native']).toBe('mock-facebookReactNativeVersion');
       });
-      expect(deps['react-native']).toBe('mock-facebookReactNativeVersion');
-    });
+    }
   });
 
   it(`doesn't add a package if it's not already installed`, () => {

--- a/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
+++ b/packages/expo-cli/src/commands/__tests__/upgrade-test.ts
@@ -34,6 +34,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
       sdkVersion: '3.0.0',
       workflow: 'bare',
       targetSdkVersion: null,
+      targetSdkVersionString: null,
     });
 
     expect(Log.warn).toHaveBeenCalledTimes(1);
@@ -51,6 +52,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
         'jest-expo': '4.0.0',
       },
     };
+    const targetSdkVersionString = '4.0.0';
 
     it(`upgrades jest-expo to bundledNativeModules when sdkVersion and targetSdkVersion aren't defined`, () => {
       const deps = getDependenciesFromBundledNativeModules({
@@ -58,6 +60,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
         bundledNativeModules,
         workflow: 'bare',
         targetSdkVersion: null,
+        targetSdkVersionString: null,
       });
       expect(deps['jest-expo']).toBe('2.0.0');
     });
@@ -69,6 +72,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
         sdkVersion,
         workflow: 'bare',
         targetSdkVersion: null,
+        targetSdkVersionString: null,
       });
       expect(deps['jest-expo']).toBe('^3.0.0');
     });
@@ -80,6 +84,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
         sdkVersion,
         workflow: 'bare',
         targetSdkVersion,
+        targetSdkVersionString,
       });
       expect(deps['jest-expo']).toBe('4.0.0');
     });
@@ -95,6 +100,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
           relatedPackages: {},
           beta: true,
         },
+        targetSdkVersionString,
       });
       expect(deps['jest-expo']).toBe('^3.0.0-beta');
     });
@@ -119,12 +125,39 @@ describe('getDependenciesFromBundledNativeModules', () => {
           sdkVersion,
           workflow: workflow as any,
           targetSdkVersion,
+          targetSdkVersionString: '4.0.0',
         });
         expect(deps['react-native']).toBe(
           'https://github.com/expo/react-native/archive/mock-expoReactNativeTag.tar.gz'
         );
       });
     }
+
+    it(`upgrades react-native to fb version in sdk < 43.0.0 bare workflow`, () => {
+      const deps = getDependenciesFromBundledNativeModules({
+        projectDependencies: { ...projectDependencies },
+        bundledNativeModules,
+        sdkVersion,
+        workflow: 'bare',
+        targetSdkVersion,
+        targetSdkVersionString: null,
+      });
+      expect(deps['react-native']).toBe('mock-facebookReactNativeVersion');
+    });
+
+    it(`upgrades react-native to expo fork in sdk < 43.0.0 managed workflow`, () => {
+      const deps = getDependenciesFromBundledNativeModules({
+        projectDependencies: { ...projectDependencies },
+        bundledNativeModules,
+        sdkVersion,
+        workflow: 'managed',
+        targetSdkVersion,
+        targetSdkVersionString: '42.0.0',
+      });
+      expect(deps['react-native']).toBe(
+        'https://github.com/expo/react-native/archive/mock-expoReactNativeTag.tar.gz'
+      );
+    });
 
     for (const workflow of ['bare', 'managed']) {
       it(`upgrades react-native to fb version in ${workflow} workflow`, () => {
@@ -134,6 +167,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
           sdkVersion,
           workflow: workflow as any,
           targetSdkVersion,
+          targetSdkVersionString: '43.0.0',
         });
         expect(deps['react-native']).toBe('mock-facebookReactNativeVersion');
       });
@@ -155,6 +189,7 @@ describe('getDependenciesFromBundledNativeModules', () => {
       sdkVersion: '100.0.0',
       workflow: 'bare',
       targetSdkVersion,
+      targetSdkVersionString: '101.0.0',
     });
     expect('react-dom' in deps).toBe(false);
   });

--- a/packages/expo-cli/src/commands/upgradeAsync.ts
+++ b/packages/expo-cli/src/commands/upgradeAsync.ts
@@ -111,6 +111,7 @@ export async function getUpdatedDependenciesAsync(
     sdkVersion: exp.sdkVersion,
     workflow,
     targetSdkVersion,
+    targetSdkVersionString,
   });
 
   const removed: string[] = [];
@@ -145,6 +146,7 @@ export type UpgradeDependenciesOptions = {
   sdkVersion?: string;
   workflow: ExpoWorkflow;
   targetSdkVersion: TargetSDKVersion | null;
+  targetSdkVersionString: string | null;
 };
 
 export function getDependenciesFromBundledNativeModules({
@@ -153,6 +155,7 @@ export function getDependenciesFromBundledNativeModules({
   sdkVersion,
   workflow,
   targetSdkVersion,
+  targetSdkVersionString,
 }: UpgradeDependenciesOptions): DependencyList {
   const result: DependencyList = {};
 
@@ -181,7 +184,16 @@ export function getDependenciesFromBundledNativeModules({
   }
 
   // Get the supported react/react-native/react-dom versions and other related packages
-  if (projectDependencies['expokit']) {
+
+  // Use expo forked react-native in these situations:
+  // 1. expokit installed
+  // 2. managed workflow and sdk version < 43.0.0 (in sdk 43 or above, we try to use the official react-native)
+  const shouldUseExpoReactNativeFork =
+    projectDependencies['expokit'] ||
+    (workflow === 'managed' &&
+      targetSdkVersionString &&
+      semver.lt(targetSdkVersionString, '43.0.0'));
+  if (shouldUseExpoReactNativeFork) {
     result[
       'react-native'
     ] = `https://github.com/expo/react-native/archive/${targetSdkVersion.expoReactNativeTag}.tar.gz`;

--- a/packages/expo-cli/src/commands/upgradeAsync.ts
+++ b/packages/expo-cli/src/commands/upgradeAsync.ts
@@ -181,7 +181,7 @@ export function getDependenciesFromBundledNativeModules({
   }
 
   // Get the supported react/react-native/react-dom versions and other related packages
-  if (workflow === 'managed' || projectDependencies['expokit']) {
+  if (projectDependencies['expokit']) {
     result[
       'react-native'
     ] = `https://github.com/expo/react-native/archive/${targetSdkVersion.expoReactNativeTag}.tar.gz`;

--- a/packages/xdl/src/project/Doctor.ts
+++ b/packages/xdl/src/project/Doctor.ts
@@ -324,57 +324,63 @@ async function _validateReactNativeVersionAsync(
     ProjectUtils.clearNotification(projectRoot, 'doctor-legacy-async-storage');
   }
 
-  if (!exp.isDetached) {
-    return NO_ISSUES;
-
-    // (TODO-2017-07-20): Validate the react-native version if it uses
-    // officially published package rather than Expo fork. Expo fork of
-    // react-native was required before CRNA. We now only run the react-native
-    // validation of the version if we are using the fork. We should probably
-    // validate the version here as well such that it matches with the
-    // react-native version compatible with the selected SDK.
-  }
-
-  // Expo fork of react-native is required
-  if (!/expo\/react-native/.test(reactNative)) {
-    ProjectUtils.logWarning(
-      projectRoot,
-      'expo',
-      `Warning: Not using the Expo fork of react-native. ${learnMore('https://docs.expo.dev/')}`,
-      'doctor-not-using-expo-fork'
-    );
-    return WARNING;
-  }
-  ProjectUtils.clearNotification(projectRoot, 'doctor-not-using-expo-fork');
-
-  try {
-    const reactNativeTag = reactNative.match(/sdk-\d+\.\d+\.\d+/)[0];
-    const sdkVersionObject = sdkVersions[sdkVersion];
-
-    // TODO: Want to be smarter about this. Maybe warn if there's a newer version.
-    if (
-      semver.major(Versions.parseSdkVersionFromTag(reactNativeTag)) !==
-      semver.major(Versions.parseSdkVersionFromTag(sdkVersionObject['expoReactNativeTag']))
-    ) {
+  const isExpoForkedReactNative = /expo\/react-native/.test(reactNative);
+  if (!isExpoForkedReactNative) {
+    // Expo fork of react-native is required for deprecated `isDetached` project
+    if (exp.isDetached) {
       ProjectUtils.logWarning(
         projectRoot,
         'expo',
-        `Warning: Invalid version of react-native for sdkVersion ${sdkVersion}. Use github:expo/react-native#${sdkVersionObject['expoReactNativeTag']}`,
+        `Warning: Not using the Expo fork of react-native. ${learnMore('https://docs.expo.dev/')}`,
+        'doctor-not-using-expo-fork'
+      );
+      return WARNING;
+    }
+    ProjectUtils.clearNotification(projectRoot, 'doctor-not-using-expo-fork');
+
+    // Check react-native version satisfies with sdk's `facebookReactNativeVersion`
+    const { facebookReactNativeVersion } = sdkVersions[sdkVersion];
+    if (!semver.satisfies(reactNative, `~${facebookReactNativeVersion}`)) {
+      ProjectUtils.logWarning(
+        projectRoot,
+        'expo',
+        `Warning: Invalid version of react-native for sdkVersion ${sdkVersion}. Use react-native@${facebookReactNativeVersion}`,
         'doctor-invalid-version-of-react-native'
       );
       return WARNING;
     }
     ProjectUtils.clearNotification(projectRoot, 'doctor-invalid-version-of-react-native');
+  } else {
+    // If `isExpoForkedReactNative === true`
+    try {
+      const reactNativeTag = reactNative.match(/sdk-\d+\.\d+\.\d+/)[0];
+      const sdkVersionObject = sdkVersions[sdkVersion];
 
-    ProjectUtils.clearNotification(projectRoot, 'doctor-malformed-version-of-react-native');
-  } catch (e) {
-    ProjectUtils.logWarning(
-      projectRoot,
-      'expo',
-      `Warning: ${reactNative} is not a valid version. Version must be in the form of sdk-x.y.z. Please update your package.json file.`,
-      'doctor-malformed-version-of-react-native'
-    );
-    return WARNING;
+      // TODO: Want to be smarter about this. Maybe warn if there's a newer version.
+      if (
+        semver.major(Versions.parseSdkVersionFromTag(reactNativeTag)) !==
+        semver.major(Versions.parseSdkVersionFromTag(sdkVersionObject['expoReactNativeTag']))
+      ) {
+        ProjectUtils.logWarning(
+          projectRoot,
+          'expo',
+          `Warning: Invalid version of react-native for sdkVersion ${sdkVersion}. Use github:expo/react-native#${sdkVersionObject['expoReactNativeTag']}`,
+          'doctor-invalid-version-of-react-native'
+        );
+        return WARNING;
+      }
+      ProjectUtils.clearNotification(projectRoot, 'doctor-invalid-version-of-react-native');
+
+      ProjectUtils.clearNotification(projectRoot, 'doctor-malformed-version-of-react-native');
+    } catch (e) {
+      ProjectUtils.logWarning(
+        projectRoot,
+        'expo',
+        `Warning: ${reactNative} is not a valid version. Version must be in the form of sdk-x.y.z. Please update your package.json file.`,
+        'doctor-malformed-version-of-react-native'
+      );
+      return WARNING;
+    }
   }
 
   return NO_ISSUES;


### PR DESCRIPTION
# Why

Close [ENG-1900](https://linear.app/expo/issue/ENG-1900/remove-forked-react-native-for-managed-apps)

# How

- `expo doctor` supports to check react-native version satisfying to sdk's `facebookReactNativeVersion`
- `expo upgrade` will use `facebookReactNativeVersion` version in managed apps

# Test Plan

## Manual Tests

```sh
$ expo init exmanaged # select managed blank
$ cd exmanaged
$ expo doctor
# 🎉 Didn't find any issues with the project!

$ yarn add 'react-native@0.63.4'
$ expo doctor
# 🎉 Didn't find any issues with the project!

$ yarn add 'react-native@~0.59.0'
$ expo doctor
# Warning: Invalid version of react-native for sdkVersion 42.0.0. Use react-native@0.63.4
```

## Unit Tests

```
 PASS   expo-cli  src/commands/__tests__/upgrade-test.ts
  getDependenciesFromBundledNativeModules
    react-native
      ✓ upgrades react-native to fb version in sdk < 43.0.0 bare workflow
      ✓ upgrades react-native to expo fork in sdk < 43.0.0 managed workflow
      ✓ upgrades react-native to fb version in bare workflow
      ✓ upgrades react-native to fb version in managed workflow
```