### PR TITLE
[cli] Use expoConfig.extra.eas.projectId to determine which type of development manifest to serve

### DIFF
--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -15,6 +15,7 @@ export default (program: any) => {
     .option('--minify', 'Minify code')
     .option('--no-minify', 'Do not minify code')
     .option('--https', 'To start webpack with https protocol')
+    .option('--force-manifest-type <manifest-type>', 'Override auto detection of manifest type')
     .option(
       '-p, --port <port>',
       'Port to start the native Metro bundler on (does not apply to web or tunnel). Default: 19000'
@@ -42,6 +43,7 @@ export default (program: any) => {
     .option('--no-minify', 'Do not minify code')
     .option('--https', 'To start webpack with https protocol')
     .option('--no-https', 'To start webpack with http protocol')
+    .option('--force-manifest-type <manifest-type>', 'Override auto detection of manifest type')
     .option('-p, --port <port>', 'Port to start the Webpack bundler on. Default: 19006')
     .option('-s, --send-to [dest]', 'An email address to send a link to')
     .urlOpts()

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -22,6 +22,7 @@ export type NormalizedOptions = URLOptions & {
   tunnel?: boolean;
   metroPort?: number;
   webpackPort?: number;
+  forceManifestType?: string;
 };
 
 export type RawStartOptions = NormalizedOptions & {
@@ -172,6 +173,15 @@ export function parseStartOptions(
 
   if (options.devClient) {
     startOpts.devClient = true;
+  }
+
+  if (options.forceManifestType) {
+    startOpts.forceManifestType =
+      options.forceManifestType === 'classic'
+        ? 'classic'
+        : options.forceManifestType === 'expo-updates'
+        ? 'expo-updates'
+        : undefined;
   }
 
   if (isLegacyImportsEnabled(exp)) {

--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -184,7 +184,14 @@ export function getManifestHandler(projectRoot: string) {
     res: express.Response | http.ServerResponse,
     next: (err?: Error) => void
   ) => {
-    if (!req.url || parse(req.url).pathname !== '/update-manifest-experimental') {
+    // Only support `/`, `/manifest`, `/index.exp` for the manifest middleware.
+    if (
+      !req.url ||
+      !['/', '/manifest', '/index.exp'].includes(
+        // Strip the query params
+        parse(req.url).pathname || req.url
+      )
+    ) {
       next();
       return;
     }

--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -123,7 +123,6 @@ export function getManifestHandler(projectRoot: string) {
     next: (err?: Error) => void
   ) => {
     // Only support `/`, `/manifest`, `/index.exp` for the manifest middleware.
-
     if (
       !req.url ||
       !['/', '/manifest', '/index.exp'].includes(


### PR DESCRIPTION
# Why

Closes ENG-2045.

# How

For the foreseeable future we want the type of manifest served to depend on whether EAS project ID is configured in `app[.config.js|.json]`. Once we discontinue support for legacy manifests in Expo Go in the far future we'll revert this behavior back to using an anonymous scope key when `extra.eas.projectId` isn't supplied.

- If present, serve the expo-updates manifest by default.
- If not present, serve the old manifest by default.
- Allow overriding inferred type using a flag on the start command.

Note that this approach has one issue: if the user adds `extra.eas.projectId` while running it won't switch behavior. We could optionally do the forking of behavior further down in the stack, but the current way it is written makes doing this tough (headers differ).

# Test Plan

Test a project with and without `extra.eas.projectId` in app.json, ensure correct manifest is served.

Test overrides to ensure they're respected.
```
~/expo/expo-cli/node_modules/.bin/expo start --force-manifest-type=classic
~/expo/expo-cli/node_modules/.bin/expo start --force-manifest-type=eas-update
~/expo/expo-cli/node_modules/.bin/expo start:web --force-manifest-type=classic
~/expo/expo-cli/node_modules/.bin/expo start:web --force-manifest-type=eas-update
```