### PR TITLE
[install-expo-modules] Add begin-rescue to Podfile

### DIFF
--- a/packages/install-expo-modules/src/plugins/ios/__tests__/__snapshots__/withIosModulesPodfile-test.ts.snap
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/__snapshots__/withIosModulesPodfile-test.ts.snap
@@ -49,7 +49,11 @@ platform :ios, '10.0'
 target 'HelloWorld' do
   use_expo_modules!
   post_integrate do |installer|
-    expo_patch_react_imports!(installer)
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end
   end
   config = use_native_modules!
 

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
@@ -52,7 +52,11 @@ platform :ios, '10.0'
 target 'HelloWorld' do
   use_expo_modules!
   post_integrate do |installer|
-    expo_patch_react_imports!(installer)
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end
   end
   config = use_native_modules!
 
@@ -108,7 +112,11 @@ target 'HelloWorld' do
   use_react_native!(:path => config["reactNativePath"])
 
   post_integrate do |installer|
-    expo_patch_react_imports!(installer)
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end
     puts "Existing post_integrate hook"
   end
 end

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesPodfile.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesPodfile.ts
@@ -43,7 +43,12 @@ export function updatePodfile(
       if (contents.match(regExpPostIntegrate)) {
         contents = contents.replace(
           regExpPostIntegrate,
-          '$1\n    expo_patch_react_imports!(installer)'
+          `$1
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end`
         );
       } else {
         // If there's no existing post_integrate hook,
@@ -52,7 +57,11 @@ export function updatePodfile(
           /(\buse_expo_modules!\n)/gm,
           `$1\
   post_integrate do |installer|
-    expo_patch_react_imports!(installer)
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end
   end\n`
         );
       }


### PR DESCRIPTION
# Why

sync to latest sdk-44 template
https://github.com/expo/expo/blob/fadd71f60b8b429e6602bcb33ee57fb66f07bdc6/templates/expo-template-bare-minimum/ios/Podfile#L41-L47

# How

add begin-rescue block

# Test Plan

```
  updatePodfile
    ✓ should support classic rn podfile (12 ms)
    ✓ minimum support for existing post_integrate hook
  withIosModulesPodfile sdkVersion snapshots
    ✓ sdkVersion 43.0.0 (1 ms)
    ✓ sdkVersion 44.0.0
```