### PR TITLE
Fix `pod repo update` not automatically running

### DIFF
--- a/packages/package-manager/src/CocoaPodsPackageManager.ts
+++ b/packages/package-manager/src/CocoaPodsPackageManager.ts
@@ -360,16 +360,24 @@ export class CocoaPodsPackageManager implements PackageManager {
     if (!this.silent) {
       console.log(`> pod ${args.join(' ')}`);
     }
-    const promise = spawnAsync('pod', [...args], {
-      // Add the cwd and other options to the spawn options.
-      ...this.options,
-      // We use pipe by default instead of inherit so that we can capture stderr/stdout and process it for errors.
-      // This is particularly required for the `pod install --repo-update` error.
+    const promise = spawnAsync(
+      'pod',
+      [
+        ...args,
+        // Enables colors while collecting output.
+        '--ansi',
+      ],
+      {
+        // Add the cwd and other options to the spawn options.
+        ...this.options,
+        // We use pipe by default instead of inherit so that we can capture stderr/stdout and process it for errors.
+        // This is particularly required for the `pod install --repo-update` error.
 
-      // Later we'll also pipe the stdout/stderr to the terminal when silent is false,
-      // currently this means we lose out on the ansi colors.
-      stdio: 'pipe',
-    });
+        // Later we'll also pipe the stdout/stderr to the terminal when silent is false,
+        // currently this means we lose out on the ansi colors unless passing the `--ansi` flag to every command.
+        stdio: 'pipe',
+      }
+    );
 
     if (!this.silent) {
       // If not silent, pipe the stdout/stderr to the terminal.

--- a/packages/package-manager/src/CocoaPodsPackageManager.ts
+++ b/packages/package-manager/src/CocoaPodsPackageManager.ts
@@ -2,6 +2,7 @@ import spawnAsync, { SpawnOptions, SpawnResult } from '@expo/spawn-async';
 import chalk from 'chalk';
 import { existsSync } from 'fs';
 import { Ora } from 'ora';
+import os from 'os';
 import path from 'path';
 
 import { PackageManager, spawnSudoAsync } from './PackageManager';
@@ -17,9 +18,9 @@ export class CocoaPodsError extends Error {
   }
 }
 
-export function extractMissingDependencyError(error: string): [string, string] | null {
+export function extractMissingDependencyError(errorOutput: string): [string, string] | null {
   // [!] Unable to find a specification for `expo-dev-menu-interface` depended upon by `expo-dev-launcher`
-  const results = error.match(
+  const results = errorOutput.match(
     /Unable to find a specification for ['"`]([\w-_\d\s]+)['"`] depended upon by ['"`]([\w-_\d\s]+)['"`]/
   );
   if (results) {
@@ -55,7 +56,7 @@ export class CocoaPodsPackageManager implements PackageManager {
     try {
       // In case the user has run sudo before running the command we can properly install CocoaPods without prompting for an interaction.
       await spawnAsync('gem', options, spawnOptions);
-    } catch (error) {
+    } catch (error: any) {
       if (nonInteractive) {
         throw new CocoaPodsError(
           'Failed to install CocoaPods CLI with gem (recommended)',
@@ -95,7 +96,7 @@ export class CocoaPodsPackageManager implements PackageManager {
       await CocoaPodsPackageManager.gemInstallCLIAsync(nonInteractive, spawnOptions);
       !silent && console.log(`\u203A Successfully installed CocoaPods CLI with Gem`);
       return true;
-    } catch (error) {
+    } catch (error: any) {
       if (!silent) {
         console.log(chalk.yellow(`\u203A Failed to install CocoaPods CLI with Gem`));
         console.log(chalk.red(error.stderr ?? error.message));
@@ -114,7 +115,7 @@ export class CocoaPodsPackageManager implements PackageManager {
                 error
               );
             }
-          } catch (error) {
+          } catch (error: any) {
             throw new CocoaPodsError(
               'Homebrew installation appeared to succeed but CocoaPods CLI not found in PATH and unable to link.',
               'NO_CLI',
@@ -125,7 +126,7 @@ export class CocoaPodsPackageManager implements PackageManager {
 
         !silent && console.log(`\u203A Successfully installed CocoaPods CLI with Homebrew`);
         return true;
-      } catch (error) {
+      } catch (error: any) {
         !silent &&
           console.warn(
             chalk.yellow(
@@ -168,11 +169,9 @@ export class CocoaPodsPackageManager implements PackageManager {
     this.silent = !!silent;
     this.options = {
       cwd,
-      ...(silent
-        ? { stdio: 'pipe' }
-        : {
-            stdio: ['inherit', 'inherit', 'pipe'],
-          }),
+      // We use pipe by default instead of inherit so that we can capture stderr/stdout and process it for errors.
+      // Later we'll also pipe the stdout/stderr to the terminal when silent is false.
+      stdio: 'pipe',
     };
   }
 
@@ -180,6 +179,7 @@ export class CocoaPodsPackageManager implements PackageManager {
     return 'CocoaPods';
   }
 
+  /** Runs `pod install` and attempts to automatically run known troubleshooting steps automatically. */
   async installAsync({ spinner }: { spinner?: Ora } = {}) {
     await this._installAsync({ spinner });
   }
@@ -201,77 +201,66 @@ export class CocoaPodsPackageManager implements PackageManager {
   }: { spinner?: Ora; shouldUpdate?: boolean } = {}): Promise<SpawnResult> {
     try {
       return await this._runAsync(['install']);
-    } catch (error) {
+    } catch (error: any) {
+      // Unknown errors are rethrown.
+      if (!error.output) throw error;
+
+      // Collect all of the spawn info.
       const output = error.output.join('\n').trim();
 
-      const isPodRepoUpdateError = output.includes('pod repo update');
-      // When pods are outdated, they'll throw an error informing you to run "pod repo update"
-      // Attempt to run that command and try installing again.
-      if (isPodRepoUpdateError && shouldUpdate) {
-        const warningInfo = extractMissingDependencyError(output);
-        let message: string;
-        if (warningInfo) {
-          message = `Couldn't install: ${warningInfo[1]} » ${chalk.underline(warningInfo[0])}.`;
-        } else {
-          message = `Couldn't install Pods.`;
-        }
-        message += ` Updating the Pods project and trying again...`;
+      // To emulate a `pod repo update` error, enter your `ios/Podfile.lock` and change one of `PODS` version numbers to some lower value.
+      const isPodRepoUpdateError = shouldPodRepoUpdate(output);
+
+      // If the error message contains `pod repo update` then we'll try to fix it automatically.
+      if (shouldUpdate && isPodRepoUpdateError) {
+        // Extract useful information from the error message and push it to the spinner.
+        const { message, update } = getPodRepoUpdateMessage(output);
         if (spinner) {
           spinner.text = chalk.bold(message);
         }
-        !this.silent && console.warn(chalk.yellow(message));
-        await this.podRepoUpdateAsync();
-        // Include a boolean to ensure pod repo update isn't invoked in the unlikely case where the pods fail to update.
-        return await this._installAsync({ spinner, shouldUpdate: false });
-      } else {
-        const cwd = this.options.cwd || process.cwd();
-        if (error.stdout.match(/No [`'"]Podfile[`'"] found in the project directory/)) {
-          error.message = `No Podfile found in directory: ${cwd}. Ensure CocoaPods is setup any try again.`;
-        } else if (isPodRepoUpdateError) {
-          const warningInfo = extractMissingDependencyError(output);
-          let reason: string;
-          if (warningInfo) {
-            reason = `Couldn't install: ${warningInfo[1]} » ${chalk.underline(warningInfo[0])}`;
-          } else {
-            reason = `This is often due to native package versions mismatching`;
-          }
 
-          let solution: string;
-          if (warningInfo?.[0]) {
-            // If the missing package is named `expo-dev-menu`, `react-native`, etc. then it might not be installed in the project.
-            if (warningInfo[0].match(/^(?:@?expo|@?react)(-|\/)/)) {
-              solution = `Ensure the node module "${warningInfo[0]}" is installed in your project, then run \`npx pod-install\` to try again.`;
-            } else {
-              solution = `Ensure the CocoaPod "${warningInfo[0]}" is installed in your project, then run \`npx pod-install\` to try again.`;
-            }
-          } else {
-            solution = `Try deleting the \`ios/Pods\` folder or the \`ios/Podfile.lock\` file and running \`npx pod-install\` to resolve.`;
-          }
-          error.message = `${reason}. ${solution}`;
-          throw new CocoaPodsError('Command `pod repo update` failed.', 'COMMAND_FAILED', error);
-        } else {
-          let stderr = error.stderr.trim();
-
-          // CocoaPods CLI prints the useful error to stdout...
-          const usefulError = error.stdout.match(/\[!\]\s((?:.|\n)*)/)?.[1];
-
-          // If there is a useful error message then prune the less useful info.
-          if (usefulError) {
-            // Delete unhelpful CocoaPods CLI error message.
-            if (error.message.match(/pod exited with non-zero code: 1/)) {
-              error.message = null;
-            }
-            // Remove `<PBXResourcesBuildPhase UUID=`13B07F8E1A680F5B00A75B9A`>` type errors when useful messages exist.
-            if (stderr.match(/PBXResourcesBuildPhase/)) {
-              stderr = null;
-            }
-          }
-
-          error.message = [usefulError, error.message, stderr].filter(Boolean).join('\n');
+        if (!this.silent) {
+          console.warn(chalk.yellow(message));
         }
 
-        throw new CocoaPodsError('Command `pod install` failed.', 'COMMAND_FAILED', error);
+        // If a single package is broken, we'll try to update it.
+        // If you manually change a version number in your `Podfile.lock`, you'll observe this error.
+        if (update) {
+          try {
+            await this._runAsync(['update', update]);
+            // If update succeeds, we'll try to install again (skipping `pod repo update`).
+            return await this._installAsync({ spinner, shouldUpdate: false });
+          } catch (error) {
+            // If the specific package update failed then simply run `pod repo update`.
+            const updateMessage = `Failed to update ${chalk.bold(
+              update
+            )}. Attempting to update the repo instead.`;
+            if (spinner) {
+              spinner.text = chalk.bold(updateMessage);
+            }
+
+            if (!this.silent) {
+              console.warn(chalk.yellow(updateMessage));
+            }
+          }
+        }
+        // Finally run `pod repo update` if nothing else worked.
+        await this.podRepoUpdateAsync();
+
+        // Assuming pod repo update succeeded, we'll try to install again.
+        return await this._installAsync({
+          spinner,
+          // Include a boolean to ensure pod repo update isn't invoked in the unlikely case where the pods fail to update.
+          shouldUpdate: false,
+        });
       }
+
+      // If we can't automatically fix the error, we'll just rethrow it with some known troubleshooting info.
+      throw getImprovedPodInstallError(error, {
+        errorOutput: output,
+        isPodRepoUpdateError,
+        cwd: this.options.cwd || process.cwd(),
+      });
     }
   }
 
@@ -304,17 +293,141 @@ export class CocoaPodsPackageManager implements PackageManager {
   private async podRepoUpdateAsync(): Promise<void> {
     try {
       await this._runAsync(['repo', 'update']);
-    } catch (error) {
+    } catch (error: any) {
       error.message = error.message || (error.stderr ?? error.stdout);
 
       throw new CocoaPodsError('The command `pod repo update` failed', 'COMMAND_FAILED', error);
     }
   }
 
-  private async _runAsync(args: string[]): Promise<SpawnResult> {
+  // Exposed for testing
+  async _runAsync(args: string[]): Promise<SpawnResult> {
     if (!this.silent) {
       console.log(`> pod ${args.join(' ')}`);
     }
-    return spawnAsync('pod', [...args], this.options);
+    const promise = spawnAsync('pod', [...args], {
+      // Add the cwd and other options to the spawn options.
+      ...this.options,
+      // We use pipe by default instead of inherit so that we can capture stderr/stdout and process it for errors.
+      // This is particularly required for the `pod repo update` error.
+
+      // Later we'll also pipe the stdout/stderr to the terminal when silent is false,
+      // currently this means we lose out on the ansi colors.
+      stdio: 'pipe',
+    });
+
+    if (!this.silent) {
+      // If not silent, pipe the stdout/stderr to the terminal.
+      // We only do this when the `stdio` is set to `pipe` (collect the results for parsing), `inherit` won't contain `promise.child`.
+      if (promise.child.stdout) {
+        promise.child.stdout.pipe(process.stdout);
+      }
+    }
+
+    return await promise;
   }
+}
+
+/** When pods are outdated, they'll throw an error informing you to run "pod repo update" */
+function shouldPodRepoUpdate(errorOutput: string) {
+  const output = errorOutput;
+  const isPodRepoUpdateError = output.includes('pod repo update');
+  return isPodRepoUpdateError;
+}
+
+export function getPodRepoUpdateMessage(errorOutput: string) {
+  const warningInfo = extractMissingDependencyError(errorOutput);
+  const brokenPackage =
+    errorOutput.match(
+      /You should run ['"`]pod update ([\w-_\d\s]+)['"`] to apply changes you've made/
+    )?.[1] ?? null;
+
+  let message: string;
+  if (warningInfo) {
+    message = `Couldn't install: ${warningInfo[1]} » ${chalk.underline(warningInfo[0])}.`;
+  } else if (brokenPackage) {
+    message = `Couldn't install: ${brokenPackage}.`;
+  } else {
+    message = `Couldn't install Pods.`;
+  }
+  message += ` Updating the Pods project and trying again...`;
+  return { message, update: brokenPackage };
+}
+
+/**
+ * Format the CocoaPods CLI install error.
+ *
+ * @param error Error from CocoaPods CLI `pod install` command.
+ * @returns
+ */
+export function getImprovedPodInstallError(
+  error: SpawnResult & Error,
+  {
+    errorOutput,
+    isPodRepoUpdateError,
+    cwd,
+  }: { errorOutput: string; isPodRepoUpdateError: boolean; cwd: string }
+): Error {
+  if (error.stdout.match(/No [`'"]Podfile[`'"] found in the project directory/)) {
+    // Ran pod install but no Podfile was found.
+    error.message = `No Podfile found in directory: ${cwd}. Ensure CocoaPods is setup any try again.`;
+  } else if (isPodRepoUpdateError) {
+    // Ran pod install but the repo update step failed.
+    const warningInfo = extractMissingDependencyError(errorOutput);
+    let reason: string;
+    if (warningInfo) {
+      reason = `Couldn't install: ${warningInfo[1]} » ${chalk.underline(warningInfo[0])}`;
+    } else {
+      reason = `This is often due to native package versions mismatching`;
+    }
+
+    // Attempt to provide a helpful message about the missing NPM dependency (containing a CocoaPod) since React Native
+    // developers will almost always be using autolinking and not interacting with CocoaPods directly.
+    let solution: string;
+    if (warningInfo?.[0]) {
+      // If the missing package is named `expo-dev-menu`, `react-native`, etc. then it might not be installed in the project.
+      if (warningInfo[0].match(/^(?:@?expo|@?react)(-|\/)/)) {
+        solution = `Ensure the node module "${warningInfo[0]}" is installed in your project, then run 'npx pod-install' to try again.`;
+      } else {
+        solution = `Ensure the CocoaPod "${warningInfo[0]}" is installed in your project, then run 'npx pod-install' to try again.`;
+      }
+    } else {
+      // Brute force
+      solution = `Try deleting the 'ios/Pods' folder or the 'ios/Podfile.lock' file and running 'npx pod-install' to resolve.`;
+    }
+    error.message = `${reason}. ${solution}`;
+
+    // Attempt to provide the troubleshooting info from CocoaPods CLI at the bottom of the error message.
+    if (error.stdout) {
+      const cocoapodsDebugInfo = error.stdout.split(os.EOL);
+      // The troubleshooting info starts with `[!]`, capture everything after that.
+      const firstWarning = cocoapodsDebugInfo.findIndex(v => v.startsWith('[!]'));
+      if (firstWarning !== -1) {
+        const warning = cocoapodsDebugInfo.slice(firstWarning).join(os.EOL);
+        error.message += `\n\n${chalk.gray(warning)}`;
+      }
+    }
+    return new CocoaPodsError('Command `pod repo update` failed.', 'COMMAND_FAILED', error);
+  } else {
+    let stderr: string | null = error.stderr.trim();
+
+    // CocoaPods CLI prints the useful error to stdout...
+    const usefulError = error.stdout.match(/\[!\]\s((?:.|\n)*)/)?.[1];
+
+    // If there is a useful error message then prune the less useful info.
+    if (usefulError) {
+      // Delete unhelpful CocoaPods CLI error message.
+      if (error.message?.match(/pod exited with non-zero code: 1/)) {
+        error.message = '';
+      }
+      // Remove `<PBXResourcesBuildPhase UUID=`13B07F8E1A680F5B00A75B9A`>` type errors when useful messages exist.
+      if (stderr.match(/PBXResourcesBuildPhase/)) {
+        stderr = null;
+      }
+    }
+
+    error.message = [usefulError, error.message, stderr].filter(Boolean).join('\n');
+  }
+
+  return new CocoaPodsError('Command `pod install` failed.', 'COMMAND_FAILED', error);
 }

--- a/packages/package-manager/src/__tests__/CocoaPodsPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/CocoaPodsPackageManager-test.ts
@@ -129,14 +129,8 @@ describe('installAsync', () => {
 
     manager._runAsync = jest.fn((commands: string[]) => {
       const cmd = commands.join(' ');
-      if (cmd === 'install') {
+      if (['install', 'update EXFileSystem', 'install --repo-update'].includes(cmd)) {
         throw fakePodRepoUpdateErrorOutput;
-      }
-      if (cmd === 'update EXFileSystem') {
-        throw fakePodRepoUpdateErrorOutput;
-      }
-      if (cmd === 'install --repo-update') {
-        return {};
       }
       // eslint-disable-next-line no-throw-literal
       throw 'unhandled ig';
@@ -199,8 +193,7 @@ describe('installAsync', () => {
     // `pod install` > `pod update EXFileSystem` > `pod install`
     expect(manager._runAsync).toHaveBeenNthCalledWith(1, ['install']);
     expect(manager._runAsync).toHaveBeenNthCalledWith(2, ['update', 'EXFileSystem']);
-    expect(manager._runAsync).toHaveBeenNthCalledWith(3, ['install']);
-    expect(manager._runAsync).toBeCalledTimes(3);
+    expect(manager._runAsync).toBeCalledTimes(2);
   });
 
   it(`runs install as expected`, async () => {

--- a/packages/package-manager/src/__tests__/CocoaPodsPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/CocoaPodsPackageManager-test.ts
@@ -30,8 +30,15 @@ beforeAll(() => {
   });
 });
 
+const originalForceColor = process.env.FORCE_COLOR;
+
 beforeEach(() => {
+  process.env.FORCE_COLOR = '1';
   delete process.env.TEST_COCOAPODS_MANAGER_SPAWN_VALUE_TO_RETURN;
+});
+
+afterAll(() => {
+  process.env.FORCE_COLOR = originalForceColor;
 });
 
 const fakePodRepoUpdateErrorOutput = {

--- a/packages/package-manager/src/__tests__/CocoaPodsPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/CocoaPodsPackageManager-test.ts
@@ -2,8 +2,9 @@
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
+import stripAnsi from 'strip-ansi';
 
-import { CocoaPodsPackageManager } from '../CocoaPodsPackageManager';
+import { CocoaPodsPackageManager, getPodRepoUpdateMessage } from '../CocoaPodsPackageManager';
 
 const projectRoot = getTemporaryPath();
 
@@ -27,6 +28,179 @@ beforeAll(() => {
 
 beforeEach(() => {
   delete process.env.TEST_COCOAPODS_MANAGER_SPAWN_VALUE_TO_RETURN;
+});
+
+const fakePodRepoUpdateErrorOutput = {
+  pid: 74312,
+  output: [
+    'Using Expo modules\n' +
+      'Auto-linking React Native modules for target `yolo74`: RNGestureHandler, RNReanimated, RNScreens, and react-native-safe-area-context\n' +
+      'Analyzing dependencies\n' +
+      '[!] CocoaPods could not find compatible versions for pod "EXFileSystem":\n' +
+      '  In snapshot (Podfile.lock):\n' +
+      '    EXFileSystem (from `../node_modules/expo-file-system/ios`)\n' +
+      '\n' +
+      '  In Podfile:\n' +
+      '    EXFileSystem (from `../node_modules/expo-file-system/ios`)\n' +
+      '\n' +
+      '\n' +
+      'You have either:\n' +
+      ' * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.\n' +
+      ' * changed the constraints of dependency `EXFileSystem` inside your development pod `EXFileSystem`.\n' +
+      "   You should run `pod update EXFileSystem` to apply changes you've made.\n",
+    'Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1\n',
+  ],
+  stdout:
+    'Using Expo modules\n' +
+    'Auto-linking React Native modules for target `yolo74`: RNGestureHandler, RNReanimated, RNScreens, and react-native-safe-area-context\n' +
+    'Analyzing dependencies\n' +
+    '[!] CocoaPods could not find compatible versions for pod "EXFileSystem":\n' +
+    '  In snapshot (Podfile.lock):\n' +
+    '    EXFileSystem (from `../node_modules/expo-file-system/ios`)\n' +
+    '\n' +
+    '  In Podfile:\n' +
+    '    EXFileSystem (from `../node_modules/expo-file-system/ios`)\n' +
+    '\n' +
+    '\n' +
+    'You have either:\n' +
+    ' * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.\n' +
+    ' * changed the constraints of dependency `EXFileSystem` inside your development pod `EXFileSystem`.\n' +
+    "   You should run `pod update EXFileSystem` to apply changes you've made.\n",
+  stderr:
+    'Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1\n' +
+    'Ignoring digest-crc-0.6.1 because its extensions are not built. Try: gem pristine digest-crc --version 0.6.1\n' +
+    'Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1\n' +
+    'Ignoring unf_ext-0.0.7.7 because its extensions are not built. Try: gem pristine unf_ext --version 0.0.7.7\n',
+  status: 1,
+  signal: null,
+};
+
+describe(getPodRepoUpdateMessage, () => {
+  it(`formats pod repo update message`, () => {
+    expect(
+      stripAnsi(
+        getPodRepoUpdateMessage(
+          '[!] Unable to find a specification for `expo-dev-menu-interface` depended upon by `expo-dev-launcher`'
+        ).message
+      )
+    ).toBe(
+      `Couldn't install: expo-dev-launcher » expo-dev-menu-interface. Updating the Pods project and trying again...`
+    );
+  });
+  it(`formats pod update message`, () => {
+    expect(
+      stripAnsi(
+        getPodRepoUpdateMessage(
+          "You should run `pod update EXFileSystem` to apply changes you've made."
+        ).message
+      )
+    ).toBe(`Couldn't install: EXFileSystem. Updating the Pods project and trying again...`);
+  });
+});
+
+describe('installAsync', () => {
+  it(`does pod repo update automatically when the Podfile.lock is malformed`, async () => {
+    const { CocoaPodsPackageManager } = require('../CocoaPodsPackageManager');
+    const manager = new CocoaPodsPackageManager({ cwd: projectRoot });
+
+    manager._runAsync = jest.fn((commands: string[]) => {
+      const cmd = commands.join(' ');
+      if (cmd === 'install') {
+        throw fakePodRepoUpdateErrorOutput;
+      }
+      if (cmd === 'update EXFileSystem') {
+        throw fakePodRepoUpdateErrorOutput;
+      }
+      if (cmd === 'repo update') {
+        return {};
+      }
+      // eslint-disable-next-line no-throw-literal
+      throw 'unhandled ig';
+    });
+
+    // Ensure a useful error is thrown
+    await expect(manager.installAsync()).rejects.toThrowErrorMatchingInlineSnapshot(`
+          "Command \`pod repo update\` failed.
+          └─ Cause: This is often due to native package versions mismatching. Try deleting the 'ios/Pods' folder or the 'ios/Podfile.lock' file and running 'npx pod-install' to resolve.
+
+          [90m[!] CocoaPods could not find compatible versions for pod \\"EXFileSystem\\":[39m
+          [90m  In snapshot (Podfile.lock):[39m
+          [90m    EXFileSystem (from \`../node_modules/expo-file-system/ios\`)[39m
+          [90m[39m
+          [90m  In Podfile:[39m
+          [90m    EXFileSystem (from \`../node_modules/expo-file-system/ios\`)[39m
+          [90m[39m
+          [90m[39m
+          [90mYou have either:[39m
+          [90m * out-of-date source repos which you can update with \`pod repo update\` or with \`pod install --repo-update\`.[39m
+          [90m * changed the constraints of dependency \`EXFileSystem\` inside your development pod \`EXFileSystem\`.[39m
+          [90m   You should run \`pod update EXFileSystem\` to apply changes you've made.[39m
+          [90m[39m"
+        `);
+
+    // `pod install` > `pod update EXFileSystem` > `pod repo update` > `pod install`
+    expect(manager._runAsync).toHaveBeenNthCalledWith(1, ['install']);
+    expect(manager._runAsync).toHaveBeenNthCalledWith(2, ['update', 'EXFileSystem']);
+    expect(manager._runAsync).toHaveBeenNthCalledWith(3, ['repo', 'update']);
+    expect(manager._runAsync).toHaveBeenNthCalledWith(4, ['install']);
+    expect(manager._runAsync).toBeCalledTimes(4);
+  });
+
+  it(`auto updates malformed package versions`, async () => {
+    const { CocoaPodsPackageManager } = require('../CocoaPodsPackageManager');
+    const manager = new CocoaPodsPackageManager({ cwd: projectRoot });
+
+    let invokedOnce = false;
+    manager._runAsync = jest.fn((commands: string[]) => {
+      const cmd = commands.join(' ');
+      if (cmd === 'install') {
+        // On the second invocation, return a successful result.
+        if (invokedOnce) {
+          return {};
+        }
+        invokedOnce = true;
+        throw fakePodRepoUpdateErrorOutput;
+      }
+      if (cmd === 'update EXFileSystem') {
+        return {};
+      }
+      if (cmd === 'repo update') {
+        return {};
+      }
+      // eslint-disable-next-line no-throw-literal
+      throw 'unhandled ig';
+    });
+
+    // Ensure an error is not thrown
+    await manager.installAsync();
+
+    // `pod install` > `pod update EXFileSystem` > `pod install`
+    expect(manager._runAsync).toHaveBeenNthCalledWith(1, ['install']);
+    expect(manager._runAsync).toHaveBeenNthCalledWith(2, ['update', 'EXFileSystem']);
+    expect(manager._runAsync).toHaveBeenNthCalledWith(3, ['install']);
+    expect(manager._runAsync).toBeCalledTimes(3);
+  });
+
+  it(`runs install as expected`, async () => {
+    const { CocoaPodsPackageManager } = require('../CocoaPodsPackageManager');
+    const manager = new CocoaPodsPackageManager({ cwd: projectRoot });
+
+    manager._runAsync = jest.fn((commands: string[]) => {
+      const cmd = commands.join(' ');
+      if (cmd === 'install') {
+        return {};
+      }
+      // eslint-disable-next-line no-throw-literal
+      throw 'unhandled ig';
+    });
+
+    // Ensure an error is not thrown
+    await manager.installAsync();
+
+    // `pod install` > success
+    expect(manager._runAsync).toHaveBeenNthCalledWith(1, ['install']);
+    expect(manager._runAsync).toBeCalledTimes(1);
+  });
 });
 
 it(`throws for unimplemented methods`, async () => {

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -51,7 +51,16 @@ async function runAsync(): Promise<void> {
     await CocoaPodsPackageManager.installCLIAsync({ nonInteractive: program.nonInteractive });
   }
   const manager = new CocoaPodsPackageManager({ cwd: projectRoot });
-  await manager.installAsync();
+  try {
+    await manager.installAsync();
+  } catch (error: any) {
+    if (error.isPackageManagerError) {
+      console.error(chalk.red(error.message));
+      process.exit(1);
+    }
+    // throw unhandled
+    throw error;
+  }
 }
 
 (async () => {


### PR DESCRIPTION
# Why

- Resolve https://github.com/expo/expo-cli/issues/4051

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

When the 'silent' feature was added it broke the `output` collection of forked processes, meaning we'd match for 'pod repo update' against an empty string. This is a bit tricky since the code in Expo CLI is often silent but the usage in `npx pod-install` is verbose.

This PR also adds support for automatically running `pod update [package]` which can often be more useful than `pod repo update` since it will fix broken versions. If `pod update X` doesn't work, we'll fallback on `pod repo update` like before.

An example of this new feature working would be to open your `Podfile.lock`:

```diff
PODS:
-  - boost-for-react-native (1.63.0)
+  - boost-for-react-native (420.63.0)
  - DoubleConversion (1.1.6)
  - EXApplication (4.0.0):
```

Running `pod-install` (or similar commands) will automatically fix this version without running `pod repo update` (which wouldn't work).




<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Added many more tests to hopefully prevent this from breaking again.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->