### PR TITLE
[repo] Disable new unknown errors feature

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
+    "useUnknownInCatchVariables": false,
     "declaration": true,
     "composite": true,
     "inlineSources": true,


### PR DESCRIPTION
# Why

- It's quite annoying that all catch statements now have type errors, we can enable this sometime in the future after we've had time to migrate.

