### PR TITLE
[prebuild-config] Add url support for splash screens

### DIFF
--- a/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashImages-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-splash-screen/__tests__/withAndroidSplashImages-test.ts
@@ -13,7 +13,7 @@ describe(setSplashImageDrawablesAsync, () => {
         'assets/splash.png': '...',
         'assets/splash-dark.png': '...',
       },
-      '/'
+      './'
     );
   });
 


### PR DESCRIPTION
# Why

We already use `generateImageAsync` for all other image related plugins. This will help us ensure that we support the same types of image references everywhere. The system also reduces the image size a bit when sharp is installed.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- Jimp `EXPO_IMAGE_UTILS_NO_SHARP=1 expod prebuild --no-install`
- Sharp `expod prebuild --no-install`