### PR TITLE
[prebuild-config] update expo-modules-autolinking version

### DIFF
--- a/packages/prebuild-config/package.json
+++ b/packages/prebuild-config/package.json
@@ -41,7 +41,7 @@
     "@expo/image-utils": "0.3.18",
     "@expo/json-file": "8.2.34",
     "debug": "^4.3.1",
-    "expo-modules-autolinking": "~0.4.0",
+    "expo-modules-autolinking": "~0.5.1",
     "fs-extra": "^9.0.0",
     "resolve-from": "^5.0.0",
     "semver": "7.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8175,10 +8175,10 @@ expo-modules-autolinking@~0.3.3:
     find-up "~5.0.0"
     fs-extra "^9.1.0"
 
-expo-modules-autolinking@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-0.4.0.tgz#ad6e52ee42dd0e40a494693d763fa4bf2248c012"
-  integrity sha512-GRGHbQ4b/aOtEup/oA6YVS7OOBKqU4sNLhoiTkEJWXmYDRERZiRvp8N2krQtn54y5PqucftqlBrMbdCinTouqg==
+expo-modules-autolinking@~0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-0.5.1.tgz#44f56288d55f6a71576ddd94c18ec9ec8141207b"
+  integrity sha512-UaqISyuWDTFWBeQv6BniPzAWOJ0R6MCL/uNt6BSMkZW+b8PUq4wYFpSNXSWUJTqY/raYWs5hcSR4HPGkqnVQlg==
   dependencies:
     chalk "^4.1.0"
     commander "^7.2.0"


### PR DESCRIPTION
# Why

the version `expo-modules-autolinking@~0.4.0` is for sdk 44 beta only. since `expo-splash-screen` depends on `@expo/prebuild-config`
this will cause multiple `expo-modules-autolinking` issue.

may to fix https://forums.expo.dev/t/expo-updates-breaking-ios-build-on-sdk-44-with-yarn-2/60238

```
$ yarn why expo-modules-autolinking
├─ @expo/prebuild-config@npm:3.0.14
│  └─ expo-modules-autolinking@npm:0.4.0 (via npm:~0.4.0)
│
└─ expo@npm:44.0.0
   └─ expo-modules-autolinking@npm:0.5.1 (via npm:0.5.1)
```

which break especially on yarn 2 where `expo-modules-autolinking@0.4.0` be hoisted to node_modules.

# How

`yarn add expo-modules-autolinking@~0.5.1` which is sdk 44 official version.

# Test Plan

`expo config --type introspect` in `expo/apps/bare-sandbox`