### PR TITLE
Remove all `yarn global add X` prompts

### DIFF
--- a/packages/expo-optimize/src/update.ts
+++ b/packages/expo-optimize/src/update.ts
@@ -1,15 +1,5 @@
 import chalk from 'chalk';
-import { execSync } from 'child_process';
 import checkForUpdate from 'update-check';
-
-function shouldUseYarn() {
-  try {
-    execSync('yarnpkg --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export default async function shouldUpdate() {
   const packageJson = () => require('expo-optimize/package.json');
@@ -19,17 +9,10 @@ export default async function shouldUpdate() {
   try {
     const res = await update;
     if (res && res.latest) {
-      const isYarn = shouldUseYarn();
-
       const _packageJson = packageJson();
       console.log();
       console.log(chalk.yellow.bold(`A new version of \`${_packageJson.name}\` is available`));
-      console.log(
-        'You can update by running: ' +
-          chalk.cyan(
-            isYarn ? `yarn global add ${_packageJson.name}` : `npm i -g ${_packageJson.name}`
-          )
-      );
+      console.log('You can update by running: ' + chalk.cyan(`npm i -g ${_packageJson.name}`));
       console.log();
     }
   } catch {

--- a/packages/next-adapter/src/cli/update.ts
+++ b/packages/next-adapter/src/cli/update.ts
@@ -1,18 +1,7 @@
 import chalk from 'chalk';
-import { execSync } from 'child_process';
-// @ts-ignore
 import checkForUpdate from 'update-check';
 
 const packageJson = () => require('@expo/next-adapter/package.json');
-
-function shouldUseYarn() {
-  try {
-    execSync('yarnpkg --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export default async function shouldUpdate() {
   const update = checkForUpdate(packageJson()).catch(() => null);
@@ -20,17 +9,10 @@ export default async function shouldUpdate() {
   try {
     const res = await update;
     if (res && res.latest) {
-      const isYarn = shouldUseYarn();
-
       const _packageJson = packageJson();
       console.log();
       console.log(chalk.yellow.bold(`A new version of \`${_packageJson.name}\` is available`));
-      console.log(
-        'You can update by running: ' +
-          chalk.cyan(
-            isYarn ? `yarn global add ${_packageJson.name}` : `npm i -g ${_packageJson.name}`
-          )
-      );
+      console.log('You can update by running: ' + chalk.cyan(`npm i -g ${_packageJson.name}`));
       console.log();
     }
   } catch {

--- a/packages/pod-install/src/update.ts
+++ b/packages/pod-install/src/update.ts
@@ -1,15 +1,5 @@
 import chalk from 'chalk';
-import { execSync } from 'child_process';
 import checkForUpdate from 'update-check';
-
-function shouldUseYarn() {
-  try {
-    execSync('yarnpkg --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export default async function shouldUpdate() {
   const packageJson = require('../package.json');
@@ -19,16 +9,9 @@ export default async function shouldUpdate() {
   try {
     const res = await update;
     if (res && res.latest) {
-      const isYarn = shouldUseYarn();
-
       console.log();
       console.log(chalk.yellow.bold(`A new version of \`${packageJson.name}\` is available`));
-      console.log(
-        'You can update by running: ' +
-          chalk.cyan(
-            isYarn ? `yarn global add ${packageJson.name}` : `npm i -g ${packageJson.name}`
-          )
-      );
+      console.log('You can update by running: ' + chalk.cyan(`npm i -g ${packageJson.name}`));
       console.log();
     }
   } catch {

--- a/packages/pwa/src/update.ts
+++ b/packages/pwa/src/update.ts
@@ -1,15 +1,5 @@
 import chalk from 'chalk';
-import { execSync } from 'child_process';
 import checkForUpdate from 'update-check';
-
-function shouldUseYarn() {
-  try {
-    execSync('yarnpkg --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export default async function shouldUpdate() {
   const packageJson = () => require('../package.json');
@@ -19,17 +9,10 @@ export default async function shouldUpdate() {
   try {
     const res = await update;
     if (res && res.latest) {
-      const isYarn = shouldUseYarn();
-
       const _packageJson = packageJson();
       console.log();
       console.log(chalk.yellow.bold(`A new version of \`${_packageJson.name}\` is available`));
-      console.log(
-        'You can update by running: ' +
-          chalk.cyan(
-            isYarn ? `yarn global add ${_packageJson.name}` : `npm i -g ${_packageJson.name}`
-          )
-      );
+      console.log('You can update by running: ' + chalk.cyan(`npm i -g ${_packageJson.name}`));
       console.log();
     }
   } catch {

--- a/packages/uri-scheme/src/update.ts
+++ b/packages/uri-scheme/src/update.ts
@@ -1,15 +1,5 @@
 import chalk from 'chalk';
-import { execSync } from 'child_process';
 import checkForUpdate from 'update-check';
-
-function shouldUseYarn(): boolean {
-  try {
-    execSync('yarnpkg --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export default async function shouldUpdate(): Promise<void> {
   const packageJson = () => require('../package.json');
@@ -19,17 +9,10 @@ export default async function shouldUpdate(): Promise<void> {
   try {
     const res = await update;
     if (res && res.latest) {
-      const isYarn = shouldUseYarn();
-
       const _packageJson = packageJson();
       console.log();
       console.log(chalk.yellow.bold(`A new version of \`${_packageJson.name}\` is available`));
-      console.log(
-        'You can update by running: ' +
-          chalk.cyan(
-            isYarn ? `yarn global add ${_packageJson.name}` : `npm i -g ${_packageJson.name}`
-          )
-      );
+      console.log('You can update by running: ' + chalk.cyan(`npm i -g ${_packageJson.name}`));
       console.log();
     }
   } catch {


### PR DESCRIPTION
# Why

Yarn CLI has a lot of issues installing modules globally. This PR removes the prompt to globally install tools with `yarn global add` and instead just always uses `npm i -g`.
