### PR TITLE
[config-plugins] consolidate getRuntimeVersionNullable

### DIFF
--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -103,6 +103,10 @@ export function setVersionsConfig(
     removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
     addMetaDataItemToMainApplication(mainApplication, Config.RUNTIME_VERSION, runtimeVersion);
   } else if (sdkVersion) {
+    /**
+     * runtime version maybe null in projects using classic updates. In that
+     * case we use SDK version
+     */
     removeMetaDataItemFromMainApplication(mainApplication, Config.RUNTIME_VERSION);
     addMetaDataItemToMainApplication(mainApplication, Config.SDK_VERSION, sdkVersion);
   } else {

--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -3,7 +3,7 @@ import resolveFrom from 'resolve-from';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidManifest } from '../plugins/android-plugins';
-import { ExpoConfigUpdates, getRuntimeVersion, getUpdateUrl } from '../utils/Updates';
+import { ExpoConfigUpdates, getRuntimeVersionNullable, getUpdateUrl } from '../utils/Updates';
 import {
   addMetaDataItemToMainApplication,
   AndroidManifest,
@@ -34,20 +34,6 @@ export const withUpdates: ConfigPlugin<{ expoUsername: string | null }> = (
     return config;
   });
 };
-
-/**
- * runtime version maybe null in projects using classic updates. In that
- * case we use SDK version
- */
-export function getRuntimeVersionNullable(
-  config: Pick<ExpoConfigUpdates, 'runtimeVersion'>
-): string | null {
-  try {
-    return getRuntimeVersion(config, 'android');
-  } catch (e) {
-    return null;
-  }
-}
 
 export function getSDKVersion(config: Pick<ExpoConfigUpdates, 'sdkVersion'>): string | null {
   return typeof config.sdkVersion === 'string' ? config.sdkVersion : null;
@@ -111,7 +97,7 @@ export function setVersionsConfig(
 ): AndroidManifest {
   const mainApplication = getMainApplicationOrThrow(androidManifest);
 
-  const runtimeVersion = getRuntimeVersionNullable(config);
+  const runtimeVersion = getRuntimeVersionNullable(config, 'android');
   const sdkVersion = getSDKVersion(config);
   if (runtimeVersion) {
     removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
@@ -212,7 +198,7 @@ export function areVersionsSynced(
   config: Pick<ExpoConfigUpdates, 'runtimeVersion' | 'sdkVersion'>,
   androidManifest: AndroidManifest
 ): boolean {
-  const expectedRuntimeVersion = getRuntimeVersionNullable(config);
+  const expectedRuntimeVersion = getRuntimeVersionNullable(config, 'android');
   const expectedSdkVersion = getSDKVersion(config);
 
   const currentRuntimeVersion = getMainApplicationMetaDataValue(

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -4,7 +4,7 @@ import xcode from 'xcode';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withExpoPlist } from '../plugins/ios-plugins';
-import { ExpoConfigUpdates, getRuntimeVersion, getUpdateUrl } from '../utils/Updates';
+import { ExpoConfigUpdates, getRuntimeVersionNullable, getUpdateUrl } from '../utils/Updates';
 import { ExpoPlist } from './IosConfig.types';
 
 const CREATE_MANIFEST_IOS_PATH = 'expo-updates/scripts/create-manifest-ios.sh';
@@ -18,20 +18,6 @@ export enum Config {
   UPDATE_URL = 'EXUpdatesURL',
   RELEASE_CHANNEL = 'EXUpdatesReleaseChannel',
   UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = 'EXUpdatesRequestHeaders',
-}
-
-/**
- * runtime version maybe null in projects using classic updates. In that
- * case we use SDK version
- */
-export function getRuntimeVersionNullable(
-  config: Pick<ExpoConfigUpdates, 'runtimeVersion'>
-): string | null {
-  try {
-    return getRuntimeVersion(config, 'ios');
-  } catch (e) {
-    return null;
-  }
 }
 
 export function getSDKVersion(config: Pick<ExpoConfigUpdates, 'sdkVersion'>): string | null {
@@ -92,7 +78,7 @@ export function setUpdatesConfig(
 export function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlist): ExpoPlist {
   const newExpoPlist = { ...expoPlist };
 
-  const runtimeVersion = getRuntimeVersionNullable(config);
+  const runtimeVersion = getRuntimeVersionNullable(config, 'ios');
   const sdkVersion = getSDKVersion(config);
   if (runtimeVersion) {
     delete newExpoPlist[Config.SDK_VERSION];
@@ -201,7 +187,7 @@ export function isPlistVersionConfigurationSynced(
   config: Pick<ExpoConfigUpdates, 'sdkVersion' | 'runtimeVersion'>,
   expoPlist: ExpoPlist
 ): boolean {
-  const expectedRuntimeVersion = getRuntimeVersionNullable(config);
+  const expectedRuntimeVersion = getRuntimeVersionNullable(config, 'ios');
   const expectedSdkVersion = getSDKVersion(config);
 
   const currentRuntimeVersion = expoPlist.EXUpdatesRuntimeVersion ?? null;

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -84,6 +84,10 @@ export function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlis
     delete newExpoPlist[Config.SDK_VERSION];
     newExpoPlist[Config.RUNTIME_VERSION] = runtimeVersion;
   } else if (sdkVersion) {
+    /**
+     * runtime version maybe null in projects using classic updates. In that
+     * case we use SDK version
+     */
     delete newExpoPlist[Config.RUNTIME_VERSION];
     newExpoPlist[Config.SDK_VERSION] = sdkVersion;
   } else {

--- a/packages/config-plugins/src/utils/Updates.ts
+++ b/packages/config-plugins/src/utils/Updates.ts
@@ -1,5 +1,6 @@
 import { Android, ExpoConfig, IOS } from '@expo/config-types';
 import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
+import { boolish } from 'getenv';
 
 import { AndroidConfig, IOSConfig } from '..';
 
@@ -75,6 +76,9 @@ export function getRuntimeVersionNullable(
   try {
     return getRuntimeVersion(config, platform);
   } catch (e) {
+    if (boolish('EXPO_DEBUG', false)) {
+      console.log(e);
+    }
     return null;
   }
 }

--- a/packages/config-plugins/src/utils/Updates.ts
+++ b/packages/config-plugins/src/utils/Updates.ts
@@ -69,6 +69,20 @@ export const withRuntimeVersion: (config: ExpoConfig) => ExpoConfig = config => 
   return config;
 };
 
+export function getRuntimeVersionNullable(
+  config: Pick<ExpoConfig, 'version' | 'runtimeVersion' | 'sdkVersion'> & {
+    android?: Pick<Android, 'versionCode' | 'runtimeVersion'>;
+    ios?: Pick<IOS, 'buildNumber' | 'runtimeVersion'>;
+  },
+  platform: 'android' | 'ios'
+): string | null {
+  try {
+    return getRuntimeVersion(config, platform);
+  } catch (e) {
+    return null;
+  }
+}
+
 export function getRuntimeVersion(
   config: Pick<ExpoConfig, 'version' | 'runtimeVersion' | 'sdkVersion'> & {
     android?: Pick<Android, 'versionCode' | 'runtimeVersion'>;

--- a/packages/config-plugins/src/utils/Updates.ts
+++ b/packages/config-plugins/src/utils/Updates.ts
@@ -70,11 +70,7 @@ export const withRuntimeVersion: (config: ExpoConfig) => ExpoConfig = config => 
 };
 
 export function getRuntimeVersionNullable(
-  config: Pick<ExpoConfig, 'version' | 'runtimeVersion' | 'sdkVersion'> & {
-    android?: Pick<Android, 'versionCode' | 'runtimeVersion'>;
-    ios?: Pick<IOS, 'buildNumber' | 'runtimeVersion'>;
-  },
-  platform: 'android' | 'ios'
+  ...[config, platform]: Parameters<typeof getRuntimeVersion>
 ): string | null {
   try {
     return getRuntimeVersion(config, platform);


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

We want to export `getRuntimeVersionNullable` for use in cases such as: https://github.com/expo/eas-cli/pull/785
# How

<!-- 
How did you build this feature or fix this bug and why? 
-->
Consolidate `getRuntimeVersionNullable` to make it more generally applicable.

# Test Plan
inspect
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->