### PR TITLE
[expo-cli] Bump envinfo

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -88,7 +88,7 @@
     "commander": "2.17.1",
     "dateformat": "3.0.3",
     "env-editor": "^0.4.1",
-    "envinfo": "7.5.0",
+    "envinfo": "^7.8.1",
     "find-up": "^5.0.0",
     "find-yarn-workspace-root": "~2.0.0",
     "form-data": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7684,12 +7684,7 @@ env-paths@^1.0.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
   integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
 
-envinfo@7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.5.0.tgz#91410bb6db262fb4f1409bd506e9ff57e91023f4"
-  integrity sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ==
-
-envinfo@^7.7.2:
+envinfo@^7.7.2, envinfo@^7.8.1:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==


### PR DESCRIPTION
# Why

Version 7.5.0 hangs on alpine linux, which causes `expo diagnostics` to also hang in that circumstance.  This issue is not present in version 7.8.1. (See #582)

# How

`yarn add envinfo`

# Test Plan

I have verified that with this change `expo diagnostics` does not hang on alpine (using `docker run node:lts-alpine`).
