### PR TITLE
[config-plugins] use new error recovery setting in config plugin for updates 0.11.x

### DIFF
--- a/packages/config-plugins/src/android/__tests__/Updates-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Updates-test.ts
@@ -36,6 +36,18 @@ describe('Android Updates config', () => {
     expect(
       Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } })
     ).toBe('NEVER');
+    expect(
+      Updates.getUpdatesCheckOnLaunch(
+        { updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } },
+        '0.11.0'
+      )
+    ).toBe('ERROR_RECOVERY_ONLY');
+    expect(
+      Updates.getUpdatesCheckOnLaunch(
+        { updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } },
+        '0.10.15'
+      )
+    ).toBe('NEVER');
     expect(Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_LOAD' } })).toBe(
       'ALWAYS'
     );
@@ -62,7 +74,7 @@ describe('Android Updates config', () => {
         checkAutomatically: 'ON_ERROR_RECOVERY',
       },
     };
-    androidManifestJson = Updates.setUpdatesConfig(config, androidManifestJson, 'user');
+    androidManifestJson = Updates.setUpdatesConfig(config, androidManifestJson, 'user', '0.11.0');
     const mainApplication = getMainApplication(androidManifestJson);
 
     const updateUrl = mainApplication['meta-data'].filter(
@@ -87,7 +99,7 @@ describe('Android Updates config', () => {
       e => e.$['android:name'] === 'expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH'
     );
     expect(checkOnLaunch).toHaveLength(1);
-    expect(checkOnLaunch[0].$['android:value']).toMatch('NEVER');
+    expect(checkOnLaunch[0].$['android:value']).toMatch('ERROR_RECOVERY_ONLY');
 
     const timeout = mainApplication['meta-data'].filter(
       e => e.$['android:name'] === 'expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS'

--- a/packages/config-plugins/src/ios/__tests__/Updates-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Updates-test.ts
@@ -24,6 +24,18 @@ describe('iOS Updates config', () => {
     expect(
       Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } })
     ).toBe('NEVER');
+    expect(
+      Updates.getUpdatesCheckOnLaunch(
+        { updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } },
+        '0.11.0'
+      )
+    ).toBe('ERROR_RECOVERY_ONLY');
+    expect(
+      Updates.getUpdatesCheckOnLaunch(
+        { updates: { checkAutomatically: 'ON_ERROR_RECOVERY' } },
+        '0.10.15'
+      )
+    ).toBe('NEVER');
     expect(Updates.getUpdatesCheckOnLaunch({ updates: { checkAutomatically: 'ON_LOAD' } })).toBe(
       'ALWAYS'
     );
@@ -45,7 +57,31 @@ describe('iOS Updates config', () => {
           },
         },
         {},
-        'user'
+        'user',
+        '0.11.0'
+      )
+    ).toMatchObject({
+      EXUpdatesEnabled: false,
+      EXUpdatesURL: 'https://exp.host/@owner/my-app',
+      EXUpdatesCheckOnLaunch: 'ERROR_RECOVERY_ONLY',
+      EXUpdatesLaunchWaitMs: 2000,
+      EXUpdatesSDKVersion: '37.0.0',
+    });
+    expect(
+      Updates.setUpdatesConfig(
+        {
+          sdkVersion: '37.0.0',
+          slug: 'my-app',
+          owner: 'owner',
+          updates: {
+            enabled: false,
+            fallbackToCacheTimeout: 2000,
+            checkAutomatically: 'ON_ERROR_RECOVERY',
+          },
+        },
+        {},
+        'user',
+        '0.10.15'
       )
     ).toMatchObject({
       EXUpdatesEnabled: false,

--- a/packages/config-plugins/src/utils/Updates.ts
+++ b/packages/config-plugins/src/utils/Updates.ts
@@ -1,13 +1,29 @@
 import { Android, ExpoConfig, IOS } from '@expo/config-types';
 import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
+import fs from 'fs';
 import { boolish } from 'getenv';
+import path from 'path';
 
 import { AndroidConfig, IOSConfig } from '..';
+import { resolvePackageRootFolder } from './resolvePackageRootFolder';
 
 export type ExpoConfigUpdates = Pick<
   ExpoConfig,
   'sdkVersion' | 'owner' | 'runtimeVersion' | 'updates' | 'slug'
 >;
+
+export function getExpoUpdatesPackageVersion(projectRoot: string): string | null {
+  const expoUpdatesRootFolder = resolvePackageRootFolder(projectRoot, 'expo-updates');
+  if (!expoUpdatesRootFolder) {
+    return null;
+  }
+  const packageJsonPath = path.join(expoUpdatesRootFolder, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return null;
+  }
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  return packageJson.version;
+}
 
 export function getUpdateUrl(
   config: Pick<ExpoConfigUpdates, 'owner' | 'slug' | 'updates'>,

--- a/packages/config-plugins/src/utils/Updates.ts
+++ b/packages/config-plugins/src/utils/Updates.ts
@@ -2,10 +2,9 @@ import { Android, ExpoConfig, IOS } from '@expo/config-types';
 import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
 import fs from 'fs';
 import { boolish } from 'getenv';
-import path from 'path';
+import resolveFrom from 'resolve-from';
 
 import { AndroidConfig, IOSConfig } from '..';
-import { resolvePackageRootFolder } from './resolvePackageRootFolder';
 
 export type ExpoConfigUpdates = Pick<
   ExpoConfig,
@@ -13,15 +12,11 @@ export type ExpoConfigUpdates = Pick<
 >;
 
 export function getExpoUpdatesPackageVersion(projectRoot: string): string | null {
-  const expoUpdatesRootFolder = resolvePackageRootFolder(projectRoot, 'expo-updates');
-  if (!expoUpdatesRootFolder) {
+  const expoUpdatesPackageJsonPath = resolveFrom.silent(projectRoot, 'expo-updates/package.json');
+  if (!expoUpdatesPackageJsonPath || !fs.existsSync(expoUpdatesPackageJsonPath)) {
     return null;
   }
-  const packageJsonPath = path.join(expoUpdatesRootFolder, 'package.json');
-  if (!fs.existsSync(packageJsonPath)) {
-    return null;
-  }
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const packageJson = JSON.parse(fs.readFileSync(expoUpdatesPackageJsonPath, 'utf8'));
   return packageJson.version;
 }
 


### PR DESCRIPTION
# Why

expo-updates 0.11.x will have a new native config setting that better matches the description & intended behavior of app.json's `updates.checkAutomatically: 'ON_ERROR_RECOVERY'` (which previously was only implemented in Expo Go-derived shell apps). We should map to this new config setting when it's available.

# How

Read expo-updates version number from package.json, and if it can be found and is >= 0.11.0, then use the new native setting; otherwise, default to the old `NEVER` setting (which doesn't have a perfect analog in app.json).

# Test Plan

Added a few test cases, all pass. Also tested manually with `expo prebuild --clean --no-install` / local `@expo/config-plugins`:
✅ expo-updates@0.10.15 `checkAutomatically: 'ON_ERROR_RECOVERY'` -> `NEVER`
✅ expo-updates@0.11.0 `checkAutomatically: 'ON_ERROR_RECOVERY'` -> `ERROR_RECOVERY_ONLY` (modified version number in node_modules/expo-updates/package.json)
✅ expo-updates@0.10.15 `checkAutomatically: 'ON_LOAD'` -> `ALWAYS`
✅ expo-updates@0.11.0 `checkAutomatically: 'ON_LOAD'` -> `ALWAYS`
