### PR TITLE
[config-plugins] throw if there is a runtime version mismatch

### DIFF
--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -122,20 +122,20 @@ export function setVersionsConfig(
       'A runtime version is set in your AndroidManifest.xml, but is missing from your app.json/app.config.js. Please either set runtimeVersion in your app.json/app.config.js or remove expo.modules.updates.EXPO_RUNTIME_VERSION from your AndroidManifest.xml.'
     );
   }
-
+  const sdkVersion = getSDKVersion(config);
   if (runtimeVersion) {
     removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
     addMetaDataItemToMainApplication(mainApplication, Config.RUNTIME_VERSION, runtimeVersion);
-  } else {
+  } else if (sdkVersion) {
     /**
      * runtime version maybe null in projects using classic updates. In that
      * case we use SDK version
      */
-    const sdkVersion = getSDKVersion(config);
-    if (!sdkVersion) {
-      throw new Error('Either a runtime or SDK version must be set in an Expo project.');
-    }
+    removeMetaDataItemFromMainApplication(mainApplication, Config.RUNTIME_VERSION);
     addMetaDataItemToMainApplication(mainApplication, Config.SDK_VERSION, sdkVersion);
+  } else {
+    removeMetaDataItemFromMainApplication(mainApplication, Config.RUNTIME_VERSION);
+    removeMetaDataItemFromMainApplication(mainApplication, Config.SDK_VERSION);
   }
 
   return androidManifest;

