### PR TITLE
[expo-cli] Skip showing dev tools UI on startup for new users

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -50,9 +50,9 @@ const div = chalk.dim(`│`);
 export async function shouldOpenDevToolsOnStartupAsync() {
   return UserSettings.getAsync(
     'openDevToolsAtStartup',
-    // Defaults to true for new users.
-    // TODO: switch this to false.
-    true
+    // Defaults to false for new users.
+    // We can swap this back to true when dev tools UI has a code owner again.
+    false
   );
 }
 


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/expo-cli/pull/3207 (9 months ago).
Dev Tools UI has race conditions and many other issues where it hasn't kept up with Expo CLI / Terminal UI and therefore is not the most optimal thing for new users to see.
We added a PR a while ago to persist the user's current preference so this PR should only effect first time users.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- My current setting should continue to work.
- Deleting `~/.expo/state.json` and rerunning `expo start` should not open the dev tools UI.
