### PR TITLE
[install-expo-modules] Add Expo SDK 44 support

### DIFF
--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -71,6 +71,10 @@ async function runAsync(programName: string) {
     isModdedConfig: true,
   });
 
+  // for react-native project, we do not verify sdkVersion with the `skipSDKVersionRequirement` flag.
+  // to get the target sdkVersion easier for config plugins, we fill the target sdkVersion into config.
+  config.sdkVersion = sdkVersion;
+
   config = withAndroidModules(config);
   config = withIosModules(config);
   config = withIosDeploymentTarget(config, {

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/__snapshots__/withIosModulesAppDelegate-test.ts.snap
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/__snapshots__/withIosModulesAppDelegate-test.ts.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withIosModulesAppDelegate sdkVersion snapshots sdkVersion 43.0.0 1`] = `
+"#import <React/RCTBridgeDelegate.h>
+#import <Expo/Expo.h>
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate>
+
+@property (nonatomic, strong) UIWindow *window;
+
+@end
+"
+`;
+
+exports[`withIosModulesAppDelegate sdkVersion snapshots sdkVersion 43.0.0 2`] = `
+"#import \\"AppDelegate.h\\"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#ifdef FB_SONARKIT_ENABLED
+  InitializeFlipper(application);
+#endif
+
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+                                               moduleName:@\\"RN0633\\"
+                                               initialProperties:nil];
+
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+  return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@\\"index\\" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@\\"main\\" withExtension:@\\"jsbundle\\"];
+#endif
+}
+
+@end
+"
+`;
+
+exports[`withIosModulesAppDelegate sdkVersion snapshots sdkVersion 43.0.0 3`] = `
+"import UIKit
+
+@UIApplicationMain
+class AppDelegate: AppDelegateWrapper, RCTBridgeDelegate {
+  var window: UIWindow?
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    let bridge = RCTBridge(delegate: self, launchOptions: launchOptions)!
+    let rootView = RCTRootView(bridge: bridge, moduleName: \\"HelloWorld\\", initialProperties: nil)
+
+    if #available(iOS 13.0, *) {
+      rootView.backgroundColor = UIColor.systemBackground
+    } else {
+      rootView.backgroundColor = UIColor.white
+    }
+
+    self.window = UIWindow(frame: UIScreen.main.bounds);
+    let rootViewController = UIViewController()
+    rootViewController.view = rootView
+    self.window?.rootViewController = rootViewController
+    self.window?.makeKeyAndVisible()
+    super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    return true
+  }
+
+  func sourceURL(for bridge: RCTBridge!) -> URL! {
+    #if DEBUG
+    return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: \\"index\\", fallbackResource: nil)
+    #else
+    return Bundle.main.url(forResource: \\"main\\", withExtension: \\"jsBundle\\")
+    #endif
+  }
+}
+"
+`;
+
+exports[`withIosModulesAppDelegate sdkVersion snapshots sdkVersion 44.0.0 1`] = `
+"#import <React/RCTBridgeDelegate.h>
+#import <Expo/Expo.h>
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate>
+
+@property (nonatomic, strong) UIWindow *window;
+
+@end
+"
+`;
+
+exports[`withIosModulesAppDelegate sdkVersion snapshots sdkVersion 44.0.0 2`] = `
+"#import \\"AppDelegate.h\\"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#ifdef FB_SONARKIT_ENABLED
+  InitializeFlipper(application);
+#endif
+
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge
+                                               moduleName:@\\"RN0633\\"
+                                               initialProperties:nil];
+
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+  return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@\\"index\\" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@\\"main\\" withExtension:@\\"jsbundle\\"];
+#endif
+}
+
+@end
+"
+`;
+
+exports[`withIosModulesAppDelegate sdkVersion snapshots sdkVersion 44.0.0 3`] = `
+"import UIKit
+
+@UIApplicationMain
+class AppDelegate: AppDelegateWrapper, RCTBridgeDelegate {
+  var window: UIWindow?
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    let bridge = reactDelegate.createBridge(delegate: self, launchOptions: launchOptions)!
+    let rootView = reactDelegate.createRootView(bridge: bridge, moduleName: \\"HelloWorld\\", initialProperties: nil)
+
+    if #available(iOS 13.0, *) {
+      rootView.backgroundColor = UIColor.systemBackground
+    } else {
+      rootView.backgroundColor = UIColor.white
+    }
+
+    self.window = UIWindow(frame: UIScreen.main.bounds);
+    let rootViewController = reactDelegate.createRootViewController()
+    rootViewController.view = rootView
+    self.window?.rootViewController = rootViewController
+    self.window?.makeKeyAndVisible()
+    super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    return true
+  }
+
+  func sourceURL(for bridge: RCTBridge!) -> URL! {
+    #if DEBUG
+    return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: \\"index\\", fallbackResource: nil)
+    #else
+    return Bundle.main.url(forResource: \\"main\\", withExtension: \\"jsBundle\\")
+    #endif
+  }
+}
+"
+`;

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate.h
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate.h
@@ -1,0 +1,8 @@
+#import <React/RCTBridgeDelegate.h>
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
+
+@property (nonatomic, strong) UIWindow *window;
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate.m
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate.m
@@ -1,0 +1,39 @@
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#ifdef FB_SONARKIT_ENABLED
+  InitializeFlipper(application);
+#endif
+
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+                                               moduleName:@"RN0633"
+                                               initialProperties:nil];
+
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate.swift
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: NSObject, UIApplicationDelegate, RCTBridgeDelegate {
+  var window: UIWindow?
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    let bridge = RCTBridge(delegate: self, launchOptions: launchOptions)!
+    let rootView = RCTRootView(bridge: bridge, moduleName: "HelloWorld", initialProperties: nil)
+
+    if #available(iOS 13.0, *) {
+      rootView.backgroundColor = UIColor.systemBackground
+    } else {
+      rootView.backgroundColor = UIColor.white
+    }
+
+    self.window = UIWindow(frame: UIScreen.main.bounds);
+    let rootViewController = UIViewController()
+    rootViewController.view = rootView
+    self.window?.rootViewController = rootViewController
+    self.window?.makeKeyAndVisible()
+    return true
+  }
+
+  func sourceURL(for bridge: RCTBridge!) -> URL! {
+    #if DEBUG
+    return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: "index", fallbackResource: nil)
+    #else
+    return Bundle.main.url(forResource: "main", withExtension: "jsBundle")
+    #endif
+  }
+}

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -2,9 +2,12 @@ interface VersionInfo {
   iosDeploymentTarget: string;
 }
 
-const DEFAULT_VERSION = '43.0.0';
+const DEFAULT_VERSION = '44.0.0';
 
 export const ExpoVersionMappings: Record<string, VersionInfo> = {
+  '44.0.0': {
+    iosDeploymentTarget: '12.0',
+  },
   '43.0.0': {
     iosDeploymentTarget: '12.0',
   },


### PR DESCRIPTION
# Why

add sdk44 support

# How

- add `44.0.0` to supported version list and also to be default version.
- add `ExpoReactDelegate` code mod support for sdk 44. 

# Test Plan

## Unit Test

```
 PASS   install-expo-modules  src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
  updateModulesAppDelegateObjcHeader
    ✓ should migrate from classic RN AppDelegate header (6 ms)
  updateModulesAppDelegateObjcImpl
    ✓ should migrate from classic RN AppDelegate implementation (12 ms)
  updateModulesAppDelegateSwift
    ✓ should migrate from basic RN AppDelegate.swift (1 ms)
  withIosModulesAppDelegate sdkVersion snapshots
    ✓ sdkVersion 43.0.0 (1 ms)
    ✓ sdkVersion 44.0.0 (1 ms)
```

## Integration Test

```
npx react-native init RN066 --version 0.66
npx install-expo-modules
yarn ios
```

```
npx react-native init RN066 --version 0.66
npx install-expo-modules -s 43.0.0
yarn ios
```
