### PR TITLE
[interstitial] Capture analytics event when user selects "custom client"

### DIFF
--- a/packages/expo-cli/src/commands/start/startAsync.ts
+++ b/packages/expo-cli/src/commands/start/startAsync.ts
@@ -87,14 +87,14 @@ export async function actionAsync(projectRoot: string, options: NormalizedOption
       const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
       StatusEventEmitter.once('deviceLogReceive', () => {
         // Send the 'ready' event once the app is running in a device.
-        UnifiedAnalytics.logEvent('dev client interstitial page', {
+        UnifiedAnalytics.logEvent('dev client start command', {
           status: 'ready',
           platform,
           ...getDevClientProperties(projectRoot, exp),
         });
       });
 
-      UnifiedAnalytics.logEvent('dev client interstitial page', {
+      UnifiedAnalytics.logEvent('dev client start command', {
         status: 'started',
         platform,
         ...getDevClientProperties(projectRoot, exp),

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -838,7 +838,7 @@ async function constructDeepLinkAsync(
     !devClient &&
     isDevClientPackageInstalled(projectRoot)
   ) {
-    return UrlUtils.constructLoadingUrlAsync(projectRoot);
+    return UrlUtils.constructLoadingUrlAsync(projectRoot, 'android');
   } else {
     return await UrlUtils.constructDeepLinkAsync(projectRoot, {
       scheme,

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -779,7 +779,7 @@ async function constructDeepLinkAsync(
     !devClient &&
     isDevClientPackageInstalled(projectRoot)
   ) {
-    return UrlUtils.constructLoadingUrlAsync(projectRoot, 'localhost');
+    return UrlUtils.constructLoadingUrlAsync(projectRoot, 'ios', 'localhost');
   } else {
     try {
       return await UrlUtils.constructDeepLinkAsync(projectRoot, {

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -101,10 +101,11 @@ export async function constructLogUrlAsync(
 
 export async function constructLoadingUrlAsync(
   projectRoot: string,
+  platform: 'ios' | 'android',
   requestHostname?: string
 ): Promise<string> {
   const baseUrl = await constructUrlAsync(projectRoot, { urlType: 'http' }, false, requestHostname);
-  return `${baseUrl}/_expo/loading`;
+  return `${baseUrl}/_expo/loading?platform=${platform}`;
 }
 
 export async function constructUrlWithExtensionAsync(

--- a/packages/xdl/src/index.ts
+++ b/packages/xdl/src/index.ts
@@ -26,6 +26,7 @@ export {
   NotificationCode,
   printBundleSizes,
   PackagerLogsStream,
+  LoadingPageHandler,
   LogRecord,
   LogUpdater,
   PKCS12Utils,

--- a/packages/xdl/static/loading-page/index.html
+++ b/packages/xdl/static/loading-page/index.html
@@ -243,8 +243,32 @@
     <p class="bottom-bar-header">
       How would you like to open this project?
     </p>
-    <a href="_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development App</a>
-    <a href="_expo/link?choice=expo-go" class="bottom-bar-button bottom-bar-button-grey">Expo Go</a>
+    <a id="expo-dev-client-link" href="/_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development App</a>
+    <a id="expo-go-link" href="/_expo/link?choice=expo-go" class="bottom-bar-button bottom-bar-button-grey">Expo Go</a>
   </div>
+  
+  <script>
+  function findGetParameter(parameterName) {
+    let result = null;
+
+    location.search
+      .substr(1)
+      .split("&")
+      .forEach(function (item) {
+        const tmp = item.split("=");
+        if (tmp[0] === parameterName) result = decodeURIComponent(tmp[1]);
+      });
+    return result;
+  }
+
+  const platform = findGetParameter("platform");
+  if (platform) {
+    const devClientLink = document.getElementById("expo-dev-client-link");
+    const goLink = document.getElementById("expo-go-link");
+
+    devClientLink.href += "&platform=" + platform;
+    goLink.href += "&platform=" + platform;
+  }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
# Why

Closes ENG-2268.

# How

- Added a listener that triggers every time user selects something on the interstitial page.
- Pipe `platform` value through interstitial page to obtain it in the listener. 


# Test Plan

I couldn't verify if the events are sent, but I replaced them with console logs. Everything seems to work.