### PR TITLE
Init using `main` as the default git branch

### DIFF
--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -369,8 +369,8 @@ export async function initGitRepoAsync(
       return false;
     }
   }
+
   // not in git tree, so let's init
-    
   try {
     await spawnAsync('git', ['init', '--initial-branch', branch], { cwd: root });
     !flags.silent && Log.log('Initialized a git repository.');

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -375,19 +375,15 @@ export async function initGitRepoAsync(
     await spawnAsync('git', ['init'], { cwd: root });
     !flags.silent && Log.log('Initialized a git repository.');
     
-    // check for a default branch setting
-    const { stdout: initialBranch } = await spawnAsync('git', 
-      ['config', '--get', 'init.defaultBranch'], 
-      {
-        cwd: root,
-        stdio: ['ignore', 'pipe', 'ignore'],
-      }
-    );
-    
-    // if there is no setting, override the git default
-    // https://git-scm.com/docs/git-init#Documentation/git-init.txt--bltbranch-namegt
-    if (!initialBranch) {
-      await spawnAsync('git', ['branch', '-m', 'main'], { cwd: root, stdio: 'ignore' });
+    try {
+      // check for a default branch setting
+      await spawnAsync('git', ['config', '--get', 'init.defaultBranch'], { cwd: root });
+    } catch (e) {
+      // if there is no setting, override the git default
+      // https://git-scm.com/docs/git-init#Documentation/git-init.txt--bltbranch-namegt
+      if (!e?.stderr && !e?.stdout) {  // no error message and no setting value
+        await spawnAsync('git', ['branch', '-m', 'main'], { cwd: root, stdio: 'ignore' });
+      } 
     }
 
     if (flags.commit) {

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -374,6 +374,13 @@ export async function initGitRepoAsync(
   try {
     await spawnAsync('git', ['init'], { cwd: root });
     !flags.silent && Log.log('Initialized a git repository.');
+
+    if (flags.commit) {
+      await spawnAsync('git', ['add', '--all'], { cwd: root, stdio: 'ignore' });
+      await spawnAsync('git', ['commit', '-m', 'Created a new Expo app'], {
+        cwd: root,
+        stdio: 'ignore',
+      });
     
     try {
       // check for a default branch setting
@@ -383,15 +390,7 @@ export async function initGitRepoAsync(
       // https://git-scm.com/docs/git-init#Documentation/git-init.txt--bltbranch-namegt
       if (!e?.stderr && !e?.stdout) {  // no error message and no setting value
         await spawnAsync('git', ['branch', '-m', 'main'], { cwd: root, stdio: 'ignore' });
-      } 
-    }
-
-    if (flags.commit) {
-      await spawnAsync('git', ['add', '--all'], { cwd: root, stdio: 'ignore' });
-      await spawnAsync('git', ['commit', '-m', 'Created a new Expo app'], {
-        cwd: root,
-        stdio: 'ignore',
-      });
+      }
     }
     return true;
   } catch (e) {

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -372,7 +372,7 @@ export async function initGitRepoAsync(
 
   // not in git tree, so let's init
   try {
-    await spawnAsync('git', ['init', '--initial-branch', branch], { cwd: root });
+    await spawnAsync('git', ['init'], { cwd: root });
     !flags.silent && Log.log('Initialized a git repository.');
     
     // check for a default branch setting

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -369,11 +369,26 @@ export async function initGitRepoAsync(
       return false;
     }
   }
-
   // not in git tree, so let's init
+    
   try {
-    await spawnAsync('git', ['init'], { cwd: root });
+    await spawnAsync('git', ['init', '--initial-branch', branch], { cwd: root });
     !flags.silent && Log.log('Initialized a git repository.');
+    
+    // check for a default branch setting
+    const { stdout: initialBranch } = await spawnAsync('git', 
+      ['config', '--get', 'init.defaultBranch'], 
+      {
+        cwd: root,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }
+    );
+    
+    // if there is no setting, override the git default
+    // https://git-scm.com/docs/git-init#Documentation/git-init.txt--bltbranch-namegt
+    if (!initialBranch) {
+      await spawnAsync('git', ['branch', '-m', 'main'], { cwd: root, stdio: 'ignore' });
+    }
 
     if (flags.commit) {
       await spawnAsync('git', ['add', '--all'], { cwd: root, stdio: 'ignore' });


### PR DESCRIPTION
# Why

I tried expo this weekend, and it made a repo for me with the default branch as `master`.  This just meant I had never updated my local git settings to do otherwise (as the manual explains https://git-scm.com/docs/git-init#Documentation/git-init.txt--bltbranch-namegt).  Even though it was easy to fix, I thought we might as well make the default avoid the non-inclusive language compiled into git.

---
This patch is more of a proposal than a change request.  If the spirit seems good to the maintainers, I can proceed with the remainder of the contributor guildelines, add tests, yada yada.

# How

I modeled my change on GitHub's new repo instructions.  It assumes that if someone had never updated their global settings, then they probably wouldn't mind renaming their base branch:
![Screenshot from 2021-09-06 15-50-09](https://user-images.githubusercontent.com/1627760/132259962-383da07b-c38e-4518-ac25-245e5218fad6.png)

I went a step further and checked if the system does have a setting, and in that case skip the rename.  That covers two scenarios:
1. They already picked a default name they like better, so Expo doesn't need to change anything.
2. They explicitly set the old default to future-proof their....worldview? against future changes in git.  Expo doesn't need to fight them about it.  Comments contradicting this assumption are welcome.  :)

# Test Plan

I didn't exactly do this formally; again I would be willing to add tests and whatnot if folks require it.

I tested manually by monkeypatching my installed copy of expo like so:
```
// /usr/local/lib/node_modules/expo-cli/build/commands/initAsync.js ~line 553
// ...
      await (0, _spawnAsync().default)('git', ['commit', '-m', 'Created a new Expo app'], {
        cwd: root,
        stdio: 'ignore'
      });
      try {
        await (0, _spawnAsync().default)('git', ['config', '--get', 'init.defaultBranch'], {cwd: root } );
      } catch (e) {
        console.log({e})
        if (!e.stderr && !e.stdout) {
          await (0, _spawnAsync().default)('git', ['branch', '-M', 'main'], { cwd: root, stdio: 'ignore' });
        }
      }
// ...
```

Sadly, this doesn't work on git with versions before 2.30.  A git user with an older version who _does_ set the `init.defaultBranch` setting will still get a `master` branch.  (The setting will be ignored, and expo won't attempt to fix it.)  But if said user blindly sets the config value without testing that it works, pity for them.  At least they tried, and GitHub will hopefully encourage them to fix it anyway.
