### PR TITLE
[Interstitial page] Ensure that development build is installed

### DIFF
--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -378,13 +378,7 @@ async function ensureDevClientInstalledAsync(device: Device, applicationId: stri
 }
 
 async function isDevClientInstalledAsync(device: Device, applicationId: string): Promise<boolean> {
-  try {
-    await ensureDevClientInstalledAsync(device, applicationId);
-  } catch (e) {
-    return false;
-  }
-
-  return true;
+  return await isInstalledAsync(device, applicationId);
 }
 
 async function getExpoVersionAsync(device: Device): Promise<string | null> {
@@ -776,7 +770,7 @@ async function openUrlAsync({
       clientApplicationId = await getClientApplicationId();
       await ensureDevClientInstalledAsync(device, clientApplicationId);
     } else if (
-      process.env['EXPO_ENABLE_INTERSTITIAL_PAGE'] &&
+      Env.isInterstitiaLPageEnabled() &&
       !devClient &&
       isDevClientPackageInstalled(projectRoot)
     ) {
@@ -797,9 +791,9 @@ async function openUrlAsync({
         // Everything is installed, we can present the interstitial page.
         clientApplicationId = ''; // it will open browser
       } else {
-        // The development build ins't available. So let's fallback to Expo Go.
+        // The development build isn't available. So let's fall back to Expo Go.
         Logger.global.warn(
-          `\u203A The 'expo-dev-client' package is installed, but the development build isn't available.\nYour app will be open in Expo Go instead. If you want to use the development build, please install it on the simulator first.\n${learnMore(
+          `\u203A The 'expo-dev-client' package is installed, but a development build isn't available.\nYour app will open in Expo Go instead. If you want to use the development build, please install it on the simulator first.\n${learnMore(
             'https://docs.expo.dev/clients/distribution-for-ios/#building-for-ios'
           )}`
         );
@@ -888,11 +882,7 @@ async function constructDeepLinkAsync(
   scheme?: string,
   devClient?: boolean
 ): Promise<string | null> {
-  if (
-    process.env['EXPO_ENABLE_INTERSTITIAL_PAGE'] &&
-    !devClient &&
-    isDevClientPackageInstalled(projectRoot)
-  ) {
+  if (Env.isInterstitiaLPageEnabled() && !devClient && isDevClientPackageInstalled(projectRoot)) {
     return UrlUtils.constructLoadingUrlAsync(projectRoot, 'android');
   } else {
     return await UrlUtils.constructDeepLinkAsync(projectRoot, {

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -880,9 +880,15 @@ export async function resolveApplicationIdAsync(projectRoot: string): Promise<st
 async function constructDeepLinkAsync(
   projectRoot: string,
   scheme?: string,
-  devClient?: boolean
+  devClient?: boolean,
+  shouldGenerateInterstitialPage: boolean = true
 ): Promise<string | null> {
-  if (Env.isInterstitiaLPageEnabled() && !devClient && isDevClientPackageInstalled(projectRoot)) {
+  if (
+    Env.isInterstitiaLPageEnabled() &&
+    !devClient &&
+    isDevClientPackageInstalled(projectRoot) &&
+    shouldGenerateInterstitialPage
+  ) {
     return UrlUtils.constructLoadingUrlAsync(projectRoot, 'android');
   } else {
     return await UrlUtils.constructDeepLinkAsync(projectRoot, {

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -377,6 +377,16 @@ async function ensureDevClientInstalledAsync(device: Device, applicationId: stri
   }
 }
 
+async function isDevClientInstalledAsync(device: Device, applicationId: string): Promise<boolean> {
+  try {
+    await ensureDevClientInstalledAsync(device, applicationId);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+}
+
 async function getExpoVersionAsync(device: Device): Promise<string | null> {
   const info = await getAdbOutputAsync(
     adbPidArgs(device.pid, 'shell', 'dumpsys', 'package', 'host.exp.exponent')
@@ -711,55 +721,100 @@ async function openUrlAsync({
   let installedExpo = false;
   let clientApplicationId = 'host.exp.exponent';
 
+  const installExpoIfNeeded = async (device: Device) => {
+    let shouldInstall = !(await _isExpoInstalledAsync(device));
+    const promptKey = device.pid ?? 'unknown';
+    if (
+      !shouldInstall &&
+      !hasPromptedToUpgrade[promptKey] &&
+      (await isClientOutdatedAsync(device, sdkVersion))
+    ) {
+      // Only prompt once per device, per run.
+      hasPromptedToUpgrade[promptKey] = true;
+      const confirm = await Prompts.confirmAsync({
+        initial: true,
+        message: `Expo Go on ${device.name} (${device.type}) is outdated, would you like to upgrade?`,
+      });
+      if (confirm) {
+        await uninstallExpoAsync(device);
+        shouldInstall = true;
+      }
+    }
+
+    if (shouldInstall) {
+      const androidClient = await getClientForSDK(sdkVersion);
+      await installExpoAsync({ device, ...androidClient });
+      installedExpo = true;
+    }
+  };
+
+  const getClientApplicationId = async () => {
+    let applicationId;
+    const isManaged = await isManagedProjectAsync(projectRoot);
+    if (isManaged) {
+      applicationId = exp?.android?.package;
+      if (!applicationId) {
+        throw new Error(
+          `Could not find property android.package in app.config.js/app.json. This setting is required to launch the app.`
+        );
+      }
+    } else {
+      applicationId = await resolveApplicationIdAsync(projectRoot);
+      if (!applicationId) {
+        throw new Error(
+          `Could not find applicationId in ${AndroidConfig.Paths.getAppBuildGradleFilePath(
+            projectRoot
+          )}`
+        );
+      }
+    }
+    return applicationId;
+  };
+
   try {
     if (devClient) {
-      let applicationId;
-      const isManaged = await isManagedProjectAsync(projectRoot);
-      if (isManaged) {
-        applicationId = exp?.android?.package;
-        if (!applicationId) {
-          throw new Error(
-            `Could not find property android.package in app.config.js/app.json. This setting is required to launch the app.`
-          );
-        }
-      } else {
-        applicationId = await resolveApplicationIdAsync(projectRoot);
-        if (!applicationId) {
-          throw new Error(
-            `Could not find applicationId in ${AndroidConfig.Paths.getAppBuildGradleFilePath(
-              projectRoot
-            )}`
-          );
-        }
-      }
-      clientApplicationId = applicationId;
+      clientApplicationId = await getClientApplicationId();
       await ensureDevClientInstalledAsync(device, clientApplicationId);
-    } else if (!isDetached) {
-      let shouldInstall = !(await _isExpoInstalledAsync(device));
-      const promptKey = device.pid ?? 'unknown';
-      if (
-        !shouldInstall &&
-        !hasPromptedToUpgrade[promptKey] &&
-        (await isClientOutdatedAsync(device, sdkVersion))
-      ) {
-        // Only prompt once per device, per run.
-        hasPromptedToUpgrade[promptKey] = true;
-        const confirm = await Prompts.confirmAsync({
-          initial: true,
-          message: `Expo Go on ${device.name} (${device.type}) is outdated, would you like to upgrade?`,
-        });
-        if (confirm) {
-          await uninstallExpoAsync(device);
-          shouldInstall = true;
+    } else if (
+      process.env['EXPO_ENABLE_INTERSTITIAL_PAGE'] &&
+      !devClient &&
+      isDevClientPackageInstalled(projectRoot)
+    ) {
+      await installExpoIfNeeded(device);
+
+      let applicationId: string | undefined;
+      try {
+        applicationId = await getClientApplicationId();
+      } catch (e) {
+        Logger.global.warn(e);
+      }
+
+      const isDevClientInstalled = applicationId
+        ? await isDevClientInstalledAsync(device, applicationId)
+        : false;
+
+      if (isDevClientInstalled) {
+        // Everything is installed, we can present the interstitial page.
+        clientApplicationId = ''; // it will open browser
+      } else {
+        // The development build ins't available. So let's fallback to Expo Go.
+        Logger.global.warn(
+          `\u203A The 'expo-dev-client' package is installed, but the development build isn't available.\nYour app will be open in Expo Go instead. If you want to use the development build, please install it on the simulator first.\n${learnMore(
+            'https://docs.expo.dev/clients/distribution-for-ios/#building-for-ios'
+          )}`
+        );
+
+        const newProjectUrl = await constructDeepLinkAsync(projectRoot, undefined, false, false);
+        if (!newProjectUrl) {
+          // This shouldn't happen.
+          throw Error('Could not generate a deep link for your project.');
         }
+        url = newProjectUrl;
+        Logger.global.debug(`iOS project url: ${url}`);
+        _lastUrl = url;
       }
-
-      if (shouldInstall) {
-        const androidClient = await getClientForSDK(sdkVersion);
-        await installExpoAsync({ device, ...androidClient });
-        installedExpo = true;
-      }
-
+    } else if (!isDetached) {
+      await installExpoIfNeeded(device);
       _lastUrl = url;
       // _checkExpoUpToDateAsync(); // let this run in background
     }

--- a/packages/xdl/src/Env.ts
+++ b/packages/xdl/src/Env.ts
@@ -15,6 +15,10 @@ export function isLocal(): boolean {
   return getenv.boolish('EXPO_LOCAL', false);
 }
 
+export function isInterstitiaLPageEnabled(): boolean {
+  return getenv.boolish('EXPO_ENABLE_INTERSTITIAL_PAGE', false);
+}
+
 export function maySkipManifestValidation(): boolean {
   return !!getenv.string('EXPO_SKIP_MANIFEST_VALIDATION_TOKEN');
 }

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -819,9 +819,15 @@ export async function resolveApplicationIdAsync(projectRoot: string) {
 async function constructDeepLinkAsync(
   projectRoot: string,
   scheme?: string,
-  devClient?: boolean
+  devClient?: boolean,
+  shouldGenerateInterstitialPage: boolean = true
 ): Promise<string | null> {
-  if (Env.isInterstitiaLPageEnabled() && !devClient && isDevClientPackageInstalled(projectRoot)) {
+  if (
+    Env.isInterstitiaLPageEnabled() &&
+    !devClient &&
+    isDevClientPackageInstalled(projectRoot) &&
+    shouldGenerateInterstitialPage
+  ) {
     return UrlUtils.constructLoadingUrlAsync(projectRoot, 'ios', 'localhost');
   } else {
     try {

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -18,6 +18,7 @@ import {
   CoreSimulator,
   delayAsync,
   downloadAppAsync,
+  Env,
   isDevClientPackageInstalled,
   learnMore,
   LoadingEvent,
@@ -625,7 +626,7 @@ async function openUrlInSimulatorSafeAsync({
         await streamLogsAsync({ udid: simulator.udid, bundleIdentifier });
       }
     } else if (
-      process.env['EXPO_ENABLE_INTERSTITIAL_PAGE'] &&
+      Env.isInterstitiaLPageEnabled() &&
       !devClient &&
       isDevClientPackageInstalled(projectRoot)
     ) {
@@ -643,9 +644,9 @@ async function openUrlInSimulatorSafeAsync({
         // Everything is installed, we can present the interstitial page.
         bundleIdentifier = ''; // it will open browser.
       } else {
-        // The development build ins't available. So let's fallback to Expo Go.
+        // The development build isn't available. So let's fall back to Expo Go.
         Logger.global.warn(
-          `\u203A The 'expo-dev-client' package is installed, but the development build isn't available.\nYour app will be open in Expo Go instead. If you want to use the development build, please install it on the simulator first.\n${learnMore(
+          `\u203A The 'expo-dev-client' package is installed, but a development build isn't available.\nYour app will open in Expo Go instead. If you want to use the development build, please install it on the simulator first.\n${learnMore(
             'https://docs.expo.dev/clients/distribution-for-ios/#building-for-ios'
           )}`
         );
@@ -735,7 +736,7 @@ async function isDevClientInstalledAsync(
   bundleIdentifier: string
 ): Promise<boolean> {
   try {
-    await profileMethod(assertDevClientInstalledAsync)(simulator, bundleIdentifier);
+    await assertDevClientInstalledAsync(simulator, bundleIdentifier);
   } catch (e) {
     return false;
   }
@@ -820,11 +821,7 @@ async function constructDeepLinkAsync(
   scheme?: string,
   devClient?: boolean
 ): Promise<string | null> {
-  if (
-    process.env['EXPO_ENABLE_INTERSTITIAL_PAGE'] &&
-    !devClient &&
-    isDevClientPackageInstalled(projectRoot)
-  ) {
+  if (Env.isInterstitiaLPageEnabled() && !devClient && isDevClientPackageInstalled(projectRoot)) {
     return UrlUtils.constructLoadingUrlAsync(projectRoot, 'ios', 'localhost');
   } else {
     try {


### PR DESCRIPTION
# Why

Close ENG-2211.

# How

Before opening a deep link to the interstitial page, we need to check if everything is installed. So I've added a logic that will install the `Expo Go` and check if the development build is available. If not we will fall back to the expo go. 

# Test Plan

Test scenarios:
- app without dev-client 
- check if the expo go will be installed if not present 
- check what happens if the development build isn't present 
- check what happens if both development build and expo go isn't available 