### PR TITLE
[expo-cli][docs] update broken flags in docs generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🧹 Chores
 
+- [expo-cli] updated markdown formatting in introspection script ([#4141)(https://github.com/expo/expo-cli/pull/4141))
+
 ### 🐛 Bug fixes
 
 - [cli] suppress unauthorized warning on login and logout commands after logging out of all sessions on the website ([#4120](https://github.com/expo/expo-cli/issues/4120))

--- a/packages/expo-cli/scripts/introspect.ts
+++ b/packages/expo-cli/scripts/introspect.ts
@@ -88,11 +88,10 @@ function commandAsJSON(command: Command): CommandData {
   };
 }
 
-/** The easiest workaround for | (pipe) being confused with a markdown table
- * separator and breaking marktown table autoformatting is to use ⎮ (U+23AE,
- * Integral Extension) instead. <> are replaced by [] for HTML reasons. */
+/** <> are replaced by [] for HTML reasons. All pipe characters are
+ * escaped not to break markdown table autoformatting. */
 function sanitizeFlags(flags: string) {
-  return flags.replace('<', '[').replace('>', ']').replace('|', '⎮');
+  return flags.replace('<', '[').replace('>', ']').split('|').join('\\|');
 }
 
 function formatOptionAsMarkdown(option: OptionData) {


### PR DESCRIPTION
# Why

The current introspection script breaks formatting when there's multiple pipe characters in the flags
![image](https://user-images.githubusercontent.com/852069/149333892-077c40f4-d2cc-4f23-860f-551e3d835f93.png)


# How

Replace _all_ occurences instead of only the first. Properly escape them instead of replacing them with a less appealing unicode character.

# Test Plan

Generated json and markdown locally to verify.