### PR TITLE
[expo-cli] Server modern manifest type with EAS Update updates.url

### DIFF
--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -183,7 +183,11 @@ export function parseStartOptions(
         ? 'expo-updates'
         : undefined;
   } else {
-    startOpts.forceManifestType = 'classic';
+    const easUpdatesUrlRegex = /^https:\/\/(staging-)?u\.expo\.dev/;
+    const updatesUrl = exp.updates?.url ?? '';
+    const isEasUpdatesUrl = easUpdatesUrlRegex.test(updatesUrl);
+
+    startOpts.forceManifestType = isEasUpdatesUrl ? 'expo-updates' : 'classic';
   }
 
   if (isLegacyImportsEnabled(exp)) {

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -184,8 +184,8 @@ export function parseStartOptions(
         : undefined;
   } else {
     const easUpdatesUrlRegex = /^https:\/\/(staging-)?u\.expo\.dev/;
-    const updatesUrl = exp.updates?.url ?? '';
-    const isEasUpdatesUrl = easUpdatesUrlRegex.test(updatesUrl);
+    const updatesUrl = exp.updates?.url;
+    const isEasUpdatesUrl = updatesUrl && easUpdatesUrlRegex.test(updatesUrl);
 
     startOpts.forceManifestType = isEasUpdatesUrl ? 'expo-updates' : 'classic';
   }

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -1,5 +1,4 @@
 import type Log from '@expo/bunyan';
-import { getConfig } from '@expo/config';
 import {
   attachInspectorProxy,
   createDevServerMiddleware,

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -158,10 +158,7 @@ function createNativeDevServerMiddleware(
   // Add manifest middleware to the other middleware.
   // TODO: Move this in to expo/dev-server.
 
-  const projectConfig = getConfig(projectRoot);
-  const easProjectId = projectConfig.exp.extra?.eas?.projectId;
-  const useExpoUpdatesManifest =
-    forceManifestType === 'expo-updates' || (forceManifestType !== 'classic' && easProjectId);
+  const useExpoUpdatesManifest = forceManifestType === 'expo-updates';
 
   const middleware = useExpoUpdatesManifest
     ? ExpoUpdatesManifestHandler.getManifestHandler(projectRoot)

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -76,11 +76,7 @@ export async function startDevServerAsync(
 
   const { server, middleware, messageSocket } = await runMetroDevServerAsync(projectRoot, options);
 
-  const easProjectId = projectConfig.exp.extra?.eas?.projectId;
-  const useExpoUpdatesManifest =
-    startOptions.forceManifestType === 'expo-updates' ||
-    (startOptions.forceManifestType !== 'classic' && easProjectId);
-
+  const useExpoUpdatesManifest = startOptions.forceManifestType === 'expo-updates';
   // We need the manifest handler to be the first middleware to run so our
   // routes take precedence over static files. For example, the manifest is
   // served from '/' and if the user has an index.html file in their project


### PR DESCRIPTION
# Why

Inspired by https://github.com/expo/expo-cli/pull/3890. Closes ENG-2607.

If a developer has an `updates.url` that matches "https://u.expo.dev" or "https://staging-u.expo.dev", and they also have not specified a `--force-manifest-type` flag when running `expo start`, we should serve the modern manifest format.

This makes is so that developers previewing EAS Update do not have to run `expo start --force-manifest-type=expo-updates` when running their project locally.

# How

Removes logic that detected the presence of a project id, and adds logic to choose the `"expo-updates"` format when no format is present and the URL matches the EAS Update URL pattern.

# Test Plan

Make sure that you can run:

- `expo start --force-manifest-type=expo-updates` and that you get the new manifest format
- `expo start --force-manifest-type=classic` and that you get the classic manifest format
- `expo start` and that you get the classic manifest format
- `expo start` after running `eas update:configure` and that you get the modern manifest format