### PR TITLE
[expo-cli][run] Fix linking issues

### DIFF
--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -14,7 +14,7 @@ import { promptToClearMalformedNativeProjectsAsync } from '../../eject/clearNati
 import { prebuildAsync } from '../../eject/prebuildAsync';
 import { installCustomExitHook } from '../../start/installExitHooks';
 import { profileMethod } from '../../utils/profileMethod';
-import { startBundlerAsync } from '../ios/startBundlerAsync';
+import { setGlobalDevClientSettingsAsync, startBundlerAsync } from '../ios/startBundlerAsync';
 import { resolvePortAsync } from '../utils/resolvePortAsync';
 import { resolveDeviceAsync } from './resolveDeviceAsync';
 import { spawnGradleAsync } from './spawnGradleAsync';
@@ -134,6 +134,7 @@ export async function actionAsync(projectRoot: string, options: Options) {
 
   await spawnGradleAsync({ androidProjectPath, variant: options.variant });
 
+  await setGlobalDevClientSettingsAsync(projectRoot);
   if (props.bundler) {
     await startBundlerAsync(projectRoot, {
       metroPort: props.port,

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -13,12 +13,12 @@ import { promptToClearMalformedNativeProjectsAsync } from '../../eject/clearNati
 import { EjectAsyncOptions, prebuildAsync } from '../../eject/prebuildAsync';
 import { installCustomExitHook } from '../../start/installExitHooks';
 import { profileMethod } from '../../utils/profileMethod';
+import { setGlobalDevClientSettingsAsync, startBundlerAsync } from '../ios/startBundlerAsync';
 import { parseBinaryPlistAsync } from '../utils/binaryPlist';
 import * as IOSDeploy from './IOSDeploy';
 import maybePromptToSyncPodsAsync from './Podfile';
 import * as XcodeBuild from './XcodeBuild';
 import { Options, resolveOptionsAsync } from './resolveOptionsAsync';
-import { startBundlerAsync } from './startBundlerAsync';
 
 const isMac = process.platform === 'darwin';
 
@@ -63,6 +63,7 @@ export async function actionAsync(projectRoot: string, options: Options) {
     'XcodeBuild.getAppBinaryPath'
   )(buildOutput);
 
+  await setGlobalDevClientSettingsAsync(projectRoot);
   if (props.shouldStartBundler) {
     await startBundlerAsync(projectRoot, {
       metroPort: props.port,

--- a/packages/expo-cli/src/commands/run/ios/startBundlerAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/startBundlerAsync.ts
@@ -4,6 +4,15 @@ import { getOptionalDevClientSchemeAsync } from '../../../schemes';
 import * as TerminalUI from '../../start/TerminalUI';
 import { installExitHooks } from '../../start/installExitHooks';
 
+export async function setGlobalDevClientSettingsAsync(projectRoot: string) {
+  const devClient = true;
+  const scheme = await getOptionalDevClientSchemeAsync(projectRoot).catch(() => null);
+  await ProjectSettings.setAsync(projectRoot, {
+    devClient,
+    scheme,
+  });
+}
+
 export async function startBundlerAsync(
   projectRoot: string,
   { metroPort, platforms }: Pick<Project.StartOptions, 'metroPort' | 'platforms'>
@@ -12,11 +21,6 @@ export async function startBundlerAsync(
   installExitHooks(projectRoot);
   // This basically means don't use the Client app.
   const devClient = true;
-  const scheme = await getOptionalDevClientSchemeAsync(projectRoot).catch(() => null);
-  await ProjectSettings.setAsync(projectRoot, {
-    devClient,
-    scheme,
-  });
   await Project.startAsync(projectRoot, { devClient, metroPort });
   await TerminalUI.startAsync(projectRoot, {
     devClient,

--- a/packages/xdl/src/Project.ts
+++ b/packages/xdl/src/Project.ts
@@ -1,40 +1,11 @@
 import {
-  assertValidProjectRoot,
-  ProjectSettings,
   startExpoServerAsync,
   StartOptions,
   startReactNativeServerAsync,
   startTunnelsAsync,
   stopReactNativeServerAsync,
   stopTunnelsAsync,
-  XDLError,
 } from './internal';
-
-/**
- * @deprecated Use `ProjectSettings.setPackagerInfoAsync`
- * @param projectRoot
- * @param options
- */
-export async function setOptionsAsync(
-  projectRoot: string,
-  options: {
-    packagerPort?: number;
-  }
-): Promise<void> {
-  assertValidProjectRoot(projectRoot); // Check to make sure all options are valid
-  if (options.packagerPort != null && !Number.isInteger(options.packagerPort)) {
-    throw new XDLError('INVALID_OPTIONS', 'packagerPort must be an integer');
-  }
-  await ProjectSettings.setPackagerInfoAsync(projectRoot, options);
-}
-
-/**
- * @deprecated `ProjectSettings.getCurrentStatusAsync`
- * @param projectRoot
- */
-export async function currentStatus(projectRoot: string) {
-  return ProjectSettings.getCurrentStatusAsync(projectRoot);
-}
 
 export {
   startTunnelsAsync,

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -188,8 +188,3 @@ export function dotExpoProjectDirectoryExists(projectRoot: string): boolean {
 
   return false;
 }
-
-export async function getPackagerOptsAsync(projectRoot: string): Promise<ProjectSettings> {
-  const projectSettings = await readAsync(projectRoot);
-  return projectSettings;
-}

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -38,8 +38,7 @@ export async function constructDeepLinkAsync(
   opts?: Partial<URLOptions>,
   requestHostname?: string
 ): Promise<string> {
-  const { devClient } = await ProjectSettings.getPackagerOptsAsync(projectRoot);
-
+  const { devClient } = await ProjectSettings.readAsync(projectRoot);
   if (devClient) {
     return constructDevClientUrlAsync(projectRoot, opts, requestHostname);
   } else {
@@ -64,7 +63,7 @@ export async function constructDevClientUrlAsync(
   if (opts?.scheme) {
     _scheme = opts?.scheme;
   } else {
-    const { scheme } = await ProjectSettings.getPackagerOptsAsync(projectRoot);
+    const { scheme } = await ProjectSettings.readAsync(projectRoot);
     if (!scheme || typeof scheme !== 'string') {
       throw new XDLError('NO_DEV_CLIENT_SCHEME', 'No scheme specified for development client');
     }
@@ -269,7 +268,7 @@ async function ensureOptionsAsync(
     assertValidOptions(opts);
   }
 
-  const defaultOpts = await ProjectSettings.getPackagerOptsAsync(projectRoot);
+  const defaultOpts = await ProjectSettings.readAsync(projectRoot);
   if (!opts) {
     return { urlType: null, ...defaultOpts };
   }


### PR DESCRIPTION
# Why

- When the `--no-bundler` flag is used, the global linking settings aren't set, and then linking gets the wrong URL.
- Split from https://github.com/expo/expo-cli/pull/3856
- Deleted deprecated functions.

# Test Plan

- `expo run:ios --no-bundler` should open in-app and not in Expo Go.
