### PR TITLE
[expo-cli] suppress unauthorized warning on login and logout after logging out of all sessions on website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [cli] suppress unauthorized warning on login and logout commands after logging out of all sessions on the website ([#4120](https://github.com/expo/expo-cli/issues/4120))
+
 ## [Wed, 22 Dec 2021 14:05:44 +0800](https://github.com/expo/expo-cli/commit/de947a91dfc3aa5c4b92330c3c03ec6649e0129f)
 
 ### 🐛 Bug fixes

--- a/packages/expo-cli/src/commands/auth/accounts.ts
+++ b/packages/expo-cli/src/commands/auth/accounts.ts
@@ -99,7 +99,7 @@ export async function loginOrRegisterIfLoggedOutAsync(): Promise<User> {
 }
 
 export async function login(options: CommandOptions): Promise<User> {
-  const user = await UserManager.getCurrentUserAsync();
+  const user = await UserManager.getCurrentUserAsync({ silent: true });
   if (user?.accessToken) {
     throw new CommandError(
       'ACCESS_TOKEN_ERROR',

--- a/packages/expo-cli/src/commands/auth/logoutAsync.ts
+++ b/packages/expo-cli/src/commands/auth/logoutAsync.ts
@@ -4,7 +4,7 @@ import CommandError from '../../CommandError';
 import Log from '../../log';
 
 export async function actionAsync() {
-  const user = await UserManager.getCurrentUserAsync();
+  const user = await UserManager.getCurrentUserAsync({ silent: true });
   if (user?.accessToken) {
     throw new CommandError(
       'ACCESS_TOKEN_ERROR',


### PR DESCRIPTION
# Why

Resolves #4050.

> When you use 'logout of all sessions' in the web UI, the next time you try to login (or logout), you get a warning message that you need to be logged in.

# How

The user retrieval already provided a silent switch, used for the `whoami` command. The same logic applies to `login` and `logout`, so I used the same switch.

# Test Plan

Manually tested.