--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -117,7 +117,7 @@ export function setVersionsConfig(
   const mainApplication = getMainApplicationOrThrow(androidManifest);
 
   const runtimeVersion = getRuntimeVersionNullable(config, 'android');
-  if (!runtimeVersion && findMetaDataItem(mainApplication, Config.RUNTIME_VERSION)) {
+  if (!runtimeVersion && findMetaDataItem(mainApplication, Config.RUNTIME_VERSION) > -1) {
     throw new Error(
       'A runtime version is set in your AndroidManifest.xml, but is missing from your app.json/app.config.js. Please either set runtimeVersion in your app.json/app.config.js or remove expo.modules.updates.EXPO_RUNTIME_VERSION from your AndroidManifest.xml.'
     );

--- a/packages/config-plugins/src/android/Updates.ts
+++ b/packages/config-plugins/src/android/Updates.ts
@@ -119,7 +119,7 @@ export function setVersionsConfig(
   const runtimeVersion = getRuntimeVersionNullable(config, 'android');
   if (!runtimeVersion && findMetaDataItem(mainApplication, Config.RUNTIME_VERSION)) {
     throw new Error(
-      'A runtime version is set in your AndroidManifest.xml, but is missing from your app.json/app.config.js. Please either set the runtimeVersion in your app.json/app.config.js or remove the runtimeVersion from your AndroidManifest.xml.'
+      'A runtime version is set in your AndroidManifest.xml, but is missing from your app.json/app.config.js. Please either set runtimeVersion in your app.json/app.config.js or remove expo.modules.updates.EXPO_RUNTIME_VERSION from your AndroidManifest.xml.'
     );
   }
 
@@ -133,7 +133,7 @@ export function setVersionsConfig(
      */
     const sdkVersion = getSDKVersion(config);
     if (!sdkVersion) {
-      throw new Error('Either a runtime or sdk version must be set in an expo project.');
+      throw new Error('Either a runtime or SDK version must be set in an Expo project.');
     }
     addMetaDataItemToMainApplication(mainApplication, Config.SDK_VERSION, sdkVersion);
   }

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -102,20 +102,20 @@ export function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlis
       'A runtime version is set in your Expo.plist, but is missing from your app.json/app.config.js. Please either set runtimeVersion in your app.json/app.config.js or remove EXUpdatesRuntimeVersion from your Expo.plist.'
     );
   }
-
+  const sdkVersion = getSDKVersion(config);
   if (runtimeVersion) {
     delete newExpoPlist[Config.SDK_VERSION];
     newExpoPlist[Config.RUNTIME_VERSION] = runtimeVersion;
-  } else {
+  } else if (sdkVersion) {
     /**
      * runtime version maybe null in projects using classic updates. In that
      * case we use SDK version
      */
-    const sdkVersion = getSDKVersion(config);
-    if (!sdkVersion) {
-      throw new Error('Either a runtime or SDK version must be set in an Expo project.');
-    }
+    delete newExpoPlist[Config.RUNTIME_VERSION];
     newExpoPlist[Config.SDK_VERSION] = sdkVersion;
+  } else {
+    delete newExpoPlist[Config.SDK_VERSION];
+    delete newExpoPlist[Config.RUNTIME_VERSION];
   }
 
   return newExpoPlist;

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -97,20 +97,25 @@ export function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlis
   const newExpoPlist = { ...expoPlist };
 
   const runtimeVersion = getRuntimeVersionNullable(config, 'ios');
-  const sdkVersion = getSDKVersion(config);
+  if (!runtimeVersion && expoPlist[Config.RUNTIME_VERSION]) {
+    throw new Error(
+      'A runtime version is set in your Expo.plist, but is missing from your app.json/app.config.js. Please either set the runtimeVersion in your app.json/app.config.js or remove the runtimeVersion from your Expo.plist.'
+    );
+  }
+
   if (runtimeVersion) {
     delete newExpoPlist[Config.SDK_VERSION];
     newExpoPlist[Config.RUNTIME_VERSION] = runtimeVersion;
-  } else if (sdkVersion) {
+  } else {
     /**
      * runtime version maybe null in projects using classic updates. In that
      * case we use SDK version
      */
-    delete newExpoPlist[Config.RUNTIME_VERSION];
+    const sdkVersion = getSDKVersion(config);
+    if (!sdkVersion) {
+      throw new Error('Either a runtime or sdk version must be set in an expo project.');
+    }
     newExpoPlist[Config.SDK_VERSION] = sdkVersion;
-  } else {
-    delete newExpoPlist[Config.SDK_VERSION];
-    delete newExpoPlist[Config.RUNTIME_VERSION];
   }
 
   return newExpoPlist;

--- a/packages/config-plugins/src/ios/Updates.ts
+++ b/packages/config-plugins/src/ios/Updates.ts
@@ -99,7 +99,7 @@ export function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlis
   const runtimeVersion = getRuntimeVersionNullable(config, 'ios');
   if (!runtimeVersion && expoPlist[Config.RUNTIME_VERSION]) {
     throw new Error(
-      'A runtime version is set in your Expo.plist, but is missing from your app.json/app.config.js. Please either set the runtimeVersion in your app.json/app.config.js or remove the runtimeVersion from your Expo.plist.'
+      'A runtime version is set in your Expo.plist, but is missing from your app.json/app.config.js. Please either set runtimeVersion in your app.json/app.config.js or remove EXUpdatesRuntimeVersion from your Expo.plist.'
     );
   }
 
@@ -113,7 +113,7 @@ export function setVersionsConfig(config: ExpoConfigUpdates, expoPlist: ExpoPlis
      */
     const sdkVersion = getSDKVersion(config);
     if (!sdkVersion) {
-      throw new Error('Either a runtime or sdk version must be set in an expo project.');
+      throw new Error('Either a runtime or SDK version must be set in an Expo project.');
     }
     newExpoPlist[Config.SDK_VERSION] = sdkVersion;
   }

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -1504,12 +1504,6 @@ Object {
                   },
                   Object {
                     "$": Object {
-                      "android:name": "expo.modules.updates.EXPO_SDK_VERSION",
-                      "android:value": "YOUR-APP-SDK-VERSION-HERE",
-                    },
-                  },
-                  Object {
-                    "$": Object {
                       "android:name": "com.facebook.sdk.ApplicationId",
                       "android:value": "@string/facebook_app_id",
                     },

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -1504,6 +1504,12 @@ Object {
                   },
                   Object {
                     "$": Object {
+                      "android:name": "expo.modules.updates.EXPO_SDK_VERSION",
+                      "android:value": "YOUR-APP-SDK-VERSION-HERE",
+                    },
+                  },
+                  Object {
+                    "$": Object {
                       "android:name": "com.facebook.sdk.ApplicationId",
                       "android:value": "@string/facebook_app_id",
                     },


### PR DESCRIPTION
# Why

When a user has set the runtime version in the native config files, but not in app.json, we silently delete the runtime version when building.

This can be confusing: [(https://github.com/expo/eas-cli/issues/855)](https://github.com/expo/eas-cli/issues/855)


# How

It seems better to throw and ask the user to specify what they want explicitly.

Since updates won't work without an sdk or runtime version defined, we should throw in this case as well.

