### PR TITLE
[config-plugins] parse build gradle and access flavor specific config…

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -42,6 +42,7 @@
     "fs-extra": "9.0.0",
     "getenv": "^1.0.0",
     "glob": "7.1.6",
+    "gradle-to-js": "^2.0.0",
     "resolve-from": "^5.0.0",
     "semver": "^7.3.5",
     "slash": "^3.0.0",

--- a/packages/config-plugins/src/android/BuildGradle.ts
+++ b/packages/config-plugins/src/android/BuildGradle.ts
@@ -1,0 +1,103 @@
+import fs from 'fs-extra';
+import g2js from 'gradle-to-js/lib/parser';
+
+import { getAppBuildGradleFilePath } from './Paths';
+
+// represents gradle command
+// e.g. for `:app:buildExampleDebug` -> { moduleName: app, flavor: example, variant: debug }
+interface GradleCommandInfo {
+  moduleName?: string;
+  flavor?: string;
+  buildType?: string;
+}
+
+interface Config {
+  applicationId?: string;
+  versionCode?: string;
+  versionName?: string;
+}
+
+interface AppBuildGradle {
+  android?: {
+    defaultConfig?: Config;
+    flavorDimensions?: string; // e.g. '"dimension1", "dimension2"'
+    productFlavors?: Record<string, Config>;
+  };
+}
+
+export async function getAppBuildGradleAsync(projectDir: string): Promise<AppBuildGradle> {
+  const buildGradlePath = getAppBuildGradleFilePath(projectDir);
+  const rawBuildGradle = await fs.readFile(buildGradlePath, 'utf8');
+  return await g2js.parseText(rawBuildGradle);
+}
+
+export function resolveConfigValue(
+  buildGradle: AppBuildGradle,
+  flavor: string | undefined,
+  field: keyof Config
+) {
+  return (
+    (flavor && buildGradle?.android?.productFlavors?.[flavor]?.[field]) ??
+    buildGradle?.android?.defaultConfig?.[field]
+  );
+}
+
+// based on gradle command extract name of the module, variant and flavor
+//
+// @param cmd can be any valid string that can be added after `./gradlew` call
+// e.g.
+//   - :app:buildDebug
+//   - app:buildDebug
+//   - buildDebug
+//   - buildDebug --console verbose
+// @param buildGradle is used to verify correct casing of the first letter in
+// the flavor name
+export function parseGradleCommand(cmd: string, buildGradle: AppBuildGradle): GradleCommandInfo {
+  const hasFlavorDimensions = (buildGradle.android?.flavorDimensions ?? '').split(',').length > 1;
+  if (hasFlavorDimensions) {
+    throw new Error('flavorDimensions in build.gradle are not supported');
+  }
+  const flavors = new Set(Object.keys(buildGradle?.android?.productFlavors ?? {}));
+
+  // remove any params specified after command name
+  const [withoutParams] = cmd.split(' ');
+
+  // remove leading :
+  let rawCmd = withoutParams;
+  if (rawCmd.startsWith(':')) {
+    rawCmd = rawCmd.slice(1);
+  }
+
+  // separate moduleName and rest of the definition
+  const splitCmd = rawCmd.split(':');
+  const [moduleName, taskName] =
+    splitCmd.length > 1 ? [splitCmd[0], splitCmd[1]] : [undefined, splitCmd[0]];
+
+  const matchResult = taskName.match(/(build|bundle|assemble)(.*)(Release|Debug)/);
+  if (!matchResult) {
+    throw new Error('Failed to parse gradle command');
+  }
+  let flavor: string | undefined;
+  if (matchResult[2]) {
+    const [firstLetter, rest] = [matchResult[2].slice(0, 1), matchResult[2].slice(1)];
+    // first letter casing is not known based on gradle task name
+    // so we need to check both options
+    const flavorOptions = [
+      firstLetter.toLowerCase().concat(rest),
+      firstLetter.toUpperCase().concat(rest),
+    ];
+    flavorOptions.forEach(option => {
+      if (flavors.has(option)) {
+        flavor = option;
+      }
+    });
+    if (!flavor) {
+      throw new Error(`flavor ${firstLetter.toLowerCase().concat(rest)} is not defined`);
+    }
+  }
+  return {
+    moduleName,
+    flavor,
+    buildType: matchResult[3] ? matchResult[3].toLowerCase() : undefined,
+  };
+}

