### PR TITLE
Ensure TeamID has quotes around it

### DIFF
--- a/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
@@ -36,6 +36,14 @@ describe('ProvisioningProfile module', () => {
       const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
       expect(pbxprojContents).toMatchSnapshot();
     });
+    it('configures the project.pbxproj file with the profile name and apple team id', () => {
+      setProvisioningProfileForPbxproj(projectRoot, {
+        profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+        appleTeamId: 'Something Spaced',
+      });
+      const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+      expect(pbxprojContents).toMatch(/DevelopmentTeam = "Something Spaced";/);
+    });
     it('throws descriptive error when target name does not exist', () => {
       expect(() =>
         setProvisioningProfileForPbxproj(projectRoot, {

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
@@ -155,7 +155,7 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures 
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
 						LastSwiftMigration = 1120;
-						DevelopmentTeam = J5FM626PE2;
+						DevelopmentTeam = \\"J5FM626PE2\\";
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -323,7 +323,7 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures 
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = \\"apple-generic\\";
 				PROVISIONING_PROFILE_SPECIFIER = \\"*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z\\";
-				DEVELOPMENT_TEAM = J5FM626PE2;
+				DEVELOPMENT_TEAM = \\"J5FM626PE2\\";
 				CODE_SIGN_IDENTITY = \\"iPhone Distribution\\";
 				CODE_SIGN_STYLE = Manual;
 			};

--- a/packages/expo-cli/src/commands/run/ios/developmentCodeSigning.ts
+++ b/packages/expo-cli/src/commands/run/ios/developmentCodeSigning.ts
@@ -83,6 +83,8 @@ function setAutoCodeSigningInfoForPbxproj(
   const project = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
   const targets = IOSConfig.Target.findSignableTargets(project);
 
+  const quotedAppleTeamId = ensureQuotes(appleTeamId);
+
   for (const [nativeTargetId, nativeTarget] of targets) {
     IOSConfig.XcodeUtils.getBuildConfigurationsForListId(
       project,
@@ -93,7 +95,7 @@ function setAutoCodeSigningInfoForPbxproj(
           item.buildSettings.PRODUCT_NAME
       )
       .forEach(([, item]: IOSConfig.XcodeUtils.ConfigurationSectionEntry) => {
-        item.buildSettings.DEVELOPMENT_TEAM = appleTeamId;
+        item.buildSettings.DEVELOPMENT_TEAM = quotedAppleTeamId;
         item.buildSettings.CODE_SIGN_IDENTITY = '"Apple Development"';
         item.buildSettings.CODE_SIGN_STYLE = 'Automatic';
       });
@@ -104,13 +106,21 @@ function setAutoCodeSigningInfoForPbxproj(
         if (!item.attributes.TargetAttributes[nativeTargetId]) {
           item.attributes.TargetAttributes[nativeTargetId] = {};
         }
-        item.attributes.TargetAttributes[nativeTargetId].DevelopmentTeam = appleTeamId;
+
+        item.attributes.TargetAttributes[nativeTargetId].DevelopmentTeam = quotedAppleTeamId;
         item.attributes.TargetAttributes[nativeTargetId].ProvisioningStyle = 'Automatic';
       });
   }
 
   fs.writeFileSync(project.filepath, project.writeSync());
 }
+
+const ensureQuotes = (value: string) => {
+  if (!value.match(/^['"]/)) {
+    return `"${value}"`;
+  }
+  return value;
+};
 
 export async function ensureDeviceIsCodeSignedForDeploymentAsync(
   projectRoot: string


### PR DESCRIPTION
# Why

[Reported on discord](https://discord.com/channels/695411232856997968/809586753719238656/914984858592354335). The build fails if the Team ID or DevelopmentTeam has a space inside.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->


# Test Plan

- [ ] Locally (not sure how since all my team IDs are a single value)
- [x] Unit tests

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->