### PR TITLE
[expo-cli] Refactor chalk imports

### DIFF
--- a/packages/expo-cli/src/commands/auth/accounts.ts
+++ b/packages/expo-cli/src/commands/auth/accounts.ts
@@ -137,8 +137,8 @@ export async function login(options: CommandOptions): Promise<User> {
 async function _promptForOTPAsync(cancelBehavior: 'cancel' | 'menu'): Promise<string | null> {
   const enterMessage =
     cancelBehavior === 'cancel'
-      ? `press ${Log.chalk.bold('Enter')} to cancel`
-      : `press ${Log.chalk.bold('Enter')} for more options`;
+      ? `press ${chalk.bold('Enter')} to cancel`
+      : `press ${chalk.bold('Enter')} for more options`;
   const otpQuestion: NewQuestion = {
     type: 'text',
     name: 'otp',

--- a/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
+++ b/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
@@ -1,12 +1,12 @@
 import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
 import chalk from 'chalk';
-import program from 'commander';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import Log from '../../log';
 import { logNewSection } from '../../utils/ora';
 import { confirmAsync } from '../../utils/prompts';
+import { isNonInteractive } from '../utils/environment';
 
 export async function directoryExistsAsync(file: string): Promise<boolean> {
   return (await fs.stat(file).catch(() => null))?.isDirectory() ?? false;
@@ -97,7 +97,7 @@ export async function promptToClearMalformedNativeProjectsAsync(
   if (
     // If the process is non-interactive, default to clearing the malformed native project.
     // This would only happen on re-running eject.
-    program.nonInteractive ||
+    isNonInteractive() ||
     // Prompt to clear the native folders.
     (await confirmAsync({
       message: `${message}, would you like to clear the project files and reinitialize them?`,

--- a/packages/expo-cli/src/commands/eject/createNativeProjectsFromTemplateAsync.ts
+++ b/packages/expo-cli/src/commands/eject/createNativeProjectsFromTemplateAsync.ts
@@ -131,14 +131,14 @@ async function cloneNativeDirectoriesAsync({
     let message = `Created native project${platforms.length > 1 ? 's' : ''}`;
 
     if (skippedPaths.length) {
-      message += Log.chalk.dim(
-        ` | ${skippedPaths.map(path => Log.chalk.bold(`/${path}`)).join(', ')} already created`
+      message += chalk.dim(
+        ` | ${skippedPaths.map(path => chalk.bold(`/${path}`)).join(', ')} already created`
       );
     }
     if (!results?.didMerge) {
-      message += Log.chalk.dim(` | gitignore already synced`);
+      message += chalk.dim(` | gitignore already synced`);
     } else if (results.didMerge && results.didClear) {
-      message += Log.chalk.dim(` | synced gitignore`);
+      message += chalk.dim(` | synced gitignore`);
     }
     creatingNativeProjectStep.succeed(message);
   } catch (e) {

--- a/packages/expo-cli/src/commands/eject/ejectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/ejectAsync.ts
@@ -4,6 +4,7 @@ import { Versions } from 'xdl';
 import CommandError from '../../CommandError';
 import Log from '../../log';
 import { confirmAsync } from '../../utils/prompts';
+import { usesOldExpoUpdatesAsync } from '../utils/ProjectUtils';
 import maybeBailOnGitStatusAsync from '../utils/maybeBailOnGitStatusAsync';
 import { promptToClearMalformedNativeProjectsAsync } from './clearNativeFolder';
 import { logNextSteps } from './logNextSteps';
@@ -35,7 +36,8 @@ async function ejectAsync(
   await promptToClearMalformedNativeProjectsAsync(projectRoot, platforms);
 
   const results = await prebuildAsync(projectRoot, { platforms, ...options });
-  logNextSteps(results);
+  const legacyUpdates = await usesOldExpoUpdatesAsync(projectRoot);
+  logNextSteps(results, { legacyUpdates });
 }
 
 export async function actionAsync(

--- a/packages/expo-cli/src/commands/eject/logNextSteps.ts
+++ b/packages/expo-cli/src/commands/eject/logNextSteps.ts
@@ -5,22 +5,23 @@ import Log from '../../log';
 import { learnMore } from '../utils/TerminalLink';
 import { PrebuildResults } from './prebuildAppAsync';
 
-export function logNextSteps({
-  hasAssetBundlePatterns,
-  hasNewProjectFiles,
-  legacyUpdates,
-  platforms,
-  podInstall,
-  nodeInstall,
-  packageManager,
-}: PrebuildResults) {
+export function logNextSteps(
+  { exp, hasNewProjectFiles, platforms, podInstall, nodeInstall, packageManager }: PrebuildResults,
+  {
+    legacyUpdates,
+  }: {
+    legacyUpdates: boolean;
+  }
+) {
+  const hasAssetBundlePatterns = exp.hasOwnProperty('assetBundlePatterns');
+
   Log.newLine();
   Log.nested(`➡️  ${chalk.bold('Next steps')}`);
 
   // Log a warning about needing to install node modules
   if (nodeInstall) {
     const installCmd = packageManager === 'npm' ? 'npm install' : 'yarn';
-    Log.nested(`\u203A ⚠️  Install node modules: ${Log.chalk.bold(installCmd)}`);
+    Log.nested(`\u203A ⚠️  Install node modules: ${chalk.bold(installCmd)}`);
   }
   if (podInstall) {
     Log.nested(
@@ -44,7 +45,7 @@ export function logNextSteps({
     Log.nested(
       `\u203A 📁 The property ${chalk.bold(
         `assetBundlePatterns`
-      )} does not have the same effect in the bare workflow.\n  ${Log.chalk.dim(
+      )} does not have the same effect in the bare workflow.\n  ${chalk.dim(
         learnMore('https://docs.expo.dev/bare/updating-your-app/#embedding-assets')
       )}`
     );
@@ -62,7 +63,7 @@ export function logNextSteps({
         })
       } has been configured in your project. Before you do a release build, make sure you run ${chalk.bold(
         'expo publish'
-      )}. ${Log.chalk.dim(learnMore('https://expo.fyi/release-builds-with-expo-updates'))}`
+      )}. ${chalk.dim(learnMore('https://expo.fyi/release-builds-with-expo-updates'))}`
     );
   }
 

--- a/packages/expo-cli/src/commands/eject/prebuildAppAsync.ts
+++ b/packages/expo-cli/src/commands/eject/prebuildAppAsync.ts
@@ -5,7 +5,6 @@ import temporary from 'tempy';
 import Log from '../../log';
 import { logNewSection } from '../../utils/ora';
 import * as CreateApp from '../utils/CreateApp';
-import { usesOldExpoUpdatesAsync } from '../utils/ProjectUtils';
 import configureProjectAsync from './configureProjectAsync';
 import { createNativeProjectsFromTemplateAsync } from './createNativeProjectsFromTemplateAsync';
 import { ensureConfigAsync } from './ensureConfigAsync';
@@ -25,8 +24,7 @@ export type EjectAsyncOptions = {
 };
 
 export type PrebuildResults = {
-  hasAssetBundlePatterns: boolean;
-  legacyUpdates: boolean;
+  exp: ExpoConfig;
   hasNewProjectFiles: boolean;
   platforms: ModPlatform[];
   podInstall: boolean;
@@ -116,9 +114,8 @@ export async function prebuildAsync(
     packageManager,
     nodeInstall: options.install === false,
     podInstall: !podsInstalled,
-    legacyUpdates: await usesOldExpoUpdatesAsync(projectRoot),
     platforms,
     hasNewProjectFiles,
-    hasAssetBundlePatterns: exp.hasOwnProperty('assetBundlePatterns'),
+    exp,
   };
 }

--- a/packages/expo-cli/src/commands/eject/setupWarnings.ts
+++ b/packages/expo-cli/src/commands/eject/setupWarnings.ts
@@ -56,7 +56,7 @@ export function getSetupWarnings({
       'Constants.manifest'
     )} is not available in the bare workflow. You should replace it with ${chalk.bold(
       'Updates.manifest'
-    )}. ${Log.chalk.dim(
+    )}. ${chalk.dim(
       learnMore('https://docs.expo.dev/versions/latest/sdk/updates/#updatesmanifest')
     )}`;
   }

--- a/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
+++ b/packages/expo-cli/src/commands/eject/writeMetroConfig.ts
@@ -60,7 +60,7 @@ export function writeMetroConfig({
     Log.nested(
       `\u203A You will need to extend the default ${chalk.bold(
         '@expo/metro-config'
-      )} in your Metro config.\n  ${Log.chalk.dim(
+      )} in your Metro config.\n  ${chalk.dim(
         learnMore('https://docs.expo.dev/guides/customizing-metro')
       )}`
     );

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -136,9 +136,9 @@ async function resolveProjectRootAsync(input?: string): Promise<string> {
     const message = [
       '',
       'Please choose your app name:',
-      `  ${Log.chalk.green(`${program.name()} init`)} ${Log.chalk.cyan('<app-name>')}`,
+      `  ${chalk.green(`${program.name()} init`)} ${chalk.cyan('<app-name>')}`,
       '',
-      `Run ${Log.chalk.green(`${program.name()} init --help`)} for more info`,
+      `Run ${chalk.green(`${program.name()} init --help`)} for more info`,
       '',
     ].join('\n');
     Log.nested(message);

--- a/packages/expo-cli/src/commands/installAsync.ts
+++ b/packages/expo-cli/src/commands/installAsync.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@expo/config';
 import * as PackageManager from '@expo/package-manager';
+import chalk from 'chalk';
 import npmPackageArg from 'npm-package-arg';
 import resolveFrom from 'resolve-from';
 import { Versions } from 'xdl';
@@ -24,7 +25,7 @@ async function resolveExpoProjectRootAsync() {
     Log.addNewLineIfNone();
     Log.error(error.message);
     Log.newLine();
-    Log.log(Log.chalk.cyan(`You can create a new project with ${Log.chalk.bold(`expo init`)}`));
+    Log.log(chalk.cyan(`You can create a new project with ${chalk.bold(`expo init`)}`));
     Log.newLine();
     throw new SilentError(error);
   }
@@ -59,22 +60,22 @@ export async function actionAsync(
   if (!exp.sdkVersion) {
     Log.addNewLineIfNone();
     throw new CommandError(
-      `The ${Log.chalk.bold(`expo`)} package was found in your ${Log.chalk.bold(
+      `The ${chalk.bold(`expo`)} package was found in your ${chalk.bold(
         `package.json`
-      )} but we couldn't resolve the Expo SDK version. Run ${Log.chalk.bold(
+      )} but we couldn't resolve the Expo SDK version. Run ${chalk.bold(
         `${packageManager.name.toLowerCase()} install`
       )} and then try this command again.\n`
     );
   }
 
   if (!Versions.gteSdkVersion(exp, '33.0.0')) {
-    const message = `${Log.chalk.bold(
+    const message = `${chalk.bold(
       `expo install`
     )} is only available for Expo SDK version 33 or higher.`;
     Log.addNewLineIfNone();
     Log.error(message);
     Log.newLine();
-    Log.log(Log.chalk.cyan(`Current version: ${Log.chalk.bold(exp.sdkVersion)}`));
+    Log.log(chalk.cyan(`Current version: ${chalk.bold(exp.sdkVersion)}`));
     Log.newLine();
     throw new SilentError(message);
   }
@@ -83,9 +84,7 @@ export async function actionAsync(
   // Every React project should have react installed...
   if (!resolveFrom.silent(projectRoot, 'react')) {
     Log.addNewLineIfNone();
-    Log.log(
-      Log.chalk.cyan(`node_modules not found, running ${packageManager.name} install command.`)
-    );
+    Log.log(chalk.cyan(`node_modules not found, running ${packageManager.name} install command.`));
     Log.newLine();
     await packageManager.installAsync();
   }

--- a/packages/expo-cli/src/commands/publish/publishAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishAsync.ts
@@ -63,14 +63,14 @@ export async function actionAsync(
   // Log building info before building.
   // This gives the user sometime to bail out if the info is unexpected.
   if (runtimeVersion) {
-    Log.log(`\u203A Runtime version: ${Log.chalk.bold(runtimeVersion)}`);
+    Log.log(`\u203A Runtime version: ${chalk.bold(runtimeVersion)}`);
   } else if (sdkVersion) {
-    Log.log(`\u203A Expo SDK: ${Log.chalk.bold(sdkVersion)}`);
+    Log.log(`\u203A Expo SDK: ${chalk.bold(sdkVersion)}`);
   }
-  Log.log(`\u203A Release channel: ${Log.chalk.bold(options.releaseChannel)}`);
-  Log.log(`\u203A Workflow: ${Log.chalk.bold(target.replace(/\b\w/g, l => l.toUpperCase()))}`);
+  Log.log(`\u203A Release channel: ${chalk.bold(options.releaseChannel)}`);
+  Log.log(`\u203A Workflow: ${chalk.bold(target.replace(/\b\w/g, l => l.toUpperCase()))}`);
   if (user.kind === 'robot') {
-    Log.log(`\u203A Owner: ${Log.chalk.bold(owner)}`);
+    Log.log(`\u203A Owner: ${chalk.bold(owner)}`);
   }
 
   Log.newLine();
@@ -183,7 +183,7 @@ function logManifestUrl({
 }) {
   const manifestUrl = getExampleManifestUrl(url, { sdkVersion, runtimeVersion }) ?? url;
   Log.log(
-    `📝  Manifest: ${Log.chalk.bold(TerminalLink.fallbackToUrl(url, manifestUrl))} ${Log.chalk.dim(
+    `📝  Manifest: ${chalk.bold(TerminalLink.fallbackToUrl(url, manifestUrl))} ${chalk.dim(
       TerminalLink.learnMore('https://expo.fyi/manifest-url')
     )}`
   );
@@ -201,14 +201,12 @@ function logProjectPageUrl({
   url: string;
   copiedToClipboard: boolean;
 }) {
-  let productionMessage = `⚙️   Project page: ${Log.chalk.bold(
-    TerminalLink.fallbackToUrl(url, url)
-  )}`;
+  let productionMessage = `⚙️   Project page: ${chalk.bold(TerminalLink.fallbackToUrl(url, url))}`;
 
   if (copiedToClipboard) {
-    productionMessage += ` ${Log.chalk.gray(`[copied to clipboard]`)}`;
+    productionMessage += ` ${chalk.gray(`[copied to clipboard]`)}`;
   }
-  productionMessage += ` ${Log.chalk.dim(TerminalLink.learnMore('https://expo.fyi/project-page'))}`;
+  productionMessage += ` ${chalk.dim(TerminalLink.learnMore('https://expo.fyi/project-page'))}`;
 
   Log.log(productionMessage);
 }

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -68,7 +68,7 @@ export async function assertFolderEmptyAsync({
   const conflicts = getConflictsForDirectory(projectRoot);
   if (conflicts.length) {
     Log.addNewLineIfNone();
-    Log.nested(`The directory ${Log.chalk.green(folderName)} has files that might be overwritten:`);
+    Log.nested(`The directory ${chalk.green(folderName)} has files that might be overwritten:`);
     Log.newLine();
     for (const file of conflicts) {
       Log.nested(`  ${file}`);
@@ -76,7 +76,7 @@ export async function assertFolderEmptyAsync({
 
     if (overwrite) {
       Log.newLine();
-      Log.nested(`Removing existing files from ${Log.chalk.green(folderName)}`);
+      Log.nested(`Removing existing files from ${chalk.green(folderName)}`);
       await Promise.all(conflicts.map(conflict => fs.remove(path.join(projectRoot, conflict))));
       return true;
     }
@@ -188,7 +188,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
     } catch (e) {
       step.stopAndPersist({
         symbol: '⚠️ ',
-        text: Log.chalk.red('Unable to install the CocoaPods CLI.'),
+        text: chalk.red('Unable to install the CocoaPods CLI.'),
       });
       if (e instanceof PackageManager.CocoaPodsError) {
         Log.log(e.message);
@@ -208,7 +208,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
   } catch (e) {
     step.stopAndPersist({
       symbol: '⚠️ ',
-      text: Log.chalk.red('Something went wrong running `pod install` in the `ios` directory.'),
+      text: chalk.red('Something went wrong running `pod install` in the `ios` directory.'),
     });
     if (e instanceof PackageManager.CocoaPodsError) {
       Log.log(e.message);

--- a/packages/expo-cli/src/commands/utils/TerminalLink.ts
+++ b/packages/expo-cli/src/commands/utils/TerminalLink.ts
@@ -1,6 +1,5 @@
+import chalk from 'chalk';
 import terminalLink from 'terminal-link';
-
-import Log from '../../log';
 
 /**
  * When linking isn't available, fallback to displaying the URL beside the
@@ -39,15 +38,15 @@ export function fallbackToUrl(text: string, url: string): string {
  * @param url
  */
 export function learnMore(url: string): string {
-  return terminalLink(Log.chalk.underline('Learn more.'), url, {
-    fallback: (text, url) => `Learn more: ${Log.chalk.underline(url)}`,
+  return terminalLink(chalk.underline('Learn more.'), url, {
+    fallback: (text, url) => `Learn more: ${chalk.underline(url)}`,
   });
 }
 
 export function linkedText(text: string, url: string): string {
   return terminalLink(text, url, {
     fallback: (text, url) => {
-      return `${text} ${Log.chalk.dim.underline(url)}`;
+      return `${text} ${chalk.dim.underline(url)}`;
     },
   });
 }

--- a/packages/expo-cli/src/commands/utils/bundledNativeModules.ts
+++ b/packages/expo-cli/src/commands/utils/bundledNativeModules.ts
@@ -1,4 +1,5 @@
 import JsonFile from '@expo/json-file';
+import chalk from 'chalk';
 import resolveFrom from 'resolve-from';
 import { ApiV2 } from 'xdl';
 
@@ -30,9 +31,9 @@ export async function getBundledNativeModulesAsync(
       return await getBundledNativeModulesFromApiAsync(sdkVersion);
     } catch {
       Log.warn(
-        `Unable to reach Expo servers. Falling back to using the cached dependency map (${Log.chalk.bold(
+        `Unable to reach Expo servers. Falling back to using the cached dependency map (${chalk.bold(
           'bundledNativeModules.json'
-        )}) from the package "${Log.chalk.bold`expo`}" installed in your project.`
+        )}) from the package "${chalk.bold`expo`}" installed in your project.`
       );
       return await getBundledNativeModulesFromExpoPackageAsync(projectRoot);
     }
@@ -83,10 +84,9 @@ async function getBundledNativeModulesFromExpoPackageAsync(
   if (!bundledNativeModulesPath) {
     Log.addNewLineIfNone();
     throw new CommandError(
-      `The dependency map ${Log.chalk.bold(
+      `The dependency map ${chalk.bold(
         `expo/bundledNativeModules.json`
-      )} cannot be found, please ensure you have the package "${Log.chalk
-        .bold`expo`}" installed in your project.\n`
+      )} cannot be found, please ensure you have the package "${chalk.bold`expo`}" installed in your project.\n`
     );
   }
   return await JsonFile.readAsync<BundledNativeModules>(bundledNativeModulesPath);

--- a/packages/expo-cli/src/commands/utils/environment.ts
+++ b/packages/expo-cli/src/commands/utils/environment.ts
@@ -1,0 +1,5 @@
+import program from 'commander';
+
+export function isNonInteractive() {
+  return program.nonInteractive;
+}

--- a/packages/expo-cli/src/commands/utils/getOrPromptApplicationId.ts
+++ b/packages/expo-cli/src/commands/utils/getOrPromptApplicationId.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '@expo/config';
+import chalk from 'chalk';
 import { UserManager } from 'xdl';
 
 import CommandError from '../../CommandError';
@@ -44,7 +45,7 @@ export async function getOrPromptForBundleIdentifier(projectRoot: string): Promi
 
   Log.addNewLineIfNone();
   Log.log(
-    `${Log.chalk.bold(`📝  iOS Bundle Identifier`)} ${Log.chalk.dim(
+    `${chalk.bold(`📝  iOS Bundle Identifier`)} ${chalk.dim(
       learnMore('https://expo.fyi/bundle-identifier')
     )}`
   );
@@ -125,7 +126,7 @@ export async function getOrPromptForPackage(projectRoot: string): Promise<string
 
   Log.addNewLineIfNone();
   Log.log(
-    `${Log.chalk.bold(`📝  Android package`)} ${Log.chalk.dim(
+    `${chalk.bold(`📝  Android package`)} ${chalk.dim(
       learnMore('https://expo.fyi/android-package')
     )}`
   );

--- a/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/logConfigWarnings.ts
@@ -1,11 +1,10 @@
 import chalk from 'chalk';
 
-import Log from '../../log';
 import * as TerminalLink from './TerminalLink';
 
 export function formatNamedWarning(property: string, warning: string, link?: string) {
   return `- ${chalk.bold(property)}: ${warning}${
-    link ? getSpacer(warning) + Log.chalk.dim(TerminalLink.learnMore(link)) : ''
+    link ? getSpacer(warning) + chalk.dim(TerminalLink.learnMore(link)) : ''
   }`;
 }
 

--- a/packages/expo-cli/src/commands/utils/modifyConfigAsync.ts
+++ b/packages/expo-cli/src/commands/utils/modifyConfigAsync.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig, modifyConfigAsync } from '@expo/config';
+import chalk from 'chalk';
 
 import { SilentError } from '../../CommandError';
 import Log from '../../log';
@@ -20,9 +21,8 @@ export async function attemptModification(
 
 function logNoConfig() {
   Log.log(
-    Log.chalk.yellow(
-      `No Expo config was found. Please create an Expo config (${Log.chalk.bold`app.json`} or ${Log
-        .chalk.bold`app.config.js`}) in your project root.`
+    chalk.yellow(
+      `No Expo config was found. Please create an Expo config (${chalk.bold`app.json`} or ${chalk.bold`app.config.js`}) in your project root.`
     )
   );
 }
@@ -55,7 +55,7 @@ export function warnAboutConfigAndThrow(type: string, message: string, edits: Pa
   Log.addNewLineIfNone();
   if (type === 'warn') {
     // The project is using a dynamic config, give the user a helpful log and bail out.
-    Log.log(Log.chalk.yellow(message));
+    Log.log(chalk.yellow(message));
   } else {
     logNoConfig();
   }
@@ -65,7 +65,7 @@ export function warnAboutConfigAndThrow(type: string, message: string, edits: Pa
 }
 
 function notifyAboutManualConfigEdits(edits: Partial<ExpoConfig>) {
-  Log.log(Log.chalk.cyan(`Please add the following to your Expo config`));
+  Log.log(chalk.cyan(`Please add the following to your Expo config`));
   Log.newLine();
   Log.log(JSON.stringify(edits, null, 2));
   Log.newLine();

--- a/packages/expo-cli/src/commands/utils/sendTo.ts
+++ b/packages/expo-cli/src/commands/utils/sendTo.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import { Exp, UserSettings } from 'xdl';
 
 import Log from '../../log';
@@ -35,7 +36,7 @@ export async function getRecipient(sendTo?: string | boolean): Promise<string> {
   return recipient;
 }
 export async function sendUrlAsync(url: string, recipient: string) {
-  const email = Log.chalk.bold(recipient);
+  const email = chalk.bold(recipient);
   const spinner = ora(`Sending URL to ${email}`).start();
   try {
     const result = await Exp.sendAsync(recipient, url);

--- a/packages/expo-cli/src/commands/utils/validateApplicationId.ts
+++ b/packages/expo-cli/src/commands/utils/validateApplicationId.ts
@@ -1,6 +1,6 @@
+import chalk from 'chalk';
 import got from 'got';
 
-import Log from '../../log';
 import { learnMore } from './TerminalLink';
 import { isUrlAvailableAsync } from './url';
 
@@ -65,9 +65,9 @@ export async function getPackageNameWarningAsync(packageName: string): Promise<s
     if (response.statusCode === 200) {
       // There is no JSON API for the Play Store so we can't concisely
       // locate the app name and developer to match the iOS warning.
-      const message = `⚠️  The package ${Log.chalk.bold(
-        packageName
-      )} is already in use. ${Log.chalk.dim(learnMore(url))}`;
+      const message = `⚠️  The package ${chalk.bold(packageName)} is already in use. ${chalk.dim(
+        learnMore(url)
+      )}`;
       cachedPackageNameResults[packageName] = message;
       return message;
     }
@@ -78,7 +78,7 @@ export async function getPackageNameWarningAsync(packageName: string): Promise<s
 }
 
 function formatInUseWarning(appName: string, author: string, id: string): string {
-  return `⚠️  The app ${Log.chalk.bold(appName)} by ${Log.chalk.italic(
+  return `⚠️  The app ${chalk.bold(appName)} by ${chalk.italic(
     author
-  )} is already using ${Log.chalk.bold(id)}`;
+  )} is already using ${chalk.bold(id)}`;
 }

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -398,9 +398,7 @@ Command.prototype.asyncActionProjectDir = function (
       if (opts.config === true) {
         Log.addNewLineIfNone();
         Log.log('Please specify your custom config path:');
-        Log.log(
-          Log.chalk.green(`  expo ${this.name()} --config ${Log.chalk.cyan(`<app-config>`)}`)
-        );
+        Log.log(chalk.green(`  expo ${this.name()} --config ${chalk.cyan(`<app-config>`)}`));
         Log.newLine();
         process.exit(1);
       }
@@ -409,13 +407,13 @@ Command.prototype.asyncActionProjectDir = function (
       // Warn the user when the custom config path they provided does not exist.
       if (!fs.existsSync(pathToConfig)) {
         const relativeInput = path.relative(process.cwd(), opts.config);
-        const formattedPath = Log.chalk
+        const formattedPath = chalk
           .reset(pathToConfig)
-          .replace(relativeInput, Log.chalk.bold(relativeInput));
+          .replace(relativeInput, chalk.bold(relativeInput));
         Log.addNewLineIfNone();
         Log.nestedWarn(`Custom config file does not exist:\n${formattedPath}`);
         Log.newLine();
-        const helpCommand = Log.chalk.green(`expo ${this.name()} --help`);
+        const helpCommand = chalk.green(`expo ${this.name()} --help`);
         Log.log(`Run ${helpCommand} for more info`);
         Log.newLine();
         process.exit(1);


### PR DESCRIPTION
- move legacy updates check

# Why

Prepping CLI code to move into expo package.
