### PR TITLE
use platforms array for disabling platforms

### DIFF
--- a/packages/dev-tools/components/ProjectManager.js
+++ b/packages/dev-tools/components/ProjectManager.js
@@ -165,6 +165,12 @@ class ProjectManager extends React.Component {
       </div>
     );
 
+    const platforms = this.props.project.config.platforms || ['ios', 'android', 'web'];
+
+    const isIosDisabled = !platforms.includes('ios');
+    const isAndroidDisabled = !platforms.includes('android');
+    const isWebDisabled = !platforms.includes('web');
+
     const viewingElements = (
       <ProjectManagerSidebarOptions
         url={this.props.project.manifestUrl}
@@ -185,6 +191,9 @@ class ProjectManager extends React.Component {
         onEmailOrNumberValidation={this._handleEmailOrPhoneNumberValidation}
         onToggleProductionMode={this.props.onToggleProductionMode}
         user={this.props.user}
+        isIosDisabled={isIosDisabled}
+        isAndroidDisabled={isAndroidDisabled}
+        isWebDisabled={isWebDisabled}
         isProduction={!this.props.project.settings.dev}
         isPublishing={this.props.isPublishing}
         isActiveDeviceIOS={this.props.isActiveDeviceIOS}

--- a/packages/dev-tools/components/ProjectManagerSidebarOptions.js
+++ b/packages/dev-tools/components/ProjectManagerSidebarOptions.js
@@ -77,11 +77,20 @@ const STYLES_CONTENT_GROUP = css`
   justify-content: space-between;
   align-items: center;
   transition: 200ms ease all;
+  cursor: pointer;
 
   :hover {
     background: ${Constants.colors.primary};
     color: ${Constants.colors.white};
-    cursor: pointer;
+  }
+`;
+
+const STYLES_CONTENT_GROUP_DISABLED = css`
+  opacity: 0.5;
+  cursor: not-allowed;
+  :hover {
+    background: unset;
+    color: currentColor;
   }
 `;
 
@@ -96,6 +105,33 @@ const STYLES_CONTENT_GROUP_RIGHT = css`
   align-items: center;
   justify-content: center;
 `;
+
+function SidebarOption({ children, onClick, tooltip, isDisabled = false }) {
+  return (
+    <div
+      className={`
+    ${STYLES_CONTENT_GROUP}
+    ${isDisabled ? STYLES_CONTENT_GROUP_DISABLED : ''}
+    `}
+      title={tooltip}
+      onClick={isDisabled ? undefined : onClick}>
+      <span className={STYLES_CONTENT_GROUP_LEFT}>{children}</span>
+    </div>
+  );
+}
+
+function PlatformSidebarOption({ platform, ...props }) {
+  return (
+    <SidebarOption
+      tooltip={
+        props.isDisabled
+          ? `Add '${platform}' to the 'platforms' array in the project app.json to enable this platform`
+          : ''
+      }
+      {...props}
+    />
+  );
+}
 
 export default class ProjectManagerSidebarOptions extends React.Component {
   state = { isSendFormVisible: false, showCopiedMessage: false };
@@ -125,23 +161,29 @@ export default class ProjectManagerSidebarOptions extends React.Component {
     const isDisabled = !this.props.url;
 
     const sendHeader = (
-      <div className={STYLES_CONTENT_GROUP} onClick={this._handleSendHeaderClick}>
-        <span className={STYLES_CONTENT_GROUP_LEFT}>Send link with email…</span>
-      </div>
+      <SidebarOption onClick={this._handleSendHeaderClick}>Send link with email…</SidebarOption>
     );
 
     return (
       <div>
-        <div className={STYLES_CONTENT_GROUP} onClick={this.props.onSimulatorClickAndroid}>
-          <span className={STYLES_CONTENT_GROUP_LEFT}>Run on Android device/emulator</span>
-        </div>
-        <div className={STYLES_CONTENT_GROUP} onClick={this.props.onSimulatorClickIOS}>
-          <span className={STYLES_CONTENT_GROUP_LEFT}>Run on iOS simulator</span>
-        </div>
-
-        <a className={STYLES_CONTENT_GROUP} onClick={this.props.onStartWebClick}>
-          <span className={STYLES_CONTENT_GROUP_LEFT}>Run in web browser</span>
-        </a>
+        <PlatformSidebarOption
+          platform="android"
+          onClick={this.props.onSimulatorClickAndroid}
+          isDisabled={this.props.isAndroidDisabled}>
+          Run on Android device/emulator
+        </PlatformSidebarOption>
+        <PlatformSidebarOption
+          platform="ios"
+          onClick={this.props.onSimulatorClickIOS}
+          isDisabled={this.props.isIosDisabled}>
+          Run on iOS simulator
+        </PlatformSidebarOption>
+        <PlatformSidebarOption
+          platform="web"
+          onClick={this.props.onStartWebClick}
+          isDisabled={this.props.isWebDisabled}>
+          Run in web browser
+        </PlatformSidebarOption>
 
         <ContentGroup header={sendHeader} isActive={isSendFormVisible}>
           <InputWithButton

--- a/packages/dev-tools/pages/index.js
+++ b/packages/dev-tools/pages/index.js
@@ -38,6 +38,7 @@ const query = gql`
         description
         slug
         githubUrl
+        platforms
       }
       sources {
         id
@@ -99,6 +100,7 @@ const projectPollQuery = gql`
         description
         slug
         githubUrl
+        platforms
       }
     }
     userSettings {

--- a/packages/dev-tools/server/graphql/GraphQLSchema.ts
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.ts
@@ -71,6 +71,7 @@ const typeDefs = graphql`
     description: String
     slug: String
     githubUrl: String
+    platforms: [String]
   }
 
   input ProjectConfigInput {

--- a/packages/dev-tools/server/graphql/__tests__/GraphQLSchema-test.ts
+++ b/packages/dev-tools/server/graphql/__tests__/GraphQLSchema-test.ts
@@ -160,6 +160,7 @@ query IndexPageQuery {
       name
       description
       slug
+      platforms
     }
     sources {
       __typename

--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -137,6 +137,7 @@ export async function actionAsync(projectRoot: string, options: Options) {
   if (props.bundler) {
     await startBundlerAsync(projectRoot, {
       metroPort: props.port,
+      platforms: exp.platforms,
     });
   }
 

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -66,6 +66,7 @@ export async function actionAsync(projectRoot: string, options: Options) {
   if (props.shouldStartBundler) {
     await startBundlerAsync(projectRoot, {
       metroPort: props.port,
+      platforms: exp.platforms,
     });
   }
   const bundleIdentifier = await profileMethod(getBundleIdentifierForBinaryAsync)(binaryPath);

--- a/packages/expo-cli/src/commands/run/ios/startBundlerAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/startBundlerAsync.ts
@@ -6,7 +6,7 @@ import { installExitHooks } from '../../start/installExitHooks';
 
 export async function startBundlerAsync(
   projectRoot: string,
-  { metroPort }: Pick<Project.StartOptions, 'metroPort'>
+  { metroPort, platforms }: Pick<Project.StartOptions, 'metroPort' | 'platforms'>
 ) {
   // Add clean up hooks
   installExitHooks(projectRoot);
@@ -23,5 +23,6 @@ export async function startBundlerAsync(
     // Enable controls
     isWebSocketsEnabled: true,
     isRemoteReloadingEnabled: true,
+    platforms,
   });
 }

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -1,3 +1,4 @@
+import { ExpoConfig } from '@expo/config-types';
 import chalk from 'chalk';
 import openBrowser from 'react-dev-utils/openBrowser';
 import wrapAnsi from 'wrap-ansi';
@@ -35,10 +36,11 @@ type StartOptions = {
   nonPersistent?: boolean;
   maxWorkers?: number;
   webOnly?: boolean;
+  platforms?: ExpoConfig['platforms'];
 };
 
 const printHelp = (): void => {
-  logCommandsTable([['?', 'show all commands']]);
+  logCommandsTable([{ key: '?', msg: 'show all commands' }]);
 };
 
 const div = chalk.dim(`│`);
@@ -56,8 +58,8 @@ const printUsageAsync = async (
   projectRoot: string,
   options: Pick<
     StartOptions,
-    'webOnly' | 'devClient' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled'
-  > = {}
+    'webOnly' | 'devClient' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled' | 'platforms'
+  >
 ) => {
   const { dev } = await ProjectSettings.readAsync(projectRoot);
   const openDevToolsAtStartup = await shouldOpenDevToolsOnStartupAsync();
@@ -66,64 +68,92 @@ const printUsageAsync = async (
 
   const isMac = process.platform === 'darwin';
 
+  const { platforms = ['ios', 'android', 'web'] } = options;
+
+  const isAndroidDisabled = !platforms.includes('android');
+  const isIosDisabled = !platforms.includes('ios');
+  const isWebDisable = !platforms.includes('web');
+
   logCommandsTable([
-    [],
-    ['a', `open Android`],
-    ['shift+a', `select a device or emulator`],
-    isMac && ['i', `open iOS simulator`],
-    isMac && ['shift+i', `select a simulator`],
-    ['w', `open web`],
-    [],
-    !!options.isRemoteReloadingEnabled && ['r', `reload app`],
-    !!options.isWebSocketsEnabled && ['m', `toggle menu`],
-    !!options.isWebSocketsEnabled && ['shift+m', `more tools`],
-    ['o', `open project code in your editor`],
-    ['c', `show project QR`],
-    ['p', `toggle build mode`, devMode],
+    {},
+    { key: 'a', msg: `open Android`, disabled: isAndroidDisabled },
+    { key: 'shift+a', msg: `select a device or emulator`, disabled: isAndroidDisabled },
+    isMac && { key: 'i', msg: `open iOS simulator`, disabled: isIosDisabled },
+    isMac && { key: 'shift+i', msg: `select a simulator`, disabled: isIosDisabled },
+    { key: 'w', msg: `open web`, disabled: isWebDisable },
+    {},
+    !!options.isRemoteReloadingEnabled && { key: 'r', msg: `reload app` },
+    !!options.isWebSocketsEnabled && { key: 'm', msg: `toggle menu` },
+    !!options.isWebSocketsEnabled && { key: 'shift+m', msg: `more tools` },
+    { key: 'o', msg: `open project code in your editor` },
+    { key: 'c', msg: `show project QR` },
+    { key: 'p', msg: `toggle build mode`, status: devMode },
     // TODO: Drop with SDK 40
-    !options.isRemoteReloadingEnabled && ['r', `restart bundler`],
-    !options.isRemoteReloadingEnabled && ['shift+r', `restart and clear cache`],
-    [],
-    ['d', `show developer tools`],
-    ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
-    [],
+    !options.isRemoteReloadingEnabled && { key: 'r', msg: `restart bundler` },
+    !options.isRemoteReloadingEnabled && { key: 'shift+r', msg: `restart and clear cache` },
+    {},
+    { key: 'd', msg: `show developer tools` },
+    {
+      key: 'shift+d',
+      msg: `toggle auto opening developer tools on startup`,
+      status: currentToggle,
+    },
+    {},
   ]);
 };
 
 const printBasicUsageAsync = async (
-  options: Pick<StartOptions, 'webOnly' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled'> = {}
+  options: Pick<
+    StartOptions,
+    'webOnly' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled' | 'platforms'
+  >
 ) => {
   const isMac = process.platform === 'darwin';
   const openDevToolsAtStartup = await shouldOpenDevToolsOnStartupAsync();
   const currentToggle = openDevToolsAtStartup ? 'enabled' : 'disabled';
 
+  const { platforms = ['ios', 'android', 'web'] } = options;
+
+  const isAndroidDisabled = !platforms.includes('android');
+  const isIosDisabled = !platforms.includes('ios');
+  const isWebDisable = !platforms.includes('web');
+
   logCommandsTable([
-    [],
-    ['a', `open Android`],
-    isMac && ['i', `open iOS simulator`],
-    ['w', `open web`],
-    [],
-    !!options.isRemoteReloadingEnabled && ['r', `reload app`],
-    !!options.isWebSocketsEnabled && ['m', `toggle menu`],
-    ['d', `show developer tools`],
-    ['shift+d', `toggle auto opening developer tools on startup`, currentToggle],
-    [],
+    {},
+    { key: 'a', msg: `open Android`, disabled: isAndroidDisabled },
+    isMac && { key: 'i', msg: `open iOS simulator`, disabled: isIosDisabled },
+    { key: 'w', msg: `open web`, disabled: isWebDisable },
+    {},
+    !!options.isRemoteReloadingEnabled && { key: 'r', msg: `reload app` },
+    !!options.isWebSocketsEnabled && { key: 'm', msg: `toggle menu` },
+    { key: 'd', msg: `show developer tools` },
+    {
+      key: 'shift+d',
+      msg: `toggle auto opening developer tools on startup`,
+      status: currentToggle,
+    },
+    {},
   ]);
 };
 
-function logCommandsTable(ui: (false | string[])[]) {
+function logCommandsTable(
+  ui: (false | { key?: string; msg?: string; status?: string; disabled?: boolean })[]
+) {
   Log.nested(
     ui
       .filter(Boolean)
       // @ts-ignore: filter doesn't work
-      .map(([key, message, status]) => {
+      .map(({ key, msg, status, disabled }) => {
         if (!key) return '';
         let view = `${BLT} `;
         if (key.length === 1) view += 'Press ';
         view += `${b(key)} ${div} `;
-        view += message;
+        view += msg;
         if (status) {
           view += ` ${chalk.dim(`(${i(status)})`)}`;
+        }
+        if (disabled) {
+          view = chalk.dim(view);
         }
         return view;
       })
@@ -133,7 +163,10 @@ function logCommandsTable(ui: (false | string[])[]) {
 
 const printServerInfo = async (
   projectRoot: string,
-  options: Pick<StartOptions, 'webOnly' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled'> = {}
+  options: Pick<
+    StartOptions,
+    'webOnly' | 'isWebSocketsEnabled' | 'isRemoteReloadingEnabled' | 'platforms'
+  >
 ) => {
   const wrapLength = process.stdout.columns || 80;
   const item = (text: string): string => `${BLT} ` + wrapAnsi(text, wrapLength).trimStart();
@@ -148,7 +181,7 @@ const printServerInfo = async (
       // TODO: if dev client, change this message!
       Log.nested(item(`Scan the QR code above with Expo Go (Android) or the Camera app (iOS)`));
     } catch (error) {
-      // If there is no dev client scheme, then skip the QR code.
+      // @ts-ignore: If there is no dev client scheme, then skip the QR code.
       if (error.code !== 'NO_DEV_CLIENT_SCHEME') {
         throw error;
       } else {
@@ -233,6 +266,8 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
     if (shouldPrompt) {
       Log.clear();
     }
+    const { platforms = ['ios', 'android', 'web'] } = options;
+
     switch (key) {
       case 'A':
       case 'a':
@@ -246,6 +281,14 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
             Log.nestedError(results.error);
           }
         } else {
+          const isDisabled = !platforms.includes('android');
+          if (isDisabled) {
+            Log.nestedWarn(
+              `Android is disabled, enable it by adding ${chalk.bold`android`} to the platforms array in your app.json or app.config.js`
+            );
+            break;
+          }
+
           Log.log(`${BLT} Opening on Android...`);
           const results = await Android.openProjectAsync({
             projectRoot,
@@ -272,6 +315,13 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
             Log.nestedError(results.error);
           }
         } else {
+          const isDisabled = !platforms.includes('ios');
+          if (isDisabled) {
+            Log.nestedWarn(
+              `iOS is disabled, enable it by adding ${chalk.bold`ios`} to the platforms array in your app.json or app.config.js`
+            );
+            break;
+          }
           Log.log(`${BLT} Opening on iOS...`);
           const results = await Simulator.openProjectAsync({
             projectRoot,
@@ -306,6 +356,14 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         break;
       }
       case 'w': {
+        const isDisabled = !platforms.includes('web');
+        if (isDisabled) {
+          Log.nestedWarn(
+            `Web is disabled, enable it by installing ${chalk.bold`react-native-web`}, and adding ${chalk.bold`web`} to the platforms array in your app.json or app.config.js`
+          );
+          break;
+        }
+
         // Ensure the Webpack dev server is running first
         const isStarted = await Webpack.getUrlAsync(projectRoot);
 
@@ -336,7 +394,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         await UserSettings.setAsync('openDevToolsAtStartup', enabled);
         const currentToggle = enabled ? 'enabled' : 'disabled';
         Log.log(`Auto opening developer tools on startup: ${chalk.bold(currentToggle)}`);
-        logCommandsTable([['d', `show developer tools now`]]);
+        logCommandsTable([{ key: 'd', msg: `show developer tools now` }]);
         break;
       }
       case 'm': {

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -359,7 +359,7 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
         const isDisabled = !platforms.includes('web');
         if (isDisabled) {
           Log.nestedWarn(
-            `Web is disabled, enable it by installing ${chalk.bold`react-native-web`}, and adding ${chalk.bold`web`} to the platforms array in your app.json or app.config.js`
+            `Web is disabled, enable it by installing ${chalk.bold`react-native-web`} and adding ${chalk.bold`web`} to the platforms array in your app.json or app.config.js`
           );
           break;
         }

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -151,6 +151,7 @@ export function parseStartOptions(
   const startOpts: Project.StartOptions = {
     metroPort: options.metroPort,
     webpackPort: options.webpackPort,
+    platforms: exp.platforms ?? ['ios', 'android', 'web'],
   };
 
   if (options.clear) {

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -1,4 +1,4 @@
-import { ProjectTarget } from '@expo/config';
+import { ExpoConfig, ProjectTarget } from '@expo/config';
 import { MessageSocket, MetroDevServerOptions, runMetroDevServerAsync } from '@expo/dev-server';
 import http from 'http';
 
@@ -23,6 +23,7 @@ export type StartOptions = {
   maxWorkers?: number;
   webOnly?: boolean;
   target?: ProjectTarget;
+  platforms?: ExpoConfig['platforms'];
 };
 
 export async function startDevServerAsync(


### PR DESCRIPTION
# Why

Remake of https://github.com/expo/expo-cli/pull/3782 by @cruzach but with better resolution for users who accidentally disable platforms.

- Attempting to open a disabled platform will warn how to enable the platform.
- Hovering over disabled platforms in dev tools will show how to enable the platform.


# Test Plan

## Dev Tools UI

<img width="496" alt="Screen Shot 2021-09-13 at 12 52 29 PM" src="https://user-images.githubusercontent.com/9664363/133140332-e700f375-0373-4241-8792-5430409e600c.png">

## Terminal UI

<img width="244" alt="Screen Shot 2021-09-13 at 12 53 02 PM" src="https://user-images.githubusercontent.com/9664363/133140384-11e14882-990e-40b4-95f5-a1c9e84c73e3.png">

Pressing `w` will log:

```
Web is disabled, enable it by installing react-native-web, and adding web to the platforms array in your app.json or app.config.js
```
