### PR TITLE
[cli] prebuild should keep expo-updates package in sdk 44

### DIFF
--- a/packages/expo-cli/src/commands/eject/__tests__/updatePackageJson-test.ts
+++ b/packages/expo-cli/src/commands/eject/__tests__/updatePackageJson-test.ts
@@ -77,7 +77,7 @@ describe(updatePackageJSONDependencies, () => {
       devDependencies: {},
     };
     updatePackageJSONDependencies({ projectRoot: 'fake path', tempDir: 'fake path', pkg });
-    expect(pkg.dependencies).toMatchObject({
+    expect(pkg.dependencies).toStrictEqual({
       ...requiredPackages,
       'optional-package': 'version-from-project-1',
       'optional-package-2': 'version-from-template-2',
@@ -108,9 +108,38 @@ describe(updatePackageJSONDependencies, () => {
       pkg,
       skipDependencyUpdate: ['react-native'],
     });
-    expect(pkg.dependencies).toMatchObject({
+    expect(pkg.dependencies).toStrictEqual({
       ...requiredPackages,
       'react-native': 'version-from-project',
+      'optional-package': 'version-from-project-1',
+      'optional-package-2': 'version-from-template-2',
+      'optional-package-3': 'version-from-project-3',
+    });
+  });
+  test('test expo-updates not required by default in sdk 44', () => {
+    const sdk44RequiredPackages = {
+      react: 'version-from-template-required-1',
+      'react-native': 'version-from-template-required-1',
+    };
+    (getPackageJson as any).mockImplementation(() => ({
+      dependencies: {
+        ...sdk44RequiredPackages,
+        'optional-package': 'version-from-template-1',
+        'optional-package-2': 'version-from-template-2',
+      },
+      devDependencies: {},
+    }));
+    const pkg = {
+      dependencies: {
+        'react-native': 'version-from-project',
+        'optional-package': 'version-from-project-1',
+        'optional-package-3': 'version-from-project-3',
+      },
+      devDependencies: {},
+    };
+    updatePackageJSONDependencies({ projectRoot: 'fake path', tempDir: 'fake path', pkg });
+    expect(pkg.dependencies).toStrictEqual({
+      ...sdk44RequiredPackages,
       'optional-package': 'version-from-project-1',
       'optional-package-2': 'version-from-template-2',
       'optional-package-3': 'version-from-project-3',

--- a/packages/expo-cli/src/commands/eject/updatePackageJson.ts
+++ b/packages/expo-cli/src/commands/eject/updatePackageJson.ts
@@ -98,7 +98,12 @@ export function updatePackageJSONDependencies({
     ...pkg.dependencies,
   });
 
-  const requiredDependencies = ['react', 'react-native-unimodules', 'react-native', 'expo-updates'];
+  const requiredDependencies = [
+    'react',
+    'react-native-unimodules',
+    'react-native',
+    'expo-updates',
+  ].filter(depKey => !!defaultDependencies[depKey]);
 
   const symlinkedPackages: string[] = [];
 


### PR DESCRIPTION
# Why

`expo-updates` was removed as default dependency in bare template, there's a side effect of `expo prebuild` in managed projects where `expo-updates` will be removed after prebuilding.

# How

the required packages should also be listed in template dependencies.

# Test Plan

## unit test

```
 PASS   expo-cli  src/commands/eject/__tests__/updatePackageJson-test.ts
  updatePackageJSONDependencies
    ✓ default bahaviour (398 ms)
    ✓ with skipDependencyUpdate (1 ms)
    ✓ test expo-updates not required by default in sdk 44
```

## integration test

1. `expo init -t blank@sdk-44 sdk44`
2. `expo install expo-updates`
3. `expo prebuild`
3. `ls node_modules/expo-updates`