### PR TITLE
[config-plugins] Don't warn in EXPO_DEBUG when runtimeVersion isn't set

### DIFF
--- a/packages/config-plugins/src/utils/Updates.ts
+++ b/packages/config-plugins/src/utils/Updates.ts
@@ -66,16 +66,22 @@ export function getNativeVersion(
  */
 export const withRuntimeVersion: (config: ExpoConfig) => ExpoConfig = config => {
   if (config.ios?.runtimeVersion || config.runtimeVersion) {
-    config.ios = {
-      ...config.ios,
-      runtimeVersion: getRuntimeVersion(config, 'ios'),
-    };
+    const runtimeVersion = getRuntimeVersion(config, 'ios');
+    if (runtimeVersion) {
+      config.ios = {
+        ...config.ios,
+        runtimeVersion,
+      };
+    }
   }
   if (config.android?.runtimeVersion || config.runtimeVersion) {
-    config.android = {
-      ...config.android,
-      runtimeVersion: getRuntimeVersion(config, 'android'),
-    };
+    const runtimeVersion = getRuntimeVersion(config, 'android');
+    if (runtimeVersion) {
+      config.android = {
+        ...config.android,
+        runtimeVersion,
+      };
+    }
   }
   delete config.runtimeVersion;
   return config;
@@ -100,12 +106,10 @@ export function getRuntimeVersion(
     ios?: Pick<IOS, 'buildNumber' | 'runtimeVersion'>;
   },
   platform: 'android' | 'ios'
-): string {
+): string | null {
   const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
   if (!runtimeVersion) {
-    throw new Error(
-      `There is neither a value or a policy set for the runtime version on "${platform}"`
-    );
+    return null;
   }
 
   if (typeof runtimeVersion === 'string') {

--- a/packages/config-plugins/src/utils/__tests__/Updates-test.ts
+++ b/packages/config-plugins/src/utils/__tests__/Updates-test.ts
@@ -73,10 +73,8 @@ describe(getRuntimeVersion, () => {
       )
     ).toBe(`${version}(${buildNumber})`);
   });
-  it('throws no runtime version is supplied', () => {
-    expect(() => {
-      getRuntimeVersion({}, 'ios');
-    }).toThrow(`There is neither a value or a policy set for the runtime version on "ios"`);
+  it('returns null if no runtime version is supplied', () => {
+    expect(getRuntimeVersion({}, 'ios')).toEqual(null);
   });
   it('throws if runtime version is not parseable', () => {
     expect(() => {

--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -119,6 +119,10 @@ export async function getManifestResponseAsync({
     platform
   );
 
+  if (!runtimeVersion) {
+    throw new Error(`Unable to determine runtime version for ${platform}`);
+  }
+
   const bundleUrl = await getBundleUrlAsync({
     projectRoot,
     platform,


### PR DESCRIPTION
# Why

When running `EXPO_DEBUG=1 expo prebuild` you get an error that could be a red herring when trying to debug prebuild issues:

```
ios.expoPlist: withVersionedExpoSDKPlugins ➜ withPlugins ➜ withStaticPlugin ➜ withExpoUpdates ➜ withStaticPlugin ➜ withRunOnce ➜ withUpdates ➜ withUpdates ➜ withExpoPlist
- Config syncing
Error: There is neither a value or a policy set for the runtime version on "ios"
    at getRuntimeVersion (/Users/brentvatne/code/mappy/node_modules/@expo/config-plugins/src/utils/Updates.ts:106:11)
    at getRuntimeVersionNullable (/Users/brentvatne/code/mappy/node_modules/@expo/config-plugins/src/utils/Updates.ts:88:12)
    at setVersionsConfig (/Users/brentvatne/code/mappy/node_modules/@expo/config-plugins/src/ios/Updates.ts:99:26)
    at setUpdatesConfig (/Users/brentvatne/code/mappy/node_modules/@expo/config-plugins/src/ios/Updates.ts:93:10)
    at /Users/brentvatne/code/mappy/node_modules/@expo/config-plugins/src/ios/Updates.ts:63:25
    at action (/Users/brentvatne/code/mappy/node_modules/@expo/config-plugins/src/plugins/withMod.ts:227:29)
    at interceptingMod (/Users/brentvatne/code/mappy/node_modules/@expo/config-plugins/src/plugins/withMod.ts:108:27)
    at action (/Users/brentvatne/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/createBaseMod.ts:82:27)
    at interceptingMod (/Users/brentvatne/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/withMod.ts:108:21)
    at evalModsAsync (/Users/brentvatne/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/mod-compiler.ts:172:25)
    at compileModsAsync (/Users/brentvatne/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/node_modules/@expo/config-plugins/src/plugins/mod-compiler.ts:82:10)
    at configureManagedProjectAsync (/Users/brentvatne/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/src/commands/eject/configureProjectAsync.ts:64:12)
    at prebuildAsync (/Users/brentvatne/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/src/commands/eject/prebuildAppAsync.ts:90:21)
    at actionAsync (/Users/brentvatne/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/src/commands/eject/prebuildAsync.ts:34:3)
```

All this means is that you didn't define a `runtimeVersion` in app.json.

# How

Return null rather than throw when there is no runtimeVersion. Note that I didn't change the existing logic here around what is treated as a null runtimeVersion - empty string will be treated as such, for example.

# Test Plan

Run `EXPO_DEBUG=1 expo prebuild -p ios` with this change and you won't se the above error log