### PR TITLE
[xdl] switch cloudfront domain to classic-assets.eascdn.net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🧹 Chores
 
 - [cli] Change "dev client" to "development build" ([#3946](https://github.com/expo/expo-cli/issues/3946))
+- [xdl] Swap out Cloudfront CDN for `classic-assets.eascdn.net`. ([#4115](https://github.com/expo/expo-cli/issues/4115))
 
 ### 📦 Packages updated
 
@@ -263,7 +264,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 📦 Packages updated
 
-*Note*: a patch version was skipped due to a failed build that was resolved in [909d47](https://github.com/expo/expo-cli/commit/909d47)
+_Note_: a patch version was skipped due to a failed build that was resolved in [909d47](https://github.com/expo/expo-cli/commit/909d47)
 
 - @expo/config-plugins@4.0.2
 - @expo/config@6.0.2
@@ -448,7 +449,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 - [next-adapter] Remove custom server and service worker code ([#3705](https://github.com/expo/expo-cli/issues/3705))
 - [webpack] Drop asset aliases ([#3706](https://github.com/expo/expo-cli/issues/3706))
-- [webpack] Drop support for deep-scope plugin  ([#3701](https://github.com/expo/expo-cli/issues/3701))
+- [webpack] Drop support for deep-scope plugin ([#3701](https://github.com/expo/expo-cli/issues/3701))
 - [webpack] Drop support for worker-loader ([#3696](https://github.com/expo/expo-cli/issues/3696))
 
 ### 🎉 New features

--- a/packages/xdl/src/ProjectAssets.ts
+++ b/packages/xdl/src/ProjectAssets.ts
@@ -14,7 +14,7 @@ import urljoin from 'url-join';
 
 import { ApiV2, ExpSchema, Logger as logger, ProjectUtils, UserManager } from './internal';
 
-const EXPO_CDN = 'https://d1wp6m56sqw74a.cloudfront.net';
+const EXPO_CDN = 'https://classic-assets.eascdn.net';
 
 type ManifestAsset = { fileHashes: string[]; files: string[]; hash: string };
 

--- a/packages/xdl/src/detach/AssetBundle.ts
+++ b/packages/xdl/src/detach/AssetBundle.ts
@@ -8,7 +8,7 @@ import urlJoin from 'url-join';
 import { AnyStandaloneContext, ExponentTools } from '../internal';
 
 const EXPO_DOMAINS = ['expo.io', 'exp.host', 'expo.test', 'localhost'];
-export const DEFAULT_CDN_HOST = 'https://d1wp6m56sqw74a.cloudfront.net';
+export const DEFAULT_CDN_HOST = 'https://classic-assets.eascdn.net';
 export const ASSETS_DIR_DEFAULT_URL = `${DEFAULT_CDN_HOST}/~assets`;
 
 type UrlResolver = (hash: string) => string;


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
This PR swaps out the hard coded `d1wp6m56sqw74a.cloudfront.net` cdn with `classic-assets.eascdn.net`

Replacing domains will help us gradually shift traffic away from CloudFront to Cloudflare if we wanted to. However, we make assumptions, including in shipped client code in end-user apps, about https://d1wp6m56sqw74a.cloudfront.net. 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

- [x] current tests still pass