### PR TITLE
[xdl] Remove md extension from expo updates config fyi link

### DIFF
--- a/packages/xdl/src/EmbeddedAssets.ts
+++ b/packages/xdl/src/EmbeddedAssets.ts
@@ -15,7 +15,7 @@ import {
 } from './internal';
 
 const PLACEHOLDER_URL = 'YOUR-APP-URL-HERE';
-const FYI_URL = 'https://expo.fyi/expo-updates-config.md';
+const FYI_URL = 'https://expo.fyi/expo-updates-config';
 
 export type EmbeddedAssetsConfiguration = {
   projectRoot: string;


### PR DESCRIPTION
# Why

Expo FYI links should be without md extension, it's added by the redirect.

See https://github.com/expo/expo-fyi/pull/1

# How

Removed md extension

# Test Plan

Try opening fixed link.