--- a/packages/config-plugins/src/android/__tests__/BuildGradle-test.ts
+++ b/packages/config-plugins/src/android/__tests__/BuildGradle-test.ts
@@ -153,7 +153,7 @@ describe(resolveConfigValue, () => {
         productFlavors: { example: { versionCode: '1234' } },
       },
     };
-    const result = resolveConfigValue(buildGradle, undefined, 'versionCode');
+    const result = resolveConfigValue(buildGradle, 'versionCode');
     expect(result).toEqual('123');
   });
   it('get versionCode for example flavor', async () => {
@@ -163,7 +163,7 @@ describe(resolveConfigValue, () => {
         productFlavors: { example: { versionCode: '1234' } },
       },
     };
-    const result = resolveConfigValue(buildGradle, 'example', 'versionCode');
+    const result = resolveConfigValue(buildGradle, 'versionCode', 'example');
     expect(result).toEqual('1234');
   });
   it('get versionCode for example flavor from default config', async () => {
@@ -173,7 +173,7 @@ describe(resolveConfigValue, () => {
         productFlavors: { example: { versionName: '1234' } },
       },
     };
-    const result = resolveConfigValue(buildGradle, 'example', 'versionCode');
+    const result = resolveConfigValue(buildGradle, 'versionCode', 'example');
     expect(result).toEqual('123');
   });
   it('get versionCode for example flavor from default config', async () => {
@@ -183,7 +183,7 @@ describe(resolveConfigValue, () => {
         productFlavors: { example: { versionName: '1234' } },
       },
     };
-    const result = resolveConfigValue(buildGradle, 'example', 'versionCode');
+    const result = resolveConfigValue(buildGradle, 'versionCode', 'example');
     expect(result).toEqual('123');
   });
 });

