### PR TITLE
Added patches system to expo/metro-config

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "expo": "37",
+    "semver": "^7.3.5",
     "metro": "^0.59.0",
     "metro-config": "^0.59.0",
     "react-native": "~0.63.4"

--- a/packages/metro-config/src/env.ts
+++ b/packages/metro-config/src/env.ts
@@ -1,0 +1,3 @@
+import { boolish } from 'getenv';
+
+export const EXPO_DEBUG = boolish('EXPO_DEBUG', false);

--- a/packages/metro-config/src/escapeRegExp.ts
+++ b/packages/metro-config/src/escapeRegExp.ts
@@ -1,0 +1,9 @@
+export function escapeRegExp(string: string) {
+  if (typeof string !== 'string') {
+    throw new TypeError('Expected a string');
+  }
+
+  // Escape characters with special meaning either inside or outside character sets.
+  // Use a simple backslash escape when it’s always valid, and a `\xnn` escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
+  return string.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
+}

--- a/packages/metro-config/src/importMetroFromProject.ts
+++ b/packages/metro-config/src/importMetroFromProject.ts
@@ -1,0 +1,33 @@
+import type MetroConfig from 'metro-config';
+import type MetroResolver from 'metro-resolver';
+import resolveFrom from 'resolve-from';
+
+class MetroImportError extends Error {
+  constructor(projectRoot: string, moduleId: string) {
+    super(
+      `Missing package "${moduleId}" in the project at: ${projectRoot}\n` +
+        'This usually means `react-native` is not installed. ' +
+        'Please verify that dependencies in package.json include "react-native" ' +
+        'and run `yarn` or `npm install`.'
+    );
+  }
+}
+
+function resolveFromProject(projectRoot: string, moduleId: string) {
+  const resolvedPath = resolveFrom.silent(projectRoot, moduleId);
+  if (!resolvedPath) {
+    throw new MetroImportError(projectRoot, moduleId);
+  }
+  return resolvedPath;
+}
+
+function importFromProject(projectRoot: string, moduleId: string) {
+  return require(resolveFromProject(projectRoot, moduleId));
+}
+
+export function importMetroConfigFromProject(projectRoot: string): typeof MetroConfig {
+  return importFromProject(projectRoot, 'metro-config');
+}
+export function importMetroResolverFromProject(projectRoot: string): typeof MetroResolver {
+  return importFromProject(projectRoot, 'metro-resolver');
+}

--- a/packages/metro-config/src/moduleReplacementResolver.ts
+++ b/packages/metro-config/src/moduleReplacementResolver.ts
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import { CustomResolver, Resolution } from 'metro-resolver';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+import { EXPO_DEBUG } from './env';
+import { escapeRegExp } from './escapeRegExp';
+import { importMetroResolverFromProject } from './importMetroFromProject';
+
+export type ModuleReplacement = { match: RegExp; replace: string };
+
+export function createModuleReplacementResolver(
+  projectRoot: string,
+  moduleReplacements: ModuleReplacement[]
+): CustomResolver | undefined {
+  if (!moduleReplacements.length) {
+    return undefined;
+  }
+  const { resolve } = importMetroResolverFromProject(projectRoot);
+
+  return (context, realModuleName, platform) => {
+    const defaultResolveRequest = context.resolveRequest;
+    delete context.resolveRequest;
+
+    try {
+      const result: Resolution = resolve(context, realModuleName, platform);
+
+      // Only apply resolution on source files, skipping noop and assets
+      if (result.type === 'sourceFile') {
+        // Iterate through the replacements
+        for (const matcher of moduleReplacements) {
+          if (matcher.match.test(result.filePath)) {
+            if (EXPO_DEBUG) {
+              console.log(`[emc] Replace: `, result.filePath, ' -> ', matcher.replace);
+            }
+            // @ts-ignore: readonly
+            result.filePath = matcher.replace;
+          }
+        }
+      }
+
+      return result;
+    } catch (e) {
+      throw e;
+    } finally {
+      context.resolveRequest = defaultResolveRequest;
+    }
+  };
+}
+
+function getAllFiles(dirPath: string, collected: string[] = []) {
+  const files = fs.readdirSync(dirPath);
+
+  files.forEach(function (file) {
+    const joined = path.join(dirPath, file);
+    if (fs.statSync(joined).isDirectory()) {
+      collected = getAllFiles(joined, collected);
+    } else {
+      collected.push(joined);
+    }
+  });
+
+  return collected;
+}
+
+// We replace modules in `expo/patches/*` in the project.
+// This is used for applying patches to the upstream `react-native` package.
+export function getVendoredExpoPatches(projectRoot: string): ModuleReplacement[] {
+  // Get the `expo/patches` folder if it exists.
+  let expoPatchesPath: string = '';
+  try {
+    expoPatchesPath = path.join(
+      path.dirname(resolveFrom(projectRoot, 'expo/package.json')),
+      'patches'
+    );
+  } catch {}
+
+  if (!expoPatchesPath || !fs.existsSync(expoPatchesPath)) {
+    if (EXPO_DEBUG) {
+      console.log('[emc] expo/patches folder not found, skipping patches');
+    }
+    return [];
+  }
+
+  // Collect all of the patches.
+  const patches = getAllFiles(expoPatchesPath).map(replace => ({
+    match: new RegExp(escapeRegExp(path.relative(expoPatchesPath, replace))),
+    replace,
+  }));
+
+  if (EXPO_DEBUG) {
+    console.log('[emc] using patches:', patches);
+  }
+  return patches;
+}

