### PR TITLE
[cli] Fix reading EAS project ID from app.json during start

### DIFF
--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -159,7 +159,7 @@ function createNativeDevServerMiddleware(
   // TODO: Move this in to expo/dev-server.
 
   const projectConfig = getConfig(projectRoot);
-  const easProjectId = projectConfig.exp.extra?.eas.projectId;
+  const easProjectId = projectConfig.exp.extra?.eas?.projectId;
   const useExpoUpdatesManifest =
     forceManifestType === 'expo-updates' || (forceManifestType !== 'classic' && easProjectId);
 

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -70,7 +70,7 @@ export async function startDevServerAsync(
   // TODO: reduce getConfig calls
   const projectConfig = getConfig(projectRoot, { skipSDKVersionRequirement: true });
 
-  const easProjectId = projectConfig.exp.extra?.eas.projectId;
+  const easProjectId = projectConfig.exp.extra?.eas?.projectId;
   const useExpoUpdatesManifest =
     startOptions.forceManifestType === 'expo-updates' ||
     (startOptions.forceManifestType !== 'classic' && easProjectId);


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo-cli/issues/3928.

Blame: https://github.com/expo/expo-cli/pull/3890

# How

Fix case where extra key exists but eas key does not by using conditional property access.

# Test Plan

Same as https://github.com/expo/expo-cli/pull/3890 but with the legacy case having `extra` in the config.