### PR TITLE
@davidtedmanjones/configure dev server body parser limit

### DIFF
--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -162,6 +162,15 @@ export interface ExpoConfig {
     silentLaunch?: boolean;
   };
   /**
+   * Configuration for dev-server package
+   */
+  devServer?: {
+    /**
+     * DevServerMiddleware option - Override for default body-parser raw-body limit for json()
+     */
+    bodyParserLimit?: string | number;
+  };
+  /**
    * **Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped.
    */
   scheme?: string;

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -24,6 +24,7 @@ export type MetroDevServerOptions = LoadOptions & {
   logger: Log;
   quiet?: boolean;
   unversioned?: boolean;
+  bodyParserLimit?: string | number;
 };
 export type BundleOptions = {
   entryPoint: string;

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -89,6 +89,7 @@ export async function runMetroDevServerAsync(
     port: metroConfig.server.port,
     watchFolders: metroConfig.watchFolders,
     logger: options.logger,
+    bodyParserLimit: options.bodyParserLimit,
   });
 
   const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;

--- a/packages/dev-server/src/middleware/devServerMiddleware.ts
+++ b/packages/dev-server/src/middleware/devServerMiddleware.ts
@@ -42,7 +42,7 @@ export function createDevServerMiddleware({
   watchFolders: readonly string[];
   port: number;
   logger: Log;
-  bodyParserLimit: string | number;
+  bodyParserLimit?: string | number;
 }): { middleware: ConnectServer; attachToServer: AttachToServerFunction; logger: Log } {
   const { middleware, attachToServer } = createReactNativeDevServerMiddleware({
     port,

--- a/packages/dev-server/src/middleware/devServerMiddleware.ts
+++ b/packages/dev-server/src/middleware/devServerMiddleware.ts
@@ -37,10 +37,12 @@ export function createDevServerMiddleware({
   watchFolders,
   port,
   logger,
+  bodyParserLimit,
 }: {
   watchFolders: readonly string[];
   port: number;
   logger: Log;
+  bodyParserLimit: string | number;
 }): { middleware: ConnectServer; attachToServer: AttachToServerFunction; logger: Log } {
   const { middleware, attachToServer } = createReactNativeDevServerMiddleware({
     port,
@@ -57,7 +59,7 @@ export function createDevServerMiddleware({
   middleware.use(remoteDevtoolsCorsMiddleware);
   prependMiddleware(middleware, suppressRemoteDebuggingErrorMiddleware);
 
-  middleware.use(bodyParser.json());
+  middleware.use(bodyParser.json({ limit: bodyParserLimit }));
   middleware.use('/logs', clientLogsMiddleware(logger));
   middleware.use('/inspector', createJsInspectorMiddleware());
 

--- a/packages/xdl/src/start/startDevServerAsync.ts
+++ b/packages/xdl/src/start/startDevServerAsync.ts
@@ -74,6 +74,11 @@ export async function startDevServerAsync(
   options.unversioned =
     !projectConfig.exp.sdkVersion || projectConfig.exp.sdkVersion === 'UNVERSIONED';
 
+  // Override for default body-parser raw-body limit for json()
+  if (projectConfig.exp.devServer?.bodyParserLimit) {
+    options.bodyParserLimit = projectConfig.exp.devServer.bodyParserLimit;
+  }
+
   const { server, middleware, messageSocket } = await runMetroDevServerAsync(projectRoot, options);
 
   const useExpoUpdatesManifest = startOptions.forceManifestType === 'expo-updates';


### PR DESCRIPTION
# Why
`PayloadTooLargeError` (see Issue https://github.com/expo/expo-cli/issues/3051) occurs when fetch post request response bodies are in excess of the default body-parser size limit i.e. 102400 bytes (100kb). 

This has been an ongoing issue - with console.log max string length being the attributed cause of error. It is however at least additionally due to the body-parser raw-body limit.

# How

The proposed change is to allow the body-parser limit to be configured via expo Config - app.config.js which will feed through to the expo dev-server body-parser middleware - specifically the body-parser json([options]) function.

# Test Plan
 
To check that the `bodyParserLimit` value is being propagated through to where it needs to be - set a very small value on the `bodyParserLimit` override and run a fetch post request i.e. Add `devServer: { bodyParserLimit: '1kb' }` to app.config.js - which should more than likely result in a PayloadTooLargeError. Then set a larger value i.e. `50mb` and see that the error no longer appears.