### PR TITLE
Remove incorrect platform from 'dev client start command' event

### DIFF
--- a/packages/expo-cli/src/commands/start/startAsync.ts
+++ b/packages/expo-cli/src/commands/start/startAsync.ts
@@ -135,7 +135,6 @@ export async function actionAsync(projectRoot: string, options: NormalizedOption
 function track(projectRoot: string, exp: ExpoConfig) {
   UnifiedAnalytics.logEvent('dev client start command', {
     status: 'started',
-    platform: 'ios',
     ...getDevClientProperties(projectRoot, exp),
   });
   installCustomExitHook(() => {


### PR DESCRIPTION
# Why

The `dev client start command` analytics event should, per spec, never include the `platform` property, which is only used in events triggered by `expo run:ios` and `expo run:android` commands, where we know the platform.

# How

🤷‍♂️ 

# Test Plan

N/A