### PR TITLE
[config-plugins] use exact xml2js version

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -46,7 +46,7 @@
     "semver": "^7.3.5",
     "slash": "^3.0.0",
     "xcode": "^3.0.1",
-    "xml2js": "^0.4.23"
+    "xml2js": "0.4.23"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19073,7 +19073,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@^0.4.23:
+xml2js@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==


### PR DESCRIPTION
# Why

xml2js added `parseStringPromise` between versions `0.4.19` and `0.4.23`

on eas worker we are using aws-sdk that depends on `0.4.19`(exact) and config-plugin that depends on `^0.4.23`
I'm not sure if it's not bug in yarn, but it looks like according to yarn version `0.4.19` satisfies `^0.4.23` and we are getting 
```
TypeError: [ios.xcodeproj]: withIosXcodeprojBaseMod: (intermediate value).parseStringPromise is not a function
```

# How

use exact version

# Test Plan

should not change anything for config plugins