### PR TITLE
[expo-cli] deprecate unused `expo start` options

### DIFF
--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -13,19 +13,19 @@ export default (program: any) => {
     .option('-c, --clear', 'Clear the Metro bundler cache')
     // TODO(anp) set a default for this dynamically based on whether we're inside a container?
     .option('--max-workers <num>', 'Maximum number of tasks to allow Metro to spawn.')
-    .option('--dev', deprecatedHelp('dev mode is used by default'))
     .option('--no-dev', 'Turn development mode off')
     .option('--minify', 'Minify code')
-    .option('--no-minify', deprecatedHelp('minify is disabled by default'))
     .option('--https', 'To start webpack with https protocol')
     .option('--force-manifest-type <manifest-type>', 'Override auto detection of manifest type')
     .option(
       '-p, --port <port>',
       'Port to start the native Metro bundler on (does not apply to web or tunnel). Default: 19000'
     )
-    .option('--no-https', deprecatedHelp('http is used by default'))
     .urlOpts()
     .allowOffline()
+    .option('--dev', deprecatedHelp('Dev mode is used by default'))
+    .option('--no-minify', deprecatedHelp('Minify is disabled by default'))
+    .option('--no-https', deprecatedHelp('https is disabled by default'))
     .asyncActionProjectDir(
       async (projectRoot: string, options: RawStartOptions): Promise<void> => {
         const { normalizeOptionsAsync } = await import('./start/parseStartOptions');
@@ -40,17 +40,17 @@ export default (program: any) => {
     .alias('web')
     .description('Start a Webpack dev server for the web app')
     .helpGroup('core')
-    .option('--dev', deprecatedHelp('dev mode is used by default'))
     .option('--no-dev', 'Turn development mode off')
     .option('--minify', 'Minify code')
-    .option('--no-minify', deprecatedHelp('minify is disabled by default'))
     .option('--https', 'To start webpack with https protocol')
-    .option('--no-https', deprecatedHelp('http is used by default'))
     .option('--force-manifest-type <manifest-type>', 'Override auto detection of manifest type')
     .option('-p, --port <port>', 'Port to start the Webpack bundler on. Default: 19006')
     .option('-s, --send-to [dest]', 'An email address to send a link to')
     .urlOpts()
     .allowOffline()
+    .option('--dev', deprecatedHelp('Dev mode is used by default'))
+    .option('--no-minify', deprecatedHelp('Minify is disabled by default'))
+    .option('--no-https', deprecatedHelp('https is disabled by default'))
     .asyncActionProjectDir(
       async (projectRoot: string, options: RawStartOptions): Promise<void> => {
         const { normalizeOptionsAsync } = await import('./start/parseStartOptions');

--- a/packages/expo-cli/src/commands/start.ts
+++ b/packages/expo-cli/src/commands/start.ts
@@ -1,6 +1,9 @@
+import chalk from 'chalk';
+
 import type { RawStartOptions } from './start/parseStartOptions';
 
 export default (program: any) => {
+  const deprecatedHelp = (value: string) => chalk.yellow`Deprecated: ` + value;
   program
     .command('start [path]')
     .alias('r')
@@ -10,17 +13,17 @@ export default (program: any) => {
     .option('-c, --clear', 'Clear the Metro bundler cache')
     // TODO(anp) set a default for this dynamically based on whether we're inside a container?
     .option('--max-workers <num>', 'Maximum number of tasks to allow Metro to spawn.')
-    .option('--dev', 'Turn development mode on')
+    .option('--dev', deprecatedHelp('dev mode is used by default'))
     .option('--no-dev', 'Turn development mode off')
     .option('--minify', 'Minify code')
-    .option('--no-minify', 'Do not minify code')
+    .option('--no-minify', deprecatedHelp('minify is disabled by default'))
     .option('--https', 'To start webpack with https protocol')
     .option('--force-manifest-type <manifest-type>', 'Override auto detection of manifest type')
     .option(
       '-p, --port <port>',
       'Port to start the native Metro bundler on (does not apply to web or tunnel). Default: 19000'
     )
-    .option('--no-https', 'To start webpack with http protocol')
+    .option('--no-https', deprecatedHelp('http is used by default'))
     .urlOpts()
     .allowOffline()
     .asyncActionProjectDir(
@@ -37,12 +40,12 @@ export default (program: any) => {
     .alias('web')
     .description('Start a Webpack dev server for the web app')
     .helpGroup('core')
-    .option('--dev', 'Turn development mode on')
+    .option('--dev', deprecatedHelp('dev mode is used by default'))
     .option('--no-dev', 'Turn development mode off')
     .option('--minify', 'Minify code')
-    .option('--no-minify', 'Do not minify code')
+    .option('--no-minify', deprecatedHelp('minify is disabled by default'))
     .option('--https', 'To start webpack with https protocol')
-    .option('--no-https', 'To start webpack with http protocol')
+    .option('--no-https', deprecatedHelp('http is used by default'))
     .option('--force-manifest-type <manifest-type>', 'Override auto detection of manifest type')
     .option('-p, --port <port>', 'Port to start the Webpack bundler on. Default: 19006')
     .option('-s, --send-to [dest]', 'An email address to send a link to')

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig, isLegacyImportsEnabled } from '@expo/config';
+import chalk from 'chalk';
 import { Project, ProjectSettings, Versions, Webpack } from 'xdl';
 import * as WebpackEnvironment from 'xdl/build/webpack-utils/WebpackEnvironment';
 
@@ -56,6 +57,21 @@ export function setBooleanArg(
   }
 }
 
+// TODO: Deprecate these features sometime around the versioned migration.
+function warnUsingDeprecatedArgs(rawArgs: string[]) {
+  const deprecatedArgs = [
+    ['--no-https', 'Https is disabled by default.'],
+    ['--no-minify', 'Minify is disabled by default.'],
+    ['--dev', 'Dev is enabled by default.'],
+  ];
+
+  for (const [arg, message] of deprecatedArgs) {
+    if (rawArgs.includes(arg)) {
+      Log.warn(`\u203A The ${chalk.bold(arg)} flag is deprecated. ${message}`);
+    }
+  }
+}
+
 // The main purpose of this function is to take existing options object and
 // support boolean args with as defined in the hasBooleanArg and getBooleanArg
 // functions.
@@ -64,7 +80,7 @@ export async function normalizeOptionsAsync(
   options: RawStartOptions
 ): Promise<NormalizedOptions> {
   const rawArgs = options.parent?.rawArgs || [];
-
+  warnUsingDeprecatedArgs(rawArgs);
   const opts = parseRawArguments(options, rawArgs);
 
   if (options.webOnly) {


### PR DESCRIPTION
# Why

Expo CLI used to persist options across runs, for example:
1. `expo start` app starts in dev mode.
2. `expo start --no-dev` app starts in prod mode.
3. `expo start` app starts in prod mode again.

As a result, we needed to add a bunch of redundant flags to reset the persisted settings. This was a bit unfortunate for DX so we removed persistence when adding web support, now we're deprecating the unused flags. We can remove them in the future when migrating to `npx expo start`.

- Partially resolves ENG-2759

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How
<img width="486" alt="Screen Shot 2021-12-22 at 12 44 57 PM" src="https://user-images.githubusercontent.com/9664363/147148511-aa3dba58-617c-4821-9517-b600088028a6.png">
<img width="774" alt="Screen Shot 2021-12-22 at 12 45 52 PM" src="https://user-images.githubusercontent.com/9664363/147148514-e6e06e02-eca9-4a80-bfed-3fd433b43499.png">

# Test Plan


- `expo start --no-https --no-minify --dev` same with `expo web` and `expo start:web`
- `expo start -h`