### PR TITLE
[next-adapter] fix incorrect detection of webpack 5

### DIFF
--- a/packages/next-adapter/src/withExpo.ts
+++ b/packages/next-adapter/src/withExpo.ts
@@ -19,7 +19,7 @@ export default function withExpo(nextConfig: any = {}): any {
         },
         {
           supportsFontLoading: false,
-          webpack5: webpack5 !== false,
+          webpack5: webpack5 && webpack5 !== false,
         }
       );
       // Use original public path


### PR DESCRIPTION
# Why

I was working on the `with-nextjs` Expo example update to use Next 10+, when I spotted that besides Next was using Webpack 4 for the compilation, Next was failing with an Internal Error pointing out to the code guarded by `isWebpack5` flag.

<img width="1098" alt="Screenshot 2021-12-10 at 13 12 56" src="https://user-images.githubusercontent.com/719641/145573066-02ca9905-4b1f-4eb3-9b3b-214989a418bc.png">

After an investigation in code, it looks like the `webpack5` flag was set incorrectly a level up, in `next-adapter`, when there was no `webpack5` entry in `args`.

<img width="1008" alt="Screenshot 2021-12-10 at 13 12 36" src="https://user-images.githubusercontent.com/719641/145573090-4b4c9d8c-1a6f-40ef-903e-31d3ddf458b9.png">

# How

This small change fixes the incorrect Webpack 5 detection and allows in the future update of `with-nextjs` example (after the new version of package including fix will be released).

# Test Plan

I have init app using `npx create-react-native-app -t with-nextjs`, bumped the Next dependency to `~10.2.3` and `next-adapter` to latest version, then I have copied in the updated build files of `next-adapter` to test app `node_modules` which fixed the Internal Server Error.