### PR TITLE
[metro-config] Added improved babel loading

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -35,12 +35,15 @@
   "dependencies": {
     "@expo/config": "5.0.9",
     "chalk": "^4.1.0",
+    "debug": "^4.3.2",
     "getenv": "^1.0.0",
     "metro-react-native-babel-transformer": "^0.59.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.15.5",
     "expo": "37",
     "metro": "^0.59.0",
+    "metro-babel-transformer": "^0.66.2",
     "metro-config": "^0.59.0",
     "react-native": "~0.63.4"
   },

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@expo/config": "5.0.9",
     "chalk": "^4.1.0",
+    "sucrase": "^3.20.0",
     "debug": "^4.3.2",
     "getenv": "^1.0.0",
     "metro-react-native-babel-transformer": "^0.59.0"

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -1,3 +1,5 @@
+// Copyright 2021-present 650 Industries (Expo). All rights reserved.
+
 import { getConfig, getDefaultTarget, isLegacyImportsEnabled, ProjectTarget } from '@expo/config';
 import { getBareExtensions, getManagedExtensions } from '@expo/config/paths';
 import chalk from 'chalk';
@@ -7,7 +9,10 @@ import type MetroConfig from 'metro-config';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
+import { importMetroConfigFromProject } from './importMetroFromProject';
+
 export const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
+export const EXPO_USE_EXOTIC = boolish('EXPO_USE_EXOTIC', false);
 
 // Import only the types here, the values will be imported from the project, at runtime.
 export const INTERNAL_CALLSITES_REGEX = new RegExp(
@@ -64,10 +69,20 @@ function getProjectBabelConfigFile(projectRoot: string): string | undefined {
   );
 }
 
