### PR TITLE
Use expo start --dev-client instead of react-native start

### DIFF
--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -194,7 +194,7 @@ function updatePackageJSONScripts({ pkg }: { pkg: PackageJSONConfig }) {
     pkg.scripts = {};
   }
   if (!pkg.scripts.start?.includes('--dev-client')) {
-    pkg.scripts.start = 'react-native start';
+    pkg.scripts.start = 'expo start --dev-client';
   }
   if (!pkg.scripts.android?.includes('run')) {
     pkg.scripts.android = 'expo run:android';


### PR DESCRIPTION
# Why

It's pretty stable and users who are used to expo managed may find it confusing when features like auto TypeScript don't work.

- potential fix for https://github.com/expo/expo-cli/issues/3962