### PR TITLE
[config plugins] Fix adding Google maps pods

### DIFF
--- a/packages/config-plugins/src/ios/Maps.ts
+++ b/packages/config-plugins/src/ios/Maps.ts
@@ -101,16 +101,14 @@ export function removeGoogleMapsAppDelegateInit(src: string): MergeResults {
 }
 
 /**
- * @param src
- * @param useGoogleMaps
- * @param googleMapsPath '../node_modules/react-native-maps'
- * @returns
+ * @param src The contents of the Podfile.
+ * @returns Podfile with Google Maps added.
  */
-export function addMapsCocoaPods(src: string, googleMapsPath: string): MergeResults {
+export function addMapsCocoaPods(src: string): MergeResults {
   return mergeContents({
     tag: 'react-native-maps',
     src,
-    newSrc: `  pod 'react-native-google-maps', path: '${googleMapsPath}'`,
+    newSrc: `  pod 'react-native-google-maps', path: File.dirname(\`node --print "require.resolve('react-native-maps/package.json')"\`)`,
     anchor: /use_native_modules/,
     offset: 0,
     comment: '#',
@@ -129,15 +127,19 @@ function isReactNativeMapsInstalled(projectRoot: string): string | null {
   return resolved ? path.dirname(resolved) : null;
 }
 
-function isReactNativeMapsAutolinked(config: Pick<ExpoConfig, '_internal'>): string | null {
+function isReactNativeMapsAutolinked(config: Pick<ExpoConfig, '_internal'>): boolean {
   // Only add the native code changes if we know that the package is going to be linked natively.
   // This is specifically for monorepo support where one app might have react-native-maps (adding it to the node_modules)
   // but another app will not have it installed in the package.json, causing it to not be linked natively.
   // This workaround only exists because react-native-maps doesn't have a config plugin vendored in the package.
-  return (
-    !config._internal?.autolinkedModules ||
-    config._internal.autolinkedModules.includes('react-native-maps')
-  );
+
+  // TODO: `react-native-maps` doesn't use Expo autolinking so we cannot safely disable the module.
+  return true;
+
+  // return (
+  //   !config._internal?.autolinkedModules ||
+  //   config._internal.autolinkedModules.includes('react-native-maps')
+  // );
 }
 
 const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { useGoogleMaps }) => {
@@ -154,13 +156,8 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
       debug('Is Expo Autolinked:', isLinked);
       debug('react-native-maps path:', googleMapsPath);
       if (isLinked && googleMapsPath && useGoogleMaps) {
-        // Make the pod path relative to the ios folder.
-        const googleMapsPodPath = path.relative(
-          config.modRequest.platformProjectRoot,
-          googleMapsPath
-        );
         try {
-          results = addMapsCocoaPods(contents, googleMapsPodPath);
+          results = addMapsCocoaPods(contents);
         } catch (error: any) {
           if (error.code === 'ERR_NO_MATCH') {
             throw new Error(

--- a/packages/config-plugins/src/ios/__tests__/Maps-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Maps-test.ts
@@ -66,7 +66,7 @@ describe(getGoogleMapsApiKey, () => {
 
 describe(addMapsCocoaPods, () => {
   it(`adds maps pods to Podfile`, () => {
-    const results = addMapsCocoaPods(PodfileBasic, '../node_modules/react-native-maps');
+    const results = addMapsCocoaPods(PodfileBasic);
     // matches a static snapshot
     expect(results.contents).toMatchSnapshot();
     expect(results.contents).toMatch(/2f0a6817224f18601deb2879c9e783ba07387bc9/);
@@ -75,7 +75,7 @@ describe(addMapsCocoaPods, () => {
     // didn't remove old content
     expect(results.didClear).toBe(false);
 
-    const modded = addMapsCocoaPods(results.contents, '../node_modules/react-native-maps');
+    const modded = addMapsCocoaPods(results.contents);
     // nothing changed
     expect(modded.didMerge).toBe(false);
     expect(modded.didClear).toBe(false);

--- a/packages/config-plugins/src/ios/__tests__/Maps-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Maps-test.ts
@@ -69,7 +69,7 @@ describe(addMapsCocoaPods, () => {
     const results = addMapsCocoaPods(PodfileBasic);
     // matches a static snapshot
     expect(results.contents).toMatchSnapshot();
-    expect(results.contents).toMatch(/2f0a6817224f18601deb2879c9e783ba07387bc9/);
+    expect(results.contents).toMatch(/e9cc66c360abe50bc66d89fffb3c55b034d7d369/);
     // did add new content
     expect(results.didMerge).toBe(true);
     // didn't remove old content

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -431,8 +431,8 @@ platform :ios, '11.0'
 
 target 'myapp' do
   use_unimodules!
-# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-2f0a6817224f18601deb2879c9e783ba07387bc9
-  pod 'react-native-google-maps', path: '../node_modules/react-native-maps'
+# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-e9cc66c360abe50bc66d89fffb3c55b034d7d369
+  pod 'react-native-google-maps', path: File.dirname(\`node --print \\"require.resolve('react-native-maps/package.json')\\"\`)
 # @generated end react-native-maps
   config = use_native_modules!
 


### PR DESCRIPTION
# Why

- `react-native-maps` doesn't use expo modules autolinking so we can't auto disable it in monorepos.
- Add dynamic pod resolution for monorepos (which won't work due to the previously mentioned autolinking issue).

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Run in a project with `expo.ios.config.googleMapsApiKey` set to some string, then `expo run:ios` and render a Google Map (not to be confused with Apple Map).

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->