### PR TITLE
[cli][init] Skip git init in monorepo

### DIFF
--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -355,6 +355,7 @@ async function installNodeDependenciesAsync(projectRoot: string, packageManager:
  * Check if the project is inside an existing Git repo, if so bail out,
  * if not then create a new git repo and commit the initial files.
  *
+ * @returns `true` if git is setup.
  */
 async function initGitRepoAsync(root: string): Promise<boolean> {
   // let's see if we're in a git tree

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -336,17 +336,7 @@ export async function actionAsync(incomingProjectRoot: string, command: Partial<
   }
 
   // Initialize Git at the end to ensure all lock files are committed.
-  // for now, we will just init a git repo if they have git installed and the
-  // project is not inside an existing git tree, and do it silently. we should
-  // at some point check if git is installed and actually bail out if not, because
-  // npm install will fail with a confusing error if so.
-  try {
-    // check if git is installed
-    // check if inside git repo
-    await initGitRepoAsync(projectPath);
-  } catch {
-    // todo: check if git is installed, bail out
-  }
+  await initGitRepoAsync(projectPath);
 }
 
 async function installNodeDependenciesAsync(projectRoot: string, packageManager: 'yarn' | 'npm') {
@@ -361,7 +351,12 @@ async function installNodeDependenciesAsync(projectRoot: string, packageManager:
   }
 }
 
-async function initGitRepoAsync(root: string) {
+/**
+ * Check if the project is inside an existing Git repo, if so bail out,
+ * if not then create a new git repo and commit the initial files.
+ *
+ */
+async function initGitRepoAsync(root: string): Promise<boolean> {
   // let's see if we're in a git tree
   try {
     await spawnAsync('git', ['rev-parse', '--is-inside-work-tree'], {


### PR DESCRIPTION
# Why

- Remove flags from git init function since it's only used once.
- Provide better logs.
- Auto skip git init in a git repo to better support monorepos. It's easy enough to manually set one up later.
- Feature split out of https://github.com/expo/expo-cli/pull/4088

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- `expo init my-app && cd my-app && expo init inner-app` -- `my-app/inner-app/.git` won't exist.