### PR TITLE
[config-plugins] Automatically remove auto generated intent filters

### DIFF
--- a/packages/config-plugins/src/android/Manifest.ts
+++ b/packages/config-plugins/src/android/Manifest.ts
@@ -40,7 +40,11 @@ type ManifestReceiver = {
   'intent-filter'?: ManifestIntentFilter[];
 };
 
-type ManifestIntentFilter = {
+export type ManifestIntentFilter = {
+  $: {
+    'android:autoVerify'?: StringBoolean;
+    'data-generated'?: StringBoolean;
+  };
   action?: ManifestAction[];
   data?: ManifestData[];
   category?: ManifestCategory[];

--- a/packages/config-plugins/src/android/Manifest.ts
+++ b/packages/config-plugins/src/android/Manifest.ts
@@ -41,7 +41,7 @@ type ManifestReceiver = {
 };
 
 export type ManifestIntentFilter = {
-  $: {
+  $?: {
     'android:autoVerify'?: StringBoolean;
     'data-generated'?: StringBoolean;
   };

--- a/packages/config-plugins/src/android/__tests__/IntentFilters-test.ts
+++ b/packages/config-plugins/src/android/__tests__/IntentFilters-test.ts
@@ -13,7 +13,7 @@ describe('Android intent filters', () => {
 
   it(`writes intent filter to android manifest`, async () => {
     let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
-    androidManifestJson = await setAndroidIntentFilters(
+    androidManifestJson = setAndroidIntentFilters(
       {
         android: {
           intentFilters: [
@@ -25,18 +25,38 @@ describe('Android intent filters', () => {
               },
               category: ['BROWSABLE', 'DEFAULT'],
             },
+            {
+              autoVerify: false,
+              action: 'VIEW',
+              data: {
+                scheme: 'https',
+                host: 'test.foo.bar',
+                pathPrefix: '/deeplink',
+              },
+              category: ['BROWSABLE', 'DEFAULT'],
+            },
           ],
         },
       },
       androidManifestJson
     );
 
-    expect(getMainActivity(androidManifestJson)['intent-filter']).toHaveLength(2);
+    expect(getMainActivity(androidManifestJson)['intent-filter']).toHaveLength(3);
+
+    // Test removing generated intent filters.
+    androidManifestJson = setAndroidIntentFilters(
+      {
+        android: {},
+      },
+      androidManifestJson
+    );
+
+    expect(getMainActivity(androidManifestJson)['intent-filter']).toHaveLength(1);
   });
 
   xit(`does not duplicate android intent filters`, async () => {
     let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
-    androidManifestJson = await setAndroidIntentFilters(
+    androidManifestJson = setAndroidIntentFilters(
       {
         android: {
           intentFilters: [
@@ -54,7 +74,7 @@ describe('Android intent filters', () => {
       androidManifestJson
     );
 
-    androidManifestJson = await setAndroidIntentFilters(
+    androidManifestJson = setAndroidIntentFilters(
       {
         android: {
           intentFilters: [

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -544,6 +544,7 @@ Object {
                       Object {
                         "$": Object {
                           "android:autoVerify": "true",
+                          "data-generated": "true",
                         },
                         "action": Array [
                           Object {
@@ -1406,6 +1407,7 @@ Object {
                       Object {
                         "$": Object {
                           "android:autoVerify": "true",
+                          "data-generated": "true",
                         },
                         "action": Array [
                           Object {


### PR DESCRIPTION
# Why

intent filters stack up on subsequent runs of `expo prebuild` (not recommended). This PR adds a tag to the generated intent-filters so we can safely remove them on subsequent runs.

Also fixes https://github.com/expo/eas-cli/issues/558 by adding support for multiple intent filters. The old syntax appears to have only parsed the first filter. ENG-2572

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->


<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `expo run:android` and `expo run:android --variant release` to ensure the tags are accepted by Gradle.
- Added improved unit tests to support testing for removing filters and adding multiple filters.
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->