### PR TITLE
[xdl] persist dev client ids locally, use to start dev sessions

### DIFF
--- a/packages/xdl/src/DevSession.ts
+++ b/packages/xdl/src/DevSession.ts
@@ -2,11 +2,11 @@ import { ExpoConfig } from '@expo/config-types';
 import os from 'os';
 import { URLSearchParams } from 'url';
 
-import { ProjectSettings } from '.';
 import {
   ApiV2 as ApiV2Client,
   ConnectionStatus,
   Logger as logger,
+  ProjectSettings,
   UrlUtils,
   UserManager,
 } from './internal';

--- a/packages/xdl/src/DevSession.ts
+++ b/packages/xdl/src/DevSession.ts
@@ -28,7 +28,7 @@ export async function startSession(
 
   if (!ConnectionStatus.isOffline() && keepUpdating) {
     const authSession = await UserManager.getSessionAsync();
-    const { devices } = await ProjectSettings.readDevicesInfoAsync(projectRoot);
+    const { devices } = await ProjectSettings.getDevicesInfoAsync(projectRoot);
 
     if (!authSession && !devices?.length) {
       // NOTE(brentvatne) let's just bail out in this case for now

--- a/packages/xdl/src/DevSession.ts
+++ b/packages/xdl/src/DevSession.ts
@@ -30,7 +30,7 @@ export async function startSession(
     const authSession = await UserManager.getSessionAsync();
     const { devices } = await ProjectSettings.readDevicesInfoAsync(projectRoot);
 
-    if (!authSession && (!devices || !devices.length)) {
+    if (!authSession && !devices?.length) {
       // NOTE(brentvatne) let's just bail out in this case for now
       // throw new Error('development sessions can only be initiated for logged in users or with a device ID');
       return;

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -259,17 +259,11 @@ export function dotExpoProjectDirectory(projectRoot: string): string {
 
 The ".expo" folder is created when an Expo project is started using "expo start" command.
 
-> What does the "packager-info.json" file contain?
+> What do the files contain?
 
-The "packager-info.json" file contains port numbers and process PIDs that are used to serve the application to the mobile device/simulator.
-
-> What does the "settings.json" file contain?
-
-The "settings.json" file contains the server configuration that is used to serve the application manifest.
-
-> What is \`devices.json\`?
-
-The "devices.json" file contains information about devices that have recently opened this project. This is used to populate the "Development sessions" list in your development builds.
+- "devices.json": contains information about devices that have recently opened this project. This is used to populate the "Development sessions" list in your development builds.
+- "packager-info.json": contains port numbers and process PIDs that are used to serve the application to the mobile device/simulator.
+- "settings.json": contains the server configuration that is used to serve the application manifest.
 
 > Should I commit the ".expo" folder?
 

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -150,17 +150,37 @@ export async function setPackagerInfoAsync(
   }
 }
 
-let devicesInfo: DevicesInfo | undefined;
+let devicesInfo: DevicesInfo | null = null;
 
-export async function readDevicesInfoAsync(projectRoot: string): Promise<DevicesInfo> {
+export async function getDevicesInfoAsync(projectRoot: string): Promise<DevicesInfo> {
   if (devicesInfo) {
     return devicesInfo;
   }
+  return readDevicesInfoAsync(projectRoot);
+}
 
+export async function readDevicesInfoAsync(projectRoot: string): Promise<DevicesInfo> {
   try {
-    return await devicesJsonFile(projectRoot).readAsync({
+    devicesInfo = await devicesJsonFile(projectRoot).readAsync({
       cantReadFileDefault: { devices: [] },
     });
+
+    // if the file on disk has old devices, filter them out here before we use them
+    const filteredDevices = filterOldDevices(devicesInfo.devices);
+    if (filteredDevices.length < devicesInfo.devices.length) {
+      devicesInfo = {
+        ...devicesInfo,
+        devices: filteredDevices,
+      };
+      // save the newly filtered list for consistency
+      try {
+        await setDevicesInfoAsync(projectRoot, devicesInfo);
+      } catch {
+        // do nothing here, we'll just keep using the filtered list in memory for now
+      }
+    }
+
+    return devicesInfo;
   } catch {
     return await devicesJsonFile(projectRoot).writeAsync({ devices: [] });
   }
@@ -188,23 +208,33 @@ export async function saveDevicesAsync(
   const currentTime = new Date().getTime();
   const newDeviceIds = typeof deviceIds === 'string' ? [deviceIds] : deviceIds;
 
-  const { devices } = await readDevicesInfoAsync(projectRoot);
+  const { devices } = await getDevicesInfoAsync(projectRoot);
   const newDevicesJson = devices
     .filter(device => {
       if (newDeviceIds.includes(device.installationId)) {
         return false;
       }
-      // delete any devices that haven't been used to open this project in 30 days
-      if (currentTime - device.lastUsed > MILLISECONDS_IN_30_DAYS) {
-        return false;
-      }
       return true;
     })
-    .concat(newDeviceIds.map(deviceId => ({ installationId: deviceId, lastUsed: currentTime })))
-    // keep only the 10 most recently used devices
-    .sort((a, b) => b.lastUsed - a.lastUsed)
-    .slice(0, 10);
-  await setDevicesInfoAsync(projectRoot, { devices: newDevicesJson });
+    .concat(newDeviceIds.map(deviceId => ({ installationId: deviceId, lastUsed: currentTime })));
+  await setDevicesInfoAsync(projectRoot, { devices: filterOldDevices(newDevicesJson) });
+}
+
+function filterOldDevices(devices: DeviceInfo[]) {
+  const currentTime = new Date().getTime();
+  return (
+    devices
+      .filter(device => {
+        // filter out any devices that haven't been used to open this project in 30 days
+        if (currentTime - device.lastUsed > MILLISECONDS_IN_30_DAYS) {
+          return false;
+        }
+        return true;
+      })
+      // keep only the 10 most recently used devices
+      .sort((a, b) => b.lastUsed - a.lastUsed)
+      .slice(0, 10)
+  );
 }
 
 export function dotExpoProjectDirectory(projectRoot: string): string {

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -159,7 +159,7 @@ export async function readDevicesInfoAsync(projectRoot: string): Promise<Devices
     return await devicesJsonFile(projectRoot).readAsync({
       cantReadFileDefault: { devices: [] },
     });
-  } catch (e) {
+  } catch {
     return await devicesJsonFile(projectRoot).writeAsync({ devices: [] });
   }
 }
@@ -174,7 +174,7 @@ export async function setDevicesInfoAsync(
     return await devicesJsonFile(projectRoot).mergeAsync(json, {
       cantReadFileDefault: { devices: [] },
     });
-  } catch (e) {
+  } catch {
     return await devicesJsonFile(projectRoot).writeAsync(json);
   }
 }
@@ -236,7 +236,7 @@ The "packager-info.json" file contains port numbers and process PIDs that are us
 
 The "settings.json" file contains the server configuration that is used to serve the application manifest.
 
-> What does the "devices.json" file contain?
+> What is `devices.json`?
 
 The "devices.json" file contains information about devices that have recently opened this project. This is used to populate the "Development sessions" list in your development builds.
 

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -51,6 +51,8 @@ export type DevicesInfo = {
 };
 const devicesFile = 'devices.json';
 
+const MILLISECONDS_IN_30_DAYS = 30 * 24 * 60 * 60 * 1000;
+
 function projectSettingsJsonFile(projectRoot: string): JsonFile<ProjectSettings> {
   return new JsonFile<ProjectSettings>(
     path.join(dotExpoProjectDirectory(projectRoot), projectSettingsFile)
@@ -179,7 +181,6 @@ export async function setDevicesInfoAsync(
   }
 }
 
-const MILLISECONDS_IN_30_DAYS = 30 * 24 * 60 * 60 * 1000;
 export async function saveDevicesAsync(
   projectRoot: string,
   deviceIds: string | string[]
@@ -236,7 +237,7 @@ The "packager-info.json" file contains port numbers and process PIDs that are us
 
 The "settings.json" file contains the server configuration that is used to serve the application manifest.
 
-> What is `devices.json`?
+> What is \`devices.json\`?
 
 The "devices.json" file contains information about devices that have recently opened this project. This is used to populate the "Development sessions" list in your development builds.
 

--- a/packages/xdl/src/__tests__/ProjectSettings-test.ts
+++ b/packages/xdl/src/__tests__/ProjectSettings-test.ts
@@ -1,0 +1,83 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import * as ProjectSettings from '../ProjectSettings';
+
+describe('devices info', () => {
+  let projectRoot: string;
+
+  beforeAll(() => {
+    projectRoot = path.join('/', 'tmp', 'xdl-project-settings');
+  });
+
+  afterEach(async () => {
+    await ProjectSettings.setDevicesInfoAsync(projectRoot, { devices: [] });
+  });
+
+  afterAll(() => {
+    if (projectRoot) {
+      fs.removeSync(projectRoot);
+    }
+  });
+
+  it('should persist device info to disk', async () => {
+    await ProjectSettings.saveDevicesAsync(projectRoot, 'test-device-id');
+
+    const file = path.join(projectRoot, '.expo', 'devices.json');
+    expect(fs.existsSync(file)).toBe(true);
+
+    const { devices } = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(devices.length).toBe(1);
+    expect(devices[0].installationId).toBe('test-device-id');
+  });
+
+  it('should save an array of devices', async () => {
+    await ProjectSettings.saveDevicesAsync(projectRoot, ['device-id-1', 'device-id-2']);
+    const { devices } = await ProjectSettings.readDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(2);
+    expect(devices.some(device => device.installationId === 'device-id-1')).toBe(true);
+    expect(devices.some(device => device.installationId === 'device-id-2')).toBe(true);
+  });
+
+  it('should save at most 10 devices', async () => {
+    const deviceIds = [];
+    for (let i = 0; i < 11; i++) {
+      deviceIds.push(`device-id-${i}`);
+    }
+    await ProjectSettings.saveDevicesAsync(projectRoot, deviceIds);
+    const { devices } = await ProjectSettings.readDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(10);
+  });
+
+  it('should remove older devices if the total number exceeds 10', async () => {
+    const currentTime = new Date().getTime();
+    const earlierTime = currentTime - 10;
+    const earliestTime = currentTime - 20;
+
+    const devicesInfo = [{ installationId: 'oldest-device', lastUsed: earliestTime }];
+    for (let i = 0; i < 9; i++) {
+      devicesInfo.push({ installationId: `device-id-${i}`, lastUsed: earlierTime });
+    }
+    await ProjectSettings.setDevicesInfoAsync(projectRoot, {
+      devices: devicesInfo,
+    });
+
+    await ProjectSettings.saveDevicesAsync(projectRoot, 'newest-device');
+    const { devices } = await ProjectSettings.readDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(10);
+    expect(devices[0].installationId).toBe('newest-device');
+    expect(devices.some(device => device.installationId === 'oldest-device')).toBe(false);
+  });
+
+  it('should remove any devices last used before 30 days ago', async () => {
+    const currentTime = new Date().getTime();
+    const time30DaysAnd1SecondAgo = currentTime - 30 * 24 * 60 * 60 * 1000 - 1000;
+    await ProjectSettings.setDevicesInfoAsync(projectRoot, {
+      devices: [{ installationId: 'very-old-device-id', lastUsed: time30DaysAnd1SecondAgo }],
+    });
+    await ProjectSettings.saveDevicesAsync(projectRoot, 'new-device-id');
+    const { devices } = await ProjectSettings.readDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(1);
+    expect(devices[0].installationId).toBe('new-device-id');
+  });
+});

--- a/packages/xdl/src/start/ManifestHandler.ts
+++ b/packages/xdl/src/start/ManifestHandler.ts
@@ -174,6 +174,15 @@ export function getManifestHandler(projectRoot: string) {
         })
       );
     }
+
+    try {
+      const deviceIds = req.headers['expo-dev-client-id'];
+      if (deviceIds) {
+        await ProjectSettings.saveDevicesAsync(projectRoot, deviceIds);
+      }
+    } catch (e) {
+      ProjectUtils.logError(projectRoot, 'expo', e.stack);
+    }
   };
 }
 


### PR DESCRIPTION
# Why

closes ENG-1987, closes ENG-1988

In order to make it easier for dev client users to find their development sessions before logging in, we're adding an installation ID flow similar to snack's device ID flow. We generate and persist an ID on the client, and pass it to expo-cli in the first manifest request (via QR code or other method) so expo-cli can persist it locally and include it in future calls to `development-sessions/notify-alive`. This PR adds those two pieces of functionality to expo-cli.

# How

- read a device ID from a manifest request and persist to disk (in `.expo/devices.json` as of now -- but definitely open to renaming/moving this)
- prune old IDs so there is a max of 10 persisted at any one time
- also prune any IDs that haven't been used in 30 days or longer
- start a development session for each device ID if there are any when starting sessions

# Test Plan

Added unit tests for storage and pruning behavior. Also tested manually with dev client from master and local www:
- [x] request manifest with `expo-dev-client-id` header in request -> id is saved to project's `.expo/devices.json` file
- [x] run `expo start --dev-client` with multiple ids in `.expo/devices.json` -> open http://localhost:3000/--/api/v2/development-sessions?deviceId=${id} for each id to verify a session has been started for each one