### PR TITLE
[install-expo-modules] Add expo_patch_react_imports! for sdk 44

### DIFF
--- a/packages/install-expo-modules/src/plugins/ios/__tests__/__snapshots__/withIosModulesPodfile-test.ts.snap
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/__snapshots__/withIosModulesPodfile-test.ts.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withIosModulesPodfile sdkVersion snapshots sdkVersion 43.0.0 1`] = `
+"require File.join(File.dirname(\`node --print \\"require.resolve('expo/package.json')\\"\`), \\"scripts/autolinking\\")
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '10.0'
+
+target 'HelloWorld' do
+  use_expo_modules!
+  config = use_native_modules!
+
+  use_react_native!(:path => config[\\"reactNativePath\\"])
+
+  target 'HelloWorldTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  # Enables Flipper.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work and
+  # you should disable these next few lines.
+  use_flipper!
+  post_install do |installer|
+    flipper_post_install(installer)
+  end
+end
+
+target 'HelloWorld-tvOS' do
+  # Pods for HelloWorld-tvOS
+
+  target 'HelloWorld-tvOSTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+end
+"
+`;
+
+exports[`withIosModulesPodfile sdkVersion snapshots sdkVersion 44.0.0 1`] = `
+"require File.join(File.dirname(\`node --print \\"require.resolve('expo/package.json')\\"\`), \\"scripts/autolinking\\")
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '10.0'
+
+target 'HelloWorld' do
+  use_expo_modules!
+  post_integrate do |installer|
+    expo_patch_react_imports!(installer)
+  end
+  config = use_native_modules!
+
+  use_react_native!(:path => config[\\"reactNativePath\\"])
+
+  target 'HelloWorldTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  # Enables Flipper.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work and
+  # you should disable these next few lines.
+  use_flipper!
+  post_install do |installer|
+    flipper_post_install(installer)
+  end
+end
+
+target 'HelloWorld-tvOS' do
+  # Pods for HelloWorld-tvOS
+
+  target 'HelloWorld-tvOSTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+end
+"
+`;

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile
@@ -1,0 +1,33 @@
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '10.0'
+
+target 'HelloWorld' do
+  config = use_native_modules!
+
+  use_react_native!(:path => config["reactNativePath"])
+
+  target 'HelloWorldTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  # Enables Flipper.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work and
+  # you should disable these next few lines.
+  use_flipper!
+  post_install do |installer|
+    flipper_post_install(installer)
+  end
+end
+
+target 'HelloWorld-tvOS' do
+  # Pods for HelloWorld-tvOS
+
+  target 'HelloWorld-tvOSTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+end

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesPodfile.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesPodfile.ts
@@ -1,5 +1,4 @@
 import { ConfigPlugin, IOSConfig, withDangerousMod } from '@expo/config-plugins';
-import { insertContentsAtOffset } from '@expo/config-plugins/build/utils/commonCodeMod';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
@@ -33,13 +32,8 @@ export function updatePodfile(
 
   // use_expo_modules!
   if (!contents.match(/^\s*use_expo_modules!\s*$/m)) {
-    const targetRegExp = new RegExp(`^\\s*target\\s+['"]${projectName}['"]\\s+do\\s*$`, 'm');
-    const matched = contents.match(targetRegExp);
-    if (!matched) {
-      throw new Error(`Cannot find target at Podfile - targetName[${projectName}]`);
-    }
-    const offset = (matched?.index ?? 0) + matched[0].length;
-    contents = insertContentsAtOffset(contents, '\n  use_expo_modules!', offset);
+    const targetRegExp = new RegExp(`(^\\s*target\\s+['"]${projectName}['"]\\s+do\\s*$)`, 'm');
+    contents = contents.replace(targetRegExp, '$1\n  use_expo_modules!');
   }
 
   // expo_patch_react_imports!

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesPodfile.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesPodfile.ts
@@ -46,6 +46,8 @@ export function updatePodfile(
           '$1\n    expo_patch_react_imports!(installer)'
         );
       } else {
+        // If there's no existing post_integrate hook,
+        // use the `use_expo_modules!` as the insertion anchor.
         contents = contents.replace(
           /(\buse_expo_modules!\n)/gm,
           `$1\

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesPodfile.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesPodfile.ts
@@ -2,6 +2,7 @@ import { ConfigPlugin, IOSConfig, withDangerousMod } from '@expo/config-plugins'
 import { insertContentsAtOffset } from '@expo/config-plugins/build/utils/commonCodeMod';
 import fs from 'fs';
 import path from 'path';
+import semver from 'semver';
 
 const { getProjectName } = IOSConfig.XcodeUtils;
 
@@ -12,7 +13,7 @@ export const withIosModulesPodfile: ConfigPlugin = config => {
       const podfile = path.join(config.modRequest.platformProjectRoot, 'Podfile');
       let contents = await fs.promises.readFile(podfile, 'utf8');
       const projectName = getProjectName(config.modRequest.projectRoot);
-      contents = updatePodfile(contents, projectName);
+      contents = updatePodfile(contents, projectName, config.sdkVersion);
 
       await fs.promises.writeFile(podfile, contents);
       return config;
@@ -20,11 +21,17 @@ export const withIosModulesPodfile: ConfigPlugin = config => {
   ]);
 };
 
-export function updatePodfile(contents: string, projectName: string): string {
+export function updatePodfile(
+  contents: string,
+  projectName: string,
+  sdkVersion: string | undefined
+): string {
+  // require autolinking module
   if (!contents.match(/^require.+'expo\/package\.json.+scripts\/autolinking/m)) {
     contents = `require File.join(File.dirname(\`node --print "require.resolve('expo/package.json')"\`), "scripts/autolinking")\n${contents}`;
   }
 
+  // use_expo_modules!
   if (!contents.match(/^\s*use_expo_modules!\s*$/m)) {
     const targetRegExp = new RegExp(`^\\s*target\\s+['"]${projectName}['"]\\s+do\\s*$`, 'm');
     const matched = contents.match(targetRegExp);
@@ -33,6 +40,27 @@ export function updatePodfile(contents: string, projectName: string): string {
     }
     const offset = (matched?.index ?? 0) + matched[0].length;
     contents = insertContentsAtOffset(contents, '\n  use_expo_modules!', offset);
+  }
+
+  // expo_patch_react_imports!
+  if (sdkVersion && semver.gte(sdkVersion, '44.0.0')) {
+    if (!contents.match(/\bexpo_patch_react_imports!\(installer\)\b/)) {
+      const regExpPostIntegrate = /(\bpost_integrate do \|installer\|)/;
+      if (contents.match(regExpPostIntegrate)) {
+        contents = contents.replace(
+          regExpPostIntegrate,
+          '$1\n    expo_patch_react_imports!(installer)'
+        );
+      } else {
+        contents = contents.replace(
+          /(\buse_expo_modules!\n)/gm,
+          `$1\
+  post_integrate do |installer|
+    expo_patch_react_imports!(installer)
+  end\n`
+        );
+      }
+    }
   }
 
   return contents;


### PR DESCRIPTION
# Why

Support https://github.com/expo/expo/pull/15655

# How

when the target installation is sdk 44 or above, insert `expo_patch_react_imports!(installer)` inside the `post_integrate do |installer|` block. if there's no existing post_integrate hook, append one right after `use_expo_modules!`

# Test Plan

# Unit Test

```
 PASS   install-expo-modules  src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
  updatePodfile
    ✓ should support classic rn podfile (14 ms)
    ✓ minimum support for existing post_integrate hook (1 ms)
  withIosModulesPodfile sdkVersion snapshots
    ✓ sdkVersion 43.0.0 (1 ms)
    ✓ sdkVersion 44.0.0
```