### PR TITLE
Bump @expo/xcpretty@4.0.0

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -79,7 +79,7 @@
     "@expo/prebuild-config": "3.0.6",
     "@expo/results": "^1.0.0",
     "@expo/spawn-async": "1.5.0",
-    "@expo/xcpretty": "^3.0.1",
+    "@expo/xcpretty": "^4.0.0",
     "base32.js": "0.1.0",
     "boxen": "^5.0.1",
     "bplist-parser": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1679,10 +1679,10 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
-"@expo/xcpretty@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-3.0.1.tgz#6469eda4d9eb8127419ce95c13e7d411cb69f045"
-  integrity sha512-TJV66goqloDxU3Kpzr6lcGqdxOYcG3OhOLbKkh2PWLxaZQDEY/AkZzqrsraXqLCungSMIrExXPU1lzV9Oml/yg==
+"@expo/xcpretty@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-4.0.0.tgz#7e5f3be24c86f1e90c042d3571946272afc6091a"
+  integrity sha512-0yx68FKGm/spdmYgSFrx6p0NePzcXBPjX+VlBHssTPGEyhxnBGKNepyW+YP/tCVlb9++ApXe2u5wIdTK72h/1w==
   dependencies:
     "@babel/code-frame" "7.10.4"
     chalk "^4.1.0"


### PR DESCRIPTION
# Why

Adds support for the new recursive pod logging

https://github.com/expo/third-party/commit/b5a71125709afc5efd9b62725feab8ef600458ac


<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->


# Test Plan

`expo run:ios` should now associate more operations with node modules.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->