### PR TITLE
[expo-cli] Move publish command to the publish help group

### DIFF
--- a/packages/expo-cli/src/commands/publish/publish.ts
+++ b/packages/expo-cli/src/commands/publish/publish.ts
@@ -8,7 +8,7 @@ export default function (program: Command) {
       .command('publish [path]')
       .alias('p')
       .description('Deploy a project to Expo hosting')
-      .helpGroup('core')
+      .helpGroup('publish')
       .option('-q, --quiet', 'Suppress verbose output from the Metro bundler.')
       .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')
       .option('-c, --clear', 'Clear the Metro bundler cache')


### PR DESCRIPTION
# Why

Move `publish` out of "core" (top of `expo --help`) and down to the "publish" group:

<img width="601" alt="Screen Shot 2021-11-17 at 3 32 07 PM" src="https://user-images.githubusercontent.com/9664363/142293090-b8fc6c68-907d-4068-8bb1-336cb746e76c.png">

This is part of an effort to divide the EAS commands from the versioned commands.
