### PR TITLE
[config-plugins] new appDelegateHeader mod/plugin

### DIFF
--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -160,6 +160,10 @@ export interface ModConfig {
      */
     appDelegate?: Mod<AppDelegateProjectFile>;
     /**
+     * Modify the `ios/<name>/AppDelegate.h` as a string (dangerous)
+     */
+    appDelegateHeader?: Mod<AppDelegateProjectFile>;
+    /**
      * Modify the `ios/Podfile.properties.json` as key-value pairs
      */
     podfileProperties?: Mod<Record<string, string>>;

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -16,20 +16,28 @@ interface ProjectFile<L extends string = string> {
 export type AppDelegateProjectFile = ProjectFile<'objc' | 'swift'>;
 
 export function getAppDelegateFilePath(projectRoot: string): string {
-  const [using, ...extra] = globSync('ios/*/AppDelegate.@(m|swift)', {
+  return getFilePath(projectRoot, 'ios/*/AppDelegate.@(m|swift)', 'AppDelegate', 'app-delegate')
+}
+
+export function getAppDelegateHeaderFilePath(projectRoot: string): string {
+  return getFilePath(projectRoot, 'ios/*/AppDelegate.h', 'AppDelegate.h', 'app-delegate-header')
+}
+
+function getFilePath(projectRoot: string, globPattern: string, fileName: string, warningTag: string): string {
+  const [using, ...extra] = globSync(globPattern, {
     absolute: true,
     cwd: projectRoot,
     ignore: ignoredPaths,
   });
 
   if (!using) {
-    throw new UnexpectedError(`Could not locate a valid AppDelegate at root: "${projectRoot}"`);
+    throw new UnexpectedError(`Could not locate a valid ${fileName} at root: "${projectRoot}"`);
   }
 
   if (extra.length) {
     warnMultipleFiles({
-      tag: 'app-delegate',
-      fileName: 'AppDelegate',
+      tag: warningTag,
+      fileName,
       projectRoot,
       using,
       extra,
@@ -43,6 +51,7 @@ function getLanguage(filePath: string): 'objc' | 'swift' {
   const extension = path.extname(filePath);
   switch (extension) {
     case '.m':
+    case '.h':
       return 'objc';
     case '.swift':
       return 'swift';
@@ -61,6 +70,11 @@ export function getFileInfo(filePath: string) {
 
 export function getAppDelegate(projectRoot: string): AppDelegateProjectFile {
   const filePath = getAppDelegateFilePath(projectRoot);
+  return getFileInfo(filePath);
+}
+
+export function getAppDelegateHeader(projectRoot: string): AppDelegateProjectFile {
+  const filePath = getAppDelegateHeaderFilePath(projectRoot);
   return getFileInfo(filePath);
 }
 

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -24,9 +24,9 @@ export function getAppDelegateHeaderFilePath(projectRoot: string): string {
 }
 
 function getFilePath(
-  projectRoot: string, 
-  globPattern: string, 
-  fileName: string, 
+  projectRoot: string,
+  globPattern: string,
+  fileName: string,
   warningTag: string
 ): string {
   const [using, ...extra] = globSync(globPattern, {

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -16,14 +16,19 @@ interface ProjectFile<L extends string = string> {
 export type AppDelegateProjectFile = ProjectFile<'objc' | 'swift'>;
 
 export function getAppDelegateFilePath(projectRoot: string): string {
-  return getFilePath(projectRoot, 'ios/*/AppDelegate.@(m|swift)', 'AppDelegate', 'app-delegate')
+  return getFilePath(projectRoot, 'ios/*/AppDelegate.@(m|swift)', 'AppDelegate', 'app-delegate');
 }
 
 export function getAppDelegateHeaderFilePath(projectRoot: string): string {
-  return getFilePath(projectRoot, 'ios/*/AppDelegate.h', 'AppDelegate.h', 'app-delegate-header')
+  return getFilePath(projectRoot, 'ios/*/AppDelegate.h', 'AppDelegate.h', 'app-delegate-header');
 }
 
-function getFilePath(projectRoot: string, globPattern: string, fileName: string, warningTag: string): string {
+function getFilePath(
+  projectRoot: string, 
+  globPattern: string, 
+  fileName: string, 
+  warningTag: string
+): string {
   const [using, ...extra] = globSync(globPattern, {
     absolute: true,
     cwd: projectRoot,

--- a/packages/config-plugins/src/ios/__tests__/Paths-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Paths-test.ts
@@ -233,17 +233,17 @@ describe(getAppDelegateHeader, () => {
     });
   });
   it(`throws on swift project`, () => {
-    expect(() => getAppDelegate('/invalid')).toThrow(UnexpectedError);
-    expect(() => getAppDelegate('/invalid')).toThrow(/AppDelegate/);
+    expect(() => getAppDelegateHeader('/invalid')).toThrow(UnexpectedError);
+    expect(() => getAppDelegateHeader('/invalid')).toThrow(/AppDelegate/);
   });
 
   it(`throws on invalid project`, () => {
-    expect(() => getAppDelegate('/invalid')).toThrow(UnexpectedError);
-    expect(() => getAppDelegate('/invalid')).toThrow(/AppDelegate/);
+    expect(() => getAppDelegateHeader('/invalid')).toThrow(UnexpectedError);
+    expect(() => getAppDelegateHeader('/invalid')).toThrow(/AppDelegate/);
   });
 
   it(`warns when multiple paths are found`, () => {
-    expect(getAppDelegate('/confusing')).toStrictEqual({
+    expect(getAppDelegateHeader('/confusing')).toStrictEqual({
       contents: '',
       path: '/confusing/ios/testproject/AppDelegate.h',
       language: 'objc',

--- a/packages/config-plugins/src/ios/__tests__/Paths-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Paths-test.ts
@@ -4,11 +4,11 @@ import * as path from 'path';
 
 import { UnexpectedError } from '../../utils/errors';
 import * as WarningAggregator from '../../utils/warnings';
-import { 
-  getAllInfoPlistPaths, 
-  getAppDelegate, 
-  getAppDelegateHeader, 
-  getXcodeProjectPath 
+import {
+  getAllInfoPlistPaths,
+  getAppDelegate,
+  getAppDelegateHeader,
+  getXcodeProjectPath,
 } from '../Paths';
 
 const fsReal = jest.requireActual('fs') as typeof fs;

--- a/packages/config-plugins/src/ios/__tests__/Paths-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Paths-test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { UnexpectedError } from '../../utils/errors';
 import * as WarningAggregator from '../../utils/warnings';
-import { getAllInfoPlistPaths, getAppDelegate, getXcodeProjectPath } from '../Paths';
+import { getAllInfoPlistPaths, getAppDelegate, getAppDelegateHeader, getXcodeProjectPath } from '../Paths';
 
 const fsReal = jest.requireActual('fs') as typeof fs;
 
@@ -154,6 +154,98 @@ describe(getAppDelegate, () => {
     expect(WarningAggregator.addWarningIOS).toHaveBeenLastCalledWith(
       'paths-app-delegate',
       'Found multiple AppDelegate file paths, using "ios/testproject/AppDelegate.m". Ignored paths: ["ios/testproject/AppDelegate.swift"]'
+    );
+  });
+});
+
+describe(getAppDelegateHeader, () => {
+  beforeAll(async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ) as string,
+        'ios/Podfile': 'content',
+        'ios/TestPod.podspec': 'noop',
+        'ios/testproject/AppDelegate.m': '',
+        'ios/testproject/AppDelegate.h': '',
+      },
+      '/objc'
+    );
+
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ) as string,
+        'ios/Podfile': 'content',
+        'ios/TestPod.podspec': 'noop',
+        'ios/testproject/AppDelegate.swift': '',
+      },
+      '/swift'
+    );
+
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ) as string,
+        'ios/Podfile': 'content',
+        'ios/TestPod.podspec': 'noop',
+      },
+      '/invalid'
+    );
+
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ) as string,
+        'ios/Podfile': 'content',
+        'ios/TestPod.podspec': 'noop',
+        'ios/testproject/AppDelegate.swift': '',
+        'ios/testproject/AppDelegate.m': '',
+        'ios/testproject/AppDelegate.h': '',
+        'ios/testproject2/AppDelegate.h': '',
+      },
+      '/confusing'
+    );
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it(`returns objc path`, () => {
+    expect(getAppDelegateHeader('/objc')).toStrictEqual({
+      contents: '',
+      path: '/objc/ios/testproject/AppDelegate.h',
+      language: 'objc',
+    });
+  });
+  it(`throws on swift project`, () => {
+    expect(() => getAppDelegate('/invalid')).toThrow(UnexpectedError);
+    expect(() => getAppDelegate('/invalid')).toThrow(/AppDelegate/);
+  });
+
+  it(`throws on invalid project`, () => {
+    expect(() => getAppDelegate('/invalid')).toThrow(UnexpectedError);
+    expect(() => getAppDelegate('/invalid')).toThrow(/AppDelegate/);
+  });
+
+  it(`warns when multiple paths are found`, () => {
+    expect(getAppDelegate('/confusing')).toStrictEqual({
+      contents: '',
+      path: '/confusing/ios/testproject/AppDelegate.h',
+      language: 'objc',
+    });
+    expect(WarningAggregator.addWarningIOS).toHaveBeenLastCalledWith(
+      'paths-app-delegate-header',
+      'Found multiple AppDelegate.h file paths, using "ios/testproject/AppDelegate.h". Ignored paths: ["ios/testproject2/AppDelegate.h"]'
     );
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/Paths-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Paths-test.ts
@@ -4,7 +4,12 @@ import * as path from 'path';
 
 import { UnexpectedError } from '../../utils/errors';
 import * as WarningAggregator from '../../utils/warnings';
-import { getAllInfoPlistPaths, getAppDelegate, getAppDelegateHeader, getXcodeProjectPath } from '../Paths';
+import { 
+  getAllInfoPlistPaths, 
+  getAppDelegate, 
+  getAppDelegateHeader, 
+  getXcodeProjectPath 
+} from '../Paths';
 
 const fsReal = jest.requireActual('fs') as typeof fs;
 

--- a/packages/config-plugins/src/plugins/ios-plugins.ts
+++ b/packages/config-plugins/src/plugins/ios-plugins.ts
@@ -72,10 +72,10 @@ export const withAppDelegate: ConfigPlugin<Mod<AppDelegateProjectFile>> = (confi
  * @param config
  * @param action
  */
- export const withAppDelegateHeader: ConfigPlugin<Mod<AppDelegateProjectFile>> = (
-   config, 
-   action
-  ) => {
+export const withAppDelegateHeader: ConfigPlugin<Mod<AppDelegateProjectFile>> = (
+  config,
+  action
+) => {
   return withMod(config, {
     platform: 'ios',
     mod: 'appDelegateHeader',

--- a/packages/config-plugins/src/plugins/ios-plugins.ts
+++ b/packages/config-plugins/src/plugins/ios-plugins.ts
@@ -67,6 +67,20 @@ export const withAppDelegate: ConfigPlugin<Mod<AppDelegateProjectFile>> = (confi
 };
 
 /**
+ * Provides the AppDelegate file for modification.
+ *
+ * @param config
+ * @param action
+ */
+ export const withAppDelegateHeader: ConfigPlugin<Mod<AppDelegateProjectFile>> = (config, action) => {
+  return withMod(config, {
+    platform: 'ios',
+    mod: 'appDelegateHeader',
+    action,
+  });
+};
+
+/**
  * Provides the Info.plist file for modification.
  * Keeps the config's expo.ios.infoPlist object in sync with the data.
  *

--- a/packages/config-plugins/src/plugins/ios-plugins.ts
+++ b/packages/config-plugins/src/plugins/ios-plugins.ts
@@ -72,7 +72,10 @@ export const withAppDelegate: ConfigPlugin<Mod<AppDelegateProjectFile>> = (confi
  * @param config
  * @param action
  */
- export const withAppDelegateHeader: ConfigPlugin<Mod<AppDelegateProjectFile>> = (config, action) => {
+ export const withAppDelegateHeader: ConfigPlugin<Mod<AppDelegateProjectFile>> = (
+   config, 
+   action
+  ) => {
   return withMod(config, {
     platform: 'ios',
     mod: 'appDelegateHeader',

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -41,6 +41,18 @@ const defaultProviders = {
       await writeFile(filePath, contents);
     },
   }),
+  // Append a rule to supply AppDelegate header data to mods on `mods.ios.appDelegateHeader`
+  appDelegateHeader: provider<Paths.AppDelegateProjectFile>({
+    getFilePath({ modRequest: { projectRoot } }) {
+      return Paths.getAppDelegateHeaderFilePath(projectRoot);
+    },
+    async read(filePath) {
+      return Paths.getFileInfo(filePath);
+    },
+    async write(filePath: string, { modResults: { contents } }) {
+      await writeFile(filePath, contents);
+    },
+  }),
   // Append a rule to supply Expo.plist data to mods on `mods.ios.expoPlist`
   expoPlist: provider<JSONObject>({
     getFilePath({ modRequest: { platformProjectRoot, projectName } }) {

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -221,7 +221,7 @@ export function getIosModFileProviders() {
 export function getIosIntrospectModFileProviders(): Omit<
   IosDefaultProviders,
   // Get rid of mods that could potentially fail by being empty.
-  'dangerous' | 'xcodeproj' | 'appDelegate'
+  'dangerous' | 'xcodeproj' | 'appDelegate' | 'appDelegateHeader'
 > {
   const createIntrospectionProvider = (
     modName: keyof typeof defaultProviders,


### PR DESCRIPTION
# Why

Config plugins offer functionality out of the box to modify the appDelegate file, but not the appDelegate.h header file.

# How

The implementation is 100% identical to the one for appDelegate.

# Test Plan

The PR includes automated tests that mimic the existing appDelegate tests to provide the same test focus and coverage. I was slightly surprised that `withIosBaseMods-test.ts` didn't have any coverage for the existing appDelegate implementation, so I didn't extend that one to include tests for appDelegateHeader.