### PR TITLE
Add asset dev server hosting for webpack

### DIFF
--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -97,8 +97,12 @@ async function clearWebCacheAsync(projectRoot: string, mode: string): Promise<vo
 }
 
 // Temporary hack while we implement multi-bundler dev server proxy.
+const _isTargetingNative: boolean = ['ios', 'android'].includes(
+  process.env.EXPO_WEBPACK_PLATFORM || ''
+);
+
 export function isTargetingNative() {
-  return ['ios', 'android'].includes(process.env.EXPO_WEBPACK_PLATFORM || '');
+  return _isTargetingNative;
 }
 
 export type WebpackDevServerResults = {

--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import express from 'express';
 import http from 'http';
 import os from 'os';
-import { parse, URL } from 'url';
+import { parse, resolve, URL } from 'url';
 
 import {
   Analytics,
@@ -22,6 +22,7 @@ import {
   UserManager,
   UserSettings,
   Versions,
+  Webpack,
 } from '../internal';
 
 interface HostInfo {
@@ -283,6 +284,11 @@ export async function getManifestResponseAsync({
     projectRoot,
     manifest,
     async resolver(path) {
+      if (Webpack.isTargetingNative()) {
+        // When using our custom dev server, just do assets normally
+        // without the `assets/` subpath redirect.
+        return resolve(manifest.bundleUrl!.match(/^https?:\/\/.*?\//)![0], path);
+      }
       return manifest.bundleUrl!.match(/^https?:\/\/.*?\//)![0] + 'assets/' + path;
     },
   });


### PR DESCRIPTION
# Why

I built the asset redirect middleware that metro uses, but then I realized that this was a ridiculous feature to add, so instead, I've updated the manifest handler to simply not add an `assets/` subfolder for assets. 

- Metro: `"iconUrl": "http://127.0.0.1:19000/assets/./assets/icon.png"`
- Webpack: `"iconUrl": "http://127.0.0.1:19000/assets/icon.png"`

Opened in Expo Go to ensure the icons and splash screens still load as expected.

