### PR TITLE
Fix running expo start --dev-client in a project without expo installed

### DIFF
--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -62,7 +62,8 @@ export async function startDevServerAsync(
   }
 
   const { server, middleware, messageSocket } = await runMetroDevServerAsync(projectRoot, options);
-  const projectConfig = getConfig(projectRoot);
+  // TODO: reduce getConfig calls
+  const projectConfig = getConfig(projectRoot, { skipSDKVersionRequirement: true });
 
   const easProjectId = projectConfig.exp.extra?.eas.projectId;
   const useExpoUpdatesManifest =


### PR DESCRIPTION
# Why

`expo start --dev-client` should work even without expo installed, currently it throws an error.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

`expo start --dev-client` in a `npx react-native init` project.

<!-- 

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->