### PR TITLE
Add support for expo_splash_screen_user_interface_style

### DIFF
--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashStrings-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashStrings-test.ts
@@ -4,11 +4,12 @@ import { setSplashStrings } from '../withAndroidSplashStrings';
 
 describe(setSplashStrings, () => {
   it('add expo_splash_screen_strings', () => {
-    const results = setSplashStrings({ resources: {} }, 'cover', false);
+    const results = setSplashStrings({ resources: {} }, 'cover', false, 'dark');
     const expectXML = `\
 <resources>
   <string name="expo_splash_screen_resize_mode" translatable="false">cover</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+  <string name="expo_splash_screen_user_interface_style" translatable="false">dark</string>
 </resources>`;
     expect(XML.format(results)).toEqual(expectXML);
   });
@@ -17,12 +18,14 @@ describe(setSplashStrings, () => {
     const results = setSplashStrings(
       { resources: { string: [{ $: { name: 'expo_splash_screen_resize_mode' }, _: 'contain' }] } },
       'native',
-      false
+      false,
+      'automatic'
     );
     const expectXML = `\
 <resources>
   <string name="expo_splash_screen_resize_mode" translatable="false">native</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+  <string name="expo_splash_screen_user_interface_style" translatable="false">automatic</string>
 </resources>`;
     expect(XML.format(results)).toEqual(expectXML);
   });

--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashStrings.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/withAndroidSplashStrings.ts
@@ -4,6 +4,7 @@ import { getAndroidSplashConfig } from './getAndroidSplashConfig';
 
 const RESIZE_MODE_KEY = 'expo_splash_screen_resize_mode';
 const STATUS_BAR_TRANSLUCENT_KEY = 'expo_splash_screen_status_bar_translucent';
+const USER_INTERFACE_STYLE_KEY = 'expo_splash_screen_user_interface_style';
 
 export const withAndroidSplashStrings: ConfigPlugin = config => {
   return withStringsXml(config, config => {
@@ -11,7 +12,14 @@ export const withAndroidSplashStrings: ConfigPlugin = config => {
     if (splashConfig) {
       const { resizeMode } = splashConfig;
       const statusBarTranslucent = !!config.androidStatusBar?.translucent;
-      config.modResults = setSplashStrings(config.modResults, resizeMode, statusBarTranslucent);
+      const userInterfaceStyle =
+        config.android?.userInterfaceStyle ?? config.userInterfaceStyle ?? 'light';
+      config.modResults = setSplashStrings(
+        config.modResults,
+        resizeMode,
+        statusBarTranslucent,
+        userInterfaceStyle
+      );
     }
     return config;
   });
@@ -20,7 +28,8 @@ export const withAndroidSplashStrings: ConfigPlugin = config => {
 export function setSplashStrings(
   strings: AndroidConfig.Resources.ResourceXML,
   resizeMode: string,
-  statusBarTranslucent: boolean
+  statusBarTranslucent: boolean,
+  userInterfaceStyle: string
 ): AndroidConfig.Resources.ResourceXML {
   return AndroidConfig.Strings.setStringItem(
     [
@@ -32,6 +41,11 @@ export function setSplashStrings(
       AndroidConfig.Resources.buildResourceItem({
         name: STATUS_BAR_TRANSLUCENT_KEY,
         value: String(statusBarTranslucent),
+        translatable: false,
+      }),
+      AndroidConfig.Resources.buildResourceItem({
+        name: USER_INTERFACE_STYLE_KEY,
+        value: userInterfaceStyle,
         translatable: false,
       }),
     ],


### PR DESCRIPTION
# Why

- plugin version https://github.com/expo/expo/pull/14931 -- replaces https://github.com/expo/expo-cli/pull/3951

# Test Plan

- unit tests