### PR TITLE
[expo-cli] replace few Lodash methods with native code

### DIFF
--- a/packages/expo-cli/src/commands/build/ios/utils/image.ts
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.ts
@@ -32,14 +32,13 @@ export async function ensurePNGIsNotTransparent(imagePathOrURL: string): Promise
           res();
         }
       })
-      .on('parsed', function () {
+      .on('parsed', () => {
         if (hasAlreadyResolved) {
           return;
         }
         try {
           // @ts-ignore: 'this' implicitly has type 'any' because it does not have a type annotation.
-          const { data, width, height } = this;
-          validateAlphaChannelIsEmpty(data, { width, height });
+          validateAlphaChannelIsEmpty(this.data, { width: this.width, height: this.height });
           res();
         } catch (err) {
           rej(err);

--- a/packages/expo-cli/src/commands/build/ios/utils/image.ts
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import fs from 'fs-extra';
-import pick from 'lodash/pick';
 import { PNG } from 'pngjs';
 import { Readable } from 'stream';
 import { UrlUtils, XDLError } from 'xdl';
@@ -39,7 +38,8 @@ export async function ensurePNGIsNotTransparent(imagePathOrURL: string): Promise
         }
         try {
           // @ts-ignore: 'this' implicitly has type 'any' because it does not have a type annotation.
-          validateAlphaChannelIsEmpty(this.data, pick(this, ['width', 'height']));
+          const { width, height, data } = this;
+          validateAlphaChannelIsEmpty(data, { width, height });
           res();
         } catch (err) {
           rej(err);

--- a/packages/expo-cli/src/commands/build/ios/utils/image.ts
+++ b/packages/expo-cli/src/commands/build/ios/utils/image.ts
@@ -38,7 +38,7 @@ export async function ensurePNGIsNotTransparent(imagePathOrURL: string): Promise
         }
         try {
           // @ts-ignore: 'this' implicitly has type 'any' because it does not have a type annotation.
-          const { width, height, data } = this;
+          const { data, width, height } = this;
           validateAlphaChannelIsEmpty(data, { width, height });
           res();
         } catch (err) {

--- a/packages/expo-cli/src/credentials/api/IosApi.ts
+++ b/packages/expo-cli/src/credentials/api/IosApi.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import forEach from 'lodash/forEach';
 import keyBy from 'lodash/keyBy';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
@@ -267,7 +266,7 @@ export default class IosApi {
     await this.client.deleteProvisioningProfileApi(appLookupParams);
     const appCredentials = this.credentials?.[accountName]?.appCredentials?.[appCredentialsIndex];
     if (appCredentials?.credentials) {
-      // teamId should still be there becaus it might be part of push cert definition
+      // teamId should still be there because it might be part of push cert definition
       appCredentials.credentials = omit(appCredentials.credentials, [
         'provisioningProfile',
         'provisioningProfileId',
@@ -286,7 +285,7 @@ export default class IosApi {
       delete this.credentials[accountName].userCredentials[String(id)];
     }
     const appCredentials = this.credentials[accountName]?.appCredentials;
-    forEach(appCredentials, (val, key) => {
+    Object.entries(appCredentials).forEach(([key, val]) => {
       if (val.distCredentialsId === id) {
         delete appCredentials[key].distCredentialsId;
       }

--- a/packages/expo-cli/src/credentials/api/IosApi.ts
+++ b/packages/expo-cli/src/credentials/api/IosApi.ts
@@ -285,14 +285,16 @@ export default class IosApi {
       delete this.credentials[accountName].userCredentials[String(id)];
     }
     const appCredentials = this.credentials[accountName]?.appCredentials;
-    Object.entries(appCredentials).forEach(([key, val]) => {
-      if (val.distCredentialsId === id) {
-        delete appCredentials[key].distCredentialsId;
-      }
-      if (val.pushCredentialsId === id) {
-        delete appCredentials[key].pushCredentialsId;
-      }
-    });
+    if (appCredentials) {
+      Object.entries(appCredentials).forEach(([key, val]) => {
+        if (val.distCredentialsId === id) {
+          delete appCredentials[key].distCredentialsId;
+        }
+        if (val.pushCredentialsId === id) {
+          delete appCredentials[key].pushCredentialsId;
+        }
+      });
+    }
   }
 
   // ensures that credentials are fetched from the server if they exists

--- a/packages/expo-cli/src/credentials/context.ts
+++ b/packages/expo-cli/src/credentials/context.ts
@@ -1,5 +1,4 @@
 import { ExpoConfig, getConfig } from '@expo/config';
-import pick from 'lodash/pick';
 import { ApiV2, RobotUser, User, UserManager } from 'xdl';
 
 import { AppleCtx, authenticateAsync } from '../appleApi';
@@ -96,10 +95,11 @@ export class Context {
   }
 
   async init(projectDir: string, options: CtxOptions = {}) {
+    const { allowAnonymous, appleId, appleIdPassword, teamId, nonInteractive } = options;
     this._user = (await UserManager.getCurrentUserAsync()) || undefined;
 
     // User isn't signed it, but needs to be signed in
-    if (!this._user && !options.allowAnonymous) {
+    if (!this._user && !allowAnonymous) {
       this._user = (await UserManager.ensureLoggedInAsync()) as User;
     }
 
@@ -107,10 +107,10 @@ export class Context {
     this._apiClient = ApiV2.clientForUser(this.user);
     this._iosApiClient = new IosApi(this.api);
     this._androidApiClient = new AndroidApi(this.api);
-    this._appleCtxOptions = pick(options, ['appleId', 'appleIdPassword', 'teamId']);
-    this._nonInteractive = options.nonInteractive;
+    this._appleCtxOptions = { appleId, appleIdPassword, teamId };
+    this._nonInteractive = nonInteractive;
 
-    // try to acccess project context
+    // try to access project context
     try {
       const { exp } = getConfig(projectDir, { skipSDKVersionRequirement: true });
       this._manifest = exp;


### PR DESCRIPTION
# Why

Another PR of the Lodash removal series. This time I have converted the easy occurrences in the `expo-cli`.

Rest of the Lodash usages might need a bit more changes which will introduce small logic changes, so I left those for the separate PR in the future.

# How

Replace some of `pick` and `forEach` usages in `expo-cli` with native code equivalents.

# Test Plan

`yarn` and `yarn test` commands ended with a success.

`yarn lint` do not report any warnings.