### PR TITLE
[config-plugins] add missing sdk-runtime-versions dep

### DIFF
--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -35,6 +35,7 @@
     "@expo/config-types": "^43.0.1",
     "@expo/json-file": "8.2.34",
     "@expo/plist": "0.0.16",
+    "@expo/sdk-runtime-versions": "^1.0.0",
     "@react-native/normalize-color": "^2.0.0",
     "chalk": "^4.1.2",
     "debug": "^4.3.1",


### PR DESCRIPTION
# Why

`@expo/sdk-runtime-version` is used here: https://github.com/expo/expo-cli/blob/main/packages/config-plugins/src/utils/Updates.ts#L2

But was missing from our dependencies.