### PR TITLE
[prebuild-config] Preserve splash ids

### DIFF
--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/InterfaceBuilder.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/InterfaceBuilder.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import crypto from 'crypto';
 import { Builder, Parser } from 'xml2js';
 
 export type IBBoolean = 'YES' | 'NO' | boolean;
@@ -172,9 +172,14 @@ function createConstraint(
       firstAttribute,
       secondItem,
       secondAttribute,
-      id: uuidv4(),
+      // Prevent updating between runs
+      id: createConstraintId(firstItem, firstAttribute, secondItem, secondAttribute),
     },
   };
+}
+
+function createConstraintId(...attributes: string[]) {
+  return crypto.createHash('sha1').update(attributes.join('-')).digest('hex');
 }
 
 export function applyImageToSplashScreenXML(


### PR DESCRIPTION
# Why

- Even though this isn't needed, fix for convenience https://github.com/expo/expo-cli/issues/3961
- Also found unlinked npm package uuid.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- IDs remain the same between updates