### PR TITLE
[config-plugins] only support dynamic runtimes in managed

### DIFF
--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -40,10 +40,11 @@ export const withUpdates: ConfigPlugin<{ expoUsername: string | null }> = (
  * case we use SDK version
  */
 export function getRuntimeVersionNullable(
-  config: Pick<ExpoConfigUpdates, 'runtimeVersion'>
+  config: Pick<ExpoConfigUpdates, 'runtimeVersion'>,
+  isManagedProject: boolean
 ): string | null {
   try {
-    return getRuntimeVersion(config, 'android');
+    return getRuntimeVersion(config, 'android', isManagedProject);
   } catch (e) {
     return null;
   }
@@ -111,7 +112,7 @@ export function setVersionsConfig(
 ): AndroidManifest {
   const mainApplication = getMainApplicationOrThrow(androidManifest);
 
-  const runtimeVersion = getRuntimeVersionNullable(config);
+  const runtimeVersion = getRuntimeVersionNullable(config, /* isManagedProject */ false);
   const sdkVersion = getSDKVersion(config);
   if (runtimeVersion) {
     removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
@@ -212,7 +213,7 @@ export function areVersionsSynced(
   config: Pick<ExpoConfigUpdates, 'runtimeVersion' | 'sdkVersion'>,
   androidManifest: AndroidManifest
 ): boolean {
-  const expectedRuntimeVersion = getRuntimeVersionNullable(config);
+  const expectedRuntimeVersion = getRuntimeVersionNullable(config, /* isManagedProject */ false);
   const expectedSdkVersion = getSDKVersion(config);
 
   const currentRuntimeVersion = getMainApplicationMetaDataValue(

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -31,10 +31,11 @@ export enum Config {
  * case we use SDK version
  */
 export function getRuntimeVersionNullable(
-  config: Pick<ExpoConfigUpdates, 'runtimeVersion'>
+  config: Pick<ExpoConfigUpdates, 'runtimeVersion'>,
+  isManagedProject: boolean
 ): string | null {
   try {
-    return getRuntimeVersion(config, 'ios');
+    return getRuntimeVersion(config, 'ios', isManagedProject);
   } catch (e) {
     return null;
   }
@@ -98,7 +99,7 @@ export function setUpdatesConfig(
 export function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlist): ExpoPlist {
   const newExpoPlist = { ...expoPlist };
 
-  const runtimeVersion = getRuntimeVersionNullable(config);
+  const runtimeVersion = getRuntimeVersionNullable(config, /*isManagedProject*/ false);
   const sdkVersion = getSDKVersion(config);
   if (runtimeVersion) {
     delete newExpoPlist[Config.SDK_VERSION];
@@ -207,7 +208,7 @@ export function isPlistVersionConfigurationSynced(
   config: Pick<ExpoConfigUpdates, 'sdkVersion' | 'runtimeVersion'>,
   expoPlist: ExpoPlist
 ): boolean {
-  const expectedRuntimeVersion = getRuntimeVersionNullable(config);
+  const expectedRuntimeVersion = getRuntimeVersionNullable(config, /*isManagedProject*/ false);
   const expectedSdkVersion = getSDKVersion(config);
 
   const currentRuntimeVersion = expoPlist.EXUpdatesRuntimeVersion ?? null;

--- a/packages/config-plugins/src/utils/__tests__/Updates-test.ts
+++ b/packages/config-plugins/src/utils/__tests__/Updates-test.ts
@@ -55,13 +55,18 @@ describe(getNativeVersion, () => {
 });
 
 describe(getRuntimeVersion, () => {
+  it('throws if runtime version is dynamic and the project is not managed', () => {
+    expect(() => {
+      getRuntimeVersion({ runtimeVersion: { policy: 'nativeVersion' } }, 'ios', false);
+    }).toThrow('Dynamic runtime versions are only supported for managed projects.');
+  });
   it('works if the top level runtimeVersion is a string', () => {
     const runtimeVersion = '42';
-    expect(getRuntimeVersion({ runtimeVersion }, 'ios')).toBe(runtimeVersion);
+    expect(getRuntimeVersion({ runtimeVersion }, 'ios', true)).toBe(runtimeVersion);
   });
   it('works if the platform specific runtimeVersion is a string', () => {
     const runtimeVersion = '42';
-    expect(getRuntimeVersion({ ios: { runtimeVersion } }, 'ios')).toBe(runtimeVersion);
+    expect(getRuntimeVersion({ ios: { runtimeVersion } }, 'ios', true)).toBe(runtimeVersion);
   });
   it('works if the runtimeVersion is a policy', () => {
     const version = '1';
@@ -69,23 +74,24 @@ describe(getRuntimeVersion, () => {
     expect(
       getRuntimeVersion(
         { version, runtimeVersion: { policy: 'nativeVersion' }, ios: { buildNumber } },
-        'ios'
+        'ios',
+        true
       )
     ).toBe(`${version}(${buildNumber})`);
   });
   it('throws no runtime version is supplied', () => {
     expect(() => {
-      getRuntimeVersion({}, 'ios');
+      getRuntimeVersion({}, 'ios', true);
     }).toThrow(`There is neither a value or a policy set for the runtime version on "ios"`);
   });
   it('throws if runtime version is not parseable', () => {
     expect(() => {
-      getRuntimeVersion({ runtimeVersion: 1 } as any, 'ios');
+      getRuntimeVersion({ runtimeVersion: 1 } as any, 'ios', true);
     }).toThrow(
       `"1" is not a valid runtime version. getRuntimeVersion only supports a string, "sdkVersion", or "nativeVersion" policy.`
     );
     expect(() => {
-      getRuntimeVersion({ runtimeVersion: { policy: 'unsupportedPlugin' } } as any, 'ios');
+      getRuntimeVersion({ runtimeVersion: { policy: 'unsupportedPlugin' } } as any, 'ios', true);
     }).toThrow(
       `"{"policy":"unsupportedPlugin"}" is not a valid runtime version. getRuntimeVersion only supports a string, "sdkVersion", or "nativeVersion" policy.`
     );

--- a/packages/expo-cli/src/commands/publishAsync.ts
+++ b/packages/expo-cli/src/commands/publishAsync.ts
@@ -52,6 +52,11 @@ export async function actionAsync(
   // Log building info before building.
   // This gives the user sometime to bail out if the info is unexpected.
   if (runtimeVersion) {
+    if (typeof runtimeVersion !== 'string') {
+      throw new Error(
+        'Dynamic runtime versions are not available for classic updates. Please look into EAS.'
+      );
+    }
     Log.log(`\u203A Runtime version: ${Log.chalk.bold(runtimeVersion)}`);
   } else if (sdkVersion) {
     Log.log(`\u203A Expo SDK: ${Log.chalk.bold(sdkVersion)}`);

--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -1,4 +1,4 @@
-import { ExpoUpdatesManifest, getConfig } from '@expo/config';
+import { ExpoUpdatesManifest, getConfig, getDefaultTarget } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
 import { JSONObject } from '@expo/json-file';
 import express from 'express';
@@ -114,9 +114,11 @@ export async function getManifestResponseAsync({
 
   const hostUri = await UrlUtils.constructHostUriAsync(projectRoot, hostname);
 
+  const isManagedProject = getDefaultTarget(projectRoot) === 'managed';
   const runtimeVersion = Updates.getRuntimeVersion(
     { ...expoConfig, runtimeVersion: expoConfig.runtimeVersion ?? { policy: 'sdkVersion' } },
-    platform
+    platform,
+    isManagedProject
   );
 
   const bundleUrl = await getBundleUrlAsync({


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

For the time being, only allow auto runtime versions in managed.

The `getRuntimeVersion` wrapper should be exported and used to compute the runtimes for `eas publish` here: https://github.com/expo/eas-cli/blob/03fa29dd5a3fae9cc926d2ba26ebc51f8b42af27/packages/eas-cli/src/commands/branch/publish.ts#L395

And for `eas build` where ever it is appropriate.

# How

Added a check for managed projects.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

added tests. 

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->