### PR TITLE
[config-plugins] fix sanitizing expo.name for rootProject.name

### DIFF
--- a/packages/config-plugins/src/android/Name.ts
+++ b/packages/config-plugins/src/android/Name.ts
@@ -8,14 +8,14 @@ import { removeStringItem, setStringItem } from './Strings';
 
 /**
  * Sanitize a name, this should be used for files and gradle names.
- * - `[/, \, :, <, >, ", ?, *, |]` are not allowed https://bit.ly/3l6xqKL
+ * - `[/, \, :, <, >, ', ", ?, *, |]` are not allowed https://bit.ly/3l6xqKL
  *
  * @param name
  */
 export function sanitizeNameForGradle(name: string): string {
   // Gradle disallows these:
-  // The project name 'My-Special 😃 Co/ol_Project' must not contain any of the following characters: [/, \, :, <, >, ", ?, *, |]. Set the 'rootProject.name' or adjust the 'include' statement (see https://docs.gradle.org/6.2/dsl/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[]) for more details).
-  return name.replace(/(\/|\\|:|<|>|"|\?|\*|\|)/g, '');
+  // The project name 'My-Special 😃 Co/ol_Project' must not contain any of the following characters: [/, \, :, <, >, ', ", ?, *, |]. Set the 'rootProject.name' or adjust the 'include' statement (see https://docs.gradle.org/6.2/dsl/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[]) for more details).
+  return name.replace(/(\/|\\|:|<|>|'|"|\?|\*|\|)/g, '');
 }
 
 export const withName = createStringsXmlPlugin(applyNameFromConfig, 'withName');

--- a/packages/config-plugins/src/android/__tests__/Name-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Name-test.ts
@@ -17,7 +17,7 @@ export const sampleStringsXML = `
   <string name="app_name">expo &amp;bo&lt;y&gt;'</string>
 </resources>`;
 
-const badName = `😃/\\:<>"?*|$F0g.`;
+const badName = `😃/\\:<>'"?*|$F0g.`;
 const badNameCleaned = `😃$F0g.`;
 
 describe(sanitizeNameForGradle, () => {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo-cli/issues/3836

# How

According to https://bit.ly/3l6xqKL it seems that `'` is actually allowed but I decided to drop it from the name.
If you think we should instead escape this character, let me know and I'll update the code.

# Test Plan

Unit test.