### PR TITLE
[metro-config] Add built-in support for Yarn workspaces

### DIFF
--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -359,6 +359,9 @@ Command.prototype.asyncAction = function (asyncFn: Action) {
         Log.error(err.message);
       } else if (err.isXDLError || err.isConfigError) {
         Log.error(err.message);
+        if (Log.isDebug) {
+          Log.error(chalk.gray(err.stack));
+        }
       } else if (err.isJsonFileError || err.isPackageManagerError) {
         if (err.code === 'EJSONEMPTY') {
           // Empty JSON is an easy bug to debug. Often this is thrown for package.json or app.json being empty.

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -35,8 +35,10 @@
   ],
   "dependencies": {
     "@expo/config": "6.0.6",
+    "@expo/json-file": "^8.2.33",
     "chalk": "^4.1.0",
     "debug": "^4.3.2",
+    "find-yarn-workspace-root": "~2.0.0",
     "getenv": "^1.0.0",
     "sucrase": "^3.20.0"
   },

--- a/packages/metro-config/src/getWatchFolders.ts
+++ b/packages/metro-config/src/getWatchFolders.ts
@@ -1,0 +1,91 @@
+import JsonFile from '@expo/json-file';
+import assert from 'assert';
+import findWorkspaceRoot from 'find-yarn-workspace-root';
+import { sync as globSync } from 'glob';
+import path from 'path';
+
+/**
+ * @param workspaceProjectRoot Root file path for the yarn workspace
+ * @param linkedPackages List of folders that contain linked node modules, ex: `['packages/*', 'apps/*']`
+ * @returns List of valid package.json file paths, ex: `['/Users/me/app/apps/my-app/package.json', '/Users/me/app/packages/my-package/package.json']`
+ */
+export function globAllPackageJsonPaths(
+  workspaceProjectRoot: string,
+  linkedPackages: string[]
+): string[] {
+  return linkedPackages
+    .map(glob => {
+      return globSync(path.join(glob, 'package.json').replace(/\\/g, '/'), {
+        cwd: workspaceProjectRoot,
+        absolute: true,
+        ignore: ['**/@(Carthage|Pods|node_modules)/**'],
+      }).map(pkgPath => {
+        try {
+          JsonFile.read(pkgPath);
+          return pkgPath;
+        } catch {
+          // Skip adding path if the package.json is invalid or cannot be read.
+        }
+        return null;
+      });
+    })
+    .flat()
+    .filter(Boolean)
+    .map(p => path.join(p as string));
+}
+
+function getWorkspacePackagesArray({ workspaces }: any): string[] {
+  if (Array.isArray(workspaces)) {
+    return workspaces;
+  }
+
+  assert(workspaces?.packages, 'Could not find a `workspaces` object in the root package.json');
+
+  return workspaces.packages;
+}
+
+/**
+ * @param workspaceProjectRoot root file path for a yarn workspace.
+ * @returns list of package.json file paths that are linked to the yarn workspace.
+ */
+export function resolveAllWorkspacePackageJsonPaths(workspaceProjectRoot: string) {
+  try {
+    const rootPackageJsonFilePath = path.join(workspaceProjectRoot, 'package.json');
+    // Could throw if package.json is invalid.
+    const rootPackageJson = JsonFile.read(rootPackageJsonFilePath);
+
+    // Extract the "packages" array or use "workspaces" as packages array (yarn workspaces spec).
+    const packages = getWorkspacePackagesArray(rootPackageJson);
+
+    // Glob all package.json files and return valid paths.
+    return globAllPackageJsonPaths(workspaceProjectRoot, packages);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * @param projectRoot file path to app's project root
+ * @returns list of node module paths to watch in Metro bundler, ex: `['/Users/me/app/node_modules/', '/Users/me/app/apps/my-app/', '/Users/me/app/packages/my-package/']`
+ */
+export function getWatchFolders(projectRoot: string): string[] {
+  const workspaceRoot = findWorkspaceRoot(path.resolve(projectRoot));
+  // Rely on default behavior in standard projects.
+  if (!workspaceRoot) {
+    return [];
+  }
+
+  const packages = resolveAllWorkspacePackageJsonPaths(workspaceRoot);
+  if (!packages.length) {
+    return [];
+  }
+
+  return uniqueItems([
+    path.join(workspaceRoot, 'node_modules'),
+    ...packages.map(pkg => path.dirname(pkg)),
+  ]);
+}
+
+function uniqueItems(items: string[]): string[] {
+  return [...new Set(items)];
+}

--- a/packages/metro-config/src/monorepoAssetsPlugin.ts
+++ b/packages/metro-config/src/monorepoAssetsPlugin.ts
@@ -1,0 +1,21 @@
+/**
+ * Assets work by fetching from the localhost using a filepath, example:
+ * `./icon.png` would be fetched via `http://127.0.0.1:19000/assets/./icon.png`
+ *
+ * In the case of a monorepo, you may need to reach outside of the root folder:
+ *
+ * App running at `monorepo/apps/my-app/` would fetch a resource from `monorepo/node_modules/my-package/icon.png`
+ * this would be done with `http://127.0.0.1:19000/assets/../../node_modules/my-package/icon.png`.
+ *
+ * The problem is that Metro dev server would collapse this URL into `http://127.0.0.1:19000/node_modules/my-package/icon.png` which is invalid.
+ *
+ * To combat this, we replace the `../` with a random character that cannot be collapsed: `@@/` (must be a character that can be encoded), then we add some dev server middleware to transform this back to `../` before fetching the asset.
+ *
+ */
+function monorepoAssetsPlugin(assetData: { httpServerLocation: string }) {
+  assetData.httpServerLocation = assetData.httpServerLocation.replace(/\.\.\//g, '@@/');
+  return assetData;
+}
+
+// Export with `module.exports` for Metro asset plugin loading.
+module.exports = monorepoAssetsPlugin;

--- a/ts-declarations/metro-config/index.d.ts
+++ b/ts-declarations/metro-config/index.d.ts
@@ -85,6 +85,7 @@ declare module 'metro-config' {
     extraNodeModules: {
       [name: string]: string;
     };
+    nodeModulesPaths?: readonly string[];
     hasteImplModulePath: string | null | undefined;
     platforms: ReadonlyArray<string>;
     resolverMainFields: ReadonlyArray<string>;


### PR DESCRIPTION
# Why

In SDK 43 we have two known metro issues:
1. Requiring assets that are outside of the root folder doesn't work.
2. The user must manually add their workspace root, which they often do by adding everything.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

1. Add middleware and an asset plugin to transform asset paths so they don't collapse in the dev server.
2. Add Yarn workspace resolution pseudo logic to detect the minimal amount of folders required to run, then automatically add them.
3. Add support for the new(ish) `nodeModulesPaths` property in Metro config. It's unclear what this does, but can't hurt to add it.
<!-- 
How did you build this feature or fix this bug and why? 
-->

The logic for this feature is all contained in `expo/metro-config` (as opposed to adding the middleware in `expo/dev-server`) so as to allow for using other Metro CLIs start the app.

# Test Plan

Not sure about a good way to continuously test this yet.

## assets

In a monorepo, open a project and use `../../path/to/packages/metro-config` as the metro.config.js file. Start the project and open `http://127.0.0.1:19000/assets/@@/app/assets/icon.png` in the browser where the url imports an asset outside of the root folder, but replacing `..` with `@@`.

Attempting to import in a normal project (not a monorepo) will throw an error about how watch folders isn't setup to allow for reaching outside of the project.

## paths

In a monorepo, open a project and use `../../path/to/packages/metro-config` as the metro.config.js file. Running `expo start` should work as expected, all dependencies should be linked. Using `EXPO_DEBUG=1` will print a list of all linked packages.

Running in a normal project should show that support is skipped.

