### PR TITLE
[xdl] adds message scrubber

### DIFF
--- a/packages/xdl/src/project/MessageScrubber.ts
+++ b/packages/xdl/src/project/MessageScrubber.ts
@@ -1,0 +1,41 @@
+class MessageScrubber {
+  private matchANSIEscapeCodesRegex: RegExp;
+  private matchFilePathRegex: RegExp;
+  private matchNewLineRegex: RegExp;
+  private matchAccountNamesRegex: RegExp;
+
+  constructor() {
+    const matchANSIEscapeCodes = `\\x1B|\\[[0-9]{1,2}m`;
+    this.matchANSIEscapeCodesRegex = new RegExp(matchANSIEscapeCodes, 'gm');
+    // ensures firstCharacter is not preceeded by https: (uses positive look behind)
+    const preceededByWhitespaceOrQuote = `(?<=[\\s'"])`;
+    // examples: ./ | ../ | / | C:\\ | E:/ | @/assets/ (uses character range + repitition + alternation)
+    const captureSlashOrLetterColon = `(@?[\\\\/]|[\\\\/]{1,2}|[.]{1,2}[\\/]{1,2}|[A-Z]:[\\\\/])`;
+    // (uses possessive search + character range)
+    const captureUntileNewlineOrQuoteOrColon = `([^'"\r\n\t\f\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff:]+)`;
+    const filePath = `${preceededByWhitespaceOrQuote}${captureSlashOrLetterColon}${captureUntileNewlineOrQuoteOrColon}`;
+    this.matchFilePathRegex = new RegExp(filePath, 'gm');
+    const matchNewLines = `[\n\r]`;
+    this.matchNewLineRegex = new RegExp(matchNewLines, 'gm');
+    const matchAccountNames = `@\\w(-?\\w)*(?!-$)`;
+    this.matchAccountNamesRegex = new RegExp(matchAccountNames, 'gm');
+  }
+
+  scrubMessage(message: string): string {
+    const messageWithoutColor = message.replace(this.matchANSIEscapeCodesRegex, '');
+    const messageWithoutPaths = messageWithoutColor.replace(this.matchFilePathRegex, '...');
+    const messageWithoutAccountNames = messageWithoutPaths.replace(
+      this.matchAccountNamesRegex,
+      '[account]'
+    );
+    const formattedMessage = messageWithoutAccountNames
+      .split(this.matchNewLineRegex)
+      .map(x => x.trim())
+      .filter(x => !!x)
+      .join(' ');
+
+    return formattedMessage;
+  }
+}
+
+export default new MessageScrubber();

--- a/packages/xdl/src/project/ProjectUtils.ts
+++ b/packages/xdl/src/project/ProjectUtils.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { Analytics, Log, Logger, LogStream } from '../internal';
+import messageScrubber from './MessageScrubber';
 
 const MAX_MESSAGE_LENGTH = 200;
 const _projectRootToLogger: { [projectRoot: string]: Log } = {};
@@ -104,7 +105,9 @@ export function logWarning(projectRoot: string, tag: LogTag, message: string, id
   }
   _getLogger(projectRoot).warn(fields, message.toString());
 
-  let truncatedMessage = message.toString();
+  const scrubbedMessage = messageScrubber.scrubMessage(message.toString());
+
+  let truncatedMessage = scrubbedMessage;
   if (truncatedMessage.length > MAX_MESSAGE_LENGTH) {
     truncatedMessage = truncatedMessage.substring(0, MAX_MESSAGE_LENGTH);
   }

