### PR TITLE
[xdl] Fix various ngrok bugs

### DIFF
--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -783,7 +783,7 @@ async function constructDeepLinkAsync(
   } else {
     try {
       return await UrlUtils.constructDeepLinkAsync(projectRoot, {
-        hostType: 'localhost',
+        // Don't pass a `hostType` or ngrok will break.
         scheme,
       });
     } catch (e) {

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -427,12 +427,7 @@ function joinURLComponents({
   const validPort = port ?? '80';
   const validProtocol = protocol ? `${protocol}://` : '';
 
-  let output = `${validProtocol}${hostname}`;
-  if (validPort) {
-    output += `:${validPort}`;
-  }
-
-  return output;
+  return `${validProtocol}${hostname}:${validPort}`;
 }
 
 export function stripJSExtension(entryPoint: string): string {

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -382,6 +382,7 @@ export async function constructUrlAsync(
         'Tunnel URL not found (it might not be ready yet), falling back to LAN URL.',
         'tunnel-url-not-found'
       );
+
       return constructUrlAsync(
         projectRoot,
         { ...opts, hostType: 'lan' },
@@ -419,11 +420,19 @@ function joinURLComponents({
   port?: string | number | null;
 }): string {
   assert(hostname, 'hostname cannot be inferred.');
-  // Android HMR breaks without this port 80
+  // Android HMR breaks without this port 80.
+  // This is because Android React Native WebSocket implementation is not spec compliant and fails without a port:
+  // `E unknown:ReactNative: java.lang.IllegalArgumentException: Invalid URL port: "-1"`
+  // Invoked first in `metro-runtime/src/modules/HMRClient.js`
   const validPort = port ?? '80';
   const validProtocol = protocol ? `${protocol}://` : '';
 
-  return `${validProtocol}${hostname}:${validPort}`;
+  let output = `${validProtocol}${hostname}`;
+  if (validPort) {
+    output += `:${validPort}`;
+  }
+
+  return output;
 }
 
 export function stripJSExtension(entryPoint: string): string {

--- a/packages/xdl/src/start/resolveNgrok.ts
+++ b/packages/xdl/src/start/resolveNgrok.ts
@@ -87,9 +87,7 @@ async function resolvePackageFromProjectAsync(projectRoot: string) {
     const pkg = require(ngrokPackagePath);
     if (pkg && semver.satisfies(pkg.version, NGROK_REQUIRED_VERSION)) {
       const ngrokPath = resolveFrom(projectRoot, '@expo/ngrok');
-      if (EXPO_DEBUG) {
-        Logger.global.info(`Resolving @expo/ngrok from project: "${ngrokPath}"`);
-      }
+      Logger.global.debug(`Resolving @expo/ngrok from project: "${ngrokPath}"`);
       return require(ngrokPath);
     }
   } catch {}
@@ -102,11 +100,9 @@ async function resolveGlobalPackageAsync() {
     // use true to disable the use of local packages.
     const pkg = requireg('@expo/ngrok/package.json', true);
     if (semver.satisfies(pkg.version, NGROK_REQUIRED_VERSION)) {
-      if (EXPO_DEBUG) {
-        Logger.global.info(
-          `Resolving global @expo/ngrok from: "${requireg.resolve('@expo/ngrok')}"`
-        );
-      }
+      Logger.global.debug(
+        `Resolving global @expo/ngrok from: "${requireg.resolve('@expo/ngrok')}"`
+      );
       return requireg('@expo/ngrok', true);
     }
   } catch {}


### PR DESCRIPTION
# Why

- Fix "pressing `i` in TerminalUI doesn't open ngrok URL".
- Prevent opening multiple ngrok servers when the new dev server API is in use.
- Fix "Tunnel URL not found (it might not be ready yet), falling back to LAN URL." warning on `rm -rf .expo && expo start --tunnel`
- Add better inline documentation about what's going on.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- `rm -rf .expo && expo start --tunnel` then open on iOS and Android.
  - Ensure Android doesn't crash (possible when port is missing).
  - Ensure iOS opens using ngrok URL and not localhost URL.