### PR TITLE
Fixes from autolinking PR

### DIFF
--- a/packages/config-plugins/src/android/Package.ts
+++ b/packages/config-plugins/src/android/Package.ts
@@ -12,7 +12,7 @@ import { addWarningAndroid } from '../utils/warnings';
 import { AndroidManifest } from './Manifest';
 import { getAppBuildGradleFilePath, getProjectFilePath } from './Paths';
 
-const debug = Debug('config-plugins:android:package');
+const debug = Debug('expo:config-plugins:android:package');
 
 export const withPackageManifest = createAndroidManifestPlugin(
   setPackageInAndroidManifest,

--- a/packages/config-plugins/src/ios/Maps.ts
+++ b/packages/config-plugins/src/ios/Maps.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
+import Debug from 'debug';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -7,6 +8,8 @@ import { createInfoPlistPlugin, withAppDelegate } from '../plugins/ios-plugins';
 import { withDangerousMod } from '../plugins/withDangerousMod';
 import { mergeContents, MergeResults, removeContents } from '../utils/generateCode';
 import { resolvePackageRootFolder } from '../utils/resolvePackageRootFolder';
+
+const debug = Debug('expo:config-plugins:ios:maps');
 
 // Match against `UMModuleRegistryAdapter` (unimodules), and React Native without unimodules (Expo Modules).
 export const MATCH_INIT = /(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[\[RCTBridge alloc\])/g;
@@ -18,7 +21,10 @@ export const withMaps: ConfigPlugin = config => {
 
   const apiKey = getGoogleMapsApiKey(config);
   // Technically adds react-native-maps (Apple maps) and google maps.
+
+  debug('Google Maps API Key:', apiKey);
   config = withMapsCocoaPods(config, { useGoogleMaps: !!apiKey });
+
   // Adds/Removes AppDelegate setup for Google Maps API on iOS
   config = withGoogleMapsAppDelegate(config, { apiKey });
 
@@ -123,6 +129,11 @@ function isReactNativeMapsInstalled(projectRoot: string): string | null {
   return resolvePackageRootFolder(projectRoot, 'react-native-maps');
 }
 
+function isReactNativeMapsAutolinked(config: Pick<ExpoConfig, '_internal'>): boolean {
+  // TODO: Detect autolinking
+  return true;
+}
+
 const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { useGoogleMaps }) => {
   return withDangerousMod(config, [
     'ios',
@@ -133,7 +144,10 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
       // Only add the block if react-native-maps is installed in the project (best effort).
       // Generally prebuild runs after a yarn install so this should always work as expected.
       const googleMapsPath = isReactNativeMapsInstalled(config.modRequest.projectRoot);
-      if (googleMapsPath && useGoogleMaps) {
+      const isLinked = isReactNativeMapsAutolinked(config);
+      debug('Is Expo Autolinked:', isLinked);
+      debug('react-native-maps path:', googleMapsPath);
+      if (isLinked && googleMapsPath && useGoogleMaps) {
         // Make the pod path relative to the ios folder.
         const googleMapsPodPath = path.relative(
           config.modRequest.platformProjectRoot,
@@ -141,7 +155,7 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
         );
         try {
           results = addMapsCocoaPods(contents, googleMapsPodPath);
-        } catch (error) {
+        } catch (error: any) {
           if (error.code === 'ERR_NO_MATCH') {
             throw new Error(
               `Cannot add react-native-maps to the project's ios/Podfile because it's malformed. Please report this with a copy of your project Podfile.`
@@ -164,7 +178,11 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
 const withGoogleMapsAppDelegate: ConfigPlugin<{ apiKey: string | null }> = (config, { apiKey }) => {
   return withAppDelegate(config, config => {
     if (config.modResults.language === 'objc') {
-      if (apiKey && isReactNativeMapsInstalled(config.modRequest.projectRoot)) {
+      if (
+        apiKey &&
+        isReactNativeMapsAutolinked(config) &&
+        isReactNativeMapsInstalled(config.modRequest.projectRoot)
+      ) {
         try {
           config.modResults.contents = addGoogleMapsAppDelegateImport(
             config.modResults.contents

--- a/packages/config-plugins/src/ios/Permissions.ts
+++ b/packages/config-plugins/src/ios/Permissions.ts
@@ -4,7 +4,7 @@ import { ConfigPlugin } from '../Plugin.types';
 import { withInfoPlist } from '../plugins/ios-plugins';
 import { InfoPlist } from './IosConfig.types';
 
-const debug = Debug('config-plugins:ios:permissions');
+const debug = Debug('expo:config-plugins:ios:permissions');
 
 export function applyPermissions<Defaults extends Record<string, string> = Record<string, string>>(
   defaults: Defaults,

--- a/packages/config-plugins/src/plugins/createBaseMod.ts
+++ b/packages/config-plugins/src/plugins/createBaseMod.ts
@@ -8,7 +8,7 @@ import {
 } from '../Plugin.types';
 import { BaseModOptions, withBaseMod } from './withMod';
 
-const debug = Debug('config-plugins:base-mods');
+const debug = Debug('expo:config-plugins:base-mods');
 
 export type ForwardedBaseModOptions = Partial<
   Pick<BaseModOptions, 'saveToInternal' | 'skipEmptyMod'>

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -9,7 +9,7 @@ import { assertModResults, ForwardedBaseModOptions } from './createBaseMod';
 import { withAndroidBaseMods } from './withAndroidBaseMods';
 import { withIosBaseMods } from './withIosBaseMods';
 
-const debug = Debug('config-plugins:mod-compiler');
+const debug = Debug('expo:config-plugins:mod-compiler');
 
 export function withDefaultBaseMods(
   config: ExportedConfig,

--- a/packages/expo-cli/src/commands/config/configAsync.ts
+++ b/packages/expo-cli/src/commands/config/configAsync.ts
@@ -1,6 +1,6 @@
 import { getConfig, ProjectConfig } from '@expo/config';
 import { compileModsAsync } from '@expo/config-plugins/build/plugins/mod-compiler';
-import { getPrebuildConfig } from '@expo/prebuild-config';
+import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 
 import CommandError from '../../CommandError';
 import Log from '../../log';
@@ -16,11 +16,11 @@ export async function actionAsync(projectRoot: string, options: Options) {
   let config: ProjectConfig;
 
   if (options.type === 'prebuild') {
-    config = profileMethod(getPrebuildConfig)(projectRoot, {
+    config = await profileMethod(getPrebuildConfigAsync)(projectRoot, {
       platforms: ['ios', 'android'],
     });
   } else if (options.type === 'introspect') {
-    config = profileMethod(getPrebuildConfig)(projectRoot, {
+    config = await profileMethod(getPrebuildConfigAsync)(projectRoot, {
       platforms: ['ios', 'android'],
     });
 

--- a/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/configureProjectAsync.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig, ProjectConfig } from '@expo/config';
 import { compileModsAsync, ModPlatform } from '@expo/config-plugins';
-import { getPrebuildConfig } from '@expo/prebuild-config';
+import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 import util from 'util';
 import { UserManager } from 'xdl';
 
@@ -51,7 +51,7 @@ export default async function configureManagedProjectAsync({
     process.env.EAS_BUILD_USERNAME ||
     (await UserManager.getCurrentUsernameAsync());
 
-  let { exp: config } = getPrebuildConfig(projectRoot, {
+  let { exp: config } = await getPrebuildConfigAsync(projectRoot, {
     platforms,
     packageName,
     bundleIdentifier,

--- a/packages/prebuild-config/src/getPrebuildConfig.ts
+++ b/packages/prebuild-config/src/getPrebuildConfig.ts
@@ -9,7 +9,21 @@ import {
   withVersionedExpoSDKPlugins,
 } from './plugins/withDefaultPlugins';
 
-export function getPrebuildConfig(
+export async function getPrebuildConfigAsync(
+  projectRoot: string,
+  props: {
+    bundleIdentifier?: string;
+    packageName?: string;
+    platforms: ModPlatform[];
+    expoUsername?: string | ((config: ExpoConfig) => string | null);
+  }
+): Promise<ReturnType<typeof getConfig>> {
+  return getPrebuildConfig(projectRoot, {
+    ...props,
+  });
+}
+
+function getPrebuildConfig(
   projectRoot: string,
   {
     platforms,

--- a/packages/prebuild-config/src/index.ts
+++ b/packages/prebuild-config/src/index.ts
@@ -1,4 +1,4 @@
 /* eslint-disable import/export */
 
-export { getPrebuildConfig } from './getPrebuildConfig';
+export { getPrebuildConfigAsync } from './getPrebuildConfig';
 export * from './plugins/withDefaultPlugins';

--- a/packages/prebuild-config/src/plugins/unversioned/react-native-maps.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/react-native-maps.ts
@@ -1,4 +1,4 @@
-import { AndroidConfig, ConfigPlugin, IOSConfig } from '@expo/config-plugins';
+import { AndroidConfig, ConfigPlugin, IOSConfig, withInfoPlist } from '@expo/config-plugins';
 import resolveFrom from 'resolve-from';
 
 import { createLegacyPlugin } from './createLegacyPlugin';
@@ -8,15 +8,19 @@ const LOCATION_USAGE = 'Allow $(PRODUCT_NAME) to access your location';
 // Copied from expo-location package, this gets used when the
 // user has react-native-maps installed but not expo-location.
 const withDefaultLocationPermissions: ConfigPlugin = config => {
+  // TODO: Autolinking
+  const isLinked = true;
   // Only add location permissions if react-native-maps is installed.
   if (
     config._internal?.projectRoot &&
-    resolveFrom.silent(config._internal.projectRoot, 'react-native-maps')
+    resolveFrom.silent(config._internal.projectRoot, 'react-native-maps') &&
+    isLinked
   ) {
-    if (!config.ios) config.ios = {};
-    if (!config.ios.infoPlist) config.ios.infoPlist = {};
-    config.ios.infoPlist.NSLocationWhenInUseUsageDescription =
-      config.ios.infoPlist.NSLocationWhenInUseUsageDescription || LOCATION_USAGE;
+    config = withInfoPlist(config, config => {
+      config.modResults.NSLocationWhenInUseUsageDescription =
+        config.modResults.NSLocationWhenInUseUsageDescription || LOCATION_USAGE;
+      return config;
+    });
 
     return AndroidConfig.Permissions.withPermissions(config, [
       'android.permission.ACCESS_COARSE_LOCATION',

--- a/packages/prebuild-config/src/plugins/withDefaultPlugins.ts
+++ b/packages/prebuild-config/src/plugins/withDefaultPlugins.ts
@@ -109,7 +109,7 @@ export const withAndroidExpoPlugins: ConfigPlugin<{
     AndroidConfig.StatusBar.withStatusBar,
     AndroidConfig.PrimaryColor.withPrimaryColor,
 
-    c => withAndroidIcons(c),
+    withAndroidIcons,
     // If we renamed the package, we should also move it around and rename it in source files
     // Added last to ensure this plugin runs first. Out of tree solutions will mistakenly resolve the package incorrectly otherwise.
     AndroidConfig.Package.withPackageRefactor,


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo-cli/pull/3926
- Many of the changes in the autolinking PR are general fixes and improvements, merging these ahead of time to make the autolinking PR simpler.
- This PR includes a breaking change for `@expo/prebuild-config` by changing the main exported function to async.