--- a/ts-declarations/metro-config/index.d.ts
+++ b/ts-declarations/metro-config/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'metro-config' {
   import { IncomingMessage, ServerResponse } from 'http';
+  import type { CustomResolver } from 'metro-resolver';
   import {
     DeltaResult,
     Graph,
@@ -14,8 +15,6 @@ declare module 'metro-config' {
 
   // TODO: import { CacheStore } from 'metro-cache';
   type CacheStore = unknown;
-  // TODO: import { CustomResolver } from 'metro-resolver';
-  type CustomResolver = unknown;
 
   import type { BasicSourceMap, MixedSourceMap } from 'metro-source-map';
 

--- a/ts-declarations/metro-resolver/index.d.ts
+++ b/ts-declarations/metro-resolver/index.d.ts
@@ -1,0 +1,124 @@
+// Respectfully borrowed from
+// https://github.com/microsoft/rnx-kit/tree/main/packages/%40types/metro-resolver
+
+declare module 'metro-resolver' {
+  export type Result<TResolution, TCandidates> =
+    | { readonly type: 'resolved'; readonly resolution: TResolution }
+    | { readonly type: 'failed'; readonly candidates: TCandidates };
+
+  export type Resolution =
+    | FileResolution
+    | {
+        readonly type: 'empty';
+      };
+
+  export type AssetFileResolution = readonly string[];
+  export type FileResolution =
+    | { readonly type: 'sourceFile'; readonly filePath: string }
+    | { readonly type: 'assetFiles'; readonly filePaths: AssetFileResolution };
+
+  export type FileAndDirCandidates = {
+    readonly dir: FileCandidates;
+    readonly file: FileCandidates;
+  };
+
+  /**
+   * This is a way to describe what files we tried to look for when resolving
+   * a module name as file. This is mainly used for error reporting, so that
+   * we can explain why we cannot resolve a module.
+   */
+  export type FileCandidates =
+    // We only tried to resolve a specific asset.
+    | { readonly type: 'asset'; readonly name: string }
+    // We attempted to resolve a name as being a source file (ex. JavaScript,
+    // JSON...), in which case there can be several extensions we tried, for
+    // example `/js/foo.ios.js`, `/js/foo.js`, etc. for a single prefix '/js/foo'.
+    | {
+        readonly type: 'sourceFile';
+        filePathPrefix: string;
+        readonly candidateExts: readonly string[];
+      };
+
+  /**
+   * Check existence of a single file.
+   */
+  export type DoesFileExist = (filePath: string) => boolean;
+  export type IsAssetFile = (fileName: string) => boolean;
+
+  /**
+   * Given a directory path and the base asset name, return a list of all the
+   * asset file names that match the given base name in that directory. Return
+   * null if there's no such named asset. `platform` is used to identify
+   * platform-specific assets, ex. `foo.ios.js` instead of a generic `foo.js`.
+   */
+  export type ResolveAsset = (
+    dirPath: string,
+    assetName: string,
+    extension: string
+  ) => readonly string[] | undefined;
+
+  export type FileContext = {
+    readonly doesFileExist: DoesFileExist;
+    readonly isAssetFile: IsAssetFile;
+    readonly nodeModulesPaths: readonly string[];
+    readonly preferNativePlatform: boolean;
+    readonly redirectModulePath: (modulePath: string) => string | false;
+    readonly resolveAsset: ResolveAsset;
+    readonly sourceExts: readonly string[];
+  };
+
+  export type FileOrDirContext = FileContext & {
+    /**
+     * This should return the path of the "main" module of the specified
+     * `package.json` file, after post-processing: for example, applying the
+     * 'browser' field if necessary.
+     *
+     * FIXME: move the post-processing here. Right now it is
+     * located in `node-haste/Package.js`, and fully duplicated in
+     * `ModuleGraph/node-haste/Package.js` (!)
+     */
+    readonly getPackageMainPath: (packageJsonPath: string) => string;
+  };
+
+  export type HasteContext = FileOrDirContext & {
+    /**
+     * Given a name, this should return the full path to the file that provides
+     * a Haste module of that name. Ex. for `Foo` it may return `/smth/Foo.js`.
+     */
+    readonly resolveHasteModule: (name: string) => string | undefined;
+    /**
+     * Given a name, this should return the full path to the package manifest that
+     * provides a Haste package of that name. Ex. for `Foo` it may return
+     * `/smth/Foo/package.json`.
+     */
+    readonly resolveHastePackage: (name: string) => string | undefined;
+  };
+
+  export type ModulePathContext = FileOrDirContext & {
+    /**
+     * Full path of the module that is requiring or importing the module to be
+     * resolved.
+     */
+    readonly originModulePath: string;
+  };
+  export type ResolutionContext = ModulePathContext &
+    HasteContext & {
+      allowHaste: boolean;
+      extraNodeModules?: { [key: string]: string };
+      originModulePath: string;
+      resolveRequest?: CustomResolver;
+    };
+
+  export type CustomResolver = (
+    context: ResolutionContext,
+    realModuleName: string,
+    platform: string | null,
+    moduleName: string | null
+  ) => Resolution;
+
+  export function resolve(
+    context: ResolutionContext,
+    moduleName: string,
+    platform: string | null
+  ): Resolution;
+}


### PR DESCRIPTION
# Why

In order to drop the react-native fork, we need certain patches applied to react-native. We can eventually upstream these features, but in the short term we need changes quickly. In the future if we need changes added, we can utilize this system to apply them.

## Patches

- https://github.com/expo/react-native/commit/a80b16c7a0233a46a1eb82fbe274344489312670

# How

The config will check `expo/patches` in the project to find module replacements. These replacements must work relative to the patch location (i.e. these aren't proper patches that get moved into the expected location). 

The patches are then used with a custom `resolver.resolveRequest` to ensure the functionality is as close to Metro as possible.

## Considerations

- This system will have to be ported to Webpack and any other bundler we want to implement.
- Users cannot use patch-package on the files we patch.
- Users can no longer implement a custom `resolver.resolveRequest` in their local config. This is probably not a huge concern since the feature is pretty cryptic. On GitHub, it seemed like some people were using it to support React Native Windows in older versions of Metro.

# Test Plan

- In a project: `touch node_modules/expo/patches/react-native/Libraries/Utilities/Appearance.js`
- Add the following (notice the imports have been updated):
```js
/**
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 *
 * @format
 * @flow strict-local
 */

 'use strict';

 import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
 import NativeEventEmitter from 'react-native/Libraries/EventEmitter/NativeEventEmitter';
 import NativeAppearance, {
   type AppearancePreferences,
   type ColorSchemeName,
 } from 'react-native/Libraries/Utilities/NativeAppearance';
 import invariant from 'invariant';
 import {isAsyncDebugging} from 'react-native/Libraries/Utilities/DebugEnvironment';
 
 type AppearanceListener = (preferences: AppearancePreferences) => void;
 const eventEmitter = new EventEmitter();
 
 if (NativeAppearance) {
   const nativeEventEmitter = new NativeEventEmitter(NativeAppearance);
   nativeEventEmitter.addListener(
     'appearanceChanged',
     (newAppearance: AppearancePreferences) => {
       const {colorScheme} = newAppearance;
       invariant(
         colorScheme === 'dark' ||
           colorScheme === 'light' ||
           colorScheme == null,
         "Unrecognized color scheme. Did you mean 'dark' or 'light'?",
       );
       // Update cached value
       preferences.colorScheme = colorScheme;
       eventEmitter.emit('change', {colorScheme});
     },
   );
 }
 
 function getInitialColorScheme(): ?ColorSchemeName {
   if (__DEV__) {
     if (isAsyncDebugging) {
       // Hard code light theme when using the async debugger as
       // sync calls aren't supported
       return 'light';
     }
   }
 
   // TODO: (hramos) T52919652 Use ?ColorSchemeName once codegen supports union
   const nativeColorScheme: ?string =
     NativeAppearance == null ? null : NativeAppearance.getColorScheme() || null;
   invariant(
     nativeColorScheme === 'dark' ||
       nativeColorScheme === 'light' ||
       nativeColorScheme == null,
     "Unrecognized color scheme. Did you mean 'dark' or 'light'?",
   );
   return nativeColorScheme;
 }
 
 function getColorScheme(): ?ColorSchemeName {
   if (!preferences.colorScheme) {
     const initialColorScheme = getInitialColorScheme();
     preferences.colorScheme = initialColorScheme;
     return preferences.colorScheme;
   }
 
   return preferences.colorScheme;
 }
 
 const preferences = {
   colorScheme: null,
 };
 
 module.exports = {
   /**
    * Note: Although color scheme is available immediately, it may change at any
    * time. Any rendering logic or styles that depend on this should try to call
    * this function on every render, rather than caching the value (for example,
    * using inline styles rather than setting a value in a `StyleSheet`).
    *
    * Example: `const colorScheme = Appearance.getColorScheme();`
    *
    * @returns {?ColorSchemeName} Value for the color scheme preference.
    */
   getColorScheme,
   /**
    * Add an event handler that is fired when appearance preferences change.
    */
   addChangeListener(listener: AppearanceListener): void {
     eventEmitter.addListener('change', listener);
   },
   /**
    * Remove an event handler.
    */
   removeChangeListener(listener: AppearanceListener): void {
     eventEmitter.removeListener('change', listener);
   },
 };
```
- Running `EXPO_DEBUG=1 expod start` should log how patches are being applied:
```
[emc] using patches: [
  {
    match: /react\x2dnative\/Libraries\/Utilities\/Appearance\.js/,
    replace: '/Users/evanbacon/Documents/GitHub/lab/yolo49/node_modules/expo/patches/react-native/Libraries/Utilities/Appearance.js'
  }
]

...

[emc] Replace:  /Users/evanbacon/Documents/GitHub/lab/yolo49/node_modules/react-native/Libraries/Utilities/Appearance.js  ->  /Users/evanbacon/Documents/GitHub/lab/yolo49/node_modules/expo/patches/react-native/Libraries/Utilities/Appearance.js
[emc] Replace:  /Users/evanbacon/Documents/GitHub/lab/yolo49/node_modules/react-native/Libraries/Utilities/Appearance.js  ->  /Users/evanbacon/Documents/GitHub/lab/yolo49/node_modules/expo/patches/react-native/Libraries/Utilities/Appearance.js

```

- [ ] integration tests