### PR TITLE
[cli] Remove prompts to install Expo Go on upgrade

### DIFF
--- a/packages/expo-cli/src/commands/upgradeAsync.ts
+++ b/packages/expo-cli/src/commands/upgradeAsync.ts
@@ -16,7 +16,7 @@ import pickBy from 'lodash/pickBy';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 import terminalLink from 'terminal-link';
-import { Android, Project, ProjectSettings, Simulator, Versions } from 'xdl';
+import { Project, ProjectSettings, Versions } from 'xdl';
 
 import CommandError from '../CommandError';
 import Log from '../log';
@@ -357,77 +357,6 @@ async function shouldBailWhenUsingLatest(
   return false;
 }
 
-async function shouldUpgradeSimulatorAsync(): Promise<boolean> {
-  // Check if we can, and probably should, upgrade the (ios) simulator
-  if (!Simulator.isPlatformSupported()) {
-    return false;
-  }
-  if (program.nonInteractive) {
-    Log.warn(`Skipping attempt to upgrade the client app on iOS simulator.`);
-    return false;
-  }
-
-  const answer = await confirmAsync({
-    message: 'Would you like to upgrade the Expo app in the iOS simulator?',
-    initial: false,
-  });
-
-  Log.newLine();
-  return answer;
-}
-
-async function maybeUpgradeSimulatorAsync(sdkVersion: TargetSDKVersion) {
-  // Check if we can, and probably should, upgrade the (ios) simulator
-  if (await shouldUpgradeSimulatorAsync()) {
-    const result = await Simulator.upgradeExpoAsync({
-      url: sdkVersion.iosClientUrl,
-      version: sdkVersion.iosClientVersion,
-    });
-    if (!result) {
-      Log.error(
-        "The upgrade of your simulator didn't go as planned. You might have to reinstall it manually with expo client:install:ios."
-      );
-    }
-
-    Log.newLine();
-  }
-}
-
-async function shouldUpgradeEmulatorAsync(): Promise<boolean> {
-  // Check if we can, and probably should, upgrade the android client
-  if (!Android.isPlatformSupported()) {
-    return false;
-  }
-  if (program.nonInteractive) {
-    Log.warn(`Skipping attempt to upgrade the Expo app on the Android emulator.`);
-    return false;
-  }
-
-  const answer = await confirmAsync({
-    message: 'Would you like to upgrade the Expo app in the Android emulator?',
-    initial: false,
-  });
-
-  Log.newLine();
-  return answer;
-}
-
-async function maybeUpgradeEmulatorAsync(sdkVersion: TargetSDKVersion) {
-  // Check if we can, and probably should, upgrade the android client
-  if (await shouldUpgradeEmulatorAsync()) {
-    const result = await Android.upgradeExpoAsync({
-      url: sdkVersion.androidClientUrl,
-      version: sdkVersion.androidClientVersion,
-    });
-    if (!result) {
-      Log.error(
-        "The upgrade of your Android client didn't go as planned. You might have to reinstall it manually with expo client:install:android."
-      );
-    }
-    Log.newLine();
-  }
-}
-
 async function promptSelectSDKVersionAsync(
   sdkVersions: string[],
   exp: Pick<ExpoConfig, 'sdkVersion'>
@@ -537,16 +466,6 @@ export async function upgradeAsync(
           `Valid SDK versions are in the range of ${minSdkVersion}.0.0 to ${maxSdkVersion}.0.0.`
       );
     }
-  }
-
-  // Check if we can, and probably should, upgrade the (ios) simulator
-  if (platforms.includes('ios') && targetSdkVersion.iosClientUrl) {
-    await maybeUpgradeSimulatorAsync(targetSdkVersion);
-  }
-
-  // Check if we can, and probably should, upgrade the android client
-  if (platforms.includes('android') && targetSdkVersion.androidClientUrl) {
-    await maybeUpgradeEmulatorAsync(targetSdkVersion);
   }
 
   const packageManager = PackageManager.createForProject(projectRoot, {

--- a/packages/expo-cli/src/commands/upgradeAsync.ts
+++ b/packages/expo-cli/src/commands/upgradeAsync.ts
@@ -414,8 +414,6 @@ export async function upgradeAsync(
   // Maybe bail out early if people are trying to update to the current version
   if (await shouldBailWhenUsingLatest(currentSdkVersionString, targetSdkVersionString)) return;
 
-  const platforms = exp.platforms || [];
-
   if (
     targetSdkVersionString === latestSdkVersionString &&
     currentSdkVersionString !== targetSdkVersionString &&


### PR DESCRIPTION
# Why

These questions during `expo upgrade` were made before we checked the Expo Go version when loading the app. This is a proposal to remove these questions, to make upgrade ask less questions to the user.

# How

These prompts helps users to get the right version of Expo Go:

Android | iOS
--- | ---
![expo start --android](https://user-images.githubusercontent.com/1203991/133639427-7840b839-8f74-45e5-8835-699511ee46e6.png) | ![expo start --ios](https://user-images.githubusercontent.com/1203991/133639435-3a99a4c1-554a-4380-83df-5d9c2a74c114.png)


# Test Plan

This is just a cleanup, no new code added.