### PR TITLE
[schemer] replace few Lodash methods with native code

### DIFF
--- a/packages/schemer/src/Util.ts
+++ b/packages/schemer/src/Util.ts
@@ -1,11 +1,8 @@
-import fill from 'lodash/fill';
-import flatten from 'lodash/flatten';
 import get from 'lodash/get';
 import zip from 'lodash/zip';
 
 export const fieldPathToSchemaPath = (fieldPath: string) => {
-  const newPath = zip(fill(fieldPath.split('.'), 'properties'), fieldPath.split('.'));
-  return flatten(newPath).join('.');
+  return zip(fieldPath.split('.').fill('properties'), fieldPath.split('.')).flat().join('.');
 };
 // Assumption: used only for jsonPointer returned from traverse
 export const schemaPointerToFieldPath = (jsonPointer: string) => {


### PR DESCRIPTION
# Why

This is first PR from the upcoming series in which I would like to focus on removing Lodash methods from the CLI codebase.

The idea is to keep the changeset small so the potential issues can be easily caught or even revert if needed.

# How

Replace `fill` and `flatten` methods by the native counterparts.

# Test Plan

`tsc` compilation and `fieldPathToSchemaPath` tests were successful.