### PR TITLE
Add environment variable for forcing the use of unversioned config plugins

### DIFF
--- a/packages/config-plugins/README.md
+++ b/packages/config-plugins/README.md
@@ -3,3 +3,17 @@
 The Expo config is a powerful tool for generating native app code from a unified JavaScript interface. Most basic functionality can be controlled by using the the [static Expo config](https://docs.expo.dev/versions/latest/config/app/), but some features require manipulation of the native project files. To support complex behavior we've created config plugins, and mods (short for modifiers).
 
 For more info, please refer to the official docs: [Config Plugins](https://docs.expo.dev/guides/config-plugins/).
+
+## Environment Variables
+
+### `EXPO_DEBUG`
+
+Print debug information related to static plugin resolution.
+
+### `EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS`
+
+Show all error info related to static plugin resolution. Requires `EXPO_DEBUG` to be enabled.
+
+### `EXPO_USE_UNVERSIONED_PLUGINS`
+
+Force using the fallback unversioned plugins instead of a local versioned copy from installed packages, this should only be used for testing the CLI.

--- a/packages/config-plugins/src/plugins/withStaticPlugin.ts
+++ b/packages/config-plugins/src/plugins/withStaticPlugin.ts
@@ -68,10 +68,7 @@ export const withStaticPlugin: ConfigPlugin<{
 
   let withPlugin: ConfigPlugin<unknown>;
 
-  if (EXPO_USE_UNVERSIONED_PLUGINS && props._isLegacyPlugin && props.fallback) {
-    console.log(`Force "${pluginResolve}" to unversioned plugin`);
-    withPlugin = props.fallback;
-  } else if (
+  if (
     // Function was provided, no need to resolve: [withPlugin, {}]
     typeof pluginResolve === 'function'
   ) {
@@ -80,6 +77,18 @@ export const withStaticPlugin: ConfigPlugin<{
     try {
       // Resolve and evaluate plugins.
       withPlugin = resolveConfigPluginFunction(projectRoot, pluginResolve);
+
+      // Only force if the project has the versioned plugin, otherwise use default behavior.
+      // This helps see which plugins are being skipped.
+      if (
+        EXPO_USE_UNVERSIONED_PLUGINS &&
+        !!withPlugin &&
+        !!props._isLegacyPlugin &&
+        !!props.fallback
+      ) {
+        console.log(`Force "${pluginResolve}" to unversioned plugin`);
+        withPlugin = props.fallback;
+      }
     } catch (error: any) {
       if (EXPO_DEBUG) {
         if (EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS) {
@@ -124,6 +133,7 @@ export const withStaticPlugin: ConfigPlugin<{
       'INVALID_PLUGIN_TYPE'
     );
   }
+
   // Execute the plugin.
   config = withPlugin(config, pluginProps);
   return config;

--- a/packages/config-plugins/src/plugins/withStaticPlugin.ts
+++ b/packages/config-plugins/src/plugins/withStaticPlugin.ts
@@ -10,7 +10,12 @@ import {
 } from '../utils/plugin-resolver';
 
 const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
+
+// Show all error info related to plugin resolution.
 const EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS = boolish('EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS', false);
+// Force using the fallback unversioned plugin instead of a local versioned copy,
+// this should only be used for testing the CLI.
+const EXPO_USE_UNVERSIONED_PLUGINS = boolish('EXPO_USE_UNVERSIONED_PLUGINS', false);
 
 function isModuleMissingError(name: string, error: Error): boolean {
   // @ts-ignore
@@ -62,14 +67,20 @@ export const withStaticPlugin: ConfigPlugin<{
   );
 
   let withPlugin: ConfigPlugin<unknown>;
-  // Function was provided, no need to resolve: [withPlugin, {}]
-  if (typeof pluginResolve === 'function') {
+
+  if (EXPO_USE_UNVERSIONED_PLUGINS && props._isLegacyPlugin && props.fallback) {
+    console.log(`Force "${pluginResolve}" to unversioned plugin`);
+    withPlugin = props.fallback;
+  } else if (
+    // Function was provided, no need to resolve: [withPlugin, {}]
+    typeof pluginResolve === 'function'
+  ) {
     withPlugin = pluginResolve;
   } else if (typeof pluginResolve === 'string') {
     try {
       // Resolve and evaluate plugins.
       withPlugin = resolveConfigPluginFunction(projectRoot, pluginResolve);
-    } catch (error) {
+    } catch (error: any) {
       if (EXPO_DEBUG) {
         if (EXPO_CONFIG_PLUGIN_VERBOSE_ERRORS) {
           // Log the error in debug mode for plugins with fallbacks (like the Expo managed plugins).


### PR DESCRIPTION
# Why

Make it easier to test plugins like `expo-splash-screen` which probably already have a versioned copy installed.

# How

Add `EXPO_USE_UNVERSIONED_PLUGINS` which skips plugin resolution for unversioned plugins.

# Test Plan

```
EXPO_USE_UNVERSIONED_PLUGINS=1 expo config --type introspect
```