### PR TITLE
[expo-cli][run:ios] JS API for iOS binary install, and connected devices

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/IOSDeploy.ts
+++ b/packages/expo-cli/src/commands/run/ios/IOSDeploy.ts
@@ -2,7 +2,6 @@ import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import { spawn } from 'child_process';
 import program from 'commander';
-import fs from 'fs-extra';
 import { Ora } from 'ora';
 import os from 'os';
 import path from 'path';
@@ -12,20 +11,6 @@ import { Prompts } from 'xdl';
 import CommandError, { SilentError } from '../../../CommandError';
 import Log from '../../../log';
 import { ora } from '../../../utils/ora';
-
-/**
- * Get the app_delta folder for faster subsequent rebuilds on devices.
- *
- * @param bundleId
- * @returns
- */
-export function getAppDeltaDirectory(bundleId: string): string {
-  // TODO: Maybe use .expo folder instead for debugging
-  // TODO: Reuse existing folder from xcode?
-  const deltaFolder = path.join(os.tmpdir(), 'ios', 'app-delta', bundleId);
-  fs.ensureDirSync(deltaFolder);
-  return deltaFolder;
-}
 
 export async function isInstalledAsync() {
   try {

--- a/packages/expo-cli/src/commands/run/ios/installOnDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/installOnDeviceAsync.ts
@@ -24,7 +24,7 @@ export function getAppDeltaDirectory(bundleId: string): string {
   return deltaFolder;
 }
 
-// To debug: `export DEBUG=native-run:*`
+// To debug: `export DEBUG=expo:xdl:*`
 export async function installOnDeviceAsync(props: {
   bundle: string;
   bundleIdentifier: string;
@@ -41,38 +41,27 @@ export async function installOnDeviceAsync(props: {
 
   try {
     // TODO: Connect for logs
-    // TODO: Progress bar
     await AppleDevice.runOnDevice({
       udid,
       appPath: bundle,
       bundleId: bundleIdentifier,
       waitForApp: false,
       deltaPath: appDeltaDirectory,
-      // TODO: Use this
       onProgress({
-        phase,
+        status,
         isComplete,
-        copiedFiles,
         progress,
       }: {
-        phase: string;
+        status: string;
         isComplete: boolean;
-        copiedFiles: number;
         progress: number;
       }) {
         if (!indicator) {
-          indicator = ora(phase).start();
+          indicator = ora(status).start();
         }
+        indicator.text = `${chalk.bold(status)} ${progress}%`;
         if (isComplete) {
-          if (phase === 'Installing') {
-            const copiedMessage = chalk.gray`Copied ${copiedFiles} file(s)`;
-            // Emulate Xcode copy file count, this helps us know if app deltas are working.
-            indicator.succeed(`${chalk.bold('Installed')} ${copiedMessage}`);
-          } else {
-            indicator.succeed();
-          }
-        } else {
-          indicator.text = `${chalk.bold(phase)} ${progress}%`;
+          indicator.succeed();
         }
       },
     });

--- a/packages/expo-cli/src/commands/run/ios/installOnDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/installOnDeviceAsync.ts
@@ -1,0 +1,101 @@
+import chalk from 'chalk';
+import program from 'commander';
+import fs from 'fs-extra';
+import { Ora } from 'ora';
+import os from 'os';
+import path from 'path';
+import { AppleDevice, Prompts } from 'xdl';
+
+import CommandError from '../../../CommandError';
+import { ora } from '../../../utils/ora';
+import * as IOSDeploy from './IOSDeploy';
+
+/**
+ * Get the app_delta folder for faster subsequent rebuilds on devices.
+ *
+ * @param bundleId
+ * @returns
+ */
+export function getAppDeltaDirectory(bundleId: string): string {
+  // TODO: Maybe use .expo folder instead for debugging
+  // TODO: Reuse existing folder from xcode?
+  const deltaFolder = path.join(os.tmpdir(), 'ios', 'app-delta', bundleId);
+  fs.ensureDirSync(deltaFolder);
+  return deltaFolder;
+}
+
+// To debug: `export DEBUG=native-run:*`
+export async function installOnDeviceAsync(props: {
+  bundle: string;
+  bundleIdentifier: string;
+  appDeltaDirectory: string;
+  udid: string;
+  deviceName: string;
+}): Promise<void> {
+  if (!AppleDevice.isEnabled()) {
+    return await IOSDeploy.installOnDeviceAsync(props);
+  }
+
+  const { bundle, bundleIdentifier, appDeltaDirectory, udid, deviceName } = props;
+  let indicator: Ora | undefined;
+
+  try {
+    // TODO: Connect for logs
+    // TODO: Progress bar
+    await AppleDevice.runOnDevice({
+      udid,
+      appPath: bundle,
+      bundleId: bundleIdentifier,
+      waitForApp: false,
+      deltaPath: appDeltaDirectory,
+      // TODO: Use this
+      onProgress({
+        phase,
+        isComplete,
+        copiedFiles,
+        progress,
+      }: {
+        phase: string;
+        isComplete: boolean;
+        copiedFiles: number;
+        progress: number;
+      }) {
+        if (!indicator) {
+          indicator = ora(phase).start();
+        }
+        if (isComplete) {
+          if (phase === 'Installing') {
+            const copiedMessage = chalk.gray`Copied ${copiedFiles} file(s)`;
+            // Emulate Xcode copy file count, this helps us know if app deltas are working.
+            indicator.succeed(`${chalk.bold('Installed')} ${copiedMessage}`);
+          } else {
+            indicator.succeed();
+          }
+        } else {
+          indicator.text = `${chalk.bold(phase)} ${progress}%`;
+        }
+      },
+    });
+  } catch (err: any) {
+    if (indicator) {
+      indicator.fail();
+    }
+    if (err.code === 'DeviceLocked') {
+      // Get the app name from the binary path.
+      const appName = path.basename(bundle).split('.')[0] ?? 'app';
+      if (
+        !program.nonInteractive &&
+        (await Prompts.confirmAsync({
+          message: `Cannot launch ${appName} because the device is locked. Unlock ${deviceName} to continue...`,
+          initial: true,
+        }))
+      ) {
+        return installOnDeviceAsync(props);
+      }
+      throw new CommandError(
+        `Cannot launch ${appName} on ${deviceName} because the device is locked.`
+      );
+    }
+    throw err;
+  }
+}

--- a/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { SimControl, Simulator } from 'xdl';
+import { AppleDevice, SimControl, Simulator } from 'xdl';
 
 import CommandError from '../../../CommandError';
 import Log from '../../../log';
@@ -39,14 +39,16 @@ export async function resolveDeviceAsync(
     return simulator;
   }
 
-  const spinner = ora(
-    `🔍 Finding ${device === true ? 'devices' : `device ${chalk.cyan(device)}`}`
-  ).start();
+  // Only use the spinner with xctrace since it's so slow (~2s), alternative
+  // method is very fast (~50ms) and the flicker makes it seem slower.
+  const spinner = AppleDevice.isEnabled()
+    ? null
+    : ora(`🔍 Finding ${device === true ? 'devices' : `device ${chalk.cyan(device)}`}`).start();
   let devices: (SimControl.SimulatorDevice | SimControl.XCTraceDevice)[] = await profileMethod(
     getBuildDestinationsAsync
   )({ osType }).catch(() => []);
 
-  spinner.stop();
+  spinner?.stop();
 
   if (device === true) {
     // If osType is defined, then filter out ineligible simulators.

--- a/packages/xdl/LICENSE-third-party
+++ b/packages/xdl/LICENSE-third-party
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Drifty Co
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -68,6 +68,7 @@
     "md5hex": "1.0.0",
     "minimatch": "3.0.4",
     "mv": "2.1.1",
+    "native-run": "^1.4.1",
     "node-forge": "0.10.0",
     "p-map": "3.0.0",
     "p-retry": "4.1.0",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -68,7 +68,6 @@
     "md5hex": "1.0.0",
     "minimatch": "3.0.4",
     "mv": "2.1.1",
-    "native-run": "^1.4.1",
     "node-forge": "0.10.0",
     "p-map": "3.0.0",
     "p-retry": "4.1.0",

--- a/packages/xdl/src/SimControl.ts
+++ b/packages/xdl/src/SimControl.ts
@@ -4,7 +4,7 @@ import { execSync } from 'child_process';
 import path from 'path';
 
 import { waitForActionAsync } from './apple/utils/waitForActionAsync';
-import { CoreSimulator, Logger, XDLError } from './internal';
+import { AppleDevice, CoreSimulator, Logger, XDLError } from './internal';
 import { profileMethod } from './utils/profileMethod';
 
 type DeviceState = 'Shutdown' | 'Booted';
@@ -127,7 +127,7 @@ export async function getContainerPathAsync({
       bundleIdentifier,
     ]);
     return stdout.trim();
-  } catch (error) {
+  } catch (error: any) {
     if (error.stderr?.match(/No such file or directory/)) {
       return null;
     }
@@ -147,7 +147,7 @@ export async function openURLAsync(options: { udid?: string; url: string }): Pro
   try {
     // Skip logging since this is likely to fail.
     await xcrunAsync(['simctl', 'openurl', deviceUDIDOrBooted(options.udid), options.url]);
-  } catch (error) {
+  } catch (error: any) {
     if (!error.stderr?.match(/Unable to lookup in current state: Shut/)) {
       throw error;
     }
@@ -215,7 +215,7 @@ export async function runBootAsync({ udid }: { udid: string }) {
   try {
     // Skip logging since this is likely to fail.
     await xcrunAsync(['simctl', 'boot', udid]);
-  } catch (error) {
+  } catch (error: any) {
     if (!error.stderr?.match(/Unable to boot device in current state: Booted/)) {
       throw error;
     }
@@ -236,7 +236,7 @@ export async function uninstallAsync(options: {
 function parseSimControlJSONResults(input: string): any {
   try {
     return JSON.parse(input);
-  } catch (error) {
+  } catch (error: any) {
     // Nov 15, 2020: Observed this can happen when opening the simulator and the simulator prompts the user to update the XC command line tools.
     // Unexpected token I in JSON at position 0
     if (error.message.match('Unexpected token')) {
@@ -287,6 +287,19 @@ export async function listSimulatorDevicesAsync() {
  * Get a list of all connected devices.
  */
 export async function listDevicesAsync(): Promise<XCTraceDevice[]> {
+  if (AppleDevice.isEnabled()) {
+    const results = await AppleDevice.getConnectedDevices();
+    // TODO: Add support for osType (ipad, watchos, etc)
+    return results.map(device => ({
+      // TODO: Better name
+      name: device.DeviceName ?? device.ProductType ?? 'unknown ios device',
+      model: device.ProductType,
+      osVersion: device.ProductVersion,
+      deviceType: 'device',
+      udid: device.UniqueDeviceID,
+    }));
+  }
+
   const { output } = await xcrunAsync(['xctrace', 'list', 'devices']);
 
   const text = output.join('');
@@ -320,7 +333,7 @@ export async function listDevicesAsync(): Promise<XCTraceDevice[]> {
 export async function shutdownAsync(udid?: string) {
   try {
     return simctlAsync(['shutdown', deviceUDIDOrBooted(udid)]);
-  } catch (e) {
+  } catch (e: any) {
     if (!e.message?.includes('No devices are booted.')) {
       throw e;
     }
@@ -446,7 +459,7 @@ export async function xcrunWithLogging(
 ): Promise<SpawnResult> {
   try {
     return await xcrunAsync(args, options);
-  } catch (e) {
+  } catch (e: any) {
     Logger.global.error(`Error running \`xcrun ${args.join(' ')}\`: ${e.stderr || e.message}`);
     throw e;
   }

--- a/packages/xdl/src/apple/AppleDevice.ts
+++ b/packages/xdl/src/apple/AppleDevice.ts
@@ -69,7 +69,6 @@ export async function runOnDevice({
     await uploadApp(clientManager, appPath, destPackagePath);
 
     const installer = await clientManager.getInstallationProxyClient();
-    // TODO: Progress callback
     await installer.installApp(
       destPackagePath,
       bundleId,

--- a/packages/xdl/src/apple/AppleDevice.ts
+++ b/packages/xdl/src/apple/AppleDevice.ts
@@ -1,0 +1,210 @@
+import Debug from 'debug';
+import { readFileSync } from 'fs';
+import { boolish } from 'getenv';
+// @ts-ignore
+import type { DeviceValues, IPLookupResult } from 'native-run/dist/ios/lib';
+import {
+  AFC_STATUS,
+  AFCError,
+  ClientManager,
+  LockdowndClient,
+  UsbmuxdClient,
+  // @ts-ignore
+} from 'native-run/dist/ios/lib';
+// @ts-ignore
+import { getDeveloperDiskImagePath } from 'native-run/dist/ios/utils/xcode';
+// @ts-ignore
+import { onBeforeExit, wait } from 'native-run/dist/utils/process';
+import * as path from 'path';
+
+const EXPO_USE_APPLE_DEVICE = boolish('EXPO_USE_APPLE_DEVICE', false);
+
+const debug = Debug('native-run:ios:utils:device');
+
+export interface DeviceValues {
+  BasebandCertId: number;
+  BasebandKeyHashInformation: {
+    AKeyStatus: number;
+    SKeyHash: Buffer;
+    SKeyStatus: number;
+  };
+  BasebandSerialNumber: Buffer;
+  BasebandVersion: string;
+  BoardId: number;
+  BuildVersion: string;
+  ChipID: number;
+  DeviceClass: string;
+  DeviceColor: string;
+  DeviceName: string;
+  DieID: number;
+  HardwareModel: string;
+  HasSiDP: boolean;
+  PartitionType: string;
+  ProductName: string;
+  ProductType: string;
+  ProductVersion: string;
+  ProductionSOC: boolean;
+  ProtocolVersion: string;
+  TelephonyCapability: boolean;
+  UniqueChipID: number;
+  UniqueDeviceID: string;
+  // TODO: Warn if connected device is using the wrong wifi address
+  WiFiAddress: string;
+  [key: string]: any;
+}
+
+export function isEnabled() {
+  return EXPO_USE_APPLE_DEVICE;
+}
+
+export async function getConnectedDevices(): Promise<DeviceValues[]> {
+  const usbmuxClient = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
+  const usbmuxDevices = await usbmuxClient.getDevices();
+  usbmuxClient.socket.end();
+
+  return Promise.all(
+    usbmuxDevices.map(
+      async (d: any): Promise<DeviceValues> => {
+        const socket = await new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket()).connect(
+          d,
+          62078
+        );
+        const device = await new LockdowndClient(socket).getAllValues();
+        socket.end();
+        return device;
+      }
+    )
+  );
+}
+
+export async function runOnDevice({
+  udid,
+  appPath,
+  bundleId,
+  waitForApp,
+  deltaPath,
+}: {
+  udid: string;
+  appPath: string;
+  bundleId: string;
+  waitForApp: boolean;
+  deltaPath: string;
+}) {
+  const clientManager = await ClientManager.create(udid);
+
+  try {
+    await mountDeveloperDiskImage(clientManager);
+
+    const packageName = path.basename(appPath);
+    const destPackagePath = path.join('PublicStaging', packageName);
+
+    await uploadApp(clientManager, appPath, destPackagePath);
+
+    const installer = await clientManager.getInstallationProxyClient();
+    // TODO: Progress callback
+    await installer.installApp(destPackagePath, bundleId, {
+      // https://github.com/ios-control/ios-deploy/blob/0f2ffb1e564aa67a2dfca7cdf13de47ce489d835/src/ios-deploy/ios-deploy.m#L2491-L2508
+      ApplicationType: 'Any',
+
+      CFBundleIdentifier: bundleId,
+      CloseOnInvalidate: '1',
+      InvalidateOnDetach: '1',
+      IsUserInitiated: '1',
+      // Disable checking for wifi devices, this is nominally faster.
+      PreferWifi: '0',
+      // Only info I could find on these:
+      // https://github.com/wwxxyx/Quectel_BG96/blob/310876f90fc1093a59e45e381160eddcc31697d0/Apple_Homekit/homekit_certification_tools/ATS%206/ATS%206/ATS.app/Contents/Frameworks/CaptureKit.framework/Versions/A/Resources/MobileDevice/MobileInstallation.h#L112-L121
+      PackageType: 'Developer',
+      ShadowParentKey: deltaPath,
+      // SkipUninstall: '1'
+    });
+
+    const { [bundleId]: appInfo } = await installer.lookupApp([bundleId]);
+    // launch fails with EBusy or ENotFound if you try to launch immediately after install
+    await wait(200);
+    const debugServerClient = await launchApp(clientManager, { appInfo, detach: !waitForApp });
+    if (waitForApp) {
+      onBeforeExit(async () => {
+        // causes continue() to return
+        debugServerClient.halt();
+        // give continue() time to return response
+        await wait(64);
+      });
+
+      debug(`Waiting for app to close...\n`);
+      const result = await debugServerClient.continue();
+      // TODO: I have no idea what this packet means yet (successful close?)
+      // if not a close (ie, most likely due to halt from onBeforeExit), then kill the app
+      if (result !== 'W00') {
+        await debugServerClient.kill();
+      }
+    }
+  } finally {
+    clientManager.end();
+  }
+}
+
+async function mountDeveloperDiskImage(clientManager: ClientManager) {
+  const imageMounter = await clientManager.getMobileImageMounterClient();
+  // Check if already mounted. If not, mount.
+  if (!(await imageMounter.lookupImage()).ImageSignature) {
+    // verify DeveloperDiskImage exists (TODO: how does this work on Windows/Linux?)
+    // TODO: if windows/linux, download?
+    const version = await (await clientManager.getLockdowndClient()).getValue('ProductVersion');
+    const developerDiskImagePath = await getDeveloperDiskImagePath(version);
+    const developerDiskImageSig = readFileSync(`${developerDiskImagePath}.signature`);
+    await imageMounter.uploadImage(developerDiskImagePath, developerDiskImageSig);
+    await imageMounter.mountImage(developerDiskImagePath, developerDiskImageSig);
+  }
+}
+
+async function uploadApp(clientManager: ClientManager, srcPath: string, destinationPath: string) {
+  const afcClient = await clientManager.getAFCClient();
+  try {
+    await afcClient.getFileInfo('PublicStaging');
+  } catch (err: any) {
+    if (err instanceof AFCError && err.status === AFC_STATUS.OBJECT_NOT_FOUND) {
+      await afcClient.makeDirectory('PublicStaging');
+    } else {
+      throw err;
+    }
+  }
+  await afcClient.uploadDirectory(srcPath, destinationPath);
+}
+
+async function launchApp(
+  clientManager: ClientManager,
+  { appInfo, detach }: { appInfo: IPLookupResult[string]; detach?: boolean }
+) {
+  let tries = 0;
+  while (tries < 3) {
+    const debugServerClient = await clientManager.getDebugserverClient();
+    await debugServerClient.setMaxPacketSize(1024);
+    await debugServerClient.setWorkingDir(appInfo.Container);
+    await debugServerClient.launchApp(appInfo.Path, appInfo.CFBundleExecutable);
+
+    const result = await debugServerClient.checkLaunchSuccess();
+    if (result === 'OK') {
+      if (detach) {
+        // https://github.com/libimobiledevice/libimobiledevice/blob/25059d4c7d75e03aab516af2929d7c6e6d4c17de/tools/idevicedebug.c#L455-L464
+        const res = await debugServerClient.sendCommand('D', []);
+        debug('Disconnect from debug server request:', res);
+        if (res !== 'OK') {
+          console.warn(
+            'Something went wrong while attempting to disconnect from iOS debug server, you may need to reopen the app manually.'
+          );
+        }
+      }
+
+      return debugServerClient;
+    } else if (result === 'EBusy' || result === 'ENotFound') {
+      debug('Device busy or app not found, trying to launch again in .5s...');
+      tries++;
+      debugServerClient.socket.end();
+      await wait(500);
+    } else {
+      throw new Error(`There was an error launching app: ${result}`);
+    }
+  }
+  throw new Error('Unable to launch app, number of tries exceeded');
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/client/afc.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/client/afc.ts
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Debug from 'debug';
+import * as fs from 'fs';
+import type * as net from 'net';
+import * as path from 'path';
+import { promisify } from 'util';
+
+import { AFC_FILE_OPEN_FLAGS, AFC_OPS, AFC_STATUS, AFCProtocolClient } from '../protocol/afc';
+import type { AFCError, AFCResponse } from '../protocol/afc';
+import { ServiceClient } from './client';
+
+const debug = Debug('expo:xdl:ios:lib:client:afc');
+const MAX_OPEN_FILES = 240;
+
+export class AFCClient extends ServiceClient<AFCProtocolClient> {
+  constructor(public socket: net.Socket) {
+    super(socket, new AFCProtocolClient(socket));
+  }
+
+  async getFileInfo(path: string): Promise<string[]> {
+    debug(`getFileInfo: ${path}`);
+
+    const resp = await this.protocolClient.sendMessage({
+      operation: AFC_OPS.GET_FILE_INFO,
+      data: toCString(path),
+    });
+
+    const strings: string[] = [];
+    let currentString = '';
+    const tokens = resp.data;
+    tokens.forEach(token => {
+      if (token === 0) {
+        strings.push(currentString);
+        currentString = '';
+      } else {
+        currentString += String.fromCharCode(token);
+      }
+    });
+    return strings;
+  }
+
+  async writeFile(fd: Buffer, data: Buffer): Promise<AFCResponse> {
+    debug(`writeFile: ${Array.prototype.toString.call(fd)}`);
+
+    return this.protocolClient.sendMessage({
+      operation: AFC_OPS.FILE_WRITE,
+      data: fd,
+      payload: data,
+    });
+  }
+
+  async openFile(path: string): Promise<Buffer> {
+    debug(`openFile: ${path}`);
+    // mode + path + null terminator
+    const data = Buffer.alloc(8 + path.length + 1);
+    // write mode
+    data.writeUInt32LE(AFC_FILE_OPEN_FLAGS.WRONLY, 0);
+    // then path to file
+    toCString(path).copy(data, 8);
+
+    const resp = await this.protocolClient.sendMessage({
+      operation: AFC_OPS.FILE_OPEN,
+      data,
+    });
+
+    if (resp.operation === AFC_OPS.FILE_OPEN_RES) {
+      return resp.data;
+    }
+
+    throw new Error(
+      `There was an unknown error opening file ${path}, response: ${Array.prototype.toString.call(
+        resp.data
+      )}`
+    );
+  }
+
+  async closeFile(fd: Buffer): Promise<AFCResponse> {
+    debug(`closeFile fd: ${Array.prototype.toString.call(fd)}`);
+    return this.protocolClient.sendMessage({
+      operation: AFC_OPS.FILE_CLOSE,
+      data: fd,
+    });
+  }
+
+  async uploadFile(srcPath: string, destPath: string): Promise<void> {
+    debug(`uploadFile: ${srcPath}`);
+
+    // read local file and get fd of destination
+    const [srcFile, destFile] = await Promise.all([
+      await promisify(fs.readFile)(srcPath),
+      await this.openFile(destPath),
+    ]);
+
+    try {
+      await this.writeFile(destFile, srcFile);
+      await this.closeFile(destFile);
+    } catch (err) {
+      await this.closeFile(destFile);
+      throw err;
+    }
+  }
+
+  async makeDirectory(path: string): Promise<AFCResponse> {
+    debug(`makeDirectory: ${path}`);
+
+    return this.protocolClient.sendMessage({
+      operation: AFC_OPS.MAKE_DIR,
+      data: toCString(path),
+    });
+  }
+
+  async uploadDirectory(srcPath: string, destPath: string): Promise<void> {
+    debug(`uploadDirectory: ${srcPath}`);
+    await this.makeDirectory(destPath);
+
+    // AFC doesn't seem to give out more than 240 file handles,
+    // so we delay any requests that would push us over until more open up
+    let numOpenFiles = 0;
+    const pendingFileUploads: (() => void)[] = [];
+    const _this = this;
+    return uploadDir(srcPath);
+
+    async function uploadDir(dirPath: string): Promise<void> {
+      const promises: Promise<void>[] = [];
+      for (const file of fs.readdirSync(dirPath)) {
+        const filePath = path.join(dirPath, file);
+        const remotePath = path.join(destPath, path.relative(srcPath, filePath));
+        if (fs.lstatSync(filePath).isDirectory()) {
+          promises.push(_this.makeDirectory(remotePath).then(() => uploadDir(filePath)));
+        } else {
+          // Create promise to add to promises array
+          // this way it can be resolved once a pending upload has finished
+          let resolve: (val?: any) => void;
+          let reject: (err: AFCError) => void;
+          const promise = new Promise<void>((res, rej) => {
+            resolve = res;
+            reject = rej;
+          });
+          promises.push(promise);
+
+          // wrap upload in a function in case we need to save it for later
+          const uploadFile = (tries = 0) => {
+            numOpenFiles++;
+            _this
+              .uploadFile(filePath, remotePath)
+              .then(() => {
+                resolve();
+                numOpenFiles--;
+                const fn = pendingFileUploads.pop();
+                if (fn) {
+                  fn();
+                }
+              })
+              .catch((err: AFCError) => {
+                // Couldn't get fd for whatever reason, try again
+                // # of retries is arbitrary and can be adjusted
+                if (err.status === AFC_STATUS.NO_RESOURCES && tries < 10) {
+                  debug(`Received NO_RESOURCES from AFC, retrying ${filePath} upload. ${tries}`);
+                  uploadFile(tries++);
+                } else {
+                  numOpenFiles--;
+                  reject(err);
+                }
+              });
+          };
+
+          if (numOpenFiles < MAX_OPEN_FILES) {
+            uploadFile();
+          } else {
+            debug(
+              `numOpenFiles >= ${MAX_OPEN_FILES}, adding to pending queue. Length: ${pendingFileUploads.length}`
+            );
+            pendingFileUploads.push(uploadFile);
+          }
+        }
+      }
+      await Promise.all(promises);
+    }
+  }
+}
+
+function toCString(s: string) {
+  const buf = Buffer.alloc(s.length + 1);
+  const len = buf.write(s);
+  buf.writeUInt8(0, len);
+  return buf;
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/client/client.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/client/client.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import type * as net from 'net';
+
+import type { ProtocolClient } from '../protocol';
+
+export abstract class ServiceClient<T extends ProtocolClient> {
+  constructor(public socket: net.Socket, protected protocolClient: T) {}
+}
+
+export class ResponseError extends Error {
+  constructor(msg: string, public response: any) {
+    super(msg);
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/client/debugserver.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/client/debugserver.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Debug from 'debug';
+import type * as net from 'net';
+import * as path from 'path';
+
+import { GDBProtocolClient } from '../protocol/gdb';
+import { ServiceClient } from './client';
+
+const debug = Debug('expo:xdl:ios:lib:client:debugserver');
+
+export class DebugserverClient extends ServiceClient<GDBProtocolClient> {
+  constructor(public socket: net.Socket) {
+    super(socket, new GDBProtocolClient(socket));
+  }
+
+  async setMaxPacketSize(size: number) {
+    return this.sendCommand('QSetMaxPacketSize:', [size.toString()]);
+  }
+
+  async setWorkingDir(workingDir: string) {
+    return this.sendCommand('QSetWorkingDir:', [workingDir]);
+  }
+
+  async checkLaunchSuccess() {
+    return this.sendCommand('qLaunchSuccess', []);
+  }
+
+  async attachByName(name: string) {
+    const hexName = Buffer.from(name).toString('hex');
+    return this.sendCommand(`vAttachName;${hexName}`, []);
+  }
+
+  async continue() {
+    return this.sendCommand('c', []);
+  }
+
+  halt() {
+    // ^C
+    debug('Sending ^C to debugserver');
+    return this.protocolClient.socket.write('\u0003');
+  }
+
+  async kill() {
+    const msg: any = { cmd: 'k', args: [] };
+    return this.protocolClient.sendMessage(msg, (resp: string, resolve: any, reject: any) => {
+      this.protocolClient.socket.write('+');
+      const parts = resp.split(';');
+      for (const part of parts) {
+        if (part.includes('description')) {
+          // description:{hex encoded message like: "Terminated with signal 9"}
+          resolve(Buffer.from(part.split(':')[1], 'hex').toString('ascii'));
+        }
+      }
+    });
+  }
+
+  // TODO support app args
+  // https://sourceware.org/gdb/onlinedocs/gdb/Packets.html#Packets
+  // A arglen,argnum,arg,
+  async launchApp(appPath: string, executableName: string) {
+    const fullPath = path.join(appPath, executableName);
+    const hexAppPath = Buffer.from(fullPath).toString('hex');
+    const appCommand = `A${hexAppPath.length},0,${hexAppPath}`;
+    return this.sendCommand(appCommand, []);
+  }
+
+  async sendCommand(cmd: string, args: string[]) {
+    const msg = { cmd, args };
+    debug(`Sending command: ${cmd}, args: ${args}`);
+    const resp = await this.protocolClient.sendMessage(msg);
+    // we need to ACK as well
+    this.protocolClient.socket.write('+');
+    return resp;
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/client/index.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/client/index.ts
@@ -1,0 +1,7 @@
+export * from './client';
+export * from './afc';
+export * from './debugserver';
+export * from './installation_proxy';
+export * from './lockdownd';
+export * from './mobile_image_mounter';
+export * from './usbmuxd';

--- a/packages/xdl/src/apple/native-run/ios/lib/client/installation_proxy.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/client/installation_proxy.ts
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Debug from 'debug';
+import type * as net from 'net';
+
+import type { LockdownCommand, LockdownResponse } from '../protocol/lockdown';
+import { LockdownProtocolClient } from '../protocol/lockdown';
+import { ResponseError, ServiceClient } from './client';
+
+const debug = Debug('expo:xdl:ios:lib:client:installation_proxy');
+
+export type OnInstallProgressCallback = (props: {
+  status: string;
+  isComplete: boolean;
+  // copiedFiles: number;
+  progress: number;
+}) => void;
+
+interface IPOptions {
+  ApplicationsType?: 'Any';
+  PackageType?: 'Developer';
+  CFBundleIdentifier?: string;
+  ReturnAttributes?: ('CFBundleIdentifier' | 'CFBundleExecutable' | 'Container' | 'Path')[];
+  BundleIDs?: string[];
+  [key: string]: undefined | string | string[];
+}
+
+interface IPInstallPercentCompleteResponseItem extends LockdownResponse {
+  PercentComplete: number;
+}
+
+interface IPInstallCFBundleIdentifierResponseItem {
+  CFBundleIdentifier: string;
+}
+
+interface IPInstallCompleteResponseItem extends LockdownResponse {
+  Status: 'Complete';
+}
+/*
+ *  [{ "PercentComplete": 5, "Status": "CreatingStagingDirectory" }]
+ *  ...
+ *  [{ "PercentComplete": 90, "Status": "GeneratingApplicationMap" }]
+ *  [{ "CFBundleIdentifier": "my.company.app" }]
+ *  [{ "Status": "Complete" }]
+ */
+type IPInstallPercentCompleteResponse = IPInstallPercentCompleteResponseItem[];
+type IPInstallCFBundleIdentifierResponse = IPInstallCFBundleIdentifierResponseItem[];
+type IPInstallCompleteResponse = IPInstallCompleteResponseItem[];
+
+interface IPMessage extends LockdownCommand {
+  Command: string;
+  ClientOptions: IPOptions;
+}
+
+interface IPLookupResponseItem extends LockdownResponse {
+  LookupResult: IPLookupResult;
+}
+/*
+ * [{
+ *    LookupResult: IPLookupResult,
+ *    Status: "Complete"
+ *  }]
+ */
+type IPLookupResponse = IPLookupResponseItem[];
+
+export interface IPLookupResult {
+  // BundleId
+  [key: string]: {
+    Container: string;
+    CFBundleIdentifier: string;
+    CFBundleExecutable: string;
+    Path: string;
+  };
+}
+
+function isIPLookupResponse(resp: any): resp is IPLookupResponse {
+  return resp.length && resp[0].LookupResult !== undefined;
+}
+
+function isIPInstallPercentCompleteResponse(resp: any): resp is IPInstallPercentCompleteResponse {
+  return resp.length && resp[0].PercentComplete !== undefined;
+}
+
+function isIPInstallCFBundleIdentifierResponse(
+  resp: any
+): resp is IPInstallCFBundleIdentifierResponse {
+  return resp.length && resp[0].CFBundleIdentifier !== undefined;
+}
+
+function isIPInstallCompleteResponse(resp: any): resp is IPInstallCompleteResponse {
+  return resp.length && resp[0].Status === 'Complete';
+}
+
+export class InstallationProxyClient extends ServiceClient<LockdownProtocolClient<IPMessage>> {
+  constructor(public socket: net.Socket) {
+    super(socket, new LockdownProtocolClient(socket));
+  }
+
+  async lookupApp(
+    bundleIds: string[],
+    options: IPOptions = {
+      ReturnAttributes: ['Path', 'Container', 'CFBundleExecutable', 'CFBundleIdentifier'],
+      ApplicationsType: 'Any',
+    }
+  ) {
+    debug(`lookupApp, options: ${JSON.stringify(options)}`);
+
+    let resp = await this.protocolClient.sendMessage({
+      Command: 'Lookup',
+      ClientOptions: {
+        BundleIDs: bundleIds,
+        ...options,
+      },
+    });
+    if (resp && !Array.isArray(resp)) resp = [resp];
+    if (isIPLookupResponse(resp)) {
+      return resp[0].LookupResult;
+    } else {
+      throw new ResponseError(`There was an error looking up app`, resp);
+    }
+  }
+
+  async installApp(
+    packagePath: string,
+    bundleId: string,
+    options: IPOptions = {
+      ApplicationsType: 'Any',
+      PackageType: 'Developer',
+    },
+    onProgress: OnInstallProgressCallback
+  ) {
+    debug(`installApp, packagePath: ${packagePath}, bundleId: ${bundleId}`);
+
+    return this.protocolClient.sendMessage(
+      {
+        Command: 'Install',
+        PackagePath: packagePath,
+        ClientOptions: {
+          CFBundleIdentifier: bundleId,
+          ...options,
+        },
+      },
+      (resp, resolve, reject) => {
+        if (resp && !Array.isArray(resp)) resp = [resp];
+
+        if (isIPInstallCompleteResponse(resp)) {
+          onProgress({
+            isComplete: true,
+            progress: 100,
+            status: resp[0].Status,
+          });
+          resolve();
+        } else if (isIPInstallPercentCompleteResponse(resp)) {
+          onProgress({
+            isComplete: false,
+            progress: resp[0].PercentComplete,
+            status: resp[0].Status,
+          });
+          debug(`Installation status: ${resp[0].Status}, %${resp[0].PercentComplete}`);
+        } else if (isIPInstallCFBundleIdentifierResponse(resp)) {
+          debug(`Installed app: ${resp[0].CFBundleIdentifier}`);
+        } else {
+          reject(
+            new ResponseError(
+              'There was an error installing app: ' + require('util').inspect(resp),
+              resp
+            )
+          );
+        }
+      }
+    );
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/client/lockdownd.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/client/lockdownd.ts
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Debug from 'debug';
+import type * as net from 'net';
+import * as tls from 'tls';
+
+import { LockdownProtocolClient } from '../protocol/lockdown';
+import { ResponseError, ServiceClient } from './client';
+import type { UsbmuxdPairRecord } from './usbmuxd';
+
+const debug = Debug('expo:xdl:ios:lib:client:lockdownd');
+
+export interface DeviceValues {
+  BasebandCertId: number;
+  BasebandKeyHashInformation: {
+    AKeyStatus: number;
+    SKeyHash: Buffer;
+    SKeyStatus: number;
+  };
+  BasebandSerialNumber: Buffer;
+  BasebandVersion: string;
+  BoardId: number;
+  BuildVersion: string;
+  ChipID: number;
+  DeviceClass: string;
+  DeviceColor: string;
+  DeviceName: string;
+  DieID: number;
+  HardwareModel: string;
+  HasSiDP: boolean;
+  PartitionType: string;
+  ProductName: string;
+  ProductType: string;
+  ProductVersion: string;
+  ProductionSOC: boolean;
+  ProtocolVersion: string;
+  TelephonyCapability: boolean;
+  UniqueChipID: number;
+  UniqueDeviceID: string;
+  WiFiAddress: string;
+  [key: string]: any;
+}
+
+interface LockdowndServiceResponse {
+  Request: 'StartService';
+  Service: string;
+  Port: number;
+  EnableServiceSSL?: boolean; // Only on iOS 13+
+}
+
+interface LockdowndSessionResponse {
+  Request: 'StartSession';
+  EnableSessionSSL: boolean;
+}
+
+interface LockdowndAllValuesResponse {
+  Request: 'GetValue';
+  Value: DeviceValues;
+}
+
+interface LockdowndValueResponse {
+  Request: 'GetValue';
+  Key: string;
+  Value: string;
+}
+
+interface LockdowndQueryTypeResponse {
+  Request: 'QueryType';
+  Type: string;
+}
+
+function isLockdowndServiceResponse(resp: any): resp is LockdowndServiceResponse {
+  return resp.Request === 'StartService' && resp.Service !== undefined && resp.Port !== undefined;
+}
+
+function isLockdowndSessionResponse(resp: any): resp is LockdowndSessionResponse {
+  return resp.Request === 'StartSession';
+}
+
+function isLockdowndAllValuesResponse(resp: any): resp is LockdowndAllValuesResponse {
+  return resp.Request === 'GetValue' && resp.Value !== undefined;
+}
+
+function isLockdowndValueResponse(resp: any): resp is LockdowndValueResponse {
+  return resp.Request === 'GetValue' && resp.Key !== undefined && typeof resp.Value === 'string';
+}
+
+function isLockdowndQueryTypeResponse(resp: any): resp is LockdowndQueryTypeResponse {
+  return resp.Request === 'QueryType' && resp.Type !== undefined;
+}
+
+export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
+  constructor(public socket: net.Socket) {
+    super(socket, new LockdownProtocolClient(socket));
+  }
+
+  async startService(name: string) {
+    debug(`startService: ${name}`);
+
+    const resp = await this.protocolClient.sendMessage({
+      Request: 'StartService',
+      Service: name,
+    });
+
+    if (isLockdowndServiceResponse(resp)) {
+      return { port: resp.Port, enableServiceSSL: !!resp.EnableServiceSSL };
+    } else {
+      throw new ResponseError(`Error starting service ${name}`, resp);
+    }
+  }
+
+  async startSession(pairRecord: UsbmuxdPairRecord) {
+    debug(`startSession: ${pairRecord}`);
+
+    const resp = await this.protocolClient.sendMessage({
+      Request: 'StartSession',
+      HostID: pairRecord.HostID,
+      SystemBUID: pairRecord.SystemBUID,
+    });
+
+    if (isLockdowndSessionResponse(resp)) {
+      if (resp.EnableSessionSSL) {
+        this.protocolClient.socket = new tls.TLSSocket(this.protocolClient.socket, {
+          secureContext: tls.createSecureContext({
+            secureProtocol: 'TLSv1_method',
+            cert: pairRecord.RootCertificate,
+            key: pairRecord.RootPrivateKey,
+          }),
+        });
+        debug(`Socket upgraded to TLS connection`);
+      }
+      // TODO: save sessionID for StopSession?
+    } else {
+      throw new ResponseError('Error starting session', resp);
+    }
+  }
+
+  async getAllValues() {
+    debug(`getAllValues`);
+
+    const resp = await this.protocolClient.sendMessage({ Request: 'GetValue' });
+
+    if (isLockdowndAllValuesResponse(resp)) {
+      return resp.Value;
+    } else {
+      throw new ResponseError('Error getting lockdown value', resp);
+    }
+  }
+
+  async getValue(val: string) {
+    debug(`getValue: ${val}`);
+
+    const resp = await this.protocolClient.sendMessage({
+      Request: 'GetValue',
+      Key: val,
+    });
+
+    if (isLockdowndValueResponse(resp)) {
+      return resp.Value;
+    } else {
+      throw new ResponseError('Error getting lockdown value', resp);
+    }
+  }
+
+  async queryType() {
+    debug('queryType');
+
+    const resp = await this.protocolClient.sendMessage({
+      Request: 'QueryType',
+    });
+
+    if (isLockdowndQueryTypeResponse(resp)) {
+      return resp.Type;
+    } else {
+      throw new ResponseError('Error getting lockdown query type', resp);
+    }
+  }
+
+  async doHandshake(pairRecord: UsbmuxdPairRecord) {
+    debug('doHandshake');
+
+    // if (await this.lockdownQueryType() !== 'com.apple.mobile.lockdown') {
+    //   throw new Error('Invalid type received from lockdown handshake');
+    // }
+    // await this.getLockdownValue('ProductVersion');
+    // TODO: validate pair and pair
+    await this.startSession(pairRecord);
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/client/mobile_image_mounter.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/client/mobile_image_mounter.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Debug from 'debug';
+import * as fs from 'fs';
+import type * as net from 'net';
+
+import type { LockdownCommand, LockdownResponse } from '../protocol/lockdown';
+import { isLockdownResponse, LockdownProtocolClient } from '../protocol/lockdown';
+import { ResponseError, ServiceClient } from './client';
+
+const debug = Debug('expo:xdl:ios:lib:client:mobile_image_mounter');
+
+export type MIMMountResponse = LockdownResponse;
+
+export interface MIMMessage extends LockdownCommand {
+  ImageType: string;
+}
+
+export interface MIMLookupResponse extends LockdownResponse {
+  ImageSignature?: string;
+}
+
+export interface MIMUploadCompleteResponse extends LockdownResponse {
+  Status: 'Complete';
+}
+
+export interface MIMUploadReceiveBytesResponse extends LockdownResponse {
+  Status: 'ReceiveBytesAck';
+}
+
+function isMIMUploadCompleteResponse(resp: any): resp is MIMUploadCompleteResponse {
+  return resp.Status === 'Complete';
+}
+
+function isMIMUploadReceiveBytesResponse(resp: any): resp is MIMUploadReceiveBytesResponse {
+  return resp.Status === 'ReceiveBytesAck';
+}
+
+export class MobileImageMounterClient extends ServiceClient<LockdownProtocolClient<MIMMessage>> {
+  constructor(socket: net.Socket) {
+    super(socket, new LockdownProtocolClient(socket));
+  }
+
+  async mountImage(imagePath: string, imageSig: Buffer) {
+    debug(`mountImage: ${imagePath}`);
+
+    const resp = await this.protocolClient.sendMessage({
+      Command: 'MountImage',
+      ImagePath: imagePath,
+      ImageSignature: imageSig,
+      ImageType: 'Developer',
+    });
+
+    if (!isLockdownResponse(resp) || resp.Status !== 'Complete') {
+      throw new ResponseError(`There was an error mounting ${imagePath} on device`, resp);
+    }
+  }
+
+  async uploadImage(imagePath: string, imageSig: Buffer) {
+    debug(`uploadImage: ${imagePath}`);
+
+    const imageSize = fs.statSync(imagePath).size;
+    return this.protocolClient.sendMessage(
+      {
+        Command: 'ReceiveBytes',
+        ImageSize: imageSize,
+        ImageSignature: imageSig,
+        ImageType: 'Developer',
+      },
+      (resp: any, resolve, reject) => {
+        if (isMIMUploadReceiveBytesResponse(resp)) {
+          const imageStream = fs.createReadStream(imagePath);
+          imageStream.pipe(this.protocolClient.socket, { end: false });
+          imageStream.on('error', err => reject(err));
+        } else if (isMIMUploadCompleteResponse(resp)) {
+          resolve();
+        } else {
+          reject(
+            new ResponseError(`There was an error uploading image ${imagePath} to the device`, resp)
+          );
+        }
+      }
+    );
+  }
+
+  async lookupImage() {
+    debug('lookupImage');
+
+    return this.protocolClient.sendMessage<MIMLookupResponse>({
+      Command: 'LookupImage',
+      ImageType: 'Developer',
+    });
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/client/usbmuxd.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/client/usbmuxd.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import plist from '@expo/plist';
+import Debug from 'debug';
+import * as net from 'net';
+
+import { parsePlistBuffer } from '../../../../../utils/parseBinaryPlistAsync';
+import { UsbmuxProtocolClient } from '../protocol/usbmux';
+import { ResponseError, ServiceClient } from './client';
+
+const debug = Debug('expo:xdl:ios:lib:client:usbmuxd');
+
+export interface UsbmuxdDeviceProperties {
+  ConnectionSpeed: number;
+  ConnectionType: 'USB';
+  DeviceID: number;
+  LocationID: number;
+  ProductID: number;
+  SerialNumber: string;
+}
+
+export interface UsbmuxdDevice {
+  DeviceID: number;
+  MessageType: 'Attached'; // TODO: what else?
+  Properties: UsbmuxdDeviceProperties;
+}
+
+export interface UsbmuxdConnectResponse {
+  MessageType: 'Result';
+  Number: number;
+}
+
+export interface UsbmuxdDeviceResponse {
+  DeviceList: UsbmuxdDevice[];
+}
+
+export interface UsbmuxdPairRecordResponse {
+  PairRecordData: Buffer;
+}
+
+export interface UsbmuxdPairRecord {
+  DeviceCertificate: Buffer;
+  EscrowBag: Buffer;
+  HostCertificate: Buffer;
+  HostID: string;
+  HostPrivateKey: Buffer;
+  RootCertificate: Buffer;
+  RootPrivateKey: Buffer;
+  SystemBUID: string;
+  WiFiMACAddress: string;
+}
+
+function isUsbmuxdConnectResponse(resp: any): resp is UsbmuxdConnectResponse {
+  return resp.MessageType === 'Result' && resp.Number !== undefined;
+}
+
+function isUsbmuxdDeviceResponse(resp: any): resp is UsbmuxdDeviceResponse {
+  return resp.DeviceList !== undefined;
+}
+
+function isUsbmuxdPairRecordResponse(resp: any): resp is UsbmuxdPairRecordResponse {
+  return resp.PairRecordData !== undefined;
+}
+
+export class UsbmuxdClient extends ServiceClient<UsbmuxProtocolClient> {
+  constructor(public socket: net.Socket) {
+    super(socket, new UsbmuxProtocolClient(socket));
+  }
+
+  static connectUsbmuxdSocket() {
+    debug('connectUsbmuxdSocket');
+    if (process.platform === 'win32') {
+      return net.connect({ port: 27015, host: 'localhost' });
+    } else {
+      return net.connect({ path: '/var/run/usbmuxd' });
+    }
+  }
+
+  async connect(device: UsbmuxdDevice, port: number) {
+    debug(`connect: ${device.DeviceID} on port ${port}`);
+
+    const resp = await this.protocolClient.sendMessage({
+      messageType: 'Connect',
+      extraFields: {
+        DeviceID: device.DeviceID,
+        PortNumber: htons(port),
+      },
+    });
+
+    if (isUsbmuxdConnectResponse(resp) && resp.Number === 0) {
+      return this.protocolClient.socket;
+    } else {
+      throw new ResponseError(
+        `There was an error connecting to ${device.DeviceID} on port ${port}`,
+        resp
+      );
+    }
+  }
+
+  async getDevices() {
+    debug('getDevices');
+
+    const resp = await this.protocolClient.sendMessage({
+      messageType: 'ListDevices',
+    });
+
+    if (isUsbmuxdDeviceResponse(resp)) {
+      return resp.DeviceList;
+    } else {
+      throw new ResponseError('Invalid response from getDevices', resp);
+    }
+  }
+
+  async getDevice(udid?: string) {
+    debug(`getDevice ${udid ? 'udid: ' + udid : ''}`);
+    const devices = await this.getDevices();
+
+    if (!devices.length) {
+      throw new Error('No devices found');
+    }
+
+    if (!udid) {
+      return devices[0];
+    }
+
+    for (const device of devices) {
+      if (device.Properties && device.Properties.SerialNumber === udid) {
+        return device;
+      }
+    }
+
+    throw new Error(`No device with udid ${udid} found`);
+  }
+
+  async readPairRecord(udid: string): Promise<UsbmuxdPairRecord> {
+    debug(`readPairRecord: ${udid}`);
+
+    const resp = await this.protocolClient.sendMessage({
+      messageType: 'ReadPairRecord',
+      extraFields: { PairRecordID: udid },
+    });
+
+    if (isUsbmuxdPairRecordResponse(resp)) {
+      // the pair record can be created as a binary plist
+      const BPLIST_MAGIC = Buffer.from('bplist00');
+      if (BPLIST_MAGIC.compare(resp.PairRecordData, 0, 8) === 0) {
+        debug('Binary plist pair record detected.');
+        return parsePlistBuffer(resp.PairRecordData)[0];
+      } else {
+        // TODO: use parsePlistBuffer
+        return plist.parse(resp.PairRecordData.toString()) as any; // TODO: type guard
+      }
+    } else {
+      throw new ResponseError(`There was an error reading pair record for udid: ${udid}`, resp);
+    }
+  }
+}
+
+function htons(n: number) {
+  return ((n & 0xff) << 8) | ((n >> 8) & 0xff);
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/index.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './client';
+export * from './protocol';
+export * from './manager';

--- a/packages/xdl/src/apple/native-run/ios/lib/lib-errors.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/lib-errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Type union of error codes we get back from the protocol.
+ */
+export type IOSLibErrorCode = 'DeviceLocked';
+
+export class IOSLibError extends Error implements NodeJS.ErrnoException {
+  constructor(message: string, readonly code: IOSLibErrorCode) {
+    super(message);
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/manager.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/manager.ts
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type * as net from 'net';
+import { Duplex } from 'stream';
+import * as tls from 'tls';
+
+import type { ServiceClient } from './client';
+import { AFCClient } from './client/afc';
+import { DebugserverClient } from './client/debugserver';
+import { InstallationProxyClient } from './client/installation_proxy';
+import { LockdowndClient } from './client/lockdownd';
+import { MobileImageMounterClient } from './client/mobile_image_mounter';
+import type { UsbmuxdDevice, UsbmuxdPairRecord } from './client/usbmuxd';
+import { UsbmuxdClient } from './client/usbmuxd';
+
+export class ClientManager {
+  private connections: net.Socket[];
+  constructor(
+    public pairRecord: UsbmuxdPairRecord,
+    public device: UsbmuxdDevice,
+    private lockdowndClient: LockdowndClient
+  ) {
+    this.connections = [lockdowndClient.socket];
+  }
+
+  static async create(udid?: string) {
+    const usbmuxClient = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
+    const device = await usbmuxClient.getDevice(udid);
+    const pairRecord = await usbmuxClient.readPairRecord(device.Properties.SerialNumber);
+    const lockdownSocket = await usbmuxClient.connect(device, 62078);
+    const lockdownClient = new LockdowndClient(lockdownSocket);
+    await lockdownClient.doHandshake(pairRecord);
+    return new ClientManager(pairRecord, device, lockdownClient);
+  }
+
+  async getUsbmuxdClient() {
+    const usbmuxClient = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
+    this.connections.push(usbmuxClient.socket);
+    return usbmuxClient;
+  }
+
+  async getLockdowndClient() {
+    const usbmuxClient = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
+    const lockdownSocket = await usbmuxClient.connect(this.device, 62078);
+    const lockdownClient = new LockdowndClient(lockdownSocket);
+    this.connections.push(lockdownClient.socket);
+    return lockdownClient;
+  }
+
+  async getLockdowndClientWithHandshake() {
+    const lockdownClient = await this.getLockdowndClient();
+    await lockdownClient.doHandshake(this.pairRecord);
+    return lockdownClient;
+  }
+
+  async getAFCClient() {
+    return this.getServiceClient('com.apple.afc', AFCClient);
+  }
+
+  async getInstallationProxyClient() {
+    return this.getServiceClient('com.apple.mobile.installation_proxy', InstallationProxyClient);
+  }
+
+  async getMobileImageMounterClient() {
+    return this.getServiceClient('com.apple.mobile.mobile_image_mounter', MobileImageMounterClient);
+  }
+
+  async getDebugserverClient() {
+    try {
+      // iOS 14 added support for a secure debug service so try to connect to that first
+      return await this.getServiceClient(
+        'com.apple.debugserver.DVTSecureSocketProxy',
+        DebugserverClient
+      );
+    } catch {
+      // otherwise, fall back to the previous implementation
+      return this.getServiceClient('com.apple.debugserver', DebugserverClient, true);
+    }
+  }
+
+  private async getServiceClient<T extends ServiceClient<any>>(
+    name: string,
+    ServiceType: new (...args: any[]) => T,
+    disableSSL = false
+  ) {
+    const { port: servicePort, enableServiceSSL } = await this.lockdowndClient.startService(name);
+    const usbmuxClient = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
+    let usbmuxdSocket = await usbmuxClient.connect(this.device, servicePort);
+
+    if (enableServiceSSL) {
+      const tlsOptions: tls.ConnectionOptions = {
+        rejectUnauthorized: false,
+        secureContext: tls.createSecureContext({
+          secureProtocol: 'TLSv1_method',
+          cert: this.pairRecord.RootCertificate,
+          key: this.pairRecord.RootPrivateKey,
+        }),
+      };
+
+      // Some services seem to not support TLS/SSL after the initial handshake
+      // More info: https://github.com/libimobiledevice/libimobiledevice/issues/793
+      if (disableSSL) {
+        // According to https://nodejs.org/api/tls.html#tls_tls_connect_options_callback we can
+        // pass any Duplex in to tls.connect instead of a Socket. So we'll use our proxy to keep
+        // the TLS wrapper and underlying usbmuxd socket separate.
+        const proxy: any = new UsbmuxdProxy(usbmuxdSocket);
+        tlsOptions.socket = proxy;
+
+        await new Promise<void>((res, rej) => {
+          const timeoutId = setTimeout(() => {
+            rej('The TLS handshake failed to complete after 5s.');
+          }, 5000);
+          tls.connect(tlsOptions, function (this: tls.TLSSocket) {
+            clearTimeout(timeoutId);
+            // After the handshake, we don't need TLS or the proxy anymore,
+            // since we'll just pass in the naked usbmuxd socket to the service client
+            this.destroy();
+            res();
+          });
+        });
+      } else {
+        tlsOptions.socket = usbmuxdSocket;
+        usbmuxdSocket = tls.connect(tlsOptions);
+      }
+    }
+    const client = new ServiceType(usbmuxdSocket);
+    this.connections.push(client.socket);
+    return client;
+  }
+
+  end() {
+    for (const socket of this.connections) {
+      // may already be closed
+      try {
+        socket.end();
+      } catch (err) {
+        // ignore
+      }
+    }
+  }
+}
+
+class UsbmuxdProxy extends Duplex {
+  constructor(private usbmuxdSock: net.Socket) {
+    super();
+
+    this.usbmuxdSock.on('data', data => {
+      this.push(data);
+    });
+  }
+
+  _write(chunk: any, encoding: string, callback: (err?: Error) => void) {
+    this.usbmuxdSock.write(chunk);
+    callback();
+  }
+
+  _read(size: number) {
+    // Stub so we don't error, since we push everything we get from usbmuxd as it comes in.
+    // TODO: better way to do this?
+  }
+
+  _destroy() {
+    this.usbmuxdSock.removeAllListeners();
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/manager.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/manager.ts
@@ -112,16 +112,16 @@ export class ClientManager {
         const proxy: any = new UsbmuxdProxy(usbmuxdSocket);
         tlsOptions.socket = proxy;
 
-        await new Promise<void>((res, rej) => {
+        await new Promise<void>((resolve, reject) => {
           const timeoutId = setTimeout(() => {
-            rej('The TLS handshake failed to complete after 5s.');
+            reject(new Error('The TLS handshake failed to complete after 5s.'));
           }, 5000);
           tls.connect(tlsOptions, function (this: tls.TLSSocket) {
             clearTimeout(timeoutId);
             // After the handshake, we don't need TLS or the proxy anymore,
             // since we'll just pass in the naked usbmuxd socket to the service client
             this.destroy();
-            res();
+            resolve();
           });
         });
       } else {

--- a/packages/xdl/src/apple/native-run/ios/lib/protocol/afc.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/protocol/afc.ts
@@ -1,0 +1,471 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Debug from 'debug';
+import type * as net from 'net';
+
+import type { ProtocolReaderCallback, ProtocolWriter } from './protocol';
+import { ProtocolClient, ProtocolReader, ProtocolReaderFactory } from './protocol';
+
+const debug = Debug('expo:xdl:ios:lib:protocol:afc');
+
+export const AFC_MAGIC = 'CFA6LPAA';
+export const AFC_HEADER_SIZE = 40;
+
+export interface AFCHeader {
+  magic: typeof AFC_MAGIC;
+  totalLength: number;
+  headerLength: number;
+  requestId: number;
+  operation: AFC_OPS;
+}
+
+export interface AFCMessage {
+  operation: AFC_OPS;
+  data?: any;
+  payload?: any;
+}
+
+export interface AFCResponse {
+  operation: AFC_OPS;
+  id: number;
+  data: Buffer;
+}
+
+export interface AFCStatusResponse {
+  operation: AFC_OPS.STATUS;
+  id: number;
+  data: number;
+}
+
+/**
+ * AFC Operations
+ */
+export enum AFC_OPS {
+  /**
+   * Invalid
+   */
+  INVALID = 0x00000000,
+
+  /**
+   * Status
+   */
+  STATUS = 0x00000001,
+
+  /**
+   * Data
+   */
+  DATA = 0x00000002,
+
+  /**
+   * ReadDir
+   */
+  READ_DIR = 0x00000003,
+
+  /**
+   * ReadFile
+   */
+  READ_FILE = 0x00000004,
+
+  /**
+   * WriteFile
+   */
+  WRITE_FILE = 0x00000005,
+
+  /**
+   * WritePart
+   */
+  WRITE_PART = 0x00000006,
+
+  /**
+   * TruncateFile
+   */
+  TRUNCATE = 0x00000007,
+
+  /**
+   * RemovePath
+   */
+  REMOVE_PATH = 0x00000008,
+
+  /**
+   * MakeDir
+   */
+  MAKE_DIR = 0x00000009,
+
+  /**
+   * GetFileInfo
+   */
+  GET_FILE_INFO = 0x0000000a,
+
+  /**
+   * GetDeviceInfo
+   */
+  GET_DEVINFO = 0x0000000b,
+
+  /**
+   * WriteFileAtomic (tmp file+rename)
+   */
+  WRITE_FILE_ATOM = 0x0000000c,
+
+  /**
+   * FileRefOpen
+   */
+  FILE_OPEN = 0x0000000d,
+
+  /**
+   * FileRefOpenResult
+   */
+  FILE_OPEN_RES = 0x0000000e,
+
+  /**
+   * FileRefRead
+   */
+  FILE_READ = 0x0000000f,
+
+  /**
+   * FileRefWrite
+   */
+  FILE_WRITE = 0x00000010,
+
+  /**
+   * FileRefSeek
+   */
+  FILE_SEEK = 0x00000011,
+
+  /**
+   * FileRefTell
+   */
+  FILE_TELL = 0x00000012,
+
+  /**
+   * FileRefTellResult
+   */
+  FILE_TELL_RES = 0x00000013,
+
+  /**
+   * FileRefClose
+   */
+  FILE_CLOSE = 0x00000014,
+
+  /**
+   * FileRefSetFileSize (ftruncate)
+   */
+  FILE_SET_SIZE = 0x00000015,
+
+  /**
+   * GetConnectionInfo
+   */
+  GET_CON_INFO = 0x00000016,
+
+  /**
+   * SetConnectionOptions
+   */
+  SET_CON_OPTIONS = 0x00000017,
+
+  /**
+   * RenamePath
+   */
+  RENAME_PATH = 0x00000018,
+
+  /**
+   * SetFSBlockSize (0x800000)
+   */
+  SET_FS_BS = 0x00000019,
+
+  /**
+   * SetSocketBlockSize (0x800000)
+   */
+  SET_SOCKET_BS = 0x0000001a,
+
+  /**
+   * FileRefLock
+   */
+  FILE_LOCK = 0x0000001b,
+
+  /**
+   * MakeLink
+   */
+  MAKE_LINK = 0x0000001c,
+
+  /**
+   * GetFileHash
+   */
+  GET_FILE_HASH = 0x0000001d,
+
+  /**
+   * SetModTime
+   */
+  SET_FILE_MOD_TIME = 0x0000001e,
+
+  /**
+   * GetFileHashWithRange
+   */
+  GET_FILE_HASH_RANGE = 0x0000001f,
+
+  // iOS 6+
+
+  /**
+   * FileRefSetImmutableHint
+   */
+  FILE_SET_IMMUTABLE_HINT = 0x00000020,
+
+  /**
+   * GetSizeOfPathContents
+   */
+  GET_SIZE_OF_PATH_CONTENTS = 0x00000021,
+
+  /**
+   * RemovePathAndContents
+   */
+  REMOVE_PATH_AND_CONTENTS = 0x00000022,
+
+  /**
+   * DirectoryEnumeratorRefOpen
+   */
+  DIR_OPEN = 0x00000023,
+
+  /**
+   * DirectoryEnumeratorRefOpenResult
+   */
+  DIR_OPEN_RESULT = 0x00000024,
+
+  /**
+   * DirectoryEnumeratorRefRead
+   */
+  DIR_READ = 0x00000025,
+
+  /**
+   * DirectoryEnumeratorRefClose
+   */
+  DIR_CLOSE = 0x00000026,
+
+  // iOS 7+
+
+  /**
+   * FileRefReadWithOffset
+   */
+  FILE_READ_OFFSET = 0x00000027,
+
+  /**
+   * FileRefWriteWithOffset
+   */
+  FILE_WRITE_OFFSET = 0x00000028,
+}
+
+/**
+ * Error Codes
+ */
+export enum AFC_STATUS {
+  SUCCESS = 0,
+  UNKNOWN_ERROR = 1,
+  OP_HEADER_INVALID = 2,
+  NO_RESOURCES = 3,
+  READ_ERROR = 4,
+  WRITE_ERROR = 5,
+  UNKNOWN_PACKET_TYPE = 6,
+  INVALID_ARG = 7,
+  OBJECT_NOT_FOUND = 8,
+  OBJECT_IS_DIR = 9,
+  PERM_DENIED = 10,
+  SERVICE_NOT_CONNECTED = 11,
+  OP_TIMEOUT = 12,
+  TOO_MUCH_DATA = 13,
+  END_OF_DATA = 14,
+  OP_NOT_SUPPORTED = 15,
+  OBJECT_EXISTS = 16,
+  OBJECT_BUSY = 17,
+  NO_SPACE_LEFT = 18,
+  OP_WOULD_BLOCK = 19,
+  IO_ERROR = 20,
+  OP_INTERRUPTED = 21,
+  OP_IN_PROGRESS = 22,
+  INTERNAL_ERROR = 23,
+  MUX_ERROR = 30,
+  NO_MEM = 31,
+  NOT_ENOUGH_DATA = 32,
+  DIR_NOT_EMPTY = 33,
+  FORCE_SIGNED_TYPE = -1,
+}
+
+export enum AFC_FILE_OPEN_FLAGS {
+  /**
+   * r (O_RDONLY)
+   */
+  RDONLY = 0x00000001,
+
+  /**
+   * r+ (O_RDWR | O_CREAT)
+   */
+  RW = 0x00000002,
+
+  /**
+   * w (O_WRONLY | O_CREAT | O_TRUNC)
+   */
+  WRONLY = 0x00000003,
+
+  /**
+   * w+ (O_RDWR | O_CREAT  | O_TRUNC)
+   */
+  WR = 0x00000004,
+
+  /**
+   * a (O_WRONLY | O_APPEND | O_CREAT)
+   */
+  APPEND = 0x00000005,
+
+  /**
+   * a+ (O_RDWR | O_APPEND | O_CREAT)
+   */
+  RDAPPEND = 0x00000006,
+}
+
+function isAFCResponse(resp: any): resp is AFCResponse {
+  return AFC_OPS[resp.operation] !== undefined && resp.id !== undefined && resp.data !== undefined;
+}
+
+function isStatusResponse(resp: any): resp is AFCStatusResponse {
+  return isAFCResponse(resp) && resp.operation === AFC_OPS.STATUS;
+}
+
+function isErrorStatusResponse(resp: AFCResponse): boolean {
+  return isStatusResponse(resp) && resp.data !== AFC_STATUS.SUCCESS;
+}
+
+class AFCInternalError extends Error {
+  constructor(msg: string, public requestId: number) {
+    super(msg);
+  }
+}
+
+export class AFCError extends Error {
+  constructor(msg: string, public status: AFC_STATUS) {
+    super(msg);
+  }
+}
+
+export class AFCProtocolClient extends ProtocolClient {
+  private requestId = 0;
+  private requestCallbacks: { [key: number]: ProtocolReaderCallback } = {};
+
+  constructor(socket: net.Socket) {
+    super(socket, new ProtocolReaderFactory(AFCProtocolReader), new AFCProtocolWriter());
+
+    const reader = this.readerFactory.create((resp, err) => {
+      if (err && err instanceof AFCInternalError) {
+        this.requestCallbacks[err.requestId](resp, err);
+      } else if (isErrorStatusResponse(resp)) {
+        this.requestCallbacks[resp.id](resp, new AFCError(AFC_STATUS[resp.data], resp.data));
+      } else {
+        this.requestCallbacks[resp.id](resp);
+      }
+    });
+    socket.on('data', reader.onData);
+  }
+
+  sendMessage(msg: AFCMessage): Promise<AFCResponse> {
+    return new Promise<AFCResponse>((resolve, reject) => {
+      const requestId = this.requestId++;
+      this.requestCallbacks[requestId] = async (resp: any, err?: Error) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        if (isAFCResponse(resp)) {
+          resolve(resp);
+        } else {
+          reject(new Error('Malformed AFC response'));
+        }
+      };
+      this.writer.write(this.socket, { ...msg, requestId });
+    });
+  }
+}
+
+export class AFCProtocolReader extends ProtocolReader {
+  private header!: AFCHeader; // TODO: ! -> ?
+
+  constructor(callback: ProtocolReaderCallback) {
+    super(AFC_HEADER_SIZE, callback);
+  }
+
+  parseHeader(data: Buffer) {
+    const magic = data.slice(0, 8).toString('ascii');
+    if (magic !== AFC_MAGIC) {
+      throw new AFCInternalError(
+        `Invalid AFC packet received (magic != ${AFC_MAGIC})`,
+        data.readUInt32LE(24)
+      );
+    }
+    // technically these are uint64
+    this.header = {
+      magic,
+      totalLength: data.readUInt32LE(8),
+      headerLength: data.readUInt32LE(16),
+      requestId: data.readUInt32LE(24),
+      operation: data.readUInt32LE(32),
+    };
+
+    debug(`parse header: ${JSON.stringify(this.header)}`);
+    if (this.header.headerLength < AFC_HEADER_SIZE) {
+      throw new AFCInternalError('Invalid AFC header', this.header.requestId);
+    }
+    return this.header.totalLength - AFC_HEADER_SIZE;
+  }
+
+  parseBody(data: Buffer): AFCResponse | AFCStatusResponse {
+    const body: any = {
+      operation: this.header.operation,
+      id: this.header.requestId,
+      data,
+    };
+    if (isStatusResponse(body)) {
+      const status = data.readUInt32LE(0);
+      debug(`${AFC_OPS[this.header.operation]} response: ${AFC_STATUS[status]}`);
+      body.data = status;
+    } else if (data.length <= 8) {
+      debug(`${AFC_OPS[this.header.operation]} response: ${Array.prototype.toString.call(body)}`);
+    } else {
+      debug(`${AFC_OPS[this.header.operation]} response length: ${data.length} bytes`);
+    }
+    return body;
+  }
+}
+
+export class AFCProtocolWriter implements ProtocolWriter {
+  write(socket: net.Socket, msg: AFCMessage & { requestId: number }) {
+    const { data, payload, operation, requestId } = msg;
+
+    const dataLength = data ? data.length : 0;
+    const payloadLength = payload ? payload.length : 0;
+
+    const header = Buffer.alloc(AFC_HEADER_SIZE);
+    const magic = Buffer.from(AFC_MAGIC);
+    magic.copy(header);
+    header.writeUInt32LE(AFC_HEADER_SIZE + dataLength + payloadLength, 8);
+    header.writeUInt32LE(AFC_HEADER_SIZE + dataLength, 16);
+    header.writeUInt32LE(requestId, 24);
+    header.writeUInt32LE(operation, 32);
+    socket.write(header);
+    socket.write(data);
+    if (data.length <= 8) {
+      debug(
+        `socket write, header: { requestId: ${requestId}, operation: ${
+          AFC_OPS[operation]
+        }}, body: ${Array.prototype.toString.call(data)}`
+      );
+    } else {
+      debug(
+        `socket write, header: { requestId: ${requestId}, operation: ${AFC_OPS[operation]}}, body: ${data.length} bytes`
+      );
+    }
+
+    debug(`socket write, bytes written ${header.length} (header), ${data.length} (body)`);
+    if (payload) {
+      socket.write(payload);
+    }
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/protocol/gdb.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/protocol/gdb.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import Debug from 'debug';
+import type * as net from 'net';
+
+import type { ProtocolReaderCallback, ProtocolWriter } from './protocol';
+import { ProtocolClient, ProtocolReader, ProtocolReaderFactory } from './protocol';
+
+const debug = Debug('expo:xdl:ios:lib:protocol:gdb');
+const ACK_SUCCESS = '+'.charCodeAt(0);
+
+export interface GDBMessage {
+  cmd: string;
+  args: string[];
+}
+
+export class GDBProtocolClient extends ProtocolClient<GDBMessage> {
+  constructor(socket: net.Socket) {
+    super(socket, new ProtocolReaderFactory(GDBProtocolReader), new GDBProtocolWriter());
+  }
+}
+
+export class GDBProtocolReader extends ProtocolReader {
+  constructor(callback: ProtocolReaderCallback) {
+    super(1 /* "Header" is '+' or '-' */, callback);
+  }
+
+  onData(data?: Buffer) {
+    // the GDB protocol does not support body length in its header so we cannot rely on
+    // the parent implementation to determine when a payload is complete
+    try {
+      // if there's data, add it to the existing buffer
+      this.buffer = data ? Buffer.concat([this.buffer, data]) : this.buffer;
+
+      // do we have enough bytes to proceed
+      if (this.buffer.length < this.headerSize) {
+        return; // incomplete header, wait for more
+      }
+
+      // first, check the header
+      if (this.parseHeader(this.buffer) === -1) {
+        // we have a valid header so check the body. GDB packets will always be a leading '$', data bytes,
+        // a trailing '#', and a two digit checksum. minimum valid body is the empty response '$#00'
+        // https://developer.apple.com/library/archive/documentation/DeveloperTools/gdb/gdb/gdb_33.html
+        const packetData = this.buffer.toString().match('\\$.*#[0-9a-f]{2}');
+        if (packetData == null) {
+          return; // incomplete body, wait for more
+        }
+        // extract the body and update the buffer
+        const body = Buffer.from(packetData[0]);
+        this.buffer = this.buffer.slice(this.headerSize + body.length);
+        // parse the payload and recurse if there is more data to process
+        this.callback(this.parseBody(body));
+        if (this.buffer.length) {
+          this.onData();
+        }
+      }
+    } catch (err: any) {
+      this.callback(null, err);
+    }
+  }
+
+  parseHeader(data: Buffer) {
+    if (data[0] !== ACK_SUCCESS) {
+      throw new Error('Unsuccessful debugserver response');
+    } // TODO: retry?
+    return -1;
+  }
+
+  parseBody(buffer: Buffer) {
+    debug(`Response body: ${buffer.toString()}`);
+    // check for checksum
+    const checksum = buffer.slice(-3).toString();
+    if (checksum.match(/#[0-9a-f]{2}/)) {
+      // remove '$' prefix and checksum
+      const msg = buffer.slice(1, -3).toString();
+      if (validateChecksum(checksum, msg)) {
+        return msg;
+      } else {
+        throw new Error('Invalid checksum received from debugserver');
+      }
+    } else {
+      throw new Error("Didn't receive checksum");
+    }
+  }
+}
+
+export class GDBProtocolWriter implements ProtocolWriter {
+  write(socket: net.Socket, msg: GDBMessage) {
+    const { cmd, args } = msg;
+    debug(`Socket write: ${cmd}, args: ${args}`);
+    // hex encode and concat all args
+    const encodedArgs = args
+      .map(arg => Buffer.from(arg).toString('hex'))
+      .join()
+      .toUpperCase();
+    const checksumStr = calculateChecksum(cmd + encodedArgs);
+    const formattedCmd = `$${cmd}${encodedArgs}#${checksumStr}`;
+    socket.write(formattedCmd);
+  }
+}
+
+// hex value of (sum of cmd chars mod 256)
+function calculateChecksum(cmdStr: string) {
+  let checksum = 0;
+  for (let i = 0; i < cmdStr.length; i++) {
+    checksum += cmdStr.charCodeAt(i);
+  }
+  let result = (checksum % 256).toString(16);
+  // pad if necessary
+  if (result.length === 1) {
+    result = `0${result}`;
+  }
+  return result;
+}
+
+function validateChecksum(checksum: string, msg: string) {
+  // remove '#' from checksum
+  const checksumVal = checksum.slice(1);
+  // remove '$' from msg and calculate its checksum
+  const computedChecksum = calculateChecksum(msg);
+  debug(`Checksum: ${checksumVal}, computed checksum: ${computedChecksum}`);
+  return checksumVal === computedChecksum;
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/protocol/index.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/protocol/index.ts
@@ -1,0 +1,5 @@
+export * from './protocol';
+export * from './afc';
+export * from './gdb';
+export * from './lockdown';
+export * from './usbmux';

--- a/packages/xdl/src/apple/native-run/ios/lib/protocol/lockdown.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/protocol/lockdown.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import plist from '@expo/plist';
+import Debug from 'debug';
+import type * as net from 'net';
+
+import { IOSLibError } from '../lib-errors';
+import type { ProtocolWriter } from './protocol';
+import { PlistProtocolReader, ProtocolClient, ProtocolReaderFactory } from './protocol';
+
+const debug = Debug('expo:xdl:ios:lib:protocol:lockdown');
+export const LOCKDOWN_HEADER_SIZE = 4;
+
+export interface LockdownCommand {
+  Command: string;
+  [key: string]: any;
+}
+
+export interface LockdownResponse {
+  Status: string;
+  [key: string]: any;
+}
+
+export interface LockdownErrorResponse {
+  Error: string;
+}
+
+export interface LockdownRequest {
+  Request: string;
+  [key: string]: any;
+}
+
+function isDefined(val: any) {
+  return typeof val !== 'undefined';
+}
+
+export function isLockdownResponse(resp: any): resp is LockdownResponse {
+  return isDefined(resp.Status);
+}
+
+export function isLockdownErrorResponse(resp: any): resp is LockdownErrorResponse {
+  return isDefined(resp.Error);
+}
+
+export class LockdownProtocolClient<
+  MessageType extends LockdownRequest | LockdownCommand = LockdownRequest
+> extends ProtocolClient<MessageType> {
+  constructor(socket: net.Socket) {
+    super(socket, new ProtocolReaderFactory(LockdownProtocolReader), new LockdownProtocolWriter());
+  }
+}
+
+export class LockdownProtocolReader extends PlistProtocolReader {
+  constructor(callback: (data: any) => any) {
+    super(LOCKDOWN_HEADER_SIZE, callback);
+  }
+
+  parseHeader(data: Buffer) {
+    return data.readUInt32BE(0);
+  }
+
+  parseBody(data: Buffer) {
+    const resp = super.parseBody(data);
+    debug(`Response: ${JSON.stringify(resp)}`);
+    if (isLockdownErrorResponse(resp)) {
+      if (resp.Error === 'DeviceLocked') {
+        throw new IOSLibError('Device is currently locked.', 'DeviceLocked');
+      }
+
+      throw new Error(resp.Error);
+    }
+    return resp;
+  }
+}
+
+export class LockdownProtocolWriter implements ProtocolWriter {
+  write(socket: net.Socket, plistData: any) {
+    debug(`socket write: ${JSON.stringify(plistData)}`);
+    const plistMessage = plist.build(plistData);
+    const header = Buffer.alloc(LOCKDOWN_HEADER_SIZE);
+    header.writeUInt32BE(plistMessage.length, 0);
+    socket.write(header);
+    socket.write(plistMessage);
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/protocol/lockdown.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/protocol/lockdown.ts
@@ -29,6 +29,8 @@ export interface LockdownResponse {
 
 export interface LockdownErrorResponse {
   Error: string;
+  Request?: string;
+  Service?: string;
 }
 
 export interface LockdownRequest {
@@ -71,6 +73,15 @@ export class LockdownProtocolReader extends PlistProtocolReader {
     if (isLockdownErrorResponse(resp)) {
       if (resp.Error === 'DeviceLocked') {
         throw new IOSLibError('Device is currently locked.', 'DeviceLocked');
+      }
+
+      if (resp.Error === 'InvalidService') {
+        let errorMessage = `${resp.Error}: ${resp.Service} (request: ${resp.Request})`;
+        if (resp.Service === 'com.apple.debugserver') {
+          errorMessage +=
+            '\nTry reconnecting your device. You can also debug service logs with `export DEBUG=expo:xdl:ios:*`';
+        }
+        throw new Error(errorMessage);
       }
 
       throw new Error(resp.Error);

--- a/packages/xdl/src/apple/native-run/ios/lib/protocol/protocol.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/protocol/protocol.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import plist from '@expo/plist';
+import type * as net from 'net';
+
+import { parsePlistBuffer } from '../../../../../utils/parseBinaryPlistAsync';
+
+const BPLIST_MAGIC = Buffer.from('bplist00');
+
+export type ProtocolReaderCallback = (resp: any, err?: Error) => void;
+
+export class ProtocolReaderFactory<T> {
+  constructor(private ProtocolReader: new (callback: ProtocolReaderCallback) => T) {}
+
+  create(callback: (resp: any, err?: Error) => void): T {
+    return new this.ProtocolReader(callback);
+  }
+}
+
+export abstract class ProtocolReader {
+  protected body!: Buffer; // TODO: ! -> ?
+  protected bodyLength!: number; // TODO: ! -> ?
+  protected buffer = Buffer.alloc(0);
+  constructor(protected headerSize: number, protected callback: ProtocolReaderCallback) {
+    this.onData = this.onData.bind(this);
+  }
+
+  /** Returns length of body, or -1 if header doesn't contain length */
+  protected abstract parseHeader(data: Buffer): number;
+  protected abstract parseBody(data: Buffer): any;
+
+  onData(data?: Buffer) {
+    try {
+      // if there's data, add it on to existing buffer
+      this.buffer = data ? Buffer.concat([this.buffer, data]) : this.buffer;
+      // we haven't gotten the body length from the header yet
+      if (!this.bodyLength) {
+        if (this.buffer.length < this.headerSize) {
+          // partial header, wait for rest
+          return;
+        }
+        this.bodyLength = this.parseHeader(this.buffer);
+        // move on to body
+        this.buffer = this.buffer.slice(this.headerSize);
+        if (!this.buffer.length) {
+          // only got header, wait for body
+          return;
+        }
+      }
+      if (this.buffer.length < this.bodyLength) {
+        // wait for rest of body
+        return;
+      }
+
+      if (this.bodyLength === -1) {
+        this.callback(this.parseBody(this.buffer));
+        this.buffer = Buffer.alloc(0);
+      } else {
+        this.body = this.buffer.slice(0, this.bodyLength);
+        this.bodyLength -= this.body.length;
+        if (!this.bodyLength) {
+          this.callback(this.parseBody(this.body));
+        }
+        this.buffer = this.buffer.slice(this.body.length);
+        // There are multiple messages here, call parse again
+        if (this.buffer.length) {
+          this.onData();
+        }
+      }
+    } catch (err: any) {
+      this.callback(null, err);
+    }
+  }
+}
+
+export abstract class PlistProtocolReader extends ProtocolReader {
+  protected parseBody(body: Buffer) {
+    if (BPLIST_MAGIC.compare(body, 0, 8) === 0) {
+      return parsePlistBuffer(body);
+    } else {
+      return plist.parse(body.toString('utf8'));
+    }
+  }
+}
+
+export interface ProtocolWriter {
+  write(sock: net.Socket, msg: any): void;
+}
+
+export abstract class ProtocolClient<MessageType = any> {
+  constructor(
+    public socket: net.Socket,
+    protected readerFactory: ProtocolReaderFactory<ProtocolReader>,
+    protected writer: ProtocolWriter
+  ) {}
+
+  sendMessage<ResponseType = any>(msg: MessageType): Promise<ResponseType>;
+  sendMessage<CallbackType = void, ResponseType = any>(
+    msg: MessageType,
+    callback: (response: ResponseType, resolve: any, reject: any) => void
+  ): Promise<CallbackType>;
+  sendMessage<CallbackType = void, ResponseType = any>(
+    msg: MessageType,
+    callback?: (response: ResponseType, resolve: any, reject: any) => void
+  ): Promise<CallbackType | ResponseType> {
+    return new Promise<ResponseType | CallbackType>((resolve, reject) => {
+      const reader = this.readerFactory.create(async (resp: ResponseType, err?: Error) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        if (callback) {
+          callback(
+            resp,
+            (value: any) => {
+              this.socket.removeListener('data', reader.onData);
+              resolve(value);
+            },
+            reject
+          );
+        } else {
+          this.socket.removeListener('data', reader.onData);
+          resolve(resp);
+        }
+      });
+      this.socket.on('data', reader.onData);
+      this.writer.write(this.socket, msg);
+    });
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/lib/protocol/usbmux.ts
+++ b/packages/xdl/src/apple/native-run/ios/lib/protocol/usbmux.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import plist from '@expo/plist';
+import Debug from 'debug';
+import type * as net from 'net';
+
+import type { ProtocolWriter } from './protocol';
+import { PlistProtocolReader, ProtocolClient, ProtocolReaderFactory } from './protocol';
+
+const debug = Debug('expo:xdl:ios:lib:protocol:usbmux');
+
+export const USBMUXD_HEADER_SIZE = 16;
+
+export interface UsbmuxMessage {
+  messageType: string;
+  extraFields?: { [key: string]: any };
+}
+
+export class UsbmuxProtocolClient extends ProtocolClient<UsbmuxMessage> {
+  constructor(socket: net.Socket) {
+    super(socket, new ProtocolReaderFactory(UsbmuxProtocolReader), new UsbmuxProtocolWriter());
+  }
+}
+
+export class UsbmuxProtocolReader extends PlistProtocolReader {
+  constructor(callback: (data: any) => any) {
+    super(USBMUXD_HEADER_SIZE, callback);
+  }
+
+  parseHeader(data: Buffer) {
+    return data.readUInt32LE(0) - USBMUXD_HEADER_SIZE;
+  }
+
+  parseBody(data: Buffer) {
+    const resp = super.parseBody(data);
+    debug(`Response: ${JSON.stringify(resp)}`);
+    return resp;
+  }
+}
+
+export class UsbmuxProtocolWriter implements ProtocolWriter {
+  private useTag = 0;
+
+  write(socket: net.Socket, msg: UsbmuxMessage) {
+    // TODO Usbmux message type
+    debug(`socket write: ${JSON.stringify(msg)}`);
+    const { messageType, extraFields } = msg;
+    const plistMessage = plist.build({
+      BundleID: 'dev.expo.native-run', // TODO
+      ClientVersionString: 'usbmux.js', // TODO
+      MessageType: messageType,
+      ProgName: 'native-run', // TODO
+      kLibUSBMuxVersion: 3,
+      ...extraFields,
+    });
+
+    const dataSize = plistMessage ? plistMessage.length : 0;
+    const protocolVersion = 1;
+    const messageCode = 8;
+
+    const header = Buffer.alloc(USBMUXD_HEADER_SIZE);
+    header.writeUInt32LE(USBMUXD_HEADER_SIZE + dataSize, 0);
+    header.writeUInt32LE(protocolVersion, 4);
+    header.writeUInt32LE(messageCode, 8);
+    header.writeUInt32LE(this.useTag++, 12); // TODO
+    socket.write(header);
+    socket.write(plistMessage);
+  }
+}

--- a/packages/xdl/src/apple/native-run/ios/utils/xcode.ts
+++ b/packages/xdl/src/apple/native-run/ios/utils/xcode.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import fs from 'fs';
+
+import { execFile } from '../../utils/process';
+
+export async function getXCodePath() {
+  try {
+    const { stdout } = await execFile('xcode-select', ['-p'], {
+      encoding: 'utf8',
+    });
+    if (stdout) {
+      return stdout.trim();
+    }
+  } catch {
+    // ignore
+  }
+  throw new Error('Unable to get Xcode location. Is Xcode installed?');
+}
+
+export async function getDeveloperDiskImagePath(version: string) {
+  const xCodePath = await getXCodePath();
+  const versionDirs = await fs.promises.readdir(
+    `${xCodePath}/Platforms/iPhoneOS.platform/DeviceSupport/`
+  );
+  const versionPrefix = version.match(/\d+\.\d+/);
+  if (versionPrefix === null) {
+    throw new Error(`Invalid iOS version: ${version}`);
+  }
+  // Can look like "11.2 (15C107)"
+  for (const dir of versionDirs) {
+    if (dir.includes(versionPrefix[0])) {
+      return `${xCodePath}/Platforms/iPhoneOS.platform/DeviceSupport/${dir}/DeveloperDiskImage.dmg`;
+    }
+  }
+  throw new Error(
+    `Unable to find Developer Disk Image path for SDK ${version}. Do you have the right version of Xcode?`
+  );
+}

--- a/packages/xdl/src/apple/native-run/utils/process.ts
+++ b/packages/xdl/src/apple/native-run/utils/process.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2021 Expo, Inc.
+ * Copyright (c) 2018 Drifty Co.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as cp from 'child_process';
+import Debug from 'debug';
+import * as util from 'util';
+
+const debug = Debug('expo:xdl:utils:process');
+
+export function once<T extends (...args: any[]) => any>(fn: T): T {
+  let called = false;
+  let r: any;
+
+  const wrapper: any = (...args: any[]): any => {
+    if (!called) {
+      called = true;
+      r = fn(...args);
+    }
+
+    return r;
+  };
+
+  return wrapper;
+}
+export const exec = util.promisify(cp.exec);
+export const execFile = util.promisify(cp.execFile);
+export const wait = util.promisify(setTimeout);
+
+export type ExitQueueFn = () => Promise<void>;
+
+const exitQueue: ExitQueueFn[] = [];
+
+export function onBeforeExit(fn: ExitQueueFn): void {
+  exitQueue.push(fn);
+}
+
+const BEFORE_EXIT_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK'];
+
+const beforeExitHandlerWrapper = (signal: NodeJS.Signals) =>
+  once(async () => {
+    debug('onBeforeExit handler: %s received', signal);
+    debug('onBeforeExit handler: running %s queued functions', exitQueue.length);
+
+    for (const [i, fn] of exitQueue.entries()) {
+      try {
+        await fn();
+      } catch (e) {
+        debug('Error from function %d in exit queue: %O', i, e);
+      }
+    }
+
+    debug('onBeforeExit handler: exiting (exit code %s)', process.exitCode ? process.exitCode : 0);
+
+    process.exit();
+  });
+
+for (const signal of BEFORE_EXIT_SIGNALS) {
+  process.on(signal, beforeExitHandlerWrapper(signal));
+}

--- a/packages/xdl/src/index.ts
+++ b/packages/xdl/src/index.ts
@@ -7,6 +7,7 @@ export {
   Analytics,
   Android,
   ApiV2,
+  AppleDevice,
   Binaries,
   Config,
   AndroidCredentials,

--- a/packages/xdl/src/internal.ts
+++ b/packages/xdl/src/internal.ts
@@ -12,6 +12,7 @@
 export { Semaphore } from './utils/Semaphore';
 export * as Env from './Env';
 export * as CoreSimulator from './apple/CoreSimulator';
+export * as AppleDevice from './apple/AppleDevice';
 export { default as Config } from './Config';
 export * as Xcode from './Xcode';
 export * as ConnectionStatus from './ConnectionStatus';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,29 +1762,6 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@ionic/utils-fs@^3.0.0":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ionic/utils-fs/-/utils-fs-3.1.5.tgz#fb87be5bd5089ca43a29bbbcab87b9907e6da4b1"
-  integrity sha512-a41bY2dHqWSEQQ/80CpbXSs8McyiCFf2DnIWWLukrhYWf46h4qi6M/8dxcMKrofRiqI/3F+cL3S2mOm9Zz/o2Q==
-  dependencies:
-    debug "^4.0.0"
-    fs-extra "^9.0.0"
-    tslib "^2.0.1"
-
-"@ionic/utils-terminal@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@ionic/utils-terminal/-/utils-terminal-2.3.1.tgz#57bb2f6e4015cb655d004bd2891629b2aea9f06b"
-  integrity sha512-cglsSd2AckI3Ldtdfczeq64vIIDjtPspV5QJtky8f8uIdxkeOIGeRV7bCj1+BEf1hyo+ZuggQxLviHnbMZhiRw==
-  dependencies:
-    debug "^4.0.0"
-    signal-exit "^3.0.3"
-    slice-ansi "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    tslib "^2.0.1"
-    untildify "^4.0.0"
-    wrap-ansi "^7.0.0"
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -5524,7 +5501,7 @@ buffer-alloc@^1.1.0:
     buffer-alloc-unsafe "^1.1.0"
     buffer-fill "^1.0.0"
 
-buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
+buffer-crc32@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
@@ -7167,13 +7144,6 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
-
 debuglog@^1.0.0, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -7705,13 +7675,6 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
-
-elementtree@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/elementtree/-/elementtree-0.1.7.tgz#9ac91be6e52fb6e6244c4e54a4ac3ed8ae8e29c0"
-  integrity sha1-mskb5uUvtuYkTE5UpKw+2K6OKcA=
-  dependencies:
-    sax "1.1.4"
 
 elliptic@^6.0.0:
   version "6.5.2"
@@ -8804,13 +8767,6 @@ fbjs@^1.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
-  dependencies:
-    pend "~1.2.0"
-
 fecha@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
@@ -9821,10 +9777,10 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@~0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.5.1.tgz#601115e4b1e0a17d9aa91243b96277de4e926e09"
-  integrity sha512-hLwqh8dejHayjlpvZY40e1aDCDvyP98cWx/L5DhAjSJLH8g4z9Tp08D7y4+3vErDsncPOdf1bxm+zUWpx0/Fxg==
+hermes-engine@0.0.0, hermes-engine@~0.5.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
+  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
 
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"
@@ -13378,23 +13334,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-native-run@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/native-run/-/native-run-1.4.1.tgz#4c44354585ecd347f7821b9243472c3d56ec2f71"
-  integrity sha512-P8nm7jxO4Y9bXIhGqfBH0qkHFmv6RREuL4SGtrF4Wm/XA3jiwXIz7edBLZd462B0xbln3ECON/RYAvzFlFl2GA==
-  dependencies:
-    "@ionic/utils-fs" "^3.0.0"
-    "@ionic/utils-terminal" "^2.3.1"
-    bplist-parser "0.2.0"
-    debug "^4.1.1"
-    elementtree "^0.1.7"
-    ini "^1.3.5"
-    plist "^3.0.1"
-    split2 "^3.1.0"
-    through2 "^4.0.2"
-    tslib "^2.0.1"
-    yauzl "^2.10.0"
-
 native-url@0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.3.4.tgz#29c943172aed86c63cee62c8c04db7f5756661f8"
@@ -14699,11 +14638,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -15944,7 +15878,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0:
+"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -16582,11 +16516,6 @@ sass-loader@10.0.2:
     schema-utils "^2.7.1"
     semver "^7.3.2"
 
-sax@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.4.tgz#74b6d33c9ae1e001510f179a91168588f1aedaa9"
-  integrity sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk=
-
 sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -16927,11 +16856,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-signal-exit@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
-  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
-
 simple-git@^1.85.0:
   version "1.126.0"
   resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.126.0.tgz#0c345372275139c8433b8277f4b3e155092aa434"
@@ -17226,13 +17150,6 @@ split2@^2.0.0:
   integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
   dependencies:
     through2 "^2.0.2"
-
-split2@^3.1.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
-  integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
-  dependencies:
-    readable-stream "^3.0.0"
 
 split@1.0.1, split@^1.0.0, split@^1.0.1:
   version "1.0.1"
@@ -18000,13 +17917,6 @@ through2@^3.0.0:
   dependencies:
     readable-stream "2 || 3"
 
-through2@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
-  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
-  dependencies:
-    readable-stream "3"
-
 through2@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
@@ -18597,11 +18507,6 @@ untildify@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.3.tgz#1e7b42b140bcfd922b22e70ca1265bfe3634c7c9"
   integrity sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==
-
-untildify@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
-  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 upath@^1.1.1:
   version "1.2.0"
@@ -19567,14 +19472,6 @@ yarn-deduplicate@^3.1.0:
     "@yarnpkg/lockfile" "^1.1.0"
     commander "^6.1.0"
     semver "^7.3.2"
-
-yauzl@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
 
 yn@3.1.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,6 +1762,29 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@ionic/utils-fs@^3.0.0":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@ionic/utils-fs/-/utils-fs-3.1.5.tgz#fb87be5bd5089ca43a29bbbcab87b9907e6da4b1"
+  integrity sha512-a41bY2dHqWSEQQ/80CpbXSs8McyiCFf2DnIWWLukrhYWf46h4qi6M/8dxcMKrofRiqI/3F+cL3S2mOm9Zz/o2Q==
+  dependencies:
+    debug "^4.0.0"
+    fs-extra "^9.0.0"
+    tslib "^2.0.1"
+
+"@ionic/utils-terminal@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@ionic/utils-terminal/-/utils-terminal-2.3.1.tgz#57bb2f6e4015cb655d004bd2891629b2aea9f06b"
+  integrity sha512-cglsSd2AckI3Ldtdfczeq64vIIDjtPspV5QJtky8f8uIdxkeOIGeRV7bCj1+BEf1hyo+ZuggQxLviHnbMZhiRw==
+  dependencies:
+    debug "^4.0.0"
+    signal-exit "^3.0.3"
+    slice-ansi "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    tslib "^2.0.1"
+    untildify "^4.0.0"
+    wrap-ansi "^7.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -5501,7 +5524,7 @@ buffer-alloc@^1.1.0:
     buffer-alloc-unsafe "^1.1.0"
     buffer-fill "^1.0.0"
 
-buffer-crc32@^0.2.13:
+buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
@@ -7144,6 +7167,13 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.0.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.0, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -7675,6 +7705,13 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
+elementtree@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/elementtree/-/elementtree-0.1.7.tgz#9ac91be6e52fb6e6244c4e54a4ac3ed8ae8e29c0"
+  integrity sha1-mskb5uUvtuYkTE5UpKw+2K6OKcA=
+  dependencies:
+    sax "1.1.4"
 
 elliptic@^6.0.0:
   version "6.5.2"
@@ -8766,6 +8803,13 @@ fbjs@^1.0.0:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  dependencies:
+    pend "~1.2.0"
 
 fecha@^4.2.0:
   version "4.2.1"
@@ -13334,6 +13378,23 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+native-run@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/native-run/-/native-run-1.4.1.tgz#4c44354585ecd347f7821b9243472c3d56ec2f71"
+  integrity sha512-P8nm7jxO4Y9bXIhGqfBH0qkHFmv6RREuL4SGtrF4Wm/XA3jiwXIz7edBLZd462B0xbln3ECON/RYAvzFlFl2GA==
+  dependencies:
+    "@ionic/utils-fs" "^3.0.0"
+    "@ionic/utils-terminal" "^2.3.1"
+    bplist-parser "0.2.0"
+    debug "^4.1.1"
+    elementtree "^0.1.7"
+    ini "^1.3.5"
+    plist "^3.0.1"
+    split2 "^3.1.0"
+    through2 "^4.0.2"
+    tslib "^2.0.1"
+    yauzl "^2.10.0"
+
 native-url@0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.3.4.tgz#29c943172aed86c63cee62c8c04db7f5756661f8"
@@ -14638,6 +14699,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -15878,7 +15944,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0:
+"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -16516,6 +16582,11 @@ sass-loader@10.0.2:
     schema-utils "^2.7.1"
     semver "^7.3.2"
 
+sax@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.4.tgz#74b6d33c9ae1e001510f179a91168588f1aedaa9"
+  integrity sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk=
+
 sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -16856,6 +16927,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+signal-exit@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
 simple-git@^1.85.0:
   version "1.126.0"
   resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.126.0.tgz#0c345372275139c8433b8277f4b3e155092aa434"
@@ -17150,6 +17226,13 @@ split2@^2.0.0:
   integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
   dependencies:
     through2 "^2.0.2"
+
+split2@^3.1.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
+  integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
+  dependencies:
+    readable-stream "^3.0.0"
 
 split@1.0.1, split@^1.0.0, split@^1.0.1:
   version "1.0.1"
@@ -17917,6 +18000,13 @@ through2@^3.0.0:
   dependencies:
     readable-stream "2 || 3"
 
+through2@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
+  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
+  dependencies:
+    readable-stream "3"
+
 through2@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
@@ -18507,6 +18597,11 @@ untildify@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.3.tgz#1e7b42b140bcfd922b22e70ca1265bfe3634c7c9"
   integrity sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==
+
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 upath@^1.1.1:
   version "1.2.0"
@@ -19472,6 +19567,14 @@ yarn-deduplicate@^3.1.0:
     "@yarnpkg/lockfile" "^1.1.0"
     commander "^6.1.0"
     semver "^7.3.2"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
# Why

To install `.app` binaries on connected iOS devices, we currently use the package `ios-deploy`, which the user must globally install before running. This new approach is pure JS and substantially faster, it's unclear how long it will last, Apple could change the underlying API, but then `ios-deploy` would probably have the same issue.

To list connected devices (required for `expo run:ios -d`) we use xctrace, which doesn't have a very reliable system for finding connected devices (https://github.com/expo/expo-cli/issues/3843). xctrace is also very slow, it takes about two seconds on fast computers, and the time varies unreliably, I've also observed that around iOS updates, xctrace can sometimes not detect the connected device unless the computer is also up to date. The new JS approach has none of these issues, it takes about 50ms to find devices, provides a JSON-type API for each device, and I've found that it tends to work more reliably than `xctrace`.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

The JS impl is based on the package `native-run` (based on [node-ioslib](https://www.npmjs.com/package/node-ioslib)), initially I pulled in native-run, but found that the net increase was pretty large and had many unneeded features (like android installation, or simulator utils). I've forked the relevant parts using the same file structure, included the licenses, and tested to ensure it was still working.

This feature is also much faster than `ios-deploy` because it doesn't attach lldb to the process, effectively making it faster to build onto a connected device than Xcode.

I had to roll support for delta installs myself, cannot confirm that they are working the same as before, I don't see any drastic time differences regardless.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Due to the nature of this feature, I've put it behind a feature flag (`EXPO_USE_APPLE_DEVICE`) that users will have to enable for a beta period.

```
EXPO_USE_APPLE_DEVICE=1 expod run:ios --device
```

Extra logs can be enabled with `export DEBUG=expo:xdl:ios:*`, `EXPO_DEBUG=1`, and `EXPO_PROFILE=1`.