### PR TITLE
[plist] Skip plist keys if value is undefined

### DIFF
--- a/packages/plist/__tests__/build-test.ts
+++ b/packages/plist/__tests__/build-test.ts
@@ -142,9 +142,7 @@ describe('plist', function () {
         `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>a</key>
-  </dict>
+  <dict/>
 </plist>`
       );
     });

--- a/packages/plist/src/build.ts
+++ b/packages/plist/src/build.ts
@@ -126,7 +126,7 @@ function walk_obj(next: any, next_child: any): void {
   } else if (name == 'Object') {
     next_child = next_child.ele('dict');
     for (prop in next) {
-      if (next.hasOwnProperty(prop)) {
+      if (next.hasOwnProperty(prop) && next[prop] !== undefined) {
         next_child.ele('key').txt(prop);
         walk_obj(next[prop], next_child);
       }


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/860

```
  'com.apple.developer.icloud-container-environment': undefined,
  'com.apple.developer.icloud-container-identifiers': [ 'iCloud.bundle.identifier' ],
```
is serialized to 

```
    <key>com.apple.developer.icloud-container-environment</key>
    <key>com.apple.developer.icloud-container-identifiers</key>
    <array>
      <string>iCloud.bundle.identifier</string>
    </array>
 ```
 
 build does not fail, but error `Unexpected key "com.apple.developer.icloud-container-identifiers" while parsing <dict/>.` is displayed

I did not find any documentation that clarifies if this is valid format for plist, but based on the error at least fastlane does not allow it

# How

skip key if undefined

# Test Plan

run prebuild