### PR TITLE
[pod-install] mention `macos` directory in Readme

### DIFF
--- a/packages/pod-install/README.md
+++ b/packages/pod-install/README.md
@@ -43,7 +43,7 @@ This package will do the following:
 - Ensure CocoaPods CLI is installed on the machine.
   - If not then it'll try to install CocoaPods CLI, first with gem, then with homebrew.
 - Check if there is an Xcode project in the current directory
-  - If not then it'll try again in an `ios/` directory (if one exists).
+  - If not then it'll try again in `ios/` than `macos/` directories (if any exists).
 - Run `pod install`
   - If `pod install` fails because the repo is out of date, then it'll run `pod repo update` and try again.
 


### PR DESCRIPTION
# Why

Refs #2461 

Since the PR above the `pod-install` package will also check the `macos` directory for the Xcode project, but the information was missing in the Readme file.

# How

Add information that also `macos` directory is checked. Feel free to suggest grammar corrections if needed. 😉 

# Test Plan

N/A