--- a/packages/config-plugins/src/android/__tests__/BuildGradle-test.ts
+++ b/packages/config-plugins/src/android/__tests__/BuildGradle-test.ts
@@ -1,0 +1,189 @@
+import fs from 'fs';
+import pick from 'lodash/pick';
+import { vol } from 'memfs';
+import path from 'path';
+
+import { getAppBuildGradleAsync, parseGradleCommand, resolveConfigValue } from '../BuildGradle';
+
+const fsReal = jest.requireActual('fs') as typeof fs;
+
+jest.mock('fs');
+
+describe(getAppBuildGradleAsync, () => {
+  afterEach(async () => {
+    vol.reset();
+  });
+
+  test('parsing build.gradle from managed template', async () => {
+    vol.fromJSON(
+      {
+        'android/app/build.gradle': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/android/app/build.gradle'),
+          'utf-8'
+        ),
+      },
+      '/test'
+    );
+    const buildGradle = await getAppBuildGradleAsync('/test');
+    expect(
+      pick(buildGradle?.android ?? {}, ['defaultConfig', 'flavorDimensions', 'productFlavors'])
+    ).toEqual({
+      defaultConfig: {
+        applicationId: 'com.helloworld',
+        minSdkVersion: 'rootProject.ext.minSdkVersion',
+        targetSdkVersion: 'rootProject.ext.targetSdkVersion',
+        versionCode: '1',
+        versionName: '1.0',
+      },
+    });
+  });
+
+  test('parsing multiflavor build.gradle', async () => {
+    vol.fromJSON(
+      {
+        'android/app/build.gradle': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/android/app/multiflavor-build.gradle'),
+          'utf-8'
+        ),
+      },
+      '/test'
+    );
+    const buildGradle = await getAppBuildGradleAsync('/test');
+    expect(
+      pick(buildGradle?.android ?? {}, ['defaultConfig', 'flavorDimensions', 'productFlavors'])
+    ).toEqual({
+      defaultConfig: {
+        applicationId: 'com.testapp',
+        minSdkVersion: 'rootProject.ext.minSdkVersion',
+        targetSdkVersion: 'rootProject.ext.targetSdkVersion',
+        versionCode: '1',
+        versionName: '1.0',
+      },
+      productFlavors: {
+        abc: {
+          applicationId: 'wefewf.wefew.abc',
+          versionCode: '123',
+        },
+        efg: {
+          applicationId: 'wefewf.wefew.efg',
+          versionCode: '124',
+        },
+      },
+    });
+  });
+
+  test('parsing build.gradle with flavor dimensions', async () => {
+    vol.fromJSON(
+      {
+        'android/app/build.gradle': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/android/app/multiflavor-with-dimensions-build.gradle'),
+          'utf-8'
+        ),
+      },
+      '/test'
+    );
+    const buildGradle = await getAppBuildGradleAsync('/test');
+    expect(
+      pick(buildGradle?.android ?? {}, ['defaultConfig', 'flavorDimensions', 'productFlavors'])
+    ).toEqual({
+      defaultConfig: {
+        applicationId: 'com.testapp',
+        minSdkVersion: 'rootProject.ext.minSdkVersion',
+        targetSdkVersion: 'rootProject.ext.targetSdkVersion',
+        versionCode: '1',
+        versionName: '1.0',
+      },
+      flavorDimensions: '"api", "mode"',
+      productFlavors: {
+        abc: {
+          applicationId: 'wefewf.wefew.abc',
+          versionCode: '123',
+          dimension: 'api',
+        },
+        efg: {
+          applicationId: 'wefewf.wefew.efg',
+          versionCode: '124',
+          dimension: 'mode',
+        },
+      },
+    });
+  });
+});
+
+describe(parseGradleCommand, () => {
+  test('parsing :app:bundleRelease', async () => {
+    const result = parseGradleCommand(':app:bundleRelease', {});
+    expect(result).toEqual({ moduleName: 'app', buildType: 'release' });
+  });
+  test('parsing :app:buildExampleDebug', async () => {
+    const result = parseGradleCommand(':app:buildExampleRelease', {
+      android: { productFlavors: { example: {} } },
+    });
+    expect(result).toEqual({ moduleName: 'app', flavor: 'example', buildType: 'release' });
+  });
+  test('parsing :app:buildExampleDebug when flavor is named with uper-case', async () => {
+    const result = parseGradleCommand(':app:buildExampleRelease', {
+      android: { productFlavors: { Example: {} } },
+    });
+    expect(result).toEqual({ moduleName: 'app', flavor: 'Example', buildType: 'release' });
+  });
+  test('parsing :app:buildExampleDebug when flavor does not exists', async () => {
+    const result = () => {
+      parseGradleCommand(':app:buildExampleRelease', {
+        android: { productFlavors: {} },
+      });
+    };
+    expect(result).toThrow('flavor example is not defined');
+  });
+  test('parsing with aditional cmdline options', async () => {
+    const result = parseGradleCommand(':app:bundleRelease --console verbose', {});
+    expect(result).toEqual({ moduleName: 'app', buildType: 'release' });
+  });
+  test('parsing without module name specified', async () => {
+    const result = parseGradleCommand('bundleRelease --console verbose', {});
+    expect(result).toEqual({ buildType: 'release' });
+  });
+});
+
+describe(resolveConfigValue, () => {
+  it('get versionCode for default flavor', async () => {
+    const buildGradle = {
+      android: {
+        defaultConfig: { versionCode: '123' },
+        productFlavors: { example: { versionCode: '1234' } },
+      },
+    };
+    const result = resolveConfigValue(buildGradle, undefined, 'versionCode');
+    expect(result).toEqual('123');
+  });
+  it('get versionCode for example flavor', async () => {
+    const buildGradle = {
+      android: {
+        defaultConfig: { versionCode: '123' },
+        productFlavors: { example: { versionCode: '1234' } },
+      },
+    };
+    const result = resolveConfigValue(buildGradle, 'example', 'versionCode');
+    expect(result).toEqual('1234');
+  });
+  it('get versionCode for example flavor from default config', async () => {
+    const buildGradle = {
+      android: {
+        defaultConfig: { versionCode: '123' },
+        productFlavors: { example: { versionName: '1234' } },
+      },
+    };
+    const result = resolveConfigValue(buildGradle, 'example', 'versionCode');
+    expect(result).toEqual('123');
+  });
+  it('get versionCode for example flavor from default config', async () => {
+    const buildGradle = {
+      android: {
+        defaultConfig: { versionCode: '123' },
+        productFlavors: { example: { versionName: '1234' } },
+      },
+    };
+    const result = resolveConfigValue(buildGradle, 'example', 'versionCode');
+    expect(result).toEqual('123');
+  });
+});

