### PR TITLE
[expo-cli] Add --no-build-cache to clear the derived data folder for ios builds

### DIFF
--- a/packages/expo-cli/src/commands/run/index.ts
+++ b/packages/expo-cli/src/commands/run/index.ts
@@ -20,6 +20,7 @@ export default function (program: Command) {
       .command('run:ios [path]')
       .description('Run the iOS app binary locally')
       .helpGroup('core')
+      .option('--no-build-cache', 'Clear the native derived data before building')
       .option('--no-install', 'Skip installing dependencies')
       .option('--no-bundler', 'Skip starting the Metro bundler')
       .option('-d, --device [device]', 'Device name or UDID to build the app on')

--- a/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
+++ b/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
@@ -19,6 +19,8 @@ export type BuildProps = {
   configuration: XcodeConfiguration;
   shouldSkipInitialBundling: boolean;
   shouldStartBundler: boolean;
+  /** Should use derived data for builds. */
+  buildCache: boolean;
   terminal?: string;
   port: number;
   scheme: string;
@@ -172,6 +174,7 @@ export async function buildAsync({
   shouldSkipInitialBundling,
   terminal,
   port,
+  buildCache,
 }: BuildProps): Promise<string> {
   const args = [
     xcodeProject.isWorkspace ? '-workspace' : '-project',
@@ -195,8 +198,20 @@ export async function buildAsync({
     }
   }
 
-  logPrettyItem(chalk.bold`Planning build`);
+  // Add last
+  if (buildCache === false) {
+    args.push(
+      // Will first clean the derived data folder.
+      'clean',
+      // Then build step must be added otherwise the process will simply clean and exit.
+      'build'
+    );
+  }
+
   Log.debug(`  xcodebuild ${args.join(' ')}`);
+
+  logPrettyItem(chalk.bold`Planning build`);
+
   const formatter = ExpoRunFormatter.create(projectRoot, {
     xcodeProject,
     isDebug: Log.isDebug,

--- a/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveOptionsAsync.ts
@@ -20,6 +20,8 @@ export type Options = {
   configuration?: XcodeConfiguration;
   bundler?: boolean;
   install?: boolean;
+  /** Should use derived data for builds. */
+  buildCache: boolean;
 };
 
 export type ProjectInfo = {
@@ -166,6 +168,7 @@ export async function resolveOptionsAsync(
     shouldStartBundler: options.bundler ?? false,
     shouldSkipInitialBundling,
     port,
+    buildCache: options.buildCache,
     terminal: getDefaultUserTerminal(),
     scheme: resolvedScheme.name,
   };


### PR DESCRIPTION
# Why

Good for testing profiling. Split out of #3970 

# Test Plan

`expo run:ios --no-build-cache`