### PR TITLE
[expo-cli] Add deprecation notice to build commands

### DIFF
--- a/packages/expo-cli/src/commands/build/buildAndroidAsync.ts
+++ b/packages/expo-cli/src/commands/build/buildAndroidAsync.ts
@@ -3,9 +3,12 @@ import program from 'commander';
 import Log from '../../log';
 import AndroidBuilder from './AndroidBuilder';
 import type { AndroidOptions } from './BaseBuilder.types';
+import { logBuildMigration } from './logBuildMigration';
 import { assertPublicUrl, assertReleaseChannel, maybeBailOnWorkflowWarning } from './utils';
 
 export async function actionAsync(projectRoot: string, options: AndroidOptions) {
+  logBuildMigration('android');
+
   if (options.generateKeystore) {
     Log.warn(
       `The --generate-keystore flag is deprecated and does not do anything. A Keystore will always be generated on the Expo servers if it's missing.`

--- a/packages/expo-cli/src/commands/build/buildIosAsync.ts
+++ b/packages/expo-cli/src/commands/build/buildIosAsync.ts
@@ -3,9 +3,11 @@ import program from 'commander';
 import CommandError from '../../CommandError';
 import type { IosOptions } from './BaseBuilder.types';
 import IOSBuilder from './ios/IOSBuilder';
+import { logBuildMigration } from './logBuildMigration';
 import { assertPublicUrl, assertReleaseChannel, maybeBailOnWorkflowWarning } from './utils';
 
 export async function actionAsync(projectRoot: string, options: IosOptions) {
+  logBuildMigration('ios');
   if (!options.skipWorkflowCheck) {
     if (
       await maybeBailOnWorkflowWarning({

--- a/packages/expo-cli/src/commands/build/logBuildMigration.ts
+++ b/packages/expo-cli/src/commands/build/logBuildMigration.ts
@@ -1,0 +1,50 @@
+import chalk from 'chalk';
+
+import Log from '../../log';
+import * as TerminalLink from '../utils/TerminalLink';
+
+const daysUntilDate = (date: string) => {
+  const today = new Date();
+  const eventDate = new Date(date);
+  const timeDiff = eventDate.getTime() - today.getTime();
+  if (timeDiff < 0) {
+    return 0;
+  }
+  const diffDays = Math.ceil(timeDiff / (1000 * 3600 * 24));
+  return diffDays;
+};
+
+export function logBuildMigration(platform: string) {
+  Log.newLine();
+  const command = chalk.bold(`expo build:${platform}`);
+  Log.log(
+    `${command} has been replaced by ${chalk.bold`eas build`}. ${chalk.dim(
+      TerminalLink.learnMore(`https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60`)
+    )}`
+  );
+  Log.newLine();
+  Log.log('Run the following:');
+  Log.newLine();
+  Log.log('\u203A ' + chalk.cyan.bold('npm install -g eas-cli'));
+  Log.log(
+    `\u203A ${TerminalLink.linkedText(
+      chalk.cyan.bold(`eas build -p ${platform}`),
+      `https://docs.expo.dev/build-reference/${platform}-builds/`
+    )}`
+  );
+
+  const endDate = 'January 4, 2023';
+  const daysLeft = daysUntilDate(endDate);
+  Log.newLine();
+
+  if (daysLeft) {
+    Log.log(
+      `${command} will be discontinued on ${chalk.bold(endDate)} (${daysLeft} day${
+        daysLeft === 1 ? '' : 's'
+      } left).`
+    );
+  } else {
+    Log.log(chalk.red(`${command} has been discontinued (${chalk.bold(endDate)}).`));
+  }
+  Log.newLine();
+}


### PR DESCRIPTION
# Why

Surface info from blog post to more users https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60

Before discontinued date:

<img width="824" alt="Screen Shot 2021-12-08 at 2 34 23 PM" src="https://user-images.githubusercontent.com/9664363/145272431-4be30d38-b0e5-46b4-8705-995cd30f54e2.png">

After discontinued date:

<img width="556" alt="Screen Shot 2021-12-08 at 2 32 24 PM" src="https://user-images.githubusercontent.com/9664363/145272434-b7fa012a-0914-45b1-b4a3-566f72a7c923.png">

