### PR TITLE
[install-expo-modules] Fix invalid installation for yarn 2

### DIFF
--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -89,8 +89,8 @@ async function runAsync(programName: string) {
 
   console.log('\u203A Installing expo packages...');
   const packageManager = PackageManager.createForProject(projectRoot);
-  // e.g. `expo@>=43.0.0-* <44.0.0`, this will cover prerelease version for beta testing.
-  await packageManager.addAsync(`expo@>=${sdkVersion}-* <${semver.inc(sdkVersion, 'major')}`);
+  // e.g. `expo@>=43.0.0-0 <44.0.0`, this will cover prerelease version for beta testing.
+  await packageManager.addAsync(`expo@>=${sdkVersion}-0 <${semver.inc(sdkVersion, 'major')}`);
 
   console.log('\u203A Installing ios pods...');
   const podPackageManager = new PackageManager.CocoaPodsPackageManager({


### PR DESCRIPTION
# Why

fix #4125

# How

`yarn add expo@">=44.0.0-* <45.0.0"` is an invalid command for yarn 2. i did that because i want to support pre-release package installation. however, `*` is also an invalid pre-release name; that's why yarn 2 doesn't support it.

```
<pre-release identifier> ::= <alphanumeric identifier>
                           | <numeric identifier>
```

the pr changes the installation command to `yarn add expo@">=44.0.0-0 <45.0.0"` for the issue.

# Test Plan

# yarn 1 installation

```sh
$ npx react-native init RN066 --version 0.66
$ yarn add expo@">=44.0.0-0 <45.0.0"
$ yarn why expo
```

# yarn 2 installation

```sh
$ npx react-native init RN066 --version 0.66
$ yarn set version berry
$ yarn add expo@">=44.0.0-0 <45.0.0"
$ yarn why expo
```