### PR TITLE
[expo-cli] Add version check fallback for packages with exports

### DIFF
--- a/packages/expo-cli/__mocks__/resolve-from.js
+++ b/packages/expo-cli/__mocks__/resolve-from.js
@@ -1,4 +1,4 @@
-function mockedResolveFrom(fromDirectory, request, silent = false) {
+function mockedResolveFrom(fromDirectory, request) {
   const fs = require('fs');
   const path = require('path');
 
@@ -18,5 +18,5 @@ function mockedResolveFrom(fromDirectory, request, silent = false) {
   }
 }
 
-module.exports = mockedResolveFrom;
-module.exports.silent = mockedResolveFrom;
+module.exports = jest.fn(mockedResolveFrom);
+module.exports.silent = jest.fn(mockedResolveFrom);

--- a/packages/expo-cli/__mocks__/resolve-from.js
+++ b/packages/expo-cli/__mocks__/resolve-from.js
@@ -1,6 +1,4 @@
-module.exports = require(require.resolve('resolve-from'));
-
-module.exports.silent = (fromDirectory, request) => {
+function mockedResolveFrom(fromDirectory, request, silent = false) {
   const fs = require('fs');
   const path = require('path');
 
@@ -18,4 +16,7 @@ module.exports.silent = (fromDirectory, request) => {
   if (fs.existsSync(outputPath)) {
     return outputPath;
   }
-};
+}
+
+module.exports = mockedResolveFrom;
+module.exports.silent = mockedResolveFrom;

--- a/packages/expo-cli/src/commands/utils/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/validateDependenciesVersions-test.ts
@@ -1,5 +1,6 @@
 import { vol } from 'memfs';
 import path from 'path';
+import resolveFrom from 'resolve-from';
 
 import { validateDependenciesVersionsAsync } from '../validateDependenciesVersions';
 
@@ -76,8 +77,10 @@ describe(validateDependenciesVersionsAsync, () => {
   });
 
   it('resolves to true when installed package uses "exports"', async () => {
+    const packageJsonPath = path.join(projectRoot, 'node_modules/firebase/package.json');
+
     vol.fromJSON({
-      [path.join(projectRoot, 'node_modules/firebase/package.json')]: JSON.stringify({
+      [packageJsonPath]: JSON.stringify({
         version: '9.1.0',
         exports: {
           './analytics': {
@@ -89,6 +92,16 @@ describe(validateDependenciesVersionsAsync, () => {
           },
         },
       }),
+    });
+
+    // Manually trigger the Node import error for "exports".
+    // This isn't triggered by memfs, or our mock, that's why we need to do it manually.
+    // see: https://github.com/expo/expo-cli/pull/3878
+    (resolveFrom as jest.MockedFunction<typeof resolveFrom>).mockImplementationOnce(() => {
+      const message = `Package subpath './package.json' is not defined by "exports" in ${packageJsonPath}`;
+      const error: any = new Error(message);
+      error.code = 'ERR_PACKAGE_PATH_NOT_EXPORTED';
+      throw error;
     });
 
     const exp = {

--- a/packages/expo-cli/src/commands/utils/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/validateDependenciesVersions-test.ts
@@ -9,6 +9,7 @@ jest.mock('../bundledNativeModules', () => ({
   getBundledNativeModulesAsync: () => ({
     'expo-splash-screen': '~1.2.3',
     'expo-updates': '~2.3.4',
+    firebase: '9.1.0',
   }),
 }));
 
@@ -71,6 +72,34 @@ describe(validateDependenciesVersionsAsync, () => {
 
     await expect(validateDependenciesVersionsAsync(projectRoot, exp as any, pkg)).resolves.toBe(
       false
+    );
+  });
+
+  it('resolves to true when installed package uses "exports"', async () => {
+    vol.fromJSON({
+      [path.join(projectRoot, 'node_modules/firebase/package.json')]: JSON.stringify({
+        version: '9.1.0',
+        exports: {
+          './analytics': {
+            node: {
+              require: './analytics/dist/index.cjs.js',
+              import: './analytics/dist/index.mjs',
+            },
+            default: './analytics/dist/index.esm.js',
+          },
+        },
+      }),
+    });
+
+    const exp = {
+      sdkVersion: '43.0.0',
+    };
+    const pkg = {
+      dependencies: { firebase: '~9.1.0' },
+    };
+
+    await expect(validateDependenciesVersionsAsync(projectRoot, exp as any, pkg)).resolves.toBe(
+      true
     );
   });
 });

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -100,8 +100,6 @@ async function getPackageVersionAsync(projectRoot: string, packageName: string):
     // include `package.json`, we have to use the error message to get the location.
     if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
       packageJsonPath = error.message.match(/ in (.*)$/i)?.[1];
-    } else {
-      packageJsonPath = resolveFrom.silent(projectRoot, `${packageName}/package.json`);
     }
   }
   if (!packageJsonPath) {

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -92,7 +92,18 @@ async function resolvePackageVersionsAsync(
 }
 
 async function getPackageVersionAsync(projectRoot: string, packageName: string): Promise<string> {
-  const packageJsonPath = resolveFrom.silent(projectRoot, `${packageName}/package.json`);
+  let packageJsonPath = '';
+  try {
+    packageJsonPath = resolveFrom(projectRoot, `${packageName}/package.json`);
+  } catch (error: any) {
+    // This is a workaround for packages using `exports`. If this doesn't
+    // include `package.json`, we have to use the error message to get the location.
+    if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      packageJsonPath = error.message.match(/ in (.*)$/i)?.[1];
+    } else {
+      throw error;
+    }
+  }
   if (!packageJsonPath) {
     throw new CommandError(
       `"${packageName}" is added as a dependency in your project's package.json but it doesn't seem to be installed. Please run "yarn" or "npm install" to fix this issue.`

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -98,9 +98,9 @@ async function getPackageVersionAsync(projectRoot: string, packageName: string):
   } catch (error: any) {
     // This is a workaround for packages using `exports`. If this doesn't
     // include `package.json`, we have to use the error message to get the location.
-    if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-      packageJsonPath = error.message.match(/ in (.*)$/i)?.[1];
-    }
+    // if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+    //   packageJsonPath = error.message.match(/ in (.*)$/i)?.[1];
+    // }
   }
   if (!packageJsonPath) {
     throw new CommandError(

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -99,7 +99,7 @@ async function getPackageVersionAsync(projectRoot: string, packageName: string):
     // This is a workaround for packages using `exports`. If this doesn't
     // include `package.json`, we have to use the error message to get the location.
     if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-      packageJsonPath = error.message.match(/ in (.*)$/i)?.[1];
+      packageJsonPath = error.message.match(/("exports"|defined) in (.*)$/i)?.[2];
     }
   }
   if (!packageJsonPath) {

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -98,9 +98,9 @@ async function getPackageVersionAsync(projectRoot: string, packageName: string):
   } catch (error: any) {
     // This is a workaround for packages using `exports`. If this doesn't
     // include `package.json`, we have to use the error message to get the location.
-    // if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-    //   packageJsonPath = error.message.match(/ in (.*)$/i)?.[1];
-    // }
+    if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      packageJsonPath = error.message.match(/ in (.*)$/i)?.[1];
+    }
   }
   if (!packageJsonPath) {
     throw new CommandError(

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -92,7 +92,7 @@ async function resolvePackageVersionsAsync(
 }
 
 async function getPackageVersionAsync(projectRoot: string, packageName: string): Promise<string> {
-  let packageJsonPath = '';
+  let packageJsonPath: string | undefined;
   try {
     packageJsonPath = resolveFrom(projectRoot, `${packageName}/package.json`);
   } catch (error: any) {
@@ -101,7 +101,7 @@ async function getPackageVersionAsync(projectRoot: string, packageName: string):
     if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
       packageJsonPath = error.message.match(/ in (.*)$/i)?.[1];
     } else {
-      throw error;
+      packageJsonPath = resolveFrom.silent(projectRoot, `${packageName}/package.json`);
     }
   }
   if (!packageJsonPath) {


### PR DESCRIPTION
# Why

Fixes #3781 

Firebase JS SDK v9 uses a [new "exports" system](https://nodejs.org/api/modules.html#modules_exports) that defines all importable modules from this package. Right now, we don't support this when detecting the versions of installed libraries. It results in weird errors like #3781:

> "firebase" is added as a dependency in your project's package.json but it doesn't seem to be installed. Please run "yarn" or "npm install" to fix this issue.

# How

This is a wacky-workaround to extract the path from [the "ERR_PACKAGE_PATH_NOT_EXPORTED" error](https://nodejs.org/api/errors.html#errors_err_package_path_not_exported), thrown by Node. It can have two different formats:

<details>
<summary><code>$ node -e "require.resolve('firebase')"</code></summary>
<pre>
> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Users/cedric/Projects/expo/expo/node_modules/firebase/package.json
    at new NodeError (node:internal/errors:371:5)
    at throwExportsNotFound (node:internal/modules/esm/resolve:335:9)
    at packageExportsResolve (node:internal/modules/esm/resolve:560:3)
    at resolveExports (node:internal/modules/cjs/loader:482:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
    at Function.resolve (node:internal/modules/cjs/helpers:100:19)
    at [eval]:1:9
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:305:38) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
</pre>
</details>

<details>
<summary><code>$ node -e "require.resolve('firebase/package.json')"</code></summary>
<pre>
> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /Users/cedric/Projects/expo/expo/node_modules/firebase/package.json
    at new NodeError (node:internal/errors:371:5)
    at throwExportsNotFound (node:internal/modules/esm/resolve:335:9)
    at packageExportsResolve (node:internal/modules/esm/resolve:560:3)
    at resolveExports (node:internal/modules/cjs/loader:482:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
    at Function.resolve (node:internal/modules/cjs/helpers:100:19)
    at [eval]:1:9
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:305:38) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
</pre>
</details>

# Test Plan

- `$ expo init . -t blank`
- `$ yarn add firebase@9.1.0`
- `$ expo start`
    - This should not error with "Firebase was not installed" 