### PR TITLE
[config-plugins] Escape single quotes in project name

### DIFF
--- a/packages/config-plugins/src/android/Name.ts
+++ b/packages/config-plugins/src/android/Name.ts
@@ -61,6 +61,6 @@ export function applyNameSettingsGradle(config: Pick<ExpoConfig, 'name'>, settin
   // Select rootProject.name = '***' and replace the contents between the quotes.
   return settingsGradle.replace(
     /rootProject.name\s?=\s?(["'])(?:(?=(\\?))\2.)*?\1/g,
-    `rootProject.name = '${name}'`
+    `rootProject.name = '${name.replace(/'/g, "\\'")}'`
   );
 }

--- a/packages/config-plugins/src/android/__tests__/Name-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Name-test.ts
@@ -39,4 +39,8 @@ describe(applyNameSettingsGradle, () => {
     // Replaces with expected linting
     expect(modified).toBe(`rootProject.name = '${badNameCleaned}'`);
   });
+  it('escapes single quotes in name', () => {
+    const modified = applyNameSettingsGradle({ name: "Nora's" }, `rootProject.name="Replace me"`);
+    expect(modified).toBe(`rootProject.name = 'Nora\\'s'`);
+  });
 });


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/599

# How

Replace any `'` character in the output with `\'`, so that it becomes a valid string.

# Test Plan

I've added a test to the package in question, and will try to test this with upstream `eas-cli` as soon as I figure out how to do that 😅 