### PR TITLE
[prebuild-config] Drop unversioned apple authentication support

### DIFF
--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -150,9 +150,6 @@ Object {
       "usesNonExemptEncryption": true,
     },
     "entitlements": Object {
-      "com.apple.developer.applesignin": Array [
-        "Default",
-      ],
       "com.apple.developer.associated-domains": Array [
         "applinks:https://pillarvalley.netlify.app",
       ],
@@ -889,9 +886,6 @@ Object {
       },
       "ios": Object {
         "entitlements": Object {
-          "com.apple.developer.applesignin": Array [
-            "Default",
-          ],
           "com.apple.developer.associated-domains": Array [
             "applinks:https://pillarvalley.netlify.app",
           ],
@@ -1139,9 +1133,6 @@ Object {
       "usesNonExemptEncryption": true,
     },
     "entitlements": Object {
-      "com.apple.developer.applesignin": Array [
-        "Default",
-      ],
       "com.apple.developer.associated-domains": Array [
         "applinks:https://pillarvalley.netlify.app",
       ],
@@ -1791,9 +1782,6 @@ Object {
       },
       "ios": Object {
         "entitlements": Object {
-          "com.apple.developer.applesignin": Array [
-            "Default",
-          ],
           "com.apple.developer.associated-domains": Array [
             "applinks:https://pillarvalley.netlify.app",
           ],
@@ -2042,9 +2030,6 @@ Object {
       "usesNonExemptEncryption": true,
     },
     "entitlements": Object {
-      "com.apple.developer.applesignin": Array [
-        "Default",
-      ],
       "com.apple.developer.associated-domains": Array [
         "applinks:https://pillarvalley.netlify.app",
       ],

--- a/packages/prebuild-config/src/plugins/unversioned/expo-apple-authentication.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-apple-authentication.ts
@@ -7,7 +7,7 @@ const withAppleSignInWarning: ConfigPlugin = config => {
     if (config.ios?.usesAppleSignIn) {
       WarningAggregator.addWarningIOS(
         'ios.usesAppleSignIn',
-        'Install expo-apple-authentication to enable the ios.usesAppleSignIn feature',
+        'Install expo-apple-authentication to enable this feature',
         'https://docs.expo.dev/versions/latest/sdk/apple-authentication/#eas-build'
       );
     }

--- a/packages/prebuild-config/src/plugins/unversioned/expo-apple-authentication.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-apple-authentication.ts
@@ -1,28 +1,22 @@
-import { ConfigPlugin, withEntitlementsPlist } from '@expo/config-plugins';
-import { ExpoConfig } from '@expo/config-types';
-import { JSONObject } from '@expo/json-file';
+import { ConfigPlugin, WarningAggregator, withEntitlementsPlist } from '@expo/config-plugins';
 
 import { createLegacyPlugin } from './createLegacyPlugin';
 
-const withAppleSignInEntitlement: ConfigPlugin = config => {
+const withAppleSignInWarning: ConfigPlugin = config => {
   return withEntitlementsPlist(config, config => {
-    config.modResults = setAppleSignInEntitlement(config, config.modResults);
+    if (config.ios?.usesAppleSignIn) {
+      WarningAggregator.addWarningIOS(
+        'ios.usesAppleSignIn',
+        'Install expo-apple-authentication to enable the ios.usesAppleSignIn feature',
+        'https://docs.expo.dev/versions/latest/sdk/apple-authentication/#eas-build'
+      );
+    }
+
     return config;
   });
 };
 
-function setAppleSignInEntitlement(config: ExpoConfig, entitlementsPlist: JSONObject): JSONObject {
-  if (config.ios?.usesAppleSignIn) {
-    return {
-      ...entitlementsPlist,
-      'com.apple.developer.applesignin': ['Default'],
-    };
-  }
-
-  return entitlementsPlist;
-}
-
 export default createLegacyPlugin({
   packageName: 'expo-apple-authentication',
-  fallback: withAppleSignInEntitlement,
+  fallback: withAppleSignInWarning,
 });


### PR DESCRIPTION
# Why

Recommend installing `expo-apple-authentication` instead of using unversioned setup for apple authentication.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Warn when users enable `ios.usesAppleSignIn` and don't have `expo-apple-authentication` installed.