--- a/packages/config-plugins/src/android/__tests__/fixtures/android/app/multiflavor-build.gradle
+++ b/packages/config-plugins/src/android/__tests__/fixtures/android/app/multiflavor-build.gradle
@@ -1,0 +1,231 @@
+apply plugin: "com.android.application"
+
+import com.android.build.OutputFile
+
+/**
+ * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
+ * and bundleReleaseJsAndAssets).
+ * These basically call `react-native bundle` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * `apply from: "../../node_modules/react-native/react.gradle"` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: "index.android.bundle",
+ *
+ *   // the entry file for bundle generation. If none specified and
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
+ *   entryFile: "index.android.js",
+ *
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
+ *   bundleCommand: "ram-bundle",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // whether to bundle JS and assets in another build variant (if configured).
+ *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+ *   // The configuration property can be in the following formats
+ *   //         'bundleIn${productFlavor}${buildType}'
+ *   //         'bundleIn${buildType}'
+ *   // bundleInFreeDebug: true,
+ *   // bundleInPaidRelease: true,
+ *   // bundleInBeta: true,
+ *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn${productFlavor}${buildType}'
+ *   //         'devDisabledIn${buildType}'
+ *
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: ["android/**", "ios/**"],
+ *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: ["node"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
+ * ]
+ */
+
+project.ext.react = [
+    enableHermes: false
+]
+
+apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
+apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gradle"
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = false
+
+/**
+ * Run Proguard to shrink the Java bytecode in release builds.
+ */
+def enableProguardInReleaseBuilds = false
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.testapp"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile rootProject.file('keystores/debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    productFlavors {
+        abc {
+            applicationId "wefewf.wefew.abc"
+            versionCode 123
+        }
+        efg {
+            applicationId "wefewf.wefew.efg"
+            versionCode 124
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    addUnimodulesDependencies()
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: "./eas-build.gradle"
+

--- a/packages/config-plugins/src/android/__tests__/fixtures/android/app/multiflavor-with-dimensions-build.gradle
+++ b/packages/config-plugins/src/android/__tests__/fixtures/android/app/multiflavor-with-dimensions-build.gradle
@@ -1,0 +1,234 @@
+apply plugin: "com.android.application"
+
+import com.android.build.OutputFile
+
+/**
+ * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
+ * and bundleReleaseJsAndAssets).
+ * These basically call `react-native bundle` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * `apply from: "../../node_modules/react-native/react.gradle"` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: "index.android.bundle",
+ *
+ *   // the entry file for bundle generation. If none specified and
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
+ *   entryFile: "index.android.js",
+ *
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
+ *   bundleCommand: "ram-bundle",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // whether to bundle JS and assets in another build variant (if configured).
+ *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+ *   // The configuration property can be in the following formats
+ *   //         'bundleIn${productFlavor}${buildType}'
+ *   //         'bundleIn${buildType}'
+ *   // bundleInFreeDebug: true,
+ *   // bundleInPaidRelease: true,
+ *   // bundleInBeta: true,
+ *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn${productFlavor}${buildType}'
+ *   //         'devDisabledIn${buildType}'
+ *
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: ["android/**", "ios/**"],
+ *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: ["node"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
+ * ]
+ */
+
+project.ext.react = [
+    enableHermes: false
+]
+
+apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
+apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gradle"
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = false
+
+/**
+ * Run Proguard to shrink the Java bytecode in release builds.
+ */
+def enableProguardInReleaseBuilds = false
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.testapp"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile rootProject.file('keystores/debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    flavorDimensions "api", "mode"
+    productFlavors {
+        abc {
+            dimension "api"
+            applicationId "wefewf.wefew.abc"
+            versionCode 123
+        }
+        efg {
+            dimension "mode"
+            applicationId "wefewf.wefew.efg"
+            versionCode 124
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    addUnimodulesDependencies()
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: "./eas-build.gradle"
+

--- a/packages/config-plugins/src/android/index.ts
+++ b/packages/config-plugins/src/android/index.ts
@@ -1,5 +1,6 @@
 import * as AllowBackup from './AllowBackup';
 import * as Branch from './Branch';
+import * as BuildGradle from './BuildGradle';
 import * as Colors from './Colors';
 import * as EasBuild from './EasBuild';
 import * as Facebook from './Facebook';
@@ -32,6 +33,7 @@ export {
   EasBuild,
   Manifest,
   Branch,
+  BuildGradle,
   Colors,
   Facebook,
   GoogleMapsApiKey,

--- a/ts-declarations/gradle-to-js/index.d.ts
+++ b/ts-declarations/gradle-to-js/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'gradle-to-js/lib/parser' {
+  export function parseText(text: string): Promise<object>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9593,6 +9593,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+gradle-to-js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gradle-to-js/-/gradle-to-js-2.0.0.tgz#b790a97376d3d713105a086590e569610f7e6bc4"
+  integrity sha512-eoYJiSoreHG0cS5aUmv7ISJhajuULlqdqG3QKVti6x1EFkBXE8rGH6ipGKWEesXpCkfNgzBrhzo5ztIH1JWZMw==
+  dependencies:
+    lodash.merge "4.6.2"
+
 graphql-extensions@^0.0.x, graphql-extensions@~0.0.9:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.0.10.tgz#34bdb2546d43f6a5bc89ab23c295ec0466c6843d"
@@ -12204,6 +12211,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.merge@4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.set@^4.3.2:
   version "4.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9784,10 +9784,10 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@~0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.5.1.tgz#601115e4b1e0a17d9aa91243b96277de4e926e09"
-  integrity sha512-hLwqh8dejHayjlpvZY40e1aDCDvyP98cWx/L5DhAjSJLH8g4z9Tp08D7y4+3vErDsncPOdf1bxm+zUWpx0/Fxg==
+hermes-engine@0.0.0, hermes-engine@~0.5.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
+  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
 
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION

# Why

partial support for multi flavor builds

this pr adds support for the project that have multiple flavors defined, but project still need to use 'app' module and do not use flavor dimension

I did not modify any eject related code to use that logic because
- parser does not support serializing the file back with modifications so we can use it only to read values
- eject/prebuilt does no need multiflavor support

# How

- parse build.gradle using `gradle-to-js` lib
- extract module name, flavor and buildType from gradle command (parsed build gradle is necessary for context because we don't know the case of the first letter when resolving flavor name) e.g. `:buildAbcDebug` might be `abc`or `Abc`

# Test Plan

added some tests