### PR TITLE
Resolve against fully qualified MainApplications

### DIFF
--- a/packages/config-plugins/src/android/Manifest.ts
+++ b/packages/config-plugins/src/android/Manifest.ts
@@ -172,10 +172,11 @@ function isManifest(xml: XML.XMLObject): xml is AndroidManifest {
   return !!xml.manifest;
 }
 
+/** Returns the `manifest.application` tag ending in `.MainApplication` */
 export function getMainApplication(androidManifest: AndroidManifest): ManifestApplication | null {
   return (
-    androidManifest?.manifest?.application?.filter(
-      e => e?.$?.['android:name'] === '.MainApplication'
+    androidManifest?.manifest?.application?.filter(e =>
+      e?.$?.['android:name'].endsWith('.MainApplication')
     )[0] ?? null
   );
 }

--- a/packages/config-plugins/src/android/__tests__/Manifest-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Manifest-test.ts
@@ -50,6 +50,12 @@ describe(getMainApplication, () => {
     const app = getMainApplication({} as any);
     expect(app).toBe(null);
   });
+  it(`matches against fully qualified MainApplications`, async () => {
+    const manifest = await readAndroidManifestAsync(sampleManifestPath);
+    const app = getMainApplication(manifest);
+    app.$['android:name'] = 'dev.expo.go.MainApplication';
+    expect(getMainApplication(manifest)).toBeDefined();
+  });
 });
 describe(addMetaDataItemToMainApplication, () => {
   it(`adds then removes meta-data item`, async () => {


### PR DESCRIPTION
# Why

Better support updates code which uses config plugins to partially configure projects https://github.com/expo/expo-cli/issues/3971#issuecomment-970732766

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Check if the application ends with `.MainApplication` rather than `==`

# Test Plan

Added a test