### PR TITLE
Update AndroidManifest.xml template for introspection

### DIFF
--- a/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withAndroidBaseMods.ts
@@ -30,6 +30,16 @@ function getAndroidManifestTemplate(config: ExportedConfig) {
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <!-- END OPTIONAL PERMISSIONS -->
+
+    <queries>
+      <!-- Support checking for http(s) links via the Linking API -->
+      <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https" />
+      </intent>
+    </queries>
+
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"


### PR DESCRIPTION
# Why

This is a temporary solution anyways, but keeping the AndroidManifest.xml up to date with https://github.com/expo/expo/pull/14638 for config plugin introspection when the android/ folder doesn't currently exist.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
