### PR TITLE
[expo run:ios] Don't export logs as markdown

### DIFF
--- a/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
+++ b/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
@@ -275,22 +275,15 @@ export async function buildAsync({
 }
 
 function writeBuildLogs(projectRoot: string, buildOutput: string, errorOutput: string) {
-  const output =
-    '# Build output\n\n```log\n' +
-    buildOutput +
-    '\n```\n\n# Error output\n\n```log\n' +
-    errorOutput +
-    '\n```\n';
-  const [mdFilePath, logFilePath] = getErrorLogFilePath(projectRoot);
+  const [logFilePath, errorFilePath] = getErrorLogFilePath(projectRoot);
 
-  fs.writeFileSync(mdFilePath, output);
-  fs.writeFileSync(logFilePath, buildOutput);
-  return mdFilePath;
+  fs.writeFileSync(logFilePath, errorOutput);
+  fs.writeFileSync(errorFilePath, buildOutput);
+  return logFilePath;
 }
 
 function getErrorLogFilePath(projectRoot: string): [string, string] {
-  const filename = 'xcodebuild.md';
   const folder = path.join(projectRoot, '.expo');
   fs.ensureDirSync(folder);
-  return [path.join(folder, filename), path.join(folder, 'xcodebuild-output.log')];
+  return [path.join(folder, 'xcodebuild.log'), path.join(folder, 'xcodebuild-error.log')];
 }

--- a/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
+++ b/packages/expo-cli/src/commands/run/ios/XcodeBuild.ts
@@ -277,8 +277,8 @@ export async function buildAsync({
 function writeBuildLogs(projectRoot: string, buildOutput: string, errorOutput: string) {
   const [logFilePath, errorFilePath] = getErrorLogFilePath(projectRoot);
 
-  fs.writeFileSync(logFilePath, errorOutput);
-  fs.writeFileSync(errorFilePath, buildOutput);
+  fs.writeFileSync(logFilePath, buildOutput);
+  fs.writeFileSync(errorFilePath, errorOutput);
   return logFilePath;
 }
 


### PR DESCRIPTION
# Why

Now that the formatter can be used as a standalone tool, we don't really need the markdown file reporting of xcodebuild logs. xcodebuild logs are also pretty big and take up a lot of space, this will reduce the size by half.

We'll now export:
- `.expo/xcodebuild.log`
- `.expo/xcodebuild-error.log`

In the future this may change to be `.expo/ios/run/date-id/`
