### PR TITLE
[config plugins] extend base mods

### DIFF
--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -85,6 +85,13 @@ export type Mod<Props = any> = ((
    * This mod should always be the last one added.
    */
   isProvider?: boolean;
+  /**
+   * If the mod supports introspection, and avoids making any filesystem modifications during compilation.
+   * By enabling, this mod, and all of its descendants will be run in introspection mode.
+   * This should only be used for static files like JSON or XML, and not for application files that require regexes,
+   * or complex static files that require other files to be generated like Xcode `.pbxproj`.
+   */
+  isIntrospectCapable?: boolean;
 };
 
 export interface ModConfig {

--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -91,7 +91,7 @@ export type Mod<Props = any> = ((
    * This should only be used for static files like JSON or XML, and not for application files that require regexes,
    * or complex static files that require other files to be generated like Xcode `.pbxproj`.
    */
-  isIntrospectCapable?: boolean;
+  isIntrospective?: boolean;
 };
 
 export interface ModConfig {

--- a/packages/config-plugins/src/index.ts
+++ b/packages/config-plugins/src/index.ts
@@ -3,16 +3,9 @@
  */
 import * as AndroidConfig from './android';
 import * as IOSConfig from './ios';
-import {
-  getAndroidIntrospectModFileProviders,
-  getAndroidModFileProviders,
-  withAndroidBaseMods,
-} from './plugins/withAndroidBaseMods';
-import {
-  getIosIntrospectModFileProviders,
-  getIosModFileProviders,
-  withIosBaseMods,
-} from './plugins/withIosBaseMods';
+import { provider, withGeneratedBaseMods } from './plugins/createBaseMod';
+import { getAndroidModFileProviders, withAndroidBaseMods } from './plugins/withAndroidBaseMods';
+import { getIosModFileProviders, withIosBaseMods } from './plugins/withIosBaseMods';
 import * as XML from './utils/XML';
 import * as History from './utils/history';
 import * as WarningAggregator from './utils/warnings';
@@ -63,10 +56,10 @@ export { compileModsAsync, withDefaultBaseMods, evalModsAsync } from './plugins/
 export { PluginError } from './utils/errors';
 
 export const BaseMods = {
+  withGeneratedBaseMods,
+  provider,
   withAndroidBaseMods,
   getAndroidModFileProviders,
-  getAndroidIntrospectModFileProviders,
   withIosBaseMods,
   getIosModFileProviders,
-  getIosIntrospectModFileProviders,
 };

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -15,6 +15,32 @@ interface ProjectFile<L extends string = string> {
 
 export type AppDelegateProjectFile = ProjectFile<'objc' | 'swift'>;
 
+export function getAppDelegateHeaderFilePath(projectRoot: string): string {
+  const [using, ...extra] = globSync('ios/*/AppDelegate.h', {
+    absolute: true,
+    cwd: projectRoot,
+    ignore: ignoredPaths,
+  });
+
+  if (!using) {
+    throw new UnexpectedError(
+      `Could not locate a valid AppDelegate header at root: "${projectRoot}"`
+    );
+  }
+
+  if (extra.length) {
+    warnMultipleFiles({
+      tag: 'app-delegate-header',
+      fileName: 'AppDelegate',
+      projectRoot,
+      using,
+      extra,
+    });
+  }
+
+  return using;
+}
+
 export function getAppDelegateFilePath(projectRoot: string): string {
   const [using, ...extra] = globSync('ios/*/AppDelegate.@(m|swift)', {
     absolute: true,

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -43,6 +43,7 @@ function getLanguage(filePath: string): 'objc' | 'swift' {
   const extension = path.extname(filePath);
   switch (extension) {
     case '.m':
+    case '.h':
       return 'objc';
     case '.swift':
       return 'swift';

--- a/packages/config-plugins/src/plugins/createBaseMod.ts
+++ b/packages/config-plugins/src/plugins/createBaseMod.ts
@@ -29,8 +29,13 @@ export type BaseModProviderMethods<
     config: ExportedConfigWithProps<ModType>,
     props: Props
   ) => Promise<void> | void;
-  /** Mod can be run in introspection mode without modifying the filesystem */
-  isIdempotent?: boolean;
+  /**
+   * If the mod supports introspection, and avoids making any filesystem modifications during compilation.
+   * By enabling, this mod, and all of its descendants will be run in introspection mode.
+   * This should only be used for static files like JSON or XML, and not for application files that require regexes,
+   * or complex static files that require other files to be generated like Xcode `.pbxproj`.
+   */
+  isIntrospectCapable?: boolean;
 };
 
 export type CreateBaseModProps<
@@ -52,7 +57,7 @@ export function createBaseMod<
   getFilePath,
   read,
   write,
-  isIdempotent,
+  isIntrospectCapable,
 }: CreateBaseModProps<ModType, Props>): ConfigPlugin<Props | void> {
   const withUnknown: ConfigPlugin<Props | void> = (config, _props) => {
     const props = _props || ({} as Props);
@@ -62,7 +67,7 @@ export function createBaseMod<
       skipEmptyMod: props.skipEmptyMod ?? true,
       saveToInternal: props.saveToInternal ?? false,
       isProvider: true,
-      isIdempotent,
+      isIntrospectCapable,
       async action({ modRequest: { nextMod, ...modRequest }, ...config }) {
         try {
           let results: ExportedConfigWithProps<ModType> = {

--- a/packages/config-plugins/src/plugins/createBaseMod.ts
+++ b/packages/config-plugins/src/plugins/createBaseMod.ts
@@ -35,7 +35,7 @@ export type BaseModProviderMethods<
    * This should only be used for static files like JSON or XML, and not for application files that require regexes,
    * or complex static files that require other files to be generated like Xcode `.pbxproj`.
    */
-  isIntrospectCapable?: boolean;
+  isIntrospective?: boolean;
 };
 
 export type CreateBaseModProps<
@@ -57,7 +57,7 @@ export function createBaseMod<
   getFilePath,
   read,
   write,
-  isIntrospectCapable,
+  isIntrospective,
 }: CreateBaseModProps<ModType, Props>): ConfigPlugin<Props | void> {
   const withUnknown: ConfigPlugin<Props | void> = (config, _props) => {
     const props = _props || ({} as Props);
@@ -67,7 +67,7 @@ export function createBaseMod<
       skipEmptyMod: props.skipEmptyMod ?? true,
       saveToInternal: props.saveToInternal ?? false,
       isProvider: true,
-      isIntrospectCapable,
+      isIntrospective,
       async action({ modRequest: { nextMod, ...modRequest }, ...config }) {
         try {
           let results: ExportedConfigWithProps<ModType> = {

--- a/packages/config-plugins/src/plugins/createBaseMod.ts
+++ b/packages/config-plugins/src/plugins/createBaseMod.ts
@@ -139,12 +139,14 @@ export function createPlatformBaseMod<
   });
 }
 
+/** A TS wrapper for creating provides */
 export function provider<ModType, Props extends ForwardedBaseModOptions = ForwardedBaseModOptions>(
   props: BaseModProviderMethods<ModType, Props>
 ) {
   return props;
 }
 
+/** Plugin to create and append base mods from file providers */
 export function withGeneratedBaseMods<ModName extends string>(
   config: ExportedConfig,
   {

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -46,24 +46,21 @@ export function withIntrospectionBaseMods(
     ...props,
   });
 
-  const preserve = {
-    ios: Object.keys(iosProviders),
-    android: Object.keys(androidProviders),
-  };
-
   if (config.mods) {
     // Remove all mods that don't have an introspection base mod, for instance `dangerous` mods.
     for (const platform of Object.keys(config.mods) as ModPlatform[]) {
-      if (!(platform in preserve)) {
-        delete config.mods[platform];
-      }
-      const platformPreserve = preserve[platform];
+      // const platformPreserve = preserve[platform];
       for (const key of Object.keys(config.mods[platform] || {})) {
-        if (!platformPreserve?.includes(key)) {
-          // @ts-ignore
-          delete config.mods[platform][key];
+        // @ts-ignore
+        if (!config.mods[platform][key].isIdempotent) {
+          debug(`removing non-idempotent mod: ${platform}.${key}`);
+          delete config.mods[platform]?.[key];
         }
       }
+
+      // if (!(platform in preserve)) {
+      //   delete config.mods[platform];
+      // }
     }
   }
 

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -48,7 +48,7 @@ export function withIntrospectionBaseMods(
       // const platformPreserve = preserve[platform];
       for (const key of Object.keys(config.mods[platform] || {})) {
         // @ts-ignore
-        if (!config.mods[platform]?.[key]?.isIntrospectCapable) {
+        if (!config.mods[platform]?.[key]?.isIntrospective) {
           debug(`removing non-idempotent mod: ${platform}.${key}`);
           // @ts-ignore
           delete config.mods[platform]?.[key];

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -6,8 +6,8 @@ import { getHackyProjectName } from '../ios/utils/Xcodeproj';
 import { PluginError } from '../utils/errors';
 import * as Warnings from '../utils/warnings';
 import { assertModResults, ForwardedBaseModOptions } from './createBaseMod';
-import { getAndroidIntrospectModFileProviders, withAndroidBaseMods } from './withAndroidBaseMods';
-import { getIosIntrospectModFileProviders, withIosBaseMods } from './withIosBaseMods';
+import { withAndroidBaseMods } from './withAndroidBaseMods';
+import { withIosBaseMods } from './withIosBaseMods';
 
 const debug = Debug('config-plugins:mod-compiler');
 
@@ -29,10 +29,7 @@ export function withIntrospectionBaseMods(
   config: ExportedConfig,
   props: ForwardedBaseModOptions = {}
 ): ExportedConfig {
-  const iosProviders = getIosIntrospectModFileProviders();
-  const androidProviders = getAndroidIntrospectModFileProviders();
   config = withIosBaseMods(config, {
-    providers: iosProviders,
     saveToInternal: true,
     // This writing optimization can be skipped since we never write in introspection mode.
     // Including empty mods will ensure that all mods get introspected.
@@ -40,7 +37,6 @@ export function withIntrospectionBaseMods(
     ...props,
   });
   config = withAndroidBaseMods(config, {
-    providers: androidProviders,
     saveToInternal: true,
     skipEmptyMod: false,
     ...props,

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -52,15 +52,12 @@ export function withIntrospectionBaseMods(
       // const platformPreserve = preserve[platform];
       for (const key of Object.keys(config.mods[platform] || {})) {
         // @ts-ignore
-        if (!config.mods[platform][key].isIdempotent) {
+        if (!config.mods[platform]?.[key]?.isIntrospectCapable) {
           debug(`removing non-idempotent mod: ${platform}.${key}`);
+          // @ts-ignore
           delete config.mods[platform]?.[key];
         }
       }
-
-      // if (!(platform in preserve)) {
-      //   delete config.mods[platform];
-      // }
     }
   }
 

--- a/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
@@ -225,7 +225,7 @@ export function getAndroidIntrospectModFileProviders(): Omit<
   ) => {
     const realProvider = defaultProviders[modName];
     return provider<any>({
-      isIdempotent: true,
+      isIntrospectCapable: true,
       async getFilePath(...props) {
         try {
           return await realProvider.getFilePath(...props);

--- a/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
@@ -225,6 +225,7 @@ export function getAndroidIntrospectModFileProviders(): Omit<
   ) => {
     const realProvider = defaultProviders[modName];
     return provider<any>({
+      isIdempotent: true,
       async getFilePath(...props) {
         try {
           return await realProvider.getFilePath(...props);

--- a/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
@@ -12,6 +12,54 @@ const { readFile, writeFile } = promises;
 
 type AndroidModName = keyof Required<ModConfig>['android'];
 
+function getAndroidManifestTemplate(config: ExportedConfig) {
+  // Keep in sync with https://github.com/expo/expo/blob/master/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+  // TODO: Read from remote template when possible
+  return parseXMLAsync(`
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${
+    config.android?.package ?? 'com.placeholder.appid'
+  }">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- OPTIONAL PERMISSIONS, REMOVE WHATEVER YOU DO NOT NEED -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <!-- These require runtime permissions on M -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- END OPTIONAL PERMISSIONS -->
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="false"
+      android:theme="@style/AppTheme"
+      android:usesCleartextTraffic="true"
+    >
+      <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="YOUR-APP-URL-HERE"/>
+      <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="YOUR-APP-SDK-VERSION-HERE"/>
+      <activity
+        android:name=".MainActivity"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:launchMode="singleTask"
+        android:windowSoftInputMode="adjustResize"
+        android:theme="@style/Theme.App.SplashScreen"
+      >
+        <intent-filter>
+          <action android:name="android.intent.action.MAIN"/>
+          <category android:name="android.intent.category.LAUNCHER"/>
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
+    </application>
+  </manifest>
+  `) as Promise<AndroidManifest>;
+}
+
 export function sortAndroidManifest(obj: AndroidManifest) {
   if (obj.manifest) {
     // Reverse sort so application is last and permissions are first
@@ -59,77 +107,166 @@ const defaultProviders = {
 
   // Append a rule to supply gradle.properties data to mods on `mods.android.gradleProperties`
   manifest: provider<Manifest.AndroidManifest>({
+    isIntrospectCapable: true,
     getFilePath({ modRequest: { platformProjectRoot } }) {
       return path.join(platformProjectRoot, 'app/src/main/AndroidManifest.xml');
     },
-    async read(filePath) {
-      return await Manifest.readAndroidManifestAsync(filePath);
+    async read(filePath, config) {
+      try {
+        return await Manifest.readAndroidManifestAsync(filePath);
+      } catch (error: any) {
+        if (!config.modRequest.introspect) {
+          throw error;
+        }
+      }
+      return await getAndroidManifestTemplate(config);
     },
-    async write(filePath, { modResults }) {
+    async write(filePath, { modResults, modRequest: { introspect } }) {
+      if (introspect) return;
       await Manifest.writeAndroidManifestAsync(filePath, sortAndroidManifest(modResults));
     },
   }),
 
   // Append a rule to supply gradle.properties data to mods on `mods.android.gradleProperties`
   gradleProperties: provider<Properties.PropertiesItem[]>({
+    isIntrospectCapable: true,
+
     getFilePath({ modRequest: { platformProjectRoot } }) {
       return path.join(platformProjectRoot, 'gradle.properties');
     },
-    async read(filePath) {
-      return Properties.parsePropertiesFile(await readFile(filePath, 'utf8'));
+    async read(filePath, config) {
+      try {
+        return await Properties.parsePropertiesFile(await readFile(filePath, 'utf8'));
+      } catch (error) {
+        if (!config.modRequest.introspect) {
+          throw error;
+        }
+      }
+      return [];
     },
-    async write(filePath, { modResults }) {
+    async write(filePath, { modResults, modRequest: { introspect } }) {
+      if (introspect) return;
       await writeFile(filePath, Properties.propertiesListToString(modResults));
     },
   }),
 
   // Append a rule to supply strings.xml data to mods on `mods.android.strings`
   strings: provider<Resources.ResourceXML>({
-    getFilePath({ modRequest: { projectRoot } }) {
-      return Strings.getProjectStringsXMLPathAsync(projectRoot);
+    isIntrospectCapable: true,
+
+    async getFilePath({ modRequest: { projectRoot, introspect } }) {
+      try {
+        return await Strings.getProjectStringsXMLPathAsync(projectRoot);
+      } catch (error: any) {
+        if (!introspect) {
+          throw error;
+        }
+      }
+      return '';
     },
-    async read(filePath) {
-      return Resources.readResourcesXMLAsync({ path: filePath });
+
+    async read(filePath, config) {
+      try {
+        return await Resources.readResourcesXMLAsync({ path: filePath });
+      } catch (error) {
+        if (!config.modRequest.introspect) {
+          throw error;
+        }
+      }
+      return { resources: {} };
     },
-    async write(filePath, { modResults }) {
+    async write(filePath, { modResults, modRequest: { introspect } }) {
+      if (introspect) return;
       await writeXMLAsync({ path: filePath, xml: modResults });
     },
   }),
 
   colors: provider<Resources.ResourceXML>({
-    getFilePath({ modRequest: { projectRoot } }) {
-      return Colors.getProjectColorsXMLPathAsync(projectRoot);
+    isIntrospectCapable: true,
+
+    async getFilePath({ modRequest: { projectRoot, introspect } }) {
+      try {
+        return await Colors.getProjectColorsXMLPathAsync(projectRoot);
+      } catch (error: any) {
+        if (!introspect) {
+          throw error;
+        }
+      }
+      return '';
     },
-    async read(filePath) {
-      return Resources.readResourcesXMLAsync({ path: filePath });
+
+    async read(filePath, { modRequest: { introspect } }) {
+      try {
+        return await Resources.readResourcesXMLAsync({ path: filePath });
+      } catch (error: any) {
+        if (!introspect) {
+          throw error;
+        }
+      }
+      return { resources: {} };
     },
-    async write(filePath, { modResults }) {
+    async write(filePath, { modResults, modRequest: { introspect } }) {
+      if (introspect) return;
       await writeXMLAsync({ path: filePath, xml: modResults });
     },
   }),
 
   colorsNight: provider<Resources.ResourceXML>({
-    getFilePath({ modRequest: { projectRoot } }) {
-      return Colors.getProjectColorsXMLPathAsync(projectRoot, { kind: 'values-night' });
+    isIntrospectCapable: true,
+
+    async getFilePath({ modRequest: { projectRoot, introspect } }) {
+      try {
+        return await Colors.getProjectColorsXMLPathAsync(projectRoot, { kind: 'values-night' });
+      } catch (error: any) {
+        if (!introspect) {
+          throw error;
+        }
+      }
+      return '';
     },
-    async read(filePath) {
-      return Resources.readResourcesXMLAsync({ path: filePath });
+    async read(filePath, config) {
+      try {
+        return await Resources.readResourcesXMLAsync({ path: filePath });
+      } catch (error: any) {
+        if (!config.modRequest.introspect) {
+          throw error;
+        }
+      }
+      return { resources: {} };
     },
-    async write(filePath, { modResults }) {
+    async write(filePath, { modResults, modRequest: { introspect } }) {
+      if (introspect) return;
       await writeXMLAsync({ path: filePath, xml: modResults });
     },
   }),
 
   styles: provider<Resources.ResourceXML>({
-    getFilePath({ modRequest: { projectRoot } }) {
-      return Styles.getProjectStylesXMLPathAsync(projectRoot);
+    isIntrospectCapable: true,
+
+    async getFilePath({ modRequest: { projectRoot, introspect } }) {
+      try {
+        return await Styles.getProjectStylesXMLPathAsync(projectRoot);
+      } catch (error: any) {
+        if (!introspect) {
+          throw error;
+        }
+      }
+      return '';
     },
-    async read(filePath) {
-      // Adds support for `tools:x`
-      const styles = await Resources.readResourcesXMLAsync({
-        path: filePath,
-        fallback: `<?xml version="1.0" encoding="utf-8"?><resources xmlns:tools="http://schemas.android.com/tools"></resources>`,
-      });
+    async read(filePath, config) {
+      let styles: Resources.ResourceXML = { resources: {} };
+
+      try {
+        // Adds support for `tools:x`
+        styles = await Resources.readResourcesXMLAsync({
+          path: filePath,
+          fallback: `<?xml version="1.0" encoding="utf-8"?><resources xmlns:tools="http://schemas.android.com/tools"></resources>`,
+        });
+      } catch (error: any) {
+        if (!config.modRequest.introspect) {
+          throw error;
+        }
+      }
 
       // Ensure support for tools is added...
       if (!styles.resources.$) {
@@ -140,7 +277,8 @@ const defaultProviders = {
       }
       return styles;
     },
-    async write(filePath, { modResults }) {
+    async write(filePath, { modResults, modRequest: { introspect } }) {
+      if (introspect) return;
       await writeXMLAsync({ path: filePath, xml: modResults });
     },
   }),
@@ -212,124 +350,4 @@ export function withAndroidBaseMods(
 
 export function getAndroidModFileProviders() {
   return defaultProviders;
-}
-
-export function getAndroidIntrospectModFileProviders(): Omit<
-  AndroidDefaultProviders,
-  // Get rid of mods that could potentially fail by being empty.
-  'dangerous' | 'projectBuildGradle' | 'settingsGradle' | 'appBuildGradle' | 'mainActivity'
-> {
-  const createIntrospectionProvider = (
-    modName: keyof typeof defaultProviders,
-    { fallbackContents }: { fallbackContents: any }
-  ) => {
-    const realProvider = defaultProviders[modName];
-    return provider<any>({
-      isIntrospectCapable: true,
-      async getFilePath(...props) {
-        try {
-          return await realProvider.getFilePath(...props);
-        } catch {
-          // fallback to an empty string in introspection mode.
-          return '';
-        }
-      },
-      async read(...props) {
-        try {
-          return await realProvider.read(...props);
-        } catch {
-          // fallback if a file is missing in introspection mode.
-          if (fallbackContents instanceof Function) {
-            return await fallbackContents(...props);
-          }
-          return fallbackContents;
-        }
-      },
-      async write() {
-        // write nothing in introspection mode.
-      },
-    });
-  };
-
-  // dangerous should never be added
-  return {
-    manifest: createIntrospectionProvider('manifest', {
-      fallbackContents(filePath: string, config: ExportedConfig) {
-        // Keep in sync with https://github.com/expo/expo/blob/master/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
-        // TODO: Read from remote template when possible
-        return parseXMLAsync(`
-      <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${
-        config.android?.package ?? 'com.placeholder.appid'
-      }">
-
-        <uses-permission android:name="android.permission.INTERNET"/>
-        <!-- OPTIONAL PERMISSIONS, REMOVE WHATEVER YOU DO NOT NEED -->
-        <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-        <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
-        <uses-permission android:name="android.permission.VIBRATE"/>
-        <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-        <!-- These require runtime permissions on M -->
-        <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-        <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-        <!-- END OPTIONAL PERMISSIONS -->
-        <application
-          android:name=".MainApplication"
-          android:label="@string/app_name"
-          android:icon="@mipmap/ic_launcher"
-          android:roundIcon="@mipmap/ic_launcher_round"
-          android:allowBackup="false"
-          android:theme="@style/AppTheme"
-          android:usesCleartextTraffic="true"
-        >
-          <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="YOUR-APP-URL-HERE"/>
-          <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="YOUR-APP-SDK-VERSION-HERE"/>
-          <activity
-            android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-            android:launchMode="singleTask"
-            android:windowSoftInputMode="adjustResize"
-            android:theme="@style/Theme.App.SplashScreen"
-          >
-            <intent-filter>
-              <action android:name="android.intent.action.MAIN"/>
-              <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-          </activity>
-          <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
-        </application>
-      </manifest>
-      `);
-      },
-    }),
-    gradleProperties: createIntrospectionProvider('gradleProperties', { fallbackContents: [] }),
-    strings: createIntrospectionProvider('strings', {
-      fallbackContents: { resources: {} } as Resources.ResourceXML,
-    }),
-    colors: createIntrospectionProvider('colors', {
-      fallbackContents: { resources: {} } as Resources.ResourceXML,
-    }),
-    colorsNight: createIntrospectionProvider('colorsNight', {
-      fallbackContents: { resources: {} } as Resources.ResourceXML,
-    }),
-    styles: createIntrospectionProvider('styles', {
-      fallbackContents: { resources: {} } as Resources.ResourceXML,
-    }),
-    // projectBuildGradle: createIntrospectionProvider('projectBuildGradle', {
-    //   fallbackContents: { path: '', contents: '', language: 'groovy' } as Paths.GradleProjectFile,
-    // }),
-    // settingsGradle: createIntrospectionProvider('settingsGradle', {
-    //   fallbackContents: { path: '', contents: '', language: 'groovy' } as Paths.GradleProjectFile,
-    // }),
-    // appBuildGradle: createIntrospectionProvider('appBuildGradle', {
-    //   fallbackContents: { path: '', contents: '', language: 'groovy' } as Paths.GradleProjectFile,
-    // }),
-    // mainActivity: createIntrospectionProvider('mainActivity', {
-    //   fallbackContents: {
-    //     path: '',
-    //     contents: '',
-    //     language: 'java',
-    //   } as Paths.ApplicationProjectFile,
-    // }),
-  };
 }

--- a/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
@@ -107,7 +107,7 @@ const defaultProviders = {
 
   // Append a rule to supply gradle.properties data to mods on `mods.android.gradleProperties`
   manifest: provider<Manifest.AndroidManifest>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
     getFilePath({ modRequest: { platformProjectRoot } }) {
       return path.join(platformProjectRoot, 'app/src/main/AndroidManifest.xml');
     },
@@ -129,7 +129,7 @@ const defaultProviders = {
 
   // Append a rule to supply gradle.properties data to mods on `mods.android.gradleProperties`
   gradleProperties: provider<Properties.PropertiesItem[]>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
 
     getFilePath({ modRequest: { platformProjectRoot } }) {
       return path.join(platformProjectRoot, 'gradle.properties');
@@ -152,7 +152,7 @@ const defaultProviders = {
 
   // Append a rule to supply strings.xml data to mods on `mods.android.strings`
   strings: provider<Resources.ResourceXML>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
 
     async getFilePath({ modRequest: { projectRoot, introspect } }) {
       try {
@@ -182,7 +182,7 @@ const defaultProviders = {
   }),
 
   colors: provider<Resources.ResourceXML>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
 
     async getFilePath({ modRequest: { projectRoot, introspect } }) {
       try {
@@ -212,7 +212,7 @@ const defaultProviders = {
   }),
 
   colorsNight: provider<Resources.ResourceXML>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
 
     async getFilePath({ modRequest: { projectRoot, introspect } }) {
       try {
@@ -241,7 +241,7 @@ const defaultProviders = {
   }),
 
   styles: provider<Resources.ResourceXML>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
 
     async getFilePath({ modRequest: { projectRoot, introspect } }) {
       try {

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -217,7 +217,7 @@ export function getIosIntrospectModFileProviders(): Omit<
   ) => {
     const realProvider = defaultProviders[modName];
     return provider<any>({
-      isIdempotent: true,
+      isIntrospectCapable: true,
       async getFilePath(...props) {
         try {
           return await realProvider.getFilePath(...props);
@@ -257,7 +257,7 @@ export function getIosIntrospectModFileProviders(): Omit<
     }),
 
     infoPlist: {
-      isIdempotent: true,
+      isIntrospectCapable: true,
       async getFilePath(...props) {
         try {
           return await defaultProviders.infoPlist.getFilePath(...props);
@@ -307,7 +307,7 @@ export function getIosIntrospectModFileProviders(): Omit<
     },
 
     entitlements: {
-      isIdempotent: true,
+      isIntrospectCapable: true,
       async getFilePath(...props) {
         try {
           return await defaultProviders.entitlements.getFilePath(...props);
@@ -334,7 +334,7 @@ export function getIosIntrospectModFileProviders(): Omit<
     },
 
     podfileProperties: {
-      isIdempotent: true,
+      isIntrospectCapable: true,
       async getFilePath(...props) {
         try {
           return await defaultProviders.podfileProperties.getFilePath(...props);

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -74,7 +74,7 @@ const defaultProviders = {
   }),
   // Append a rule to supply Expo.plist data to mods on `mods.ios.expoPlist`
   expoPlist: provider<JSONObject>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
     getFilePath({ modRequest: { platformProjectRoot, projectName } }) {
       const supportingDirectory = path.join(platformProjectRoot, projectName!, 'Supporting');
       return path.resolve(supportingDirectory, 'Expo.plist');
@@ -112,7 +112,7 @@ const defaultProviders = {
   }),
   // Append a rule to supply Info.plist data to mods on `mods.ios.infoPlist`
   infoPlist: provider<InfoPlist, ForwardedBaseModOptions>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
     async getFilePath(config) {
       let project: xcode.XcodeProject | null = null;
       try {
@@ -200,7 +200,7 @@ const defaultProviders = {
   }),
   // Append a rule to supply .entitlements data to mods on `mods.ios.entitlements`
   entitlements: provider<JSONObject, ForwardedBaseModOptions>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
 
     async getFilePath(config) {
       try {
@@ -261,7 +261,7 @@ const defaultProviders = {
 
   // Append a rule to supply Podfile.properties.json data to mods on `mods.ios.podfileProperties`
   podfileProperties: provider<Record<string, string>>({
-    isIntrospectCapable: true,
+    isIntrospective: true,
 
     getFilePath({ modRequest: { platformProjectRoot } }) {
       return path.resolve(platformProjectRoot, 'Podfile.properties.json');

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -217,6 +217,7 @@ export function getIosIntrospectModFileProviders(): Omit<
   ) => {
     const realProvider = defaultProviders[modName];
     return provider<any>({
+      isIdempotent: true,
       async getFilePath(...props) {
         try {
           return await realProvider.getFilePath(...props);
@@ -256,6 +257,7 @@ export function getIosIntrospectModFileProviders(): Omit<
     }),
 
     infoPlist: {
+      isIdempotent: true,
       async getFilePath(...props) {
         try {
           return await defaultProviders.infoPlist.getFilePath(...props);
@@ -305,6 +307,7 @@ export function getIosIntrospectModFileProviders(): Omit<
     },
 
     entitlements: {
+      isIdempotent: true,
       async getFilePath(...props) {
         try {
           return await defaultProviders.entitlements.getFilePath(...props);
@@ -331,6 +334,7 @@ export function getIosIntrospectModFileProviders(): Omit<
     },
 
     podfileProperties: {
+      isIdempotent: true,
       async getFilePath(...props) {
         try {
           return await defaultProviders.podfileProperties.getFilePath(...props);

--- a/packages/config-plugins/src/plugins/withMod.ts
+++ b/packages/config-plugins/src/plugins/withMod.ts
@@ -14,8 +14,13 @@ export type BaseModOptions = {
   isProvider?: boolean;
   skipEmptyMod?: boolean;
   saveToInternal?: boolean;
-  /** Mod can be run in introspection mode without modifying the filesystem */
-  isIdempotent?: boolean;
+  /**
+   * If the mod supports introspection, and avoids making any filesystem modifications during compilation.
+   * By enabling, this mod, and all of its descendants will be run in introspection mode.
+   * This should only be used for static files like JSON or XML, and not for application files that require regexes,
+   * or complex static files that require other files to be generated like Xcode `.pbxproj`.
+   */
+  isIntrospectCapable?: boolean;
 };
 
 /**
@@ -40,7 +45,7 @@ export function withBaseMod<T>(
     action,
     skipEmptyMod,
     isProvider,
-    isIdempotent,
+    isIntrospectCapable,
     saveToInternal,
   }: BaseModOptions & { action: Mod<T> }
 ): ExportedConfig {
@@ -114,9 +119,9 @@ export function withBaseMod<T>(
   // Ensure this base mod is registered as the provider.
   interceptingMod.isProvider = isProvider;
 
-  if (isIdempotent) {
+  if (isIntrospectCapable) {
     // Register the mode as idempotent so introspection doesn't remove it.
-    interceptingMod.isIdempotent = isIdempotent;
+    interceptingMod.isIntrospectCapable = isIntrospectCapable;
   }
 
   (config.mods[platform] as any)[mod] = interceptingMod;

--- a/packages/config-plugins/src/plugins/withMod.ts
+++ b/packages/config-plugins/src/plugins/withMod.ts
@@ -14,6 +14,8 @@ export type BaseModOptions = {
   isProvider?: boolean;
   skipEmptyMod?: boolean;
   saveToInternal?: boolean;
+  /** Mod can be run in introspection mode without modifying the filesystem */
+  isIdempotent?: boolean;
 };
 
 /**
@@ -38,6 +40,7 @@ export function withBaseMod<T>(
     action,
     skipEmptyMod,
     isProvider,
+    isIdempotent,
     saveToInternal,
   }: BaseModOptions & { action: Mod<T> }
 ): ExportedConfig {
@@ -110,6 +113,11 @@ export function withBaseMod<T>(
 
   // Ensure this base mod is registered as the provider.
   interceptingMod.isProvider = isProvider;
+
+  if (isIdempotent) {
+    // Register the mode as idempotent so introspection doesn't remove it.
+    interceptingMod.isIdempotent = isIdempotent;
+  }
 
   (config.mods[platform] as any)[mod] = interceptingMod;
 

--- a/packages/config-plugins/src/plugins/withMod.ts
+++ b/packages/config-plugins/src/plugins/withMod.ts
@@ -20,7 +20,7 @@ export type BaseModOptions = {
    * This should only be used for static files like JSON or XML, and not for application files that require regexes,
    * or complex static files that require other files to be generated like Xcode `.pbxproj`.
    */
-  isIntrospectCapable?: boolean;
+  isIntrospective?: boolean;
 };
 
 /**
@@ -45,7 +45,7 @@ export function withBaseMod<T>(
     action,
     skipEmptyMod,
     isProvider,
-    isIntrospectCapable,
+    isIntrospective,
     saveToInternal,
   }: BaseModOptions & { action: Mod<T> }
 ): ExportedConfig {
@@ -119,9 +119,9 @@ export function withBaseMod<T>(
   // Ensure this base mod is registered as the provider.
   interceptingMod.isProvider = isProvider;
 
-  if (isIntrospectCapable) {
+  if (isIntrospective) {
     // Register the mode as idempotent so introspection doesn't remove it.
-    interceptingMod.isIntrospectCapable = isIntrospectCapable;
+    interceptingMod.isIntrospective = isIntrospective;
   }
 
   (config.mods[platform] as any)[mod] = interceptingMod;

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -1689,8 +1689,15 @@ Object {
           "EXUpdatesURL": "https://exp.host/@bacon/mycoolapp",
         },
         "infoPlist": Object {
+          "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
           "CFBundleDisplayName": "my cool app",
+          "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+          "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+          "CFBundleInfoDictionaryVersion": "6.0",
+          "CFBundleName": "$(PRODUCT_NAME)",
+          "CFBundlePackageType": "$(PRODUCT_BUNDLE_PACKAGE_TYPE)",
           "CFBundleShortVersionString": "1.0.0",
+          "CFBundleSignature": "????",
           "CFBundleURLTypes": Array [
             Object {
               "CFBundleURLSchemes": Array [
@@ -1724,15 +1731,29 @@ Object {
             "fbauth2",
             "fbshareextension",
           ],
+          "LSRequiresIPhoneOS": true,
+          "NSAppTransportSecurity": Object {
+            "NSAllowsArbitraryLoads": true,
+            "NSExceptionDomains": Object {
+              "localhost": Object {
+                "NSExceptionAllowsInsecureHTTPLoads": true,
+              },
+            },
+          },
           "RCTRootViewBackgroundColor": 4294901760,
           "UILaunchStoryboardName": "SplashScreen",
+          "UIRequiredDeviceCapabilities": Array [
+            "armv7",
+          ],
           "UIRequiresFullScreen": true,
+          "UIStatusBarStyle": "UIStatusBarStyleDefault",
           "UISupportedInterfaceOrientations": Array [
             "UIInterfaceOrientationPortrait",
             "UIInterfaceOrientationPortraitUpsideDown",
             "UIInterfaceOrientationLandscapeLeft",
             "UIInterfaceOrientationLandscapeRight",
           ],
+          "UIViewControllerBasedStatusBarAppearance": false,
           "bar": Object {
             "val": Array [
               "foo",
@@ -1896,8 +1917,15 @@ Object {
     },
     "googleServicesFile": "./config/GoogleService-Info.plist",
     "infoPlist": Object {
+      "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
       "CFBundleDisplayName": "my cool app",
+      "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+      "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+      "CFBundleInfoDictionaryVersion": "6.0",
+      "CFBundleName": "$(PRODUCT_NAME)",
+      "CFBundlePackageType": "$(PRODUCT_BUNDLE_PACKAGE_TYPE)",
       "CFBundleShortVersionString": "1.0.0",
+      "CFBundleSignature": "????",
       "CFBundleURLTypes": Array [
         Object {
           "CFBundleURLSchemes": Array [
@@ -1931,15 +1959,29 @@ Object {
         "fbauth2",
         "fbshareextension",
       ],
+      "LSRequiresIPhoneOS": true,
+      "NSAppTransportSecurity": Object {
+        "NSAllowsArbitraryLoads": true,
+        "NSExceptionDomains": Object {
+          "localhost": Object {
+            "NSExceptionAllowsInsecureHTTPLoads": true,
+          },
+        },
+      },
       "RCTRootViewBackgroundColor": 4294901760,
       "UILaunchStoryboardName": "SplashScreen",
+      "UIRequiredDeviceCapabilities": Array [
+        "armv7",
+      ],
       "UIRequiresFullScreen": true,
+      "UIStatusBarStyle": "UIStatusBarStyleDefault",
       "UISupportedInterfaceOrientations": Array [
         "UIInterfaceOrientationPortrait",
         "UIInterfaceOrientationPortraitUpsideDown",
         "UIInterfaceOrientationLandscapeLeft",
         "UIInterfaceOrientationLandscapeRight",
       ],
+      "UIViewControllerBasedStatusBarAppearance": false,
       "bar": Object {
         "val": Array [
           "foo",


### PR DESCRIPTION
# Why

Follow up: https://github.com/expo/expo-cli/pull/3839#issuecomment-920415032

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Added static mod property `isIntrospectCapable` which will prevent a base mod from being removed during introspection.
- Combined introspection providers with regular providers for a more unified interface, and as a way to test the public interface for introspection providers.
- Exposed `BaseMods.provider` helper and `BaseMods.withGeneratedBaseMods` so users could create their own base mods locally and add them to the compiler sequence.

# Test Plan

- Existing tests
- Locally using:
```ts
import {
  ConfigPlugin,
  IOSConfig,
  Mod,
  withMod,
  BaseMods,
} from "../../cli/packages/config-plugins/build/index";
import fs from "fs";

export function withCustomBaseMods(config) {
  return BaseMods.withGeneratedBaseMods<"appDelegateHeader">(config, {
    platform: "ios",
    skipEmptyMod: false,
    providers: {
      // Append a custom rule to supply AppDelegate header data to mods on `mods.ios.appDelegateHeader`
      appDelegateHeader:
        BaseMods.provider<IOSConfig.Paths.AppDelegateProjectFile>({
          isIntrospectCapable: true,
          getFilePath({ modRequest: { projectRoot } }) {
            return IOSConfig.Paths.getAppDelegateHeaderFilePath(projectRoot);
          },
          async read(filePath) {
            return IOSConfig.Paths.getFileInfo(filePath);
          },
          async write(filePath, { modResults: { contents } }) {
            await fs.promises.writeFile(filePath, contents);
          },
        }),
    },
  });
}

/**
 * Provides the AppDelegate header file for modification.
 *
 * @param config
 * @param action
 */
export const withAppDelegateHeader: ConfigPlugin<
  Mod<IOSConfig.Paths.AppDelegateProjectFile>
> = (config, action) => {
  return withMod(config, {
    platform: "ios",
    mod: "appDelegateHeader",
    action,
  });
};

export const withCustomHeaderInterface = (config) => {
  return withAppDelegateHeader(config, (config) => {
    console.log("modify header:", config.modResults);
    return config;
  });
};
```

`app.config.js`

```js
// Required for external files using TS
require("ts-node/register");

import {
  withCustomBaseMods,
  withCustomHeaderInterface,
} from "./withAppDelegateHeaderBaseMod.plugin.ts";

export default ({ config }) => {
  if (!config.plugins) config.plugins = [];
  config.plugins.push(
    withCustomHeaderInterface,
    // Base mods MUST be last
    withCustomBaseMods
  );
  return config;
};
```
