### PR TITLE
Add --no-install option to expo run:ios

### DIFF
--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -20,6 +20,7 @@ export default function (program: Command) {
       .command('run:ios [path]')
       .description('Run the iOS app binary locally')
       .helpGroup('core')
+      .option('--no-install', 'Skip installing dependencies')
       .option('--no-bundler', 'Skip starting the Metro bundler')
       .option('-d, --device [device]', 'Device name or UDID to build the app on')
       .option('-p, --port <port>', 'Port to start the Metro bundler on. Default: 8081')

--- a/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
@@ -19,6 +19,7 @@ export type Options = {
   scheme?: string;
   configuration?: XcodeConfiguration;
   bundler?: boolean;
+  install?: boolean;
 };
 
 export type ProjectInfo = {

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -42,10 +42,10 @@ export async function actionAsync(projectRoot: string, options: Options) {
   // If the project doesn't have native code, prebuild it...
   if (!fs.existsSync(path.join(projectRoot, 'ios'))) {
     await prebuildAsync(projectRoot, {
-      install: true,
+      install: options.install,
       platforms: ['ios'],
     } as EjectAsyncOptions);
-  } else {
+  } else if (options.install) {
     await maybePromptToSyncPodsAsync(projectRoot);
     // TODO: Ensure the pods are in sync -- https://github.com/expo/expo/pull/11593
   }


### PR DESCRIPTION
# Why

sometimes you don't want the pods to be installed
