### PR TITLE
Fix loader bug

### DIFF
--- a/packages/expo-cli/src/utils/ora.ts
+++ b/packages/expo-cli/src/utils/ora.ts
@@ -1,8 +1,17 @@
 import chalk from 'chalk';
 import program from 'commander';
-import oraReal from 'ora';
+import oraReal, { Ora } from 'ora';
 
 import Log from '../log';
+
+// eslint-disable-next-line no-console
+const logReal = console.log;
+// eslint-disable-next-line no-console
+const infoReal = console.info;
+// eslint-disable-next-line no-console
+const warnReal = console.warn;
+// eslint-disable-next-line no-console
+const errorReal = console.error;
 
 /**
  * A custom ora spinner that sends the stream to stdout in CI, non-TTY, or expo's non-interactive flag instead of stderr (the default).
@@ -13,7 +22,7 @@ import Log from '../log';
 export function ora(options?: oraReal.Options | string): oraReal.Ora {
   const inputOptions = typeof options === 'string' ? { text: options } : options || {};
   const disabled = program.nonInteractive || Log.isDebug;
-  const ora = oraReal({
+  const spinner = oraReal({
     // Ensure our non-interactive mode emulates CI mode.
     isEnabled: !disabled,
     // In non-interactive mode, send the stream to stdout so it prevents looking like an error.
@@ -21,35 +30,28 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
     ...inputOptions,
   });
 
-  // eslint-disable-next-line no-console
-  const logReal = console.log;
-  // eslint-disable-next-line no-console
-  const infoReal = console.info;
-  // eslint-disable-next-line no-console
-  const warnReal = console.warn;
-  // eslint-disable-next-line no-console
-  const errorReal = console.error;
+  const oraStart = spinner.start.bind(spinner);
+  const oraStop = spinner.stop.bind(spinner);
+  const oraStopAndPersist = spinner.stopAndPersist.bind(spinner);
 
-  const oraStop = ora.stop.bind(ora);
-
-  const origStopAndPersist = ora.stopAndPersist.bind(ora);
-
-  const logWrap = (method: any, args: any[]) => {
+  const logWrap = (method: any, args: any[]): void => {
     oraStop();
     method(...args);
-    ora!.start();
+    spinner.start();
   };
 
-  // eslint-disable-next-line no-console
-  console.log = (...args: any) => logWrap(logReal, args);
-  // eslint-disable-next-line no-console
-  console.info = (...args: any) => logWrap(infoReal, args);
-  // eslint-disable-next-line no-console
-  console.warn = (...args: any) => logWrap(warnReal, args);
-  // eslint-disable-next-line no-console
-  console.error = (...args: any) => logWrap(errorReal, args);
+  const wrapNativeLogs = (): void => {
+    // eslint-disable-next-line no-console
+    console.log = (...args: any) => logWrap(logReal, args);
+    // eslint-disable-next-line no-console
+    console.info = (...args: any) => logWrap(infoReal, args);
+    // eslint-disable-next-line no-console
+    console.warn = (...args: any) => logWrap(warnReal, args);
+    // eslint-disable-next-line no-console
+    console.error = (...args: any) => logWrap(errorReal, args);
+  };
 
-  const resetNativeLogs = () => {
+  const resetNativeLogs = (): void => {
     // eslint-disable-next-line no-console
     console.log = logReal;
     // eslint-disable-next-line no-console
@@ -60,22 +62,27 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
     console.error = errorReal;
   };
 
-  ora.stopAndPersist = (): oraReal.Ora => {
-    origStopAndPersist();
-    resetNativeLogs();
-    return ora!;
+  spinner.start = (text: string): Ora => {
+    wrapNativeLogs();
+    return oraStart(text);
   };
 
-  ora.stop = (): oraReal.Ora => {
-    oraStop();
+  spinner.stopAndPersist = (options): Ora => {
+    const result = oraStopAndPersist(options);
     resetNativeLogs();
-    return ora!;
+    return result;
+  };
+
+  spinner.stop = (): Ora => {
+    const result = oraStop();
+    resetNativeLogs();
+    return result;
   };
 
   // Always make the central logging module aware of the current spinner
-  Log.setSpinner(ora);
+  Log.setSpinner(spinner);
 
-  return ora;
+  return spinner;
 }
 
 /**

--- a/packages/expo-cli/src/utils/ora.ts
+++ b/packages/expo-cli/src/utils/ora.ts
@@ -62,7 +62,7 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
     console.error = errorReal;
   };
 
-  spinner.start = (text: string): Ora => {
+  spinner.start = (text): Ora => {
     wrapNativeLogs();
     return oraStart(text);
   };


### PR DESCRIPTION
# Why

ora.complete is not changing the message.

# Test Plan

`expo prebuild -p ios` should log correctly:

```
✔ Updated package.json and added index.js entry point for iOS and Android
🧶 Using Yarn to install packages. Pass --npm to use npm instead.
✔ Installed JavaScript dependencies 1559ms
✔ Config synced
✔ Installed pods and initialized Xcode workspace.
```

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->