### PR TITLE
[dev-server] Enhance hermes inspector opening experience

### DIFF
--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@expo/bunyan": "4.0.0",
     "@expo/metro-config": "0.2.6",
+    "@expo/osascript": "2.0.30",
     "@react-native-community/cli-server-api": "^5.0.1",
     "body-parser": "1.19.0",
     "chalk": "^4.0.0",

--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -217,6 +217,7 @@ export function openDeveloperTools(url: string) {
 }
 
 async function openJsInsectorAsync(projectRoot: string) {
+  Log.log(`Opening JavaScript inspector in the browser...`);
   const { packagerPort } = await ProjectSettings.readPackagerInfoAsync(projectRoot);
   const metroServerOrigin = `http://localhost:${packagerPort}`;
   const apps = await queryAllInspectorAppsAsync(metroServerOrigin);

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig, getConfig } from '@expo/config';
-import { MessageSocket } from '@expo/dev-server';
+import { closeJsInspector, MessageSocket } from '@expo/dev-server';
 import { Server } from 'http';
 
 import {
@@ -94,6 +94,7 @@ export async function startAsync(
 async function stopDevServerAsync() {
   return new Promise<void>((resolve, reject) => {
     if (serverInstance) {
+      closeJsInspector();
       serverInstance.close(error => {
         if (error) {
           reject(error);


### PR DESCRIPTION
# Why

this pr addresses an unfriendly experience on macos. chrome does not exit process even all windows be closed. with the following steps, press `j` to open inspector will nothing happen.

1. press j in expo-cli terminal ui to open inspector
2. press cmd-w in the inspector to close the window
3. press j in terminal ui again. nothing will happen because the previous process is still alive.

# How

1. add a `Opening JavaScript inspector in the browser...` message
2. specific on macos, use `spawn` to control process lifecycle. when pressing j to open inspector, we try to kill previous process if needed.

# Test Plan

1. press j multiple times and see if previous inspector process be killed.
2. ctrl-c to stop server and see if inspector process be killed.
3. press j to open inspector on ubuntu host. this makes sure the pr does not break the functionalities on other platforms.