### PR TITLE
[expo-cli] Add environment variables for prebuild template and skipDependencyUpdate parameters

### DIFF
--- a/packages/expo-cli/src/commands/eject/prebuildAppAsync.ts
+++ b/packages/expo-cli/src/commands/eject/prebuildAppAsync.ts
@@ -50,6 +50,13 @@ export async function prebuildAsync(
   const { exp, pkg } = await ensureConfigAsync({ projectRoot, platforms });
   const tempDir = temporary.directory();
 
+  const template = options.template || process.env.EXPO_PREBUILD_TEMPLATE;
+  const skipDependencyUpdate =
+    options.skipDependencyUpdate ||
+    (process.env.EXPO_PREBUILD_SKIP_DEPENDENCY_UPDATE
+      ? process.env.EXPO_PREBUILD_SKIP_DEPENDENCY_UPDATE.split(',')
+      : undefined);
+
   const {
     hasNewProjectFiles,
     needsPodInstall,
@@ -58,10 +65,10 @@ export async function prebuildAsync(
     projectRoot,
     exp,
     pkg,
-    template: options.template != null ? resolveTemplateOption(options.template) : undefined,
+    template: template != null ? resolveTemplateOption(template) : undefined,
     tempDir,
     platforms,
-    skipDependencyUpdate: options.skipDependencyUpdate,
+    skipDependencyUpdate,
   });
 
   // Install node modules


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/eas-cli/issues/887.
> `expo prebuild` allows a custom template. You can subsequently build this with `eas build` without issues. Therefore, it would be useful for managed workflow projects, to be able to specify the template directly in eas.json, instead of having to prebuild locally.

# How

Instead of using eas.json, which might clutter the config, and would also require changes outside of `expo-cli`, this initial implementation introduced environment variables `EXPO_PREBUILD_TEMPLATE` and (through a stretch goal of the original issue) `EXPO_PREBUILD_SKIP_DEPENDENCY_UPDATE` that are alternatively observed when the command-line parameter is not provided.

# Test Plan

[ ] TBD (only tested locally by setting the ENV vars)