### PR TITLE
[install-expo-modules] Fix workspace support

### DIFF
--- a/packages/install-expo-modules/src/plugins/android/withAndroidModules.ts
+++ b/packages/install-expo-modules/src/plugins/android/withAndroidModules.ts
@@ -20,11 +20,11 @@ const withAndroidModulesSettingGradle: ConfigPlugin = config => {
     const isGroovy = config.modResults.language === 'groovy';
     const addCodeBlock = isGroovy
       ? [
-          'apply from: new File(["node", "--print", "require.resolve(\'expo/package.json\')"].execute().text.trim(), "../scripts/autolinking.gradle")',
+          'apply from: new File(["node", "--print", "require.resolve(\'expo/package.json\')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")',
           'useExpoModules()',
         ]
       : [
-          'val pathExpoPackageJson = org.codehaus.groovy.runtime.ProcessGroovyMethods.getText(org.codehaus.groovy.runtime.ProcessGroovyMethods.execute("node --print require.resolve(\'expo/package.json\')"))',
+          'val pathExpoPackageJson = org.codehaus.groovy.runtime.ProcessGroovyMethods.getText(org.codehaus.groovy.runtime.ProcessGroovyMethods.execute("node --print require.resolve(\'expo/package.json\')", null, rootDir))',
           'apply(from = File(pathExpoPackageJson.trim(), "../scripts/autolinking.gradle"))',
           'val useExpoModules = extra["useExpoModules"] as groovy.lang.Closure<Any>',
           'useExpoModules()',


### PR DESCRIPTION
# Why

aligned template change in https://github.com/expo/expo/pull/15109

# How

passing rootDir to `execute()`

# Test Plan

verify class react-native project with install-expo-modules