### PR TITLE
[expo-cli] Handle unhandled errors from Terminal UI

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -19,6 +19,7 @@ import { loginOrRegisterIfLoggedOutAsync } from '../../accounts';
 import Log from '../../log';
 import { selectAsync } from '../../prompts';
 import urlOpts from '../../urlOpts';
+import { handleErrorsAsync } from '../../utils/handleErrors';
 import { learnMore } from '../utils/TerminalLink';
 import { openInEditorAsync } from '../utils/openInEditorAsync';
 
@@ -283,6 +284,15 @@ export async function startAsync(projectRoot: string, options: StartOptions) {
   await printServerInfo(projectRoot, options);
 
   async function handleKeypress(key: string) {
+    try {
+      await handleKeypressAsync(key);
+    } catch (err) {
+      await handleErrorsAsync(err, {});
+      process.exit(1);
+    }
+  }
+
+  async function handleKeypressAsync(key: string) {
     const shouldPrompt = !options.nonInteractive && ['I', 'A'].includes(key);
     if (shouldPrompt) {
       Log.clear();

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -1,6 +1,5 @@
 import bunyan from '@expo/bunyan';
 import { setCustomConfigPath } from '@expo/config';
-import { AssertionError } from 'assert';
 import boxen from 'boxen';
 import chalk from 'chalk';
 import program, { Command } from 'commander';

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -30,7 +30,6 @@ import {
   UserManager,
 } from 'xdl';
 
-import { AbortCommandError, SilentError } from './CommandError';
 import StatusEventEmitter from './StatusEventEmitter';
 import { loginOrRegisterAsync } from './accounts';
 import { registerCommands } from './commands';
@@ -39,6 +38,7 @@ import { profileMethod } from './commands/utils/profileMethod';
 import Log from './log';
 import update from './update';
 import urlOpts from './urlOpts';
+import { handleErrorsAsync } from './utils/handleErrors';
 import { matchFileNameOrURLFromStackTrace } from './utils/matchFileNameOrURLFromStackTrace';
 import { logNewSection, ora } from './utils/ora';
 
@@ -350,31 +350,7 @@ Command.prototype.asyncAction = function (asyncFn: Action) {
       // This allows node js to exit immediately
       await Promise.all([Analytics.flush(), UnifiedAnalytics.flush()]);
     } catch (err) {
-      // TODO: Find better ways to consolidate error messages
-      if (err instanceof AbortCommandError || err instanceof SilentError) {
-        // Do nothing when a prompt is cancelled or the error is logged in a pretty way.
-      } else if (err.isCommandError || err.isPluginError || err instanceof AssertionError) {
-        Log.error(err.message);
-      } else if (err._isApiError) {
-        Log.error(err.message);
-      } else if (err.isXDLError || err.isConfigError) {
-        Log.error(err.message);
-      } else if (err.isJsonFileError || err.isPackageManagerError) {
-        if (err.code === 'EJSONEMPTY') {
-          // Empty JSON is an easy bug to debug. Often this is thrown for package.json or app.json being empty.
-          Log.error(err.message);
-        } else {
-          Log.addNewLineIfNone();
-          Log.error(err.message);
-          const { formatStackTrace } = await import('./utils/formatStackTrace');
-          const stacktrace = formatStackTrace(err.stack, this.name());
-          Log.error(chalk.gray(stacktrace));
-        }
-      } else {
-        Log.error(err.message);
-        Log.error(chalk.gray(err.stack));
-      }
-
+      await handleErrorsAsync(err, { command: this.name() });
       process.exit(1);
     }
   });

--- a/packages/expo-cli/src/utils/handleErrors.ts
+++ b/packages/expo-cli/src/utils/handleErrors.ts
@@ -1,0 +1,34 @@
+import { AssertionError } from 'assert';
+import chalk from 'chalk';
+
+import { AbortCommandError, SilentError } from '../CommandError';
+import Log from '../log';
+
+export async function handleErrorsAsync(err: any, { command = '[unknown]' }: { command?: string }) {
+  // TODO: Find better ways to consolidate error messages
+  if (err instanceof AbortCommandError || err instanceof SilentError) {
+    // Do nothing when a prompt is cancelled or the error is logged in a pretty way.
+  } else if (err.isCommandError || err.isPluginError || err instanceof AssertionError) {
+    Log.error(err.message);
+  } else if (err._isApiError) {
+    Log.error(err.message);
+  } else if (err.isXDLError || err.isConfigError) {
+    Log.error(err.message);
+  } else if (err.isJsonFileError || err.isPackageManagerError) {
+    if (err.code === 'EJSONEMPTY') {
+      // Empty JSON is an easy bug to debug. Often this is thrown for package.json or app.json being empty.
+      Log.error(err.message);
+    } else {
+      Log.addNewLineIfNone();
+      Log.error(err.message);
+      const { formatStackTrace } = await import('./formatStackTrace');
+      const stacktrace = formatStackTrace(err.stack, command);
+      Log.error(chalk.gray(stacktrace));
+    }
+  } else {
+    Log.error(err.message);
+    Log.error(chalk.gray(err.stack));
+  }
+
+  //   process.exit(1);
+}


### PR DESCRIPTION
# Why

Metro now hijacks the unhandled errors which overwrites our unhandled error behavior, this causes the Terminal UI errors to be formatted poorly.

<img width="1079" alt="Screen Shot 2021-11-15 at 4 05 06 PM" src="https://user-images.githubusercontent.com/9664363/141866640-4cbc91b1-d31d-4b4a-8a18-5f3d7b14a4cd.png">

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

This PR extracts the error handling code and applies it to TerminalUI.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Break `Android.ts`:
```diff
- if (!allDevices.length) {
+ if (allDevices.length) { 
```
Then run `expo start` and press `a` at the Terminal UI, the formatting should be fixed and not mention hermes.


<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->