### PR TITLE
[xdl] bumps rudder sdk version

### DIFF
--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -40,7 +40,7 @@
     "@expo/osascript": "2.0.30",
     "@expo/package-manager": "0.0.47",
     "@expo/plist": "0.0.15",
-    "@expo/rudder-sdk-node": "1.1.0",
+    "@expo/rudder-sdk-node": "1.1.1",
     "@expo/schemer": "1.3.31",
     "@expo/sdk-runtime-versions": "^1.0.0",
     "@expo/spawn-async": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,10 +1704,10 @@
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
 
-"@expo/rudder-sdk-node@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/rudder-sdk-node/-/rudder-sdk-node-1.1.0.tgz#90c6ef615fbf34473180aa439e3daac7b5af9eed"
-  integrity sha512-XUxJi2xUEi3RNdKc78emywcl8jQ+iGzpBq0gC1Gpu2/3gAuIxIfp/vGWp1vWo58cZtabhbQx/AMmbOfsHK35Qw==
+"@expo/rudder-sdk-node@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/rudder-sdk-node/-/rudder-sdk-node-1.1.1.tgz#6aa575f346833eb6290282118766d4919c808c6a"
+  integrity sha512-uy/hS/awclDJ1S88w9UGpc6Nm9XnNUjzOAAib1A3PVAnGQIwebg8DpFqOthFBTlZxeuV/BKbZ5jmTbtNZkp1WQ==
   dependencies:
     "@expo/bunyan" "^4.0.0"
     "@segment/loosely-validate-event" "^2.0.0"


### PR DESCRIPTION
# Why

There was a [bug](https://github.com/expo/rudder-sdk-node/pull/30) where flushing an empty queue would clobber some flush state. This caused subsequent flushes to return an outdated nullResponse.

# How

Bumped to the newest rudder client which included a fix

# Test Plan

Ran some commands and saw events made it to the backend