### PR TITLE
Force link expo-dev-client

### DIFF
--- a/packages/prebuild-config/src/getAutolinkedPackages.ts
+++ b/packages/prebuild-config/src/getAutolinkedPackages.ts
@@ -43,6 +43,11 @@ export function shouldSkipAutoPlugin(
   config: Pick<ExpoConfig, '_internal'>,
   plugin: StaticPlugin | string
 ) {
+  // Hack workaround because expo-dev-client doesn't use expo modules.
+  if (plugin === 'expo-dev-client') {
+    return false;
+  }
+
   // Only perform the check if `autolinkedModules` is defined, otherwise we assume
   // this is a legacy runner which doesn't support autolinking.
   if (Array.isArray(config._internal?.autolinkedModules)) {


### PR DESCRIPTION
# Why

`expo-dev-client` doesn't use our own tooling so we need to add a permanent unversioned workaround to make it linked even if the package isn't installed. This will break monorepo support when one app has dev client but another doesn't.