### PR TITLE
[xdl] Fix expo-updates EAS manifest assets for iOS

### DIFF
--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -128,14 +128,13 @@ export async function getManifestResponseAsync({
     hostname,
   });
 
-  // For each manifest asset (for example `icon`):
-  // - set a field on the manifest containing a reference to the asset: iconAsset: { rawUrl?: string, assetKey?: string }
-  // - gather the data needed to embed a reference to that asset in the expo-updates assets key
-  const assets = await ProjectAssets.resolveAndCollectExpoUpdatesManifestAssets(
+  await ProjectAssets.resolveManifestAssets({
     projectRoot,
-    expoConfig,
-    path => bundleUrl!.match(/^https?:\/\/.*?\//)![0] + 'assets/' + path
-  );
+    manifest: expoConfig,
+    async resolver(path) {
+      return bundleUrl!.match(/^https?:\/\/.*?\//)![0] + 'assets/' + path;
+    },
+  });
 
   const easProjectId = expoConfig.extra?.eas.projectId;
   const shouldUseAnonymousManifest = await shouldUseAnonymousManifestAsync(easProjectId);
@@ -149,11 +148,11 @@ export async function getManifestResponseAsync({
     createdAt: new Date().toISOString(),
     runtimeVersion,
     launchAsset: {
-      key: mainModuleName,
+      key: 'bundle',
       contentType: 'application/javascript',
       url: bundleUrl,
     },
-    assets,
+    assets: [], // assets are not used in development
     metadata: {}, // required for the client to detect that this is an expo-updates manifest
     extra: {
       eas: {

--- a/packages/xdl/src/start/__tests__/ExpoUpdatesManifestHandler-test.ts
+++ b/packages/xdl/src/start/__tests__/ExpoUpdatesManifestHandler-test.ts
@@ -64,6 +64,7 @@ describe('ExpoUpdatesManifestHandler', () => {
         projectRoot: '/alpha',
         host: '127.0.0.1:19000',
         platform: 'ios',
+        acceptSignature: false,
       });
 
       expect(res.headers).toEqual(
@@ -82,24 +83,11 @@ describe('ExpoUpdatesManifestHandler', () => {
         createdAt: expect.any(String),
         runtimeVersion: 'exposdk:38.0.0',
         launchAsset: {
-          key: 'index',
+          key: 'bundle',
           contentType: 'application/javascript',
           url: 'http://127.0.0.1:80/index.bundle?platform=ios&dev=true&hot=false&minify=false',
         },
-        assets: [
-          {
-            contentType: 'image/png',
-            hash: 'bc8dff68bbfd008f5c5cd9f33711cb31d4ffc207d31e7da9b944f9d79a07e4ef',
-            key: './icon.png',
-            url: 'http://127.0.0.1:80/assets/./icon.png',
-          },
-          {
-            contentType: 'image/png',
-            hash: 'bc8dff68bbfd008f5c5cd9f33711cb31d4ffc207d31e7da9b944f9d79a07e4ef',
-            key: './assets/splash.png',
-            url: 'http://127.0.0.1:80/assets/./assets/splash.png',
-          },
-        ],
+        assets: [],
         metadata: {},
         extra: {
           eas: {},
@@ -112,14 +100,11 @@ describe('ExpoUpdatesManifestHandler', () => {
             platforms: [],
             extras: { myExtra: '123' },
             icon: './icon.png',
-            iconAsset: { assetKey: './icon.png', rawUrl: null },
+            iconUrl: 'http://127.0.0.1:80/assets/./icon.png',
             hostUri: '127.0.0.1:80',
             splash: {
               image: './assets/splash.png',
-              imageAsset: {
-                assetKey: './assets/splash.png',
-                rawUrl: null,
-              },
+              imageUrl: 'http://127.0.0.1:80/assets/./assets/splash.png',
             },
             _internal: {
               isDebug: expect.any(Boolean),


### PR DESCRIPTION
# Why

Assets in the manifest are only used in production as far as I understand. In development, these don't matter (the bundler creates a map and serves and uses them).

This also fixes the issue I created by trying to use the new asset format for local development manifest assets (splash screen URL for example). I was planning to try to use a new augmented format in the manifest for these, but it is far easier to just reuse the `${field}Url` augmentation pattern from legacy manifests since all the client libraries are already looking for this field.

# How

Revert the asset portion of https://github.com/expo/expo-cli/commit/d8eb71f0d778514349f43d78829d635fbb68f7be and replace it with a) an empty manifest.assets array, and b) the same logic as is used in classic manifests for local development.

# Test Plan

1. `yarn start` in this repo
2. In a project, `EXPO_DEBUG=true ~/expo/expo-cli/node_modules/.bin/expo start`
3. Load http://192.168.1.133:19000/update-manifest-experimental?platform=ios on ios and the android equivalent on android, ensure `Image` assets show correctly.