+let hasWarnedAboutExotic = false;
+
 export function getDefaultConfig(
   projectRoot: string,
   options: DefaultConfigOptions = {}
 ): MetroConfig.InputConfigT {
+  if (EXPO_USE_EXOTIC && !hasWarnedAboutExotic) {
+    hasWarnedAboutExotic = true;
+    console.log(
+      chalk.gray(
+        `\u203A Unstable feature ${chalk.bold`EXPO_USE_EXOTIC`} is enabled. Bundling may not work as expected, and is subject to breaking changes.`
+      )
+    );
+  }
   const MetroConfig = importMetroConfigFromProject(projectRoot);
 
   const reactNativePath = path.dirname(resolveFrom(projectRoot, 'react-native/package.json'));
@@ -143,6 +158,11 @@ export function getDefaultConfig(
       ? getBareExtensions([], sourceExtsConfig)
       : getManagedExtensions([], sourceExtsConfig);
 
+  if (EXPO_USE_EXOTIC) {
+    // Add support for cjs (without platform extensions).
+    sourceExts.push('cjs');
+  }
+
   const babelConfigPath = getProjectBabelConfigFile(projectRoot);
   const isCustomBabelConfigDefined = !!babelConfigPath;
 
@@ -154,6 +174,7 @@ export function getDefaultConfig(
     console.log(`- Extensions: ${sourceExts.join(', ')}`);
     console.log(`- React Native: ${reactNativePath}`);
     console.log(`- Babel config: ${babelConfigPath || 'babel-preset-expo (default)'}`);
+    console.log(`- Exotic: ${EXPO_USE_EXOTIC}`);
     console.log();
   }
   const {
@@ -163,11 +184,20 @@ export function getDefaultConfig(
     ...metroDefaultValues
   } = MetroConfig.getDefaultConfig.getDefaultValues(projectRoot);
 
+  const resolverMainFields: string[] = [];
+
+  // Disable `react-native` in exotic mode, since library authors
+  // use it to ship raw application code to the project.
+  if (!EXPO_USE_EXOTIC) {
+    resolverMainFields.push('react-native');
+  }
+  resolverMainFields.push('browser', 'main');
+
   // Merge in the default config from Metro here, even though loadConfig uses it as defaults.
   // This is a convenience for getDefaultConfig use in metro.config.js, e.g. to modify assetExts.
   return MetroConfig.mergeConfig(metroDefaultValues, {
     resolver: {
-      resolverMainFields: ['react-native', 'browser', 'main'],
+      resolverMainFields,
       platforms: ['ios', 'android', 'native'],
       sourceExts,
     },
@@ -203,14 +233,15 @@ export function getDefaultConfig(
     },
     transformer: {
       allowOptionalDependencies: true,
-      babelTransformerPath: isCustomBabelConfigDefined
+      babelTransformerPath: EXPO_USE_EXOTIC
+        ? require.resolve('./transformer/metro-expo-exotic-babel-transformer')
+        : isCustomBabelConfigDefined
         ? // If the user defined a babel config file in their project,
           // then use the default transformer.
           // Try to use the project copy before falling back on the global version
-          resolveFrom.silent(projectRoot, 'metro-react-native-babel-transformer') ??
-          require.resolve('metro-react-native-babel-transformer')
+          resolveFrom.silent(projectRoot, 'metro-react-native-babel-transformer')
         : // Otherwise, use a custom transformer that uses `babel-preset-expo` by default for projects.
-          require.resolve('./metro-expo-babel-transformer'),
+          require.resolve('./transformer/metro-expo-babel-transformer'),
       assetRegistryPath: 'react-native/Libraries/Image/AssetRegistry',
       assetPlugins: hashAssetFilesPath ? [hashAssetFilesPath] : undefined,
     },
@@ -239,17 +270,4 @@ export async function loadAsync(
     { cwd: projectRoot, projectRoot, ...metroOptions },
     defaultConfig
   );
-}
-
-function importMetroConfigFromProject(projectRoot: string): typeof MetroConfig {
-  const resolvedPath = resolveFrom.silent(projectRoot, 'metro-config');
-  if (!resolvedPath) {
-    throw new Error(
-      'Missing package "metro-config" in the project. ' +
-        'This usually means `react-native` is not installed. ' +
-        'Please verify that dependencies in package.json include "react-native" ' +
-        'and run `yarn` or `npm install`.'
-    );
-  }
-  return require(resolvedPath);
 }

--- a/packages/metro-config/src/importMetroFromProject.ts
+++ b/packages/metro-config/src/importMetroFromProject.ts
@@ -1,0 +1,38 @@
+import type MetroConfig from 'metro-config';
+import type MetroSourceMap from 'metro-source-map';
+import resolveFrom from 'resolve-from';
+
+class MetroImportError extends Error {
+  constructor(projectRoot: string, moduleId: string) {
+    super(
+      `Missing package "${moduleId}" in the project at: ${projectRoot}\n` +
+        'This usually means `react-native` is not installed. ' +
+        'Please verify that dependencies in package.json include "react-native" ' +
+        'and run `yarn` or `npm install`.'
+    );
+  }
+}
+
+function resolveFromProject(projectRoot: string, moduleId: string) {
+  const resolvedPath = resolveFrom.silent(projectRoot, moduleId);
+  if (!resolvedPath) {
+    throw new MetroImportError(projectRoot, moduleId);
+  }
+  return resolvedPath;
+}
+
+function importFromProject<T = any>(projectRoot: string, moduleId: string): T {
+  return require(resolveFromProject(projectRoot, moduleId));
+}
+
+export function importMetroConfigFromProject(projectRoot: string): typeof MetroConfig {
+  return importFromProject(projectRoot, 'metro-config');
+}
+
+let metroSourceMap: typeof MetroSourceMap | undefined;
+
+export function importMetroSourceMapFromProject(projectRoot: string): typeof MetroSourceMap {
+  if (metroSourceMap) return metroSourceMap;
+  metroSourceMap = importFromProject<typeof MetroSourceMap>(projectRoot, 'metro-source-map');
+  return metroSourceMap;
+}

--- a/packages/metro-config/src/transformer/__tests__/createMatcher-test.ts
+++ b/packages/metro-config/src/transformer/__tests__/createMatcher-test.ts
@@ -1,9 +1,23 @@
 import { createKnownCommunityMatcher } from '../createMatcher';
 
 describe(createKnownCommunityMatcher, () => {
-  it(`tests application code`, () => {
-    expect(
-      createKnownCommunityMatcher().test('node_modules/@react-native-community/foobar.js')
-    ).toBe(false);
+  it(`tests known community packages`, () => {
+    for (const id of [
+      'node_modules/native-base/src/index.js',
+      'node_modules/@react-native-community/somn/foobar.js',
+      'node_modules/@react-native/polyfills/index.js',
+    ]) {
+      expect(createKnownCommunityMatcher().test(id)).toBe(true);
+    }
+  });
+  it(`tests in monorepos`, () => {
+    for (const id of [
+      'custom/native-base/src/index.js',
+      'node_modules/@react-native-community/foobar.js',
+    ]) {
+      expect(createKnownCommunityMatcher({ folders: ['node_modules', 'custom'] }).test(id)).toBe(
+        true
+      );
+    }
   });
 });

--- a/packages/metro-config/src/transformer/__tests__/createMatcher-test.ts
+++ b/packages/metro-config/src/transformer/__tests__/createMatcher-test.ts
@@ -1,0 +1,9 @@
+import { createKnownCommunityMatcher } from '../createMatcher';
+
+describe(createKnownCommunityMatcher, () => {
+  it(`tests application code`, () => {
+    expect(
+      createKnownCommunityMatcher().test('node_modules/@react-native-community/foobar.js')
+    ).toBe(false);
+  });
+});

--- a/packages/metro-config/src/transformer/createExoticTransformer.ts
+++ b/packages/metro-config/src/transformer/createExoticTransformer.ts
@@ -1,0 +1,231 @@
+// Copyright 2021-present 650 Industries (Expo). All rights reserved.
+
+import chalk from 'chalk';
+import Debug from 'debug';
+import type { BabelTransformer, BabelTransformerArgs } from 'metro-babel-transformer';
+import resolveFrom from 'resolve-from';
+
+import { importMetroSourceMapFromProject } from '../importMetroFromProject';
+import { getBabelConfig } from './getBabelConfig';
+
+const debug = Debug('expo:metro:exotic-babel-transformer');
+
+let babelCore: typeof import('@babel/core') | undefined;
+
+function getBabelCoreFromProject(projectRoot: string) {
+  if (babelCore) return babelCore;
+  babelCore = require(resolveFrom(projectRoot, '@babel/core'));
+  return babelCore!;
+}
+
+let babelParser: typeof import('@babel/parser') | undefined;
+
+function getBabelParserFromProject(projectRoot: string) {
+  if (babelParser) return babelParser;
+  babelParser = require(resolveFrom(projectRoot, '@babel/parser'));
+  return babelParser!;
+}
+
+function sucrase(
+  args: BabelTransformerArgs,
+  {
+    transforms,
+  }: {
+    transforms: string[];
+  }
+): Partial<ReturnType<BabelTransformer['transform']>> {
+  const {
+    src,
+    filename,
+    options: { dev },
+  } = args;
+  const { transform } = require('sucrase');
+
+  const results = transform(src, {
+    filePath: filename,
+    production: !dev,
+    transforms,
+  });
+
+  return {
+    code: results.code,
+    functionMap: null,
+  };
+}
+
+const getExpensiveSucraseTransforms = (filename: string) => [
+  'jsx',
+  'imports',
+  /\.tsx?$/.test(filename) ? 'typescript' : 'flow',
+];
+
+function parseAst(projectRoot: string, sourceCode: string) {
+  const babylon = getBabelParserFromProject(projectRoot);
+
+  return babylon.parse(sourceCode, {
+    sourceType: 'unambiguous',
+  });
+}
+
+/** Create a transformer that emulates Webpack's loader system. */
+export function createExoticTransformer({
+  getRuleType,
+  rules,
+}: {
+  getRuleType: (args: BabelTransformerArgs) => string;
+  rules: {
+    warn?: boolean;
+    type?: 'module' | 'app';
+    test: ((args: BabelTransformerArgs) => boolean) | RegExp;
+    transform: BabelTransformer['transform'];
+  }[];
+}) {
+  // const warnings: string[] = [];
+  return function transform(args: BabelTransformerArgs) {
+    const { filename, options } = args;
+    const OLD_BABEL_ENV = process.env.BABEL_ENV;
+    process.env.BABEL_ENV = options.dev ? 'development' : process.env.BABEL_ENV || 'production';
+
+    try {
+      const ruleType = getRuleType(args);
+
+      for (const rule of rules) {
+        // optimization for checking node modules
+        if (rule.type && rule.type !== ruleType) {
+          continue;
+        }
+
+        const isMatched =
+          typeof rule.test === 'function' ? rule.test(args) : rule.test.test(args.filename);
+        if (isMatched) {
+          const results = rule.transform(args);
+
+          // Perform a basic parse if none exists, this enables us to control the output, but only if it changed.
+          if (results.code && !results.ast) {
+            // Parse AST with babel otherwise Metro transformer will throw away the returned results.
+            results.ast = parseAst(options.projectRoot, results.code);
+          }
+
+          // TODO: Suboptimal warnings
+          // if (rule.warn) {
+          //   const matchName =
+          //     filename.match(/node_modules\/((:?@[\w\d-]+\/[\w\d-]+)|(:?[\w\d-]+))\/?/)?.[1] ??
+          //     filename;
+          //   if (matchName && !warnings.includes(matchName)) {
+          //     warnings.push(matchName);
+          //     console.warn(chalk.yellow.bold`warn `, matchName);
+          //     console.warn(
+          //       chalk.yellow`untranspiled module is potentially causing bundler slowdown, using modules that support commonjs will make your dev server much faster.`
+          //     );
+          //   }
+          // }
+
+          return results;
+        }
+      }
+      throw new Error('no loader rule to handle file: ' + filename);
+    } finally {
+      if (OLD_BABEL_ENV) {
+        process.env.BABEL_ENV = OLD_BABEL_ENV;
+      }
+    }
+  };
+}
+
+export const loaders: Record<string, (args: BabelTransformerArgs) => any> = {
+  /** Perform the standard, and most expensive transpilation sequence. */
+
+  app(args) {
+    debug('app:', args.filename);
+
+    const { filename, options, src, plugins } = args;
+    const babelConfig = {
+      // ES modules require sourceType='module' but OSS may not always want that
+      sourceType: 'unambiguous',
+      ...getBabelConfig(filename, options, plugins),
+      // Variables that are exposed to the user's babel preset.
+      caller: {
+        name: 'metro',
+        platform: options.platform,
+      },
+      ast: true,
+    };
+
+    // Surface a warning function so babel linters can be used.
+    Object.defineProperty(babelConfig.caller, 'onWarning', {
+      enumerable: false,
+      writable: false,
+      value: (babelConfig.caller.onWarning = function (msg: any) {
+        // Format the file path first so users know where the warning came from.
+        console.warn(chalk.bold.yellow`warn ` + args.filename);
+        console.warn(msg);
+      }),
+    });
+
+    const { parseSync, transformFromAstSync } = getBabelCoreFromProject(options.projectRoot);
+    const sourceAst = parseSync(src, babelConfig);
+
+    // Should never happen.
+    if (!sourceAst) return { ast: null };
+
+    const result = transformFromAstSync(sourceAst, src, babelConfig);
+
+    // TODO: Disable by default
+    const functionMap = importMetroSourceMapFromProject(
+      options.projectRoot
+    ).generateFunctionMap(sourceAst, { filename });
+
+    // The result from `transformFromAstSync` can be null (if the file is ignored)
+    if (!result) {
+      return { ast: null, functionMap };
+    }
+
+    return { ast: result.ast, functionMap };
+  },
+
+  reactNativeModule(args) {
+    debug('rn:', args.filename);
+    return sucrase(args, {
+      transforms: ['jsx', 'flow', 'imports'],
+    });
+  },
+
+  expoModule(args) {
+    debug('expo:', args.filename);
+    // TODO: Fix all expo packages
+    return sucrase(args, {
+      transforms: [
+        'imports',
+        // TODO: fix expo-processing, expo/vector-icons
+        /(expo-processing|expo\/vector-icons)/.test(args.filename) && 'jsx',
+        // TODO: fix expo-asset-utils
+        /(expo-asset-utils)/.test(args.filename) && 'flow',
+      ].filter(Boolean) as string[],
+    });
+  },
+
+  untranspiledModule(args) {
+    debug('known issues:', args.filename);
+    // TODO: Fix all expo packages
+    return sucrase(args, {
+      transforms: getExpensiveSucraseTransforms(args.filename),
+    });
+  },
+
+  passthroughModule(args) {
+    const { filename, options, src } = args;
+    debug('passthrough:', filename);
+
+    const ast = parseAst(options.projectRoot, src);
+    // TODO: Disable by default
+    const functionMap = importMetroSourceMapFromProject(
+      options.projectRoot
+    ).generateFunctionMap(ast, { filename });
+    return {
+      code: src,
+      functionMap,
+      // Perform a basic ast parse, this doesn't matter since the worker will parse and ignore anyways.
+      ast,
+    };
+  },
+};

--- a/packages/metro-config/src/transformer/createMatcher.ts
+++ b/packages/metro-config/src/transformer/createMatcher.ts
@@ -1,0 +1,60 @@
+// Copyright 2021-present 650 Industries (Expo). All rights reserved.
+
+export function createModuleMatcher({
+  folders = ['node_modules'],
+  moduleIds,
+}: {
+  folders?: string[];
+  moduleIds: string[];
+}) {
+  const modulePathsGroup = folders.join('|');
+
+  const moduleMatchersGroup = moduleIds.join('|');
+
+  const moduleMatcherId =
+    '^' + [modulePathsGroup, moduleMatchersGroup].map(value => `(?:${value})`).join('/');
+
+  return new RegExp(moduleMatcherId);
+}
+
+export const createReactNativeMatcher = ({ folders }: { folders?: string[] }) =>
+  createModuleMatcher({
+    folders,
+    moduleIds: ['react-native/'],
+  });
+
+export const createExpoMatcher = ({ folders }: { folders?: string[] }) =>
+  createModuleMatcher({
+    folders,
+    // We'll work to start reducing this.
+    moduleIds: ['expo', '@expo', '@unimodules', '@use-expo'],
+  });
+
+// TODO: Make this list as short as possible before releasing.
+export const createKnownCommunityMatcher = ({
+  folders,
+  moduleIds = [],
+}: {
+  folders?: string[];
+  moduleIds?: string[];
+} = {}) =>
+  createModuleMatcher({
+    folders,
+    moduleIds: [
+      ...moduleIds,
+      // The more complex, the longer the entire project takes...
+      // react-native-community, react-native-masked-view, react-native-picker, react-native-segmented-control, react-native
+      '@react-',
+      'react-native-',
+      'victory-',
+      'native-base',
+      'styled-components',
+      // three.js
+      'three/build/three.module.js',
+      'three/examples/jsm',
+      // Special case for testing expo/expo repo
+      'html-elements/',
+      // shared-element
+      'react-navigation-',
+    ],
+  });

--- a/packages/metro-config/src/transformer/generateFunctionMap.ts
+++ b/packages/metro-config/src/transformer/generateFunctionMap.ts
@@ -1,0 +1,32 @@
+import type { generateFunctionMap as generateFunctionMapType } from 'metro-source-map';
+
+import { importMetroSourceMapFromProject } from '../importMetroFromProject';
+
+export function generateFunctionMap(
+  projectRoot: string,
+  ast: Parameters<typeof generateFunctionMapType>[0],
+  context: Parameters<typeof generateFunctionMapType>[1]
+): ReturnType<typeof generateFunctionMapType> | null {
+  //  `x_facebook_sources` is a source map feature that we disable by default since it isn't documented
+  // and doesn't appear to add much value to the DX, it also increases bundle time, and source map size.
+  // The feature supposedly provides improved function names for anonymous functions, but we will opt towards
+  // linting to prevent users from adding anonymous functions for important features like React components.
+  //
+  // Here is an example stack trace for a component that throws an error
+  // in the root component (which is an anonymous function):
+  //
+  // Before:
+  // - <anonymous> App.js:5:9
+  // - renderApplication renderApplication.js:54:5
+  // - runnables.appKey.run AppRegistry.js:117:26
+  //
+  // After:
+  // - _default App.js:5:9
+  // - renderApplication renderApplication.js:54:5
+  // - run AppRegistry.js:117:26
+  //
+  if (process.env.EXPO_USE_FB_SOURCES) {
+    return importMetroSourceMapFromProject(projectRoot).generateFunctionMap(ast, context);
+  }
+  return null;
+}

--- a/packages/metro-config/src/transformer/getBabelConfig.ts
+++ b/packages/metro-config/src/transformer/getBabelConfig.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Expo.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Forks the default metro-react-native-babel-transformer and adds support for known transforms.
+ */
+
+import type { PluginItem as BabelPlugins, PluginItem } from '@babel/core';
+import fs from 'fs';
+import type { BabelTransformerOptions } from 'metro-babel-transformer';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+/**
+ * Return a memoized function that checks for the existence of a
+ * project level .babelrc file, and if it doesn't exist, reads the
+ * default RN babelrc file and uses that.
+ */
+const getBabelRC = (function () {
+  let babelRC: {
+    // `any` to avoid flow type mismatch with Babel 7's internal type of
+    // `Array<string>` even though it correctly accepts the usage below.
+    presets?: any;
+    extends?: string;
+    plugins: BabelPlugins;
+  } | null = null;
+
+  return function _getBabelRC(projectRoot: string, options: BabelTransformerOptions) {
+    if (babelRC != null) {
+      return babelRC;
+    }
+
+    babelRC = { plugins: [] };
+
+    // Let's look for a babel config file in the project root.
+    // TODO look into adding a command line option to specify this location
+    let projectBabelRCPath;
+
+    // Since this is an opt-in system, we can make certain
+    // assumptions like dropping support for `.babelrc` to speed up resolution.
+
+    // .babelrc
+    // if (projectRoot) {
+    //   projectBabelRCPath = path.resolve(projectRoot, '.babelrc');
+    // }
+
+    if (projectBabelRCPath) {
+      // .babelrc.js
+      // if (!fs.existsSync(projectBabelRCPath)) {
+      //   projectBabelRCPath = path.resolve(projectRoot, '.babelrc.js');
+      // }
+
+      // babel.config.js
+      if (!fs.existsSync(projectBabelRCPath)) {
+        projectBabelRCPath = path.resolve(projectRoot, 'babel.config.js');
+      }
+
+      // If we found a babel config file, extend our config off of it
+      // otherwise the default config will be used
+      if (fs.existsSync(projectBabelRCPath)) {
+        babelRC.extends = projectBabelRCPath;
+      }
+    }
+
+    // If a babel config file doesn't exist in the project then
+    // the default preset for react-native will be used instead.
+    if (!babelRC.extends) {
+      const { experimentalImportSupport, ...presetOptions } = options;
+
+      // Use `babel-preset-expo` instead of `metro-react-native-babel-preset`.
+      const presetPath =
+        resolveFrom.silent(projectRoot, 'babel-preset-expo') ??
+        resolveFrom.silent(projectRoot, 'metro-react-native-babel-preset') ??
+        require.resolve('babel-preset-expo');
+
+      babelRC.presets = [
+        [
+          require(presetPath),
+          {
+            ...presetOptions,
+            disableImportExportTransform: experimentalImportSupport,
+            enableBabelRuntime: options.enableBabelRuntime,
+          },
+        ],
+      ];
+    }
+
+    return babelRC;
+  };
+})();
+
+/**
+ * Given a filename and options, build a Babel
+ * config object with the appropriate plugins.
+ */
+export function getBabelConfig(
+  filename: string,
+  options: BabelTransformerOptions,
+  plugins: BabelPlugins = []
+) {
+  const babelRC = getBabelRC(options.projectRoot, options);
+
+  const extraConfig = {
+    babelrc: typeof options.enableBabelRCLookup === 'boolean' ? options.enableBabelRCLookup : true,
+    code: false,
+    filename,
+    highlightCode: true,
+  };
+
+  const config: any = { ...babelRC, ...extraConfig };
+
+  // Add extra plugins
+  const extraPlugins: (string | PluginItem)[] = [];
+
+  // TODO: This probably can be removed
+  if (options.inlineRequires) {
+    const inlineRequiresPlugin = resolveFrom(
+      options.projectRoot,
+      'babel-preset-fbjs/plugins/inline-requires'
+    );
+    extraPlugins.push(inlineRequiresPlugin);
+  }
+
+  config.plugins = extraPlugins.concat(config.plugins, plugins);
+
+  if (options.dev && options.hot) {
+    // Note: this intentionally doesn't include the path separator because
+    // I'm not sure which one it should use on Windows, and false positives
+    // are unlikely anyway. If you later decide to include the separator,
+    // don't forget that the string usually *starts* with "node_modules" so
+    // the first one often won't be there.
+    // TODO: Support monorepos
+    const mayContainEditableReactComponents = filename.indexOf('node_modules') === -1;
+
+    if (mayContainEditableReactComponents) {
+      if (!config.plugins) {
+        config.plugins = [];
+      }
+      // Add react refresh runtime.
+      // NOTICE: keep in sync with 'metro-react-native-babel-preset/src/configs/hmr'.
+      config.plugins.push(resolveFrom.silent(options.projectRoot, 'react-refresh/babel'));
+    }
+  }
+
+  return { ...babelRC, ...config };
+}

--- a/packages/metro-config/src/transformer/getCacheKey.ts
+++ b/packages/metro-config/src/transformer/getCacheKey.ts
@@ -1,0 +1,17 @@
+import crypto from 'crypto';
+import { readFileSync } from 'fs';
+
+export const cacheKeyParts = [
+  readFileSync(__filename),
+  // Since babel-preset-fbjs cannot be safely resolved relative to the
+  // project root, use this environment variable that we define earlier.
+  process.env.EXPO_METRO_CACHE_KEY_VERSION || '3.3.0',
+  //   require('babel-preset-fbjs/package.json').version,
+];
+
+// Matches upstream
+export function getCacheKey(): string {
+  const key = crypto.createHash('md5');
+  cacheKeyParts.forEach(part => key.update(part));
+  return key.digest('hex');
+}

--- a/packages/metro-config/src/transformer/metro-expo-babel-transformer.ts
+++ b/packages/metro-config/src/transformer/metro-expo-babel-transformer.ts
@@ -1,14 +1,8 @@
-import crypto from 'crypto';
-import { readFileSync } from 'fs';
+// Copyright 2021-present 650 Industries (Expo). All rights reserved.
+
 import resolveFrom from 'resolve-from';
 
-const cacheKeyParts = [
-  readFileSync(__filename),
-  // Since babel-preset-fbjs cannot be safely resolved relative to the
-  // project root, use this environment variable that we define earlier.
-  process.env.EXPO_METRO_CACHE_KEY_VERSION || '3.3.0',
-  //   require('babel-preset-fbjs/package.json').version,
-];
+import { getCacheKey } from './getCacheKey';
 
 let transformer: any = null;
 
@@ -54,13 +48,6 @@ function transform(props: {
     'babel-preset-expo'
   );
   return resolveTransformer(props.options.projectRoot).transform(props);
-}
-
-// Matches upstream
-function getCacheKey(): string {
-  const key = crypto.createHash('md5');
-  cacheKeyParts.forEach(part => key.update(part));
-  return key.digest('hex');
 }
 
 module.exports = {

--- a/packages/metro-config/src/transformer/metro-expo-exotic-babel-transformer.ts
+++ b/packages/metro-config/src/transformer/metro-expo-exotic-babel-transformer.ts
@@ -1,0 +1,94 @@
+// Copyright 2021-present 650 Industries (Expo). All rights reserved.
+
+import { createExoticTransformer, loaders } from './createExoticTransformer';
+import {
+  createExpoMatcher,
+  createKnownCommunityMatcher,
+  createModuleMatcher,
+  createReactNativeMatcher,
+} from './createMatcher';
+import { getCacheKey } from './getCacheKey';
+
+const nodeModulesPaths: string[] = ['node_modules'];
+
+// Match any node modules, or monorepo module.
+const nodeModuleMatcher = createModuleMatcher({ folders: nodeModulesPaths, moduleIds: [] });
+
+// Match node modules which are so oddly written that we must
+// transpile them with every possible option (most expensive).
+const impossibleNodeModuleMatcher = createModuleMatcher({
+  moduleIds: [
+    // victory is too wild
+    // SyntaxError in ../../node_modules/victory-native/lib/components/victory-primitives/bar.js: Missing semicolon. (9:1)
+    'victory',
+    // vector icons has some hidden issues that break NCL
+    '@expo/vector-icons',
+  ],
+  folders: nodeModulesPaths,
+});
+
+const transform = createExoticTransformer({
+  // Specify which rules to use on a per-file basis, basically
+  // this is used to determine which modules are node modules, and which are application code.
+  getRuleType({ filename }) {
+    // Is a node module, and is not one of the impossible modules.
+    return nodeModuleMatcher.test(filename) && !impossibleNodeModuleMatcher.test(filename)
+      ? 'module'
+      : 'app';
+  },
+
+  // Order is very important, we use wild card matchers to transpile
+  // "every unhandled node module" and "every unhandled application module".
+  rules: [
+    // Match bob compiler modules, use the passthrough loader.
+    {
+      type: 'module',
+      test: createModuleMatcher({ moduleIds: ['.*/lib/commonjs/'], folders: nodeModulesPaths }),
+      transform: loaders.passthroughModule,
+      warn: true,
+    },
+    // Match React Native modules, convert them statically using sucrase.
+    {
+      type: 'module',
+      test: createReactNativeMatcher({ folders: nodeModulesPaths }),
+      transform: loaders.reactNativeModule,
+      warn: true,
+    },
+    // Match Expo SDK modules, convert them statically using sucrase.
+    {
+      type: 'module',
+      test: createExpoMatcher({ folders: nodeModulesPaths }),
+      transform: loaders.expoModule,
+      warn: true,
+    },
+    // Match known problematic modules, convert them statically using an expensive, dynamic sucrase.
+    {
+      type: 'module',
+      test: createKnownCommunityMatcher({ folders: nodeModulesPaths }),
+      transform: loaders.untranspiledModule,
+      warn: true,
+    },
+    // Pass through any unhandled node modules as passthrough, this is where the most savings occur.
+    // Ideally, you want your project to pass all node modules through this loader.
+    // This should be the last "module" rule.
+    // Message library authors and ask them to ship their modules as pre-transpiled
+    // commonjs, to improve the development speed of your project.
+    {
+      type: 'module',
+      test: () => true,
+      transform: loaders.passthroughModule,
+    },
+    // All application code should be transpiled with the user's babel preset,
+    // this is the most expensive operation but provides the most customization to the user.
+    // The goal is to use this as sparingly as possible.
+    {
+      test: () => true,
+      transform: loaders.app,
+    },
+  ],
+});
+
+module.exports = {
+  transform,
+  getCacheKey,
+};

--- a/packages/xdl/src/logs/PackagerLogsStream.ts
+++ b/packages/xdl/src/logs/PackagerLogsStream.ts
@@ -416,7 +416,8 @@ export default class PackagerLogsStream {
       if (msg.percentage) {
         percentProgress = msg.percentage * 100;
       } else {
-        percentProgress = Math.floor((msg.transformedFileCount / msg.totalFileCount) * 100);
+        percentProgress = (msg.transformedFileCount / msg.totalFileCount) * 100;
+        // percentProgress = Math.floor((msg.transformedFileCount / msg.totalFileCount) * 100);
       }
       progressChunk.msg = `Building JavaScript bundle: ${percentProgress}%`;
     } else {
@@ -514,11 +515,12 @@ export default class PackagerLogsStream {
   }
 
   _formatWorkerChunk(origin: 'stdout' | 'stderr', chunk: string) {
-    const lines = chunk.split('\n');
-    if (lines.length >= 1 && lines[lines.length - 1] === '') {
-      lines.splice(lines.length - 1, 1);
-    }
-    return lines.map(line => `transform[${origin}]: ${line}`).join('\n');
+    return chunk;
+    // const lines = chunk.split('\n');
+    // if (lines.length >= 1 && lines[lines.length - 1] === '') {
+    //   lines.splice(lines.length - 1, 1);
+    // }
+    // return lines.map(line => `transform[${origin}]: ${line}`).join('\n');
   }
 
   _enqueueAppendLogChunk(chunk: LogRecord) {

--- a/ts-declarations/metro-babel-transformer/index.d.ts
+++ b/ts-declarations/metro-babel-transformer/index.d.ts
@@ -1,0 +1,43 @@
+declare module 'metro-babel-transformer' {
+  import type { FBSourceFunctionMap } from 'metro-source-map';
+  import type { Ast, PluginItem } from '@babel/core';
+
+  export type CustomTransformOptions = {
+    [key: string]: unknown;
+    __proto__: null;
+  };
+
+  export type BabelTransformerOptions = {
+    customTransformOptions?: CustomTransformOptions;
+    dev: boolean;
+    disableFlowStripTypesTransform?: boolean;
+    enableBabelRCLookup?: boolean;
+    enableBabelRuntime: boolean;
+    experimentalImportSupport?: boolean;
+    hot: boolean;
+    inlineRequires: boolean;
+    minify: boolean;
+    unstable_disableES6Transforms?: boolean;
+    platform: ?string;
+    projectRoot: string;
+    publicPath: string;
+  };
+
+  export type BabelTransformerArgs = {
+    filename: string;
+    options: BabelTransformerOptions;
+    plugins?: PluginItem[];
+    src: string;
+  };
+
+  export type BabelTransformer = {
+    transform: (
+      args: BabelTransformerArgs
+    ) => {
+      ast: Ast;
+      code: string | null;
+      functionMap?: FBSourceFunctionMap | null;
+    };
+    getCacheKey?: () => string;
+  };
+}

--- a/ts-declarations/metro-source-map/index.d.ts
+++ b/ts-declarations/metro-source-map/index.d.ts
@@ -9,7 +9,7 @@ declare module 'metro-source-map' {
 
   type FBSourcesArray = Readonly<Array<FBSourceMetadata | null>>;
   type FBSourceMetadata = [FBSourceFunctionMap | null];
-  type FBSourceFunctionMap = {
+  export type FBSourceFunctionMap = {
     names: Readonly<Array<string>>;
     mappings: string;
   };
@@ -58,6 +58,24 @@ declare module 'metro-source-map' {
   //#region metro-source-map/src/composeSourceMaps.js.flow
 
   export function composeSourceMaps(maps: Readonly<Array<MixedSourceMap>>): MixedSourceMap;
+
+  //#endregion
+
+  //#region metro-source-map/src/composeSourceMaps.js.flow
+
+  import type { Ast } from '@babel/core';
+
+  type Context = { filename?: string };
+
+  /**
+   * Generate a map of source positions to function names. The names are meant to
+   * describe the stack frame in an error trace and may contain more contextual
+   * information than just the actual name of the function.
+   *
+   * The output is encoded for use in a source map. For details about the format,
+   * see MappingEncoder below.
+   */
+  export function generateFunctionMap(ast: Ast, context?: Context): FBSourceFunctionMap;
 
   //#endregion
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.7.tgz#7b047d7a3a89a67d2258dc61f604f098f1bc7e08"
   integrity sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==
 
+"@babel/compat-data@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
+  integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
+
 "@babel/core@7.7.7":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.7.tgz#ee155d2e12300bcc0cff6a8ad46f2af5063803e9"
@@ -167,6 +172,27 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/core@^7.14.0", "@babel/core@^7.15.5":
+  version "7.15.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.5.tgz#f8ed9ace730722544609f90c9bb49162dc3bf5b9"
+  integrity sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.4"
+    "@babel/helper-compilation-targets" "^7.15.4"
+    "@babel/helper-module-transforms" "^7.15.4"
+    "@babel/helpers" "^7.15.4"
+    "@babel/parser" "^7.15.5"
+    "@babel/template" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
 "@babel/eslint-plugin@^7.11.3":
   version "7.13.16"
   resolved "https://registry.yarnpkg.com/@babel/eslint-plugin/-/eslint-plugin-7.13.16.tgz#d6937636c567b41d6ca46d291c7b2d101e6ccaf3"
@@ -180,6 +206,15 @@
   integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
   dependencies:
     "@babel/types" "^7.14.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.4.tgz#85acb159a267ca6324f9793986991ee2022a05b0"
+  integrity sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==
+  dependencies:
+    "@babel/types" "^7.15.4"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -204,6 +239,16 @@
   integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
   dependencies:
     "@babel/compat-data" "^7.14.5"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.16.6"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz#cf6d94f30fbefc139123e27dd6b02f65aeedb7b9"
+  integrity sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==
+  dependencies:
+    "@babel/compat-data" "^7.15.0"
     "@babel/helper-validator-option" "^7.14.5"
     browserslist "^4.16.6"
     semver "^6.3.0"
@@ -258,12 +303,28 @@
     "@babel/template" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-function-name@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz#845744dafc4381a4a5fb6afa6c3d36f98a787ebc"
+  integrity sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.15.4"
+    "@babel/template" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-get-function-arity@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
   integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-get-function-arity@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz#098818934a137fce78b536a3e015864be1e2879b"
+  integrity sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-hoist-variables@^7.14.5":
   version "7.14.5"
@@ -272,6 +333,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-hoist-variables@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz#09993a3259c0e918f99d104261dfdfc033f178df"
+  integrity sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-member-expression-to-functions@^7.14.5":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
@@ -279,12 +347,26 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-member-expression-to-functions@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz#bfd34dc9bba9824a4658b0317ec2fd571a51e6ef"
+  integrity sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.13.12", "@babel/helper-module-imports@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
   integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-module-imports@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz#e18007d230632dea19b47853b984476e7b4e103f"
+  integrity sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.14.5", "@babel/helper-module-transforms@^7.9.0":
   version "7.14.5"
@@ -300,12 +382,33 @@
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-module-transforms@^7.15.4":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz#7da80c8cbc1f02655d83f8b79d25866afe50d226"
+  integrity sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.15.4"
+    "@babel/helper-replace-supers" "^7.15.4"
+    "@babel/helper-simple-access" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
+    "@babel/helper-validator-identifier" "^7.15.7"
+    "@babel/template" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.6"
+
 "@babel/helper-optimise-call-expression@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
   integrity sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-optimise-call-expression@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz#f310a5121a3b9cc52d9ab19122bd729822dee171"
+  integrity sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.14.5"
@@ -331,12 +434,29 @@
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-replace-supers@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz#52a8ab26ba918c7f6dee28628b07071ac7b7347a"
+  integrity sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.15.4"
+    "@babel/helper-optimise-call-expression" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-simple-access@^7.10.4", "@babel/helper-simple-access@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz#66ea85cf53ba0b4e588ba77fc813f53abcaa41c4"
   integrity sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-simple-access@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz#ac368905abf1de8e9781434b635d8f8674bcc13b"
+  integrity sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.14.5":
   version "7.14.5"
@@ -352,10 +472,22 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-split-export-declaration@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz#aecab92dcdbef6a10aa3b62ab204b085f776e257"
+  integrity sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
   integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+
+"@babel/helper-validator-identifier@^7.14.9", "@babel/helper-validator-identifier@^7.15.7":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
+  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
 "@babel/helper-validator-option@^7.12.11", "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -381,6 +513,15 @@
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helpers@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.15.4.tgz#5f40f02050a3027121a3cf48d497c05c555eaf43"
+  integrity sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==
+  dependencies:
+    "@babel/template" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
@@ -394,6 +535,11 @@
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
   integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
+
+"@babel/parser@^7.15.4", "@babel/parser@^7.15.5":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.7.tgz#0c3ed4a2eb07b165dfa85b3cc45c727334c4edae"
+  integrity sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.14.5":
   version "7.14.5"
@@ -1318,6 +1464,15 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/template@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
+  integrity sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.9.0":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.7.tgz#64007c9774cfdc3abd23b0780bc18a3ce3631753"
@@ -1330,6 +1485,21 @@
     "@babel/helper-split-export-declaration" "^7.14.5"
     "@babel/parser" "^7.14.7"
     "@babel/types" "^7.14.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.14.0", "@babel/traverse@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.4.tgz#ff8510367a144bfbff552d9e18e28f3e2889c22d"
+  integrity sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.4"
+    "@babel/helper-function-name" "^7.15.4"
+    "@babel/helper-hoist-variables" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -1357,6 +1527,14 @@
   integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.15.4", "@babel/types@^7.15.6":
+  version "7.15.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.6.tgz#99abdc48218b2881c058dd0a7ab05b99c9be758f"
+  integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -9782,6 +9960,11 @@ hermes-engine@~0.5.0:
   resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.5.1.tgz#601115e4b1e0a17d9aa91243b96277de4e926e09"
   integrity sha512-hLwqh8dejHayjlpvZY40e1aDCDvyP98cWx/L5DhAjSJLH8g4z9Tp08D7y4+3vErDsncPOdf1bxm+zUWpx0/Fxg==
 
+hermes-parser@0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.4.7.tgz#410f5129d57183784d205a0538e6fbdcf614c9ea"
+  integrity sha512-jc+zCtXbtwTiXoMAoXOHepxAaGVFIp89wwE9qcdwnMd/uGVEtPoY8FaFSsx0ThPvyKirdR2EsIIDVrpbSXz1Ag==
+
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz#bd0f5ecceda80dd0ddaae443469ab26fb38fc27b"
@@ -12669,6 +12852,16 @@ metro-babel-transformer@0.59.0:
     "@babel/core" "^7.0.0"
     metro-source-map "0.59.0"
 
+metro-babel-transformer@^0.66.2:
+  version "0.66.2"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.66.2.tgz#fce0a3e314d28a5e7141c135665e1cc9b8e7ce86"
+  integrity sha512-aJ/7fc/Xkofw8Fqa51OTDhBzBz26mmpIWrXAZcPdQ8MSTt883EWncxeCEjasc79NJ89BRi7sOkkaWZo2sXlKvw==
+  dependencies:
+    "@babel/core" "^7.14.0"
+    hermes-parser "0.4.7"
+    metro-source-map "0.66.2"
+    nullthrows "^1.1.1"
+
 metro-cache@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.59.0.tgz#ef3c055f276933979b731455dc8317d7a66f0f2d"
@@ -12833,6 +13026,20 @@ metro-source-map@0.59.0:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
+metro-source-map@0.66.2:
+  version "0.66.2"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.66.2.tgz#b5304a282a5d55fa67b599265e9cf3217175cdd7"
+  integrity sha512-038tFmB7vSh73VQcDWIbr5O1m+WXWyYafDaOy+1A/2K308YP0oj33gbEgDnZsLZDwcJ+xt1x6KUEBIzlX4YGeQ==
+  dependencies:
+    "@babel/traverse" "^7.14.0"
+    "@babel/types" "^7.0.0"
+    invariant "^2.2.4"
+    metro-symbolicate "0.66.2"
+    nullthrows "^1.1.1"
+    ob1 "0.66.2"
+    source-map "^0.5.6"
+    vlq "^1.0.0"
+
 metro-symbolicate@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.59.0.tgz#fc7f93957a42b02c2bfc57ed1e8f393f5f636a54"
@@ -12840,6 +13047,18 @@ metro-symbolicate@0.59.0:
   dependencies:
     invariant "^2.2.4"
     metro-source-map "0.59.0"
+    source-map "^0.5.6"
+    through2 "^2.0.1"
+    vlq "^1.0.0"
+
+metro-symbolicate@0.66.2:
+  version "0.66.2"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.66.2.tgz#addd095ce5f77e73ca21ddb5dfb396ff5d4fa041"
+  integrity sha512-u+DeQHyAFXVD7mVP+GST/894WHJ3i/U8oEJFnT7U3P52ZuLgX8n4tMNxhqZU12RcLR6etF8143aP0Ktx1gFLEQ==
+  dependencies:
+    invariant "^2.2.4"
+    metro-source-map "0.66.2"
+    nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
@@ -13877,6 +14096,11 @@ ob1@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.59.0.tgz#ee103619ef5cb697f2866e3577da6f0ecd565a36"
   integrity sha512-opXMTxyWJ9m68ZglCxwo0OPRESIC/iGmKFPXEXzMZqsVIrgoRXOHmoMDkQzz4y3irVjbyPJRAh5pI9fd0MJTFQ==
+
+ob1@0.66.2:
+  version "0.66.2"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.66.2.tgz#8caf548202cf2688944bae47db405a08bca17a61"
+  integrity sha512-RFewnL/RjE0qQBOuM+2bbY96zmJPIge/aDtsiDbLSb+MOiK8CReAhBHDgL+zrA3F1hQk00lMWpUwYcep750plA==
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
# Why

Create an interface for Metro to transform babel like Webpack does. Instead of running a single babel preset against all files, we now have an array of loader rules which parses some files faster than others. This system enables users to have all the same customization as before, and rewards projects that pre-transpile their JS code. 

The API also surfaces helper functions so projects can extend the system locally to fit their needs. For now, we'll be rolling it out behind a feature flag name `EXPO_USE_EXOTIC`. 

# How

When exotic is enabled:
- remove react-native resolver field
- add cjs to the src extensions
- use a custom transformer which parses:
  - bob modules with passthrough.
  - expo, react-native, and known community modules with sucrase.
  - all remaining modules with passthrough.
  - and all application code with the local babel preset.



## Source Maps

This PR also disables the `x_facebook_sources` generation by default. The feature can be re-enabled with `EXPO_USE_FB_SOURCES`. Here are the results:

<table>
<tr>
    <th>Enabled</th>
    <th>Disabled</th>
  </tr>
 <tr>
    <td>iOS Bundling: <b>7664ms</b></td>
    <td>iOS Bundling: <b>6875ms</b></td>
  </tr>
 <tr>
    <td><img src="https://user-images.githubusercontent.com/9664363/134078785-c9b0d93d-3dfb-4552-b786-b45059e10c3b.png" width="200" /></td>
    <td><img src="https://user-images.githubusercontent.com/9664363/134078781-9f79e9d8-56c7-4e20-952f-8214deb3f0ca.png" width="200" /></td>
  </tr>
</table>

# Test Plan

Results should be ~2x faster in basic projects, and should work to load NCL. NCL requires a few extra modifications, like adding `['node_modules', '../../node_modules', '../../packages', '../../react-native-lab']` to the folders array.

- `EXPO_USE_EXOTIC=true expo start -c` dev
- `EXPO_USE_EXOTIC=true expo export` prod