### PR TITLE
[xdl][config] Implement naive manifest signing for EAS update manifests

### DIFF
--- a/packages/config/src/Config.types.ts
+++ b/packages/config/src/Config.types.ts
@@ -78,21 +78,33 @@ export type ExpoGoConfig = {
   };
 };
 
-export type ExpoAppManifest = ExpoConfig &
+export type EASConfig = {
+  projectId?: string;
+};
+
+export type ClientScopingConfig = {
+  scopeKey?: string;
+};
+
+export type ExpoClientConfig = ExpoConfig & {
+  id?: string;
+  releaseId?: string;
+  revisionId?: string;
+  bundleUrl?: string;
+  hostUri?: string;
+  publishedTime?: string;
+};
+
+export type ExpoAppManifest = ExpoClientConfig &
+  EASConfig &
   Partial<ExpoGoConfig> & {
     sdkVersion: string;
     bundledAssets?: string[];
     isKernel?: boolean;
     kernel?: { androidManifestPath?: string; iosManifestPath?: string };
     assetUrlOverride?: string;
-    publishedTime?: string;
     commitTime?: string;
-    releaseId?: string;
-    revisionId?: string;
     env?: Record<string, any>;
-    bundleUrl?: string;
-    hostUri?: string;
-    id?: string;
   };
 
 export interface ExpoUpdatesManifestAsset {
@@ -109,7 +121,11 @@ export interface ExpoUpdatesManifest {
   launchAsset: ExpoUpdatesManifestAsset;
   assets: ExpoUpdatesManifestAsset[];
   metadata: { [key: string]: string };
-  extra: { [key: string]: any };
+  extra: ClientScopingConfig & {
+    expoClient?: ExpoClientConfig;
+    expoGo?: ExpoGoConfig;
+    eas?: EASConfig;
+  };
 }
 
 export type Hook = {

--- a/packages/xdl/src/ProjectAssets.ts
+++ b/packages/xdl/src/ProjectAssets.ts
@@ -404,8 +404,16 @@ export async function resolveAndCollectExpoUpdatesManifestAssets(
   projectRoot: string,
   exp: ExpoConfig,
   urlResolver: (path: string) => string
-): Promise<{ url: string; hash: string; key: string; contentType: string }[]> {
-  const manifestAssets: { url: string; hash: string; key: string; contentType: string }[] = [];
+): Promise<
+  { url: string; hash: string; key: string; contentType: string; fileExtension: string }[]
+> {
+  const manifestAssets: {
+    url: string;
+    hash: string;
+    key: string;
+    contentType: string;
+    fileExtension: string;
+  }[] = [];
   await resolveExpoUpdatesManifestAssets({
     projectRoot,
     manifest: exp,
@@ -414,11 +422,13 @@ export async function resolveAndCollectExpoUpdatesManifestAssets(
       const contents = await fs.readFile(absolutePath);
       // Expo Updates spec dictates that this hash is sha256
       const hash = crypto.createHash('sha256').update(contents).digest('hex');
+      const contentType = mime.getType(absolutePath) ?? 'application/octet-stream';
       manifestAssets.push({
         url: urlResolver(assetPath),
         hash,
         key: assetPath,
-        contentType: mime.getType(absolutePath) ?? 'application/octet-stream',
+        contentType,
+        fileExtension: path.extname(absolutePath),
       });
       return assetPath;
     },

--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -64,7 +64,9 @@ async function shouldUseAnonymousManifestAsync(
 
 async function getScopeKeyForProjectIdAsync(projectId: string): Promise<string> {
   const user = await UserManager.ensureLoggedInAsync();
-  const project = await ApiV2.clientForUser(user).getAsync(`projects/${projectId}`);
+  const project = await ApiV2.clientForUser(user).getAsync(
+    `projects/${encodeURIComponent(projectId)}`
+  );
   return project.scopeKey;
 }
 

--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -1,17 +1,24 @@
 import { ExpoUpdatesManifest, getConfig } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
+import { JSONObject } from '@expo/json-file';
 import express from 'express';
 import http from 'http';
+import nullthrows from 'nullthrows';
 import { parse } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
   Analytics,
+  ANONYMOUS_USERNAME,
+  ApiV2,
   Config,
+  ConnectionStatus,
   ProjectAssets,
   ProjectUtils,
   resolveEntryPoint,
   UrlUtils,
+  UserManager,
+  UserSettings,
 } from '../internal';
 import {
   getBundleUrlAsync,
@@ -34,14 +41,51 @@ function getPlatformFromRequest(req: express.Request | http.IncomingMessage): 'a
   return stringifiedPlatform as 'android' | 'ios';
 }
 
+/**
+ * Whether an anonymous scope key should be used. It should be used when:
+ * 1. Offline
+ * 2. Not logged-in
+ * 3. No EAS project ID in config
+ */
+async function shouldUseAnonymousManifestAsync(
+  easProjectId: string | undefined | null
+): Promise<boolean> {
+  if (!easProjectId || ConnectionStatus.isOffline()) {
+    return true;
+  }
+
+  const currentSession = await UserManager.getSessionAsync();
+  if (!currentSession) {
+    return true;
+  }
+
+  return false;
+}
+
+async function getScopeKeyForProjectIdAsync(projectId: string): Promise<string> {
+  const user = await UserManager.ensureLoggedInAsync();
+  const project = await ApiV2.clientForUser(user).getAsync(`projects/${projectId}`);
+  return project.scopeKey;
+}
+
+async function signManifestAsync(manifest: ExpoUpdatesManifest): Promise<string> {
+  const user = await UserManager.ensureLoggedInAsync();
+  const { signature } = await ApiV2.clientForUser(user).postAsync('manifest/eas/sign', {
+    manifest: (manifest as any) as JSONObject,
+  });
+  return signature;
+}
+
 export async function getManifestResponseAsync({
   projectRoot,
   platform,
   host,
+  acceptSignature,
 }: {
   projectRoot: string;
   platform: 'android' | 'ios';
   host?: string;
+  acceptSignature: boolean;
 }): Promise<{
   body: ExpoUpdatesManifest;
   headers: Map<string, number | string | readonly string[]>;
@@ -91,6 +135,13 @@ export async function getManifestResponseAsync({
     path => bundleUrl!.match(/^https?:\/\/.*?\//)![0] + 'assets/' + path
   );
 
+  const easProjectId = expoConfig.extra?.eas.projectId;
+  const shouldUseAnonymousManifest = await shouldUseAnonymousManifestAsync(easProjectId);
+  const userAnonymousIdentifier = await UserSettings.getAnonymousIdentifierAsync();
+  const scopeKey = shouldUseAnonymousManifest
+    ? `@${ANONYMOUS_USERNAME}/${expoConfig.slug}-${userAnonymousIdentifier}`
+    : await getScopeKeyForProjectIdAsync(nullthrows(easProjectId));
+
   const expoUpdatesManifest = {
     id: uuidv4(),
     createdAt: new Date().toISOString(),
@@ -103,14 +154,22 @@ export async function getManifestResponseAsync({
     assets,
     metadata: {}, // required for the client to detect that this is an expo-updates manifest
     extra: {
-      eas: {}, // TODO(wschurman): somehow inject EAS config in here if known
+      eas: {
+        projectId: easProjectId ?? undefined,
+      },
       expoClient: {
         ...expoConfig,
         hostUri,
       },
       expoGo: expoGoConfig,
+      scopeKey,
     },
   };
+
+  if (acceptSignature && !shouldUseAnonymousManifest) {
+    const manifestSignature = await signManifestAsync(expoUpdatesManifest);
+    headers.set('expo-manifest-signature', manifestSignature);
+  }
 
   return {
     body: expoUpdatesManifest,
@@ -134,6 +193,7 @@ export function getManifestHandler(projectRoot: string) {
         projectRoot,
         host: req.headers.host,
         platform: getPlatformFromRequest(req),
+        acceptSignature: !!req.headers['expo-accept-signature'],
       });
       for (const [headerName, headerValue] of headers) {
         res.setHeader(headerName, headerValue);


### PR DESCRIPTION
# Why

This is the simplest solution towards getting EAS update manifests working in development in Expo Go and the dev client. This doesn't require client changes as the client currently assumes that EAS update manifests are signed using the same strategy (which they are on the server as well).

Closes ENG-1756.

# How

The way this works is by looking for the EAS project ID in the config, and then manufacturing a manifest at the time it is served with the values from the EAS server for `manifest.extra.eas.projectId` and `manifest.extra.scopeKey` if an EAS project ID was set in the config.

If the EAS project ID is not set in the config, the anonymous setting is used which allows access to most scoped modules but not EAS services like push notifications or auth session.

# Test Plan

This is tested in tandem with the necessary EAS server implementation: https://github.com/expo/universe/pull/8119 (landed) and https://github.com/expo/universe/pull/8150

1. Terminal window 1: Start a www dev server with dependent PR patched in.
2. Terminal window 2: `yarn start` this repo
3. Terminal window 3: 
    a. `export EXPO_LOCAL=1`
    b. Create a new project: `expo init blah`, 
    c. `EXPO_DEBUG=true ~/expo-cli/node_modules/.bin/expo start`
4. In insomnia/curl, load `http://localhost:19000/update-manifest-experimental?platform=android` with and without the `expo-accept-signature` header. Ensure that when `expo-accept-signature` header is present it creates an app on the server idempotently.
2. Load `exp://localhost:19000/update-manifest-experimental?platform=android` in locally-running Expo Go android client, ensure it loads. Breakpoint on the signature verification code and ensure the signature verification succeeds.