--- a/packages/xdl/src/project/__tests__/MessageScrubber-test.ts
+++ b/packages/xdl/src/project/__tests__/MessageScrubber-test.ts
@@ -1,0 +1,145 @@
+import messageScrubber from '../MessageScrubber';
+
+describe(messageScrubber.constructor.name, () => {
+  it.each([
+    [
+      [`Compiled with warnings.`, `Attempted import error: 'InternMap' is not exported f`],
+      [
+        `/Users/someuser/Documents/someaccount.Application/frontend/node_modules/d3-scale/src/ordinal.js`,
+      ],
+      `[33mCompiled with warnings.[39m
+            [33m[39m/Users/someuser/Documents/someaccount.Application/frontend/node_modules/d3-scale/src/ordinal.js
+            Attempted import error: 'InternMap' is not exported f`,
+    ],
+    [
+      [`Compiled with warnings.`, `Attempted import error: 'InternMap' is not exported f`],
+      [`/Users/some user/Documents/@someaccount/src/thing.js`],
+      `[33mCompiled with warnings.[39m
+            [33m[39m/Users/some user/Documents/@someaccount/src/thing.js
+            Attempted import error: 'InternMap' is not exported f`,
+    ],
+    [
+      ['Compiled with warnings.', "Attempted import error: 'Animated' is not exported from"],
+      ['./node_modules/react-native-maps/index.js', './lib/components/MapView'],
+      `[33mCompiled with warnings.[39m
+            [33m[39m./node_modules/react-native-maps/index.js
+            Attempted import error: 'Animated' is not exported from './lib/components/MapView'.
+
+            ./node_modules/react-native-m`,
+    ],
+    [
+      ['Unable to resolve asset', 'from "splash.image" in your app.json or app.config.js'],
+      ['./assets/something.png'],
+      `Unable to resolve asset "./assets/something.png" from "splash.image" in your app.json or app.config.js`,
+    ],
+    [
+      ['Unable to resolve asset', 'from "icon" in your app.json or app.config.js'],
+      ['../app/brands/connect/assets/ASSET.png'],
+      `Unable to resolve asset "../app/brands/connect/assets/ASSET.png" from "icon" in your app.json or app.config.js`,
+    ],
+    [
+      ['Compiled with warnings.', "Attempted import error: 'ViewPropTypes' is not exported from"],
+      [
+        '/Users/somebody with spaces/in their/thing-native/node_modules/react-native-view-pdf/src/RNPDFView.js',
+      ],
+      `[33mCompiled with warnings.[39m
+            [33m[39m/Users/somebody with spaces/in their/thing-native/node_modules/react-native-view-pdf/src/RNPDFView.js
+            Attempted import error: 'ViewPropTypes' is not exported from`,
+    ],
+    [
+      [`Warning: Problem validating app.json: Cannot find module '...' Require stack: - ... - ...`],
+      [
+        '/Users/a user with space/node_modules/xdl/build/project/Doctor.js',
+        '/Users/auser/node_modules/xdl/build/internal.',
+      ],
+      `Warning: Problem validating app.json: Cannot find module '../logs/TerminalLink'
+          Require stack:
+          - /Users/a user/node_modules/xdl/build/project/Doctor.js
+          - /Users/auser/node_modules/xdl/build/internal.`,
+    ],
+    [
+      [
+        'Warning: Problem validating app.json: Unable to perform cache refresh for ...: Error: Request failed with status code 404.',
+      ],
+      [`C:\\Users\\User\\AppData\\Local\\Expo\\schema-undefined.json`],
+      `Warning: Problem validating app.json: Unable to perform cache refresh for C:\\Users\\User\\AppData\\Local\\Expo\\schema-undefined.json: Error: Request failed with status code 404.`,
+    ],
+    [
+      [`Unable to resolve asset "..." from "icon" in your app.json or app.config.js`],
+      ['@/assets/icon.png'],
+      `Unable to resolve asset "@/assets/icon.png" from "icon" in your app.json or app.config.js`,
+    ],
+    [
+      ['Error starting tunnel EPERM', 'operation not permitted, rename'],
+      [
+        'C:\\Users\\ASDoadfj90\\Desktop\\1440 Season\\Some Name\\athing\\mhm\\.expo\\packager-info.json.2224590387',
+        'C:\\Users\\ASDoadfj91\\Deskto',
+      ],
+      `Error starting tunnel EPERM: operation not permitted, rename 'C:\\Users\\ASDoadfj90\\Desktop\\1440 Season\\Some Name\\athing\\mhm\\.expo\\packager-info.json.2224590387' -> 'C:\\Users\\ASDoadfj91\\Deskto`,
+    ],
+    [
+      [
+        `Compiled with warnings. ... Attempted import error: 'AppLoading' is not exported from 'expo'.`,
+      ],
+      [`C:/Some User/Some Folder/project/App.js`],
+      `	
+      [33mCompiled with warnings.[39m
+      [33m[39mC:/Some User/Some Folder/project/App.js
+      Attempted import error: 'AppLoading' is not exported from 'expo'.`,
+    ],
+  ])('scrubs system paths from incoming warnings', (retainedText, scrubbedText, rawMessage) => {
+    const scrubbedMessage = messageScrubber.scrubMessage(rawMessage);
+    retainedText.forEach(text => expect(scrubbedMessage).toContain(text));
+    scrubbedText.forEach(text => expect(scrubbedMessage).not.toContain(text));
+  });
+
+  it.each([
+    [
+      ['This project belongs to', 'and you have not been granted the appropriate permissions'],
+      ['@some_person23-xx'],
+      `This project belongs to [1m@some_person23-xx[22m and you have not been granted the appropriate permissions.
+              Please request access from an admin of @some_person23-xx or change the "owner" field to an account y`,
+    ],
+    [
+      ['This project belongs to', 'and you have not been granted the appropriate permissions'],
+      ['@yourbuddy'],
+      `This project belongs to [1m@yourbuddy[22m and you have not been granted the appropriate permissions.
+              Please request access from an admin of @yourbuddy or change the "owner" field to an account y`,
+    ],
+  ])('scrubs account names from incoming warnings', (retainedText, scrubbedText, rawMessage) => {
+    const scrubbedMessage = messageScrubber.scrubMessage(rawMessage);
+    retainedText.forEach(text => expect(scrubbedMessage).toContain(text));
+    scrubbedText.forEach(text => expect(scrubbedMessage).not.toContain(text));
+  });
+
+  it.each([
+    [
+      [
+        'Warning: You are using an old version of watchman (v20211206). It is recommend to always use the latest version, or at least v4.6.0. If you are using homebrew, try: brew uninstall watchman; brew ins',
+      ],
+      [],
+      `Warning: You are using an old version of watchman (v20211206).
+
+                It is recommend to always use the latest version, or at least v4.6.0.
+
+                If you are using homebrew, try:
+                brew uninstall watchman; brew ins`,
+    ],
+    [
+      ['Tunnel URL not found (it might not be ready yet), falling back to LAN URL.'],
+      [],
+      `Tunnel URL not found (it might not be ready yet), falling back to LAN URL.`,
+    ],
+    [
+      [
+        'Warning: https://github.com/expo/react-native/archive/sdk-43.tar.gz is not a valid version. Version must be in the form of sdk-x.y.z. Please update your package.json file.',
+      ],
+      [],
+      `Warning: https://github.com/expo/react-native/archive/sdk-43.tar.gz is not a valid version. Version must be in the form of sdk-x.y.z. Please update your package.json file.`,
+    ],
+  ])('does not alter generalized warnings', (retainedText, scrubbedText, rawMessage) => {
+    const scrubbedMessage = messageScrubber.scrubMessage(rawMessage);
+    retainedText.forEach(text => expect(scrubbedMessage).toContain(text));
+    scrubbedText.forEach(text => expect(scrubbedMessage).not.toContain(text));
+  });
+});


### PR DESCRIPTION
# Why

Added a message scrubber to keep things like system paths and account names out of the logger warnings that we collect to monitor and ensure CLI health.

# How

Created a `MessageScrubber` class which contains a `scrubMethod` function. Went with a class-based approach because there's a bunch of logic that I wanted to keep together, and there's a number of private variables and RegExps that I wanted to cache for subsequent usage.

lmk if there are any performance concerns. it's a pretty beefy regex and i may be able to trim down the # of steps if folks feel it would be a good idea.

# Test Plan

Added a bunch of tests to make sure file paths get removed, account names get removed, general messages do not get altered.