### PR TITLE
Forbidden project names

### DIFF
--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -44,3 +44,13 @@ test('init', async () => {
   expect(gitBranch).toMatch(/On branch (master|main)\nnothing to commit, working tree clean\n/);
   // expect(gitBranch).toBe('On branch master\nnothing to commit, working tree clean\n');
 });
+
+test('init react-native should exit', async () => {
+  const cwd = temporary.directory();
+  const { stdout } = await tryRunAsync(
+    ['init', 'react-native', '--template', 'blank', '--name', 'react-native', '--no-install'],
+    { cwd, env: { ...process.env, YARN_CACHE_FOLDER: path.join(cwd, 'yarn-cache') } }
+  );
+
+  expect(stdout).toBe('');
+});

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -64,6 +64,10 @@ function assertValidName(folderName: string) {
       `Cannot create an app named ${chalk.red(`"${folderName}"`)}. ${validation}`
     );
   }
+  const isFolderNameBlacklisted = CreateApp.isFolderNameBlacklisted(folderName);
+  if (isFolderNameBlacklisted) {
+    throw new CommandError(`Cannot create an app named ${chalk.red(`"${folderName}"`)}.`);
+  }
 }
 
 function parseOptions(command: Partial<Options>): Options {

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -64,8 +64,8 @@ function assertValidName(folderName: string) {
       `Cannot create an app named ${chalk.red(`"${folderName}"`)}. ${validation}`
     );
   }
-  const isFolderNameBlacklisted = CreateApp.isFolderNameBlacklisted(folderName);
-  if (isFolderNameBlacklisted) {
+  const isFolderNameForbidden = CreateApp.isFolderNameForbidden(folderName);
+  if (isFolderNameForbidden) {
     throw new CommandError(`Cannot create an app named ${chalk.red(`"${folderName}"`)}.`);
   }
 }

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -66,7 +66,11 @@ function assertValidName(folderName: string) {
   }
   const isFolderNameForbidden = CreateApp.isFolderNameForbidden(folderName);
   if (isFolderNameForbidden) {
-    throw new CommandError(`Cannot create an app named ${chalk.red(`"${folderName}"`)}.`);
+    throw new CommandError(
+      `Cannot create an app named ${chalk.red(
+        `"${folderName}"`
+      )} because it would conflict with a dependency of the same name.`
+    );
   }
 }
 

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -20,6 +20,12 @@ export function validateName(name?: string): string | true {
   return true;
 }
 
+const BLACKLISTED_NAMES = ['react-native', 'react', 'react-dom', 'react-native-web', 'expo'];
+
+export function isFolderNameBlacklisted(folderName: string): boolean {
+  return BLACKLISTED_NAMES.includes(folderName);
+}
+
 // Any of these files are allowed to exist in the projectRoot
 const TOLERABLE_FILES = [
   // System

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -20,10 +20,10 @@ export function validateName(name?: string): string | true {
   return true;
 }
 
-const BLACKLISTED_NAMES = ['react-native', 'react', 'react-dom', 'react-native-web', 'expo'];
+const FORBIDDEN_NAMES = ['react-native', 'react', 'react-dom', 'react-native-web', 'expo'];
 
-export function isFolderNameBlacklisted(folderName: string): boolean {
-  return BLACKLISTED_NAMES.includes(folderName);
+export function isFolderNameForbidden(folderName: string): boolean {
+  return FORBIDDEN_NAMES.includes(folderName);
 }
 
 // Any of these files are allowed to exist in the projectRoot


### PR DESCRIPTION
# Why
This pull request resolves the following issue:
https://github.com/expo/expo-cli/issues/3979

If project names such as `react-native` or `expo` is fed to the command  `expo init <project_name>`, it leads to the project being correctly initialized however crashing upon starting up. These edge cases should be caught and handled. 

# How
There is an array of blacklisted project names. Upon initializing the project, it is checked if the project name is included in this array. If so, the user is stopped from creating the project with that name.  

Here is how the result looks like:
![Screenshot from 2021-11-21 15-51-02](https://user-images.githubusercontent.com/40788573/142766829-c3ea151a-3c2b-4308-9f33-8639dd76199d.png)
# Test Plan
For testing using the command line simply run `node ./packages/expo-cli/bin/expo.js init react` and the error should pop up. Make sure the project is built and running in the background using `yarn build` and `yarn start` respectively.  

There is also an E2E test case for this fix that checks if the command has failed by checking if `stdout` is empty in comparison to a passing state in which the `stdout` is `Your project is ready!`. However currently a warning gets thrown on executing the test. The warning is present in the following screenshot:
<img width="922" alt="expotest" src="https://user-images.githubusercontent.com/40788573/142767123-00c5aaf3-9167-42fd-b933-3ff38e3ec4da.png">
