### PR TITLE
[expo-cli] Always upgrade expo package when prereleased

### DIFF
--- a/packages/expo-cli/src/commands/info/upgradeAsync.ts
+++ b/packages/expo-cli/src/commands/info/upgradeAsync.ts
@@ -478,10 +478,16 @@ export async function upgradeAsync(
     ? `expo@next`
     : `expo@^${targetSdkVersionString}`;
 
+  const exactExpoPackageVersion = await getExactInstalledModuleVersionAsync('expo', projectRoot);
+  const isExpoPackageVersionPrerelease =
+    exactExpoPackageVersion && semver.prerelease(exactExpoPackageVersion) !== null;
+
   // Skip installing the Expo package again if it's already installed. @satya164
   // wanted this in order to work around an issue with yarn workspaces on
   // react-navigation.
-  if (targetSdkVersionString !== currentSdkVersionString) {
+  // Note, if the installed Expo SDK is a prerelease, it will always reinstall.
+  // TODO(cedric): check if we can fully remove this check
+  if (isExpoPackageVersionPrerelease || targetSdkVersionString !== currentSdkVersionString) {
     const installingPackageStep = logNewSection(
       `Installing the ${expoPackageToInstall} package...`
     );


### PR DESCRIPTION
# Why

Fixes #3919

The upgrade command doesn't upgrade the `expo` package during prerelease. It's disabled to avoid some issues at react-navigation (cc @satya164, do you know which one and/or if we can remove this check all together?). But, doing this causes issues like #3919. 

We could also remove the check, but I don't want to break the react-navigation repo. It would help installing newer patch versions though, these aren't installed atm.

# How

This adds an exception to that rule when the installed `expo` package is a prerelease (e.g. alpha/beta/rc versions).

Upgrading from `expo@43.0.0-beta.3` | Upgrading from `expo@43.0.0`
--- | ---
![Screenshot 2021-10-22 at 15 15 14](https://user-images.githubusercontent.com/1203991/138460598-dc344846-4bf0-4063-bb26-8cb83dc29d94.png) |  ![Screenshot 2021-10-22 at 15 16 37](https://user-images.githubusercontent.com/1203991/138460613-ce40edf9-4082-455f-a261-fe173142f148.png)


# Test Plan

- Initialize a new project
- Use the prerelease `expo` version
- Run `expo upgrade`
    - This should always reinstall `expo`, using the newer prerelease or stable version 