### PR TITLE
[dev-server] fix app hanging if hermes inspector opening and reload app

### DIFF
--- a/packages/dev-server/src/__tests__/JsInspector-test.ts
+++ b/packages/dev-server/src/__tests__/JsInspector-test.ts
@@ -34,7 +34,9 @@ describe(openJsInspector, () => {
 
 describe(queryAllInspectorAppsAsync, () => {
   it('should return all available app entities', async () => {
-    const entities = METRO_INSPECTOR_RESPONSE_FIXTURE.filter(app => app.vm !== "don't use");
+    const entities = METRO_INSPECTOR_RESPONSE_FIXTURE.filter(
+      app => app.title === 'React Native Experimental (Improved Chrome Reloads)'
+    );
 
     const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
     mockFetch.mockReturnValue(
@@ -42,7 +44,11 @@ describe(queryAllInspectorAppsAsync, () => {
     );
 
     const result = await queryAllInspectorAppsAsync('http://localhost:8081');
-    expect(result).toEqual(entities);
+    expect(result.length).toBe(entities.length);
+    for (let i = 0; i < result.length; ++i) {
+      expect(result[i].webSocketDebuggerUrl).toBe(entities[i].webSocketDebuggerUrl);
+      expect(result[i].description).not.toBe("don't use");
+    }
   });
 });
 
@@ -56,6 +62,5 @@ describe(queryInspectorAppAsync, () => {
 
     const result = await queryInspectorAppAsync('http://localhost:8081', appId);
     expect(result?.description).toBe(appId);
-    expect(result?.vm).not.toBe("don't use");
   });
 });


### PR DESCRIPTION
# Why

app hangs if keep hermes inspector opening and press `r` to reload app

<img width="200" src="https://user-images.githubusercontent.com/46429/138135895-f171aa25-8316-49dc-af3e-54d317271102.png" />

# How

use the inspector targets with better reloading support [like flipper did](https://github.com/facebook/flipper/blob/6bd4a07286cbd693995a2f13279ec4254f871853/desktop/plugins/public/hermesdebuggerrn/index.tsx#L96-L101).

to be honest, these targets are just the `don't use` vm 😅 , but looks like hermes works better with these targets.
metro just reuse device page for this target type. search `REACT_NATIVE_RELOADABLE_PAGE_ID` in metro source code:
https://github.com/facebook/metro/blob/147b8a3bc9196ff20a135c63250c2969d7271e88/packages/metro-inspector-proxy/src/Device.js


# Test Plan

1. launch a hermes app
2. press `j` in expo-cli terminal ui to open inspector
3. after inspector opened, press `r` in terminal ui and see if app can reload or not.