### PR TITLE
improvement: round bundle progress % to 2 digits

### DIFF
--- a/packages/xdl/src/logs/PackagerLogsStream.ts
+++ b/packages/xdl/src/logs/PackagerLogsStream.ts
@@ -419,7 +419,8 @@ export default class PackagerLogsStream {
         percentProgress = (msg.transformedFileCount / msg.totalFileCount) * 100;
         // percentProgress = Math.floor((msg.transformedFileCount / msg.totalFileCount) * 100);
       }
-      progressChunk.msg = `Building JavaScript bundle: ${percentProgress}%`;
+      const roundedPercentProgress = Math.floor(100 * percentProgress) / 100;
+      progressChunk.msg = `Building JavaScript bundle: ${roundedPercentProgress}%`;
     } else {
       return;
     }


### PR DESCRIPTION
When building JS bundles, the percentage in the dev tools
was being output in maximum precision. This is noisy and
distracting and not useful information.

This change rounds the progress % to two digits, similar to
what you see in the Expo Go client app. 

# Why

I noticed this problem myself and saw people discussing it in the #expo-cli slack channel as well.

# How

I rounded the number down to the the nearest hundredth.

# Test Plan

I tested by making a new project and observing the bundle being built