### PR TITLE
[config-plugins] fix setting CODE_SIGN_ENTITLEMENTS

### DIFF
--- a/packages/config-plugins/src/ios/Entitlements.ts
+++ b/packages/config-plugins/src/ios/Entitlements.ts
@@ -84,7 +84,7 @@ export function getEntitlementsPath(projectRoot: string): string {
       .filter(isBuildConfig)
       .filter(isNotTestHost)
       .forEach(({ 1: { buildSettings } }: any) => {
-        buildSettings.CODE_SIGN_ENTITLEMENTS = entitlementsRelativePath;
+        buildSettings.CODE_SIGN_ENTITLEMENTS = `"${entitlementsRelativePath}"`;
       });
     fs.writeFileSync(project.filepath, project.writeSync());
   }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/eas-cli/issues/496

# How

Surround entitlements path with double-quotes.

# Test Plan

Followed the repro steps from https://github.com/expo/eas-cli/issues/496#issuecomment-969438233