### PR TITLE
[prebuild-config] add missing dependency

### DIFF
--- a/packages/prebuild-config/package.json
+++ b/packages/prebuild-config/package.json
@@ -31,7 +31,8 @@
     "build"
   ],
   "devDependencies": {
-    "@types/debug": "^4.1.5"
+    "@types/debug": "^4.1.5",
+    "@types/xml2js": "^0.4.5"
   },
   "dependencies": {
     "@expo/config": "6.0.7",
@@ -42,7 +43,8 @@
     "debug": "^4.3.1",
     "fs-extra": "^9.0.0",
     "resolve-from": "^5.0.0",
-    "semver": "7.3.2"
+    "semver": "7.3.2",
+    "xml2js": "0.4.23"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# Why

```
[stderr] [01:45:18] [ios.xcodeproj]: withIosXcodeprojBaseMod: (intermediate value).parseStringPromise is not a function
[stderr] [01:45:18] TypeError: [ios.xcodeproj]: withIosXcodeprojBaseMod: (intermediate value).parseStringPromise is not a function
[stderr]     at createTemplateSplashScreenAsync (/usr/local/eas-build-worker/node_modules/@expo/prebuild-config/src/plugins/unversioned/expo-splash-screen/InterfaceBuilder.ts:327:29)
[stderr]     at getSplashStoryboardContentsAsync (/usr/local/eas-build-worker/node_modules/@expo/prebuild-config/src/plugins/unversioned/expo-splash-screen/withIosSplashXcodeProject.ts:74:19)
[stderr]     at setSplashStoryboardAsync (/usr/local/eas-build-worker/node_modules/@expo/prebuild-config/src/plugins/unversioned/expo-splash-screen/withIosSplashXcodeProject.ts:96:26)
[stderr]     at /usr/local/eas-build-worker/node_modules/@expo/prebuild-config/src/plugins/unversioned/expo-splash-screen/withIosSplashXcodeProject.ts:22:31
[stderr]     at action (/usr/local/eas-build-worker/node_modules/@expo/config-plugins/src/plugins/withMod.ts:227:29)
[stderr]     at interceptingMod (/usr/local/eas-build-worker/node_modules/@expo/config-plugins/src/plugins/withMod.ts:108:27)
[stderr]     at action (/usr/local/eas-build-worker/node_modules/@expo/config-plugins/src/plugins/withMod.ts:228:14)
[stderr]     at interceptingMod (/usr/local/eas-build-worker/node_modules/@expo/config-plugins/src/plugins/withMod.ts:108:21)
```
prebuild fails if expo-cli is installed in project(in this case eas worker) that has an older version of the xml2js package

# How

add explicit version

# Test Plan

not tested, the content of yarn lock did not change, so there should not be any changes