### PR TITLE
[prebuild-config] Added warning for using backgroundColor on iOS

### DIFF
--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -213,7 +213,6 @@ Object {
         },
       },
       "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
-      "RCTRootViewBackgroundColor": 4294901760,
       "SKAdNetworkItems": Array [
         Object {
           "SKAdNetworkIdentifier": "v9wttpbfk9.skadnetwork",
@@ -958,7 +957,6 @@ Object {
             },
           },
           "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
-          "RCTRootViewBackgroundColor": 4294901760,
           "SKAdNetworkItems": Array [
             Object {
               "SKAdNetworkIdentifier": "v9wttpbfk9.skadnetwork",
@@ -1204,7 +1202,6 @@ Object {
         },
       },
       "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
-      "RCTRootViewBackgroundColor": 4294901760,
       "SKAdNetworkItems": Array [
         Object {
           "SKAdNetworkIdentifier": "v9wttpbfk9.skadnetwork",
@@ -1862,7 +1859,6 @@ Object {
             },
           },
           "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
-          "RCTRootViewBackgroundColor": 4294901760,
           "SKAdNetworkItems": Array [
             Object {
               "SKAdNetworkIdentifier": "v9wttpbfk9.skadnetwork",
@@ -2109,7 +2105,6 @@ Object {
         },
       },
       "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
-      "RCTRootViewBackgroundColor": 4294901760,
       "SKAdNetworkItems": Array [
         Object {
           "SKAdNetworkIdentifier": "v9wttpbfk9.skadnetwork",

--- a/packages/prebuild-config/src/plugins/unversioned/expo-system-ui/__tests__/withIosRootViewBackgroundColor-test.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-system-ui/__tests__/withIosRootViewBackgroundColor-test.ts
@@ -1,4 +1,26 @@
-import { setRootViewBackgroundColor } from '../withIosRootViewBackgroundColor';
+import {
+  setRootViewBackgroundColor,
+  shouldUseLegacyBehavior,
+} from '../withIosRootViewBackgroundColor';
+
+describe(shouldUseLegacyBehavior, () => {
+  it(`should use legacy behavior in SDK –43`, () => {
+    expect(shouldUseLegacyBehavior({ sdkVersion: '43.0.0' })).toBe(true);
+    expect(shouldUseLegacyBehavior({ sdkVersion: '42.0.0' })).toBe(true);
+    expect(shouldUseLegacyBehavior({ sdkVersion: '31.0.0' })).toBe(true);
+  });
+  it(`should not use legacy behavior in SDK +44`, () => {
+    expect(shouldUseLegacyBehavior({ sdkVersion: '44.0.0' })).toBe(false);
+    expect(shouldUseLegacyBehavior({ sdkVersion: '46.0.0' })).toBe(false);
+    expect(shouldUseLegacyBehavior({ sdkVersion: '100.0.0' })).toBe(false);
+  });
+  it(`should not use legacy behavior when UNVERSIONED`, () => {
+    expect(shouldUseLegacyBehavior({ sdkVersion: 'UNVERSIONED' })).toBe(false);
+  });
+  it(`should not use legacy behavior when undefined`, () => {
+    expect(shouldUseLegacyBehavior({})).toBe(false);
+  });
+});
 
 describe(setRootViewBackgroundColor, () => {
   it(`sets color`, () => {

--- a/packages/prebuild-config/src/plugins/unversioned/expo-system-ui/withIosRootViewBackgroundColor.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-system-ui/withIosRootViewBackgroundColor.ts
@@ -1,7 +1,8 @@
-import { ConfigPlugin, InfoPlist, withInfoPlist } from '@expo/config-plugins';
+import { ConfigPlugin, InfoPlist, WarningAggregator, withInfoPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 // @ts-ignore: uses flow
 import normalizeColor from '@react-native/normalize-color';
+import semver from 'semver';
 
 // Maps to the template AppDelegate.m
 const BACKGROUND_COLOR_KEY = 'RCTRootViewBackgroundColor';
@@ -10,11 +11,38 @@ const debug = require('debug')('expo:system-ui:plugin:ios');
 
 export const withIosRootViewBackgroundColor: ConfigPlugin = config => {
   config = withInfoPlist(config, config => {
-    config.modResults = setRootViewBackgroundColor(config, config.modResults);
+    if (shouldUseLegacyBehavior(config)) {
+      config.modResults = setRootViewBackgroundColor(config, config.modResults);
+    } else {
+      warnSystemUIMissing(config);
+    }
     return config;
   });
   return config;
 };
+
+/** The template was changed in SDK 43 to move the background color logic to the `expo-system-ui` module */
+export function shouldUseLegacyBehavior(config: Pick<ExpoConfig, 'sdkVersion'>): boolean {
+  try {
+    return !!(config.sdkVersion && semver.lt(config.sdkVersion, '44.0.0'));
+  } catch {}
+  return false;
+}
+
+export function warnSystemUIMissing(
+  config: Pick<ExpoConfig, 'sdkVersion' | 'backgroundColor' | 'ios'>
+) {
+  const backgroundColor = getRootViewBackgroundColor(config);
+
+  if (backgroundColor) {
+    // Background color needs to be set programmatically
+    WarningAggregator.addWarningIOS(
+      'ios.backgroundColor',
+      'Install expo-system-ui to enable this feature',
+      'https://docs.expo.dev/build-reference/migrating/#expo-config--backgroundcolor--depends-on'
+    );
+  }
+}
 
 export function setRootViewBackgroundColor(
   config: Pick<ExpoConfig, 'backgroundColor' | 'ios'>,


### PR DESCRIPTION
# Why

We moved the background color logic out of the template and into the `expo-system-ui` module, which means users will now need to install that module when the backgroundColor is defined.

- https://github.com/expo/expo/pull/15213
- https://github.com/expo/expo/pull/15146

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->