### PR TITLE
[Interstitial page] Add option to remember user choice

### DIFF
--- a/packages/expo-cli/src/commands/start/startAsync.ts
+++ b/packages/expo-cli/src/commands/start/startAsync.ts
@@ -2,7 +2,14 @@ import { ConfigError, ExpoConfig, getConfig, isLegacyImportsEnabled } from '@exp
 import chalk from 'chalk';
 import path from 'path';
 import resolveFrom from 'resolve-from';
-import { LoadingPageHandler, Project, UnifiedAnalytics, UrlUtils, Versions } from 'xdl';
+import {
+  LoadingPageHandler,
+  Project,
+  ProjectSettings,
+  UnifiedAnalytics,
+  UrlUtils,
+  Versions,
+} from 'xdl';
 
 import StatusEventEmitter from '../../analytics/StatusEventEmitter';
 import getDevClientProperties from '../../analytics/getDevClientProperties';
@@ -78,6 +85,10 @@ export async function actionAsync(projectRoot: string, options: NormalizedOption
   }
 
   const startOptions = profileMethod(parseStartOptions)(options, exp);
+  if (startOptions.reset) {
+    await ProjectSettings.setAsync(projectRoot, { forceExecutionEnvironment: null });
+  }
+
   LoadingPageHandler.setOnDeepLink(
     async (projectRoot: string, isDevClient: boolean, platform: string | null) => {
       if (!isDevClient) {

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -831,12 +831,14 @@ export async function resolveApplicationIdAsync(projectRoot: string): Promise<st
 async function constructDeepLinkAsync(
   projectRoot: string,
   scheme?: string,
-  devClient?: boolean
+  devClient?: boolean,
+  shouldGenerateInterstitialPage: boolean = true
 ): Promise<string | null> {
   if (
     process.env['EXPO_ENABLE_INTERSTITIAL_PAGE'] &&
     !devClient &&
-    isDevClientPackageInstalled(projectRoot)
+    isDevClientPackageInstalled(projectRoot) &&
+    shouldGenerateInterstitialPage
   ) {
     return UrlUtils.constructLoadingUrlAsync(projectRoot, 'android');
   } else {
@@ -870,7 +872,20 @@ export async function openProjectAsync({
 }): Promise<{ success: true; url: string } | { success: false; error: Error | string }> {
   await startAdbReverseAsync(projectRoot);
 
-  const projectUrl = await constructDeepLinkAsync(projectRoot, scheme, devClient);
+  let shouldGenerateInterstitialPage = true;
+  if (!devClient) {
+    const { forceExecutionEnvironment } = await ProjectSettings.readAsync(projectRoot);
+    devClient = forceExecutionEnvironment === 'expo-dev-client';
+    shouldGenerateInterstitialPage = forceExecutionEnvironment === null;
+    await ProjectSettings.setAsync(projectRoot, { devClient });
+  }
+
+  const projectUrl = await constructDeepLinkAsync(
+    projectRoot,
+    scheme,
+    devClient,
+    shouldGenerateInterstitialPage
+  );
 
   const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,

--- a/packages/xdl/src/ProjectSettings.ts
+++ b/packages/xdl/src/ProjectSettings.ts
@@ -14,6 +14,7 @@ export type ProjectSettings = {
   minify: boolean;
   urlRandomness: string | null;
   https: boolean;
+  forceExecutionEnvironment: 'expo-go' | 'expo-dev-client' | null;
 };
 export type Settings = ProjectSettings;
 
@@ -27,6 +28,7 @@ const projectSettingsDefaults: ProjectSettings = {
   minify: false,
   urlRandomness: null,
   https: false,
+  forceExecutionEnvironment: null,
 };
 
 type PackagerInfo = {

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -250,6 +250,7 @@ function assertValidOptions(opts: Partial<URLOptions>): URLOptions {
   const schema = Joi.object().keys({
     devClient: Joi.boolean().optional(),
     scheme: Joi.string().optional().allow(null),
+    forceExecutionEnvironment: Joi.any().valid('expo-go', 'expo-dev-client').allow(null),
     // Replaced by `scheme`
     urlType: Joi.any().valid('exp', 'http', 'redirect', 'no-protocol').allow(null),
     lanType: Joi.any().valid('ip', 'hostname'),

--- a/packages/xdl/src/start/LoadingPageHandler.ts
+++ b/packages/xdl/src/start/LoadingPageHandler.ts
@@ -4,7 +4,7 @@ import http from 'http';
 import { resolve } from 'path';
 import { parse } from 'url';
 
-import { UrlUtils } from './../internal';
+import { ProjectSettings, UrlUtils } from './../internal';
 
 export const LoadingEndpoint = '/_expo/loading';
 export const DeepLinkEndpoint = '/_expo/link';
@@ -56,6 +56,8 @@ async function deeplinkEndpointHandler(
 ) {
   const { query } = parse(req.url!, true);
   const isDevClient = query['choice'] === 'expo-dev-client';
+  const shouldSave = query['shouldSave'];
+
   if (isDevClient) {
     const projectUrl = await UrlUtils.constructDevClientUrlAsync(projectRoot, {
       hostType: 'localhost',
@@ -69,6 +71,13 @@ async function deeplinkEndpointHandler(
   }
 
   onDeepLink(projectRoot, isDevClient, getPlatform(query));
+
+  if (shouldSave) {
+    const forceExecutionEnvironment = isDevClient ? 'expo-dev-client' : 'expo-go';
+    await ProjectSettings.setAsync(projectRoot, {
+      forceExecutionEnvironment,
+    });
+  }
 
   res.setHeader('Cache-Control', 'private, no-cache, no-store, must-revalidate');
   res.setHeader('Expires', '-1');

--- a/packages/xdl/static/loading-page/index.html
+++ b/packages/xdl/static/loading-page/index.html
@@ -185,6 +185,17 @@
       color: var(--secondary-text-color);
     }
 
+    .bottom-bar label {
+      font-size: 14px;
+      letter-spacing: -8.5e;
+      color: var(--text-color);
+    }
+
+    .bottom-bar input[type=checkbox] {
+      vertical-align: middle;
+      padding: 10px;
+    }
+
   </style>
   <title>Expo Start | Loading Page</title>
 </head>
@@ -245,6 +256,10 @@
     </p>
     <a id="expo-dev-client-link" href="/_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development App</a>
     <a id="expo-go-link" href="/_expo/link?choice=expo-go" class="bottom-bar-button bottom-bar-button-grey">Expo Go</a>
+    <label for="shouldSave">
+      <input type="checkbox" id="shouldSave" name="shouldSave">
+      Remember my choice
+    </label>
   </div>
   
   <script>
@@ -261,14 +276,27 @@
     return result;
   }
 
+  const devClientLink = document.getElementById("expo-dev-client-link");
+  const goLink = document.getElementById("expo-go-link");
+  const shouldSaveCheckbox = document.getElementById("shouldSave");
+  
   const platform = findGetParameter("platform");
-  if (platform) {
-    const devClientLink = document.getElementById("expo-dev-client-link");
-    const goLink = document.getElementById("expo-go-link");
 
-    devClientLink.href += "&platform=" + platform;
-    goLink.href += "&platform=" + platform;
+  const onLinkClick = (event) => {
+    const element = event.target;
+  
+    if (platform) {
+      element.href += "&platform=" + platform;
+    }
+
+    const shouldSave = shouldSaveCheckbox.checked
+    if (shouldSave) {
+      element.href += "&shouldSave=1";
+    }
   }
+
+  devClientLink.onclick = onLinkClick;
+  goLink.onclick = onLinkClick;
   </script>
 </body>
 </html>


### PR DESCRIPTION
# Why

Closes ENG-2210.

# How

Added the `forceExecutionEnvironment` flag that determined where we should open a deep link if the dev-client was installed but the `--dev-client` flag wasn't provided. You can clear that variable using the `-c` option. 

# Test Plan

Test scenarios:

- app without dev-client
- check what happens if a user chooses the development builds 
- check what happens if a user chooses the Expo Go
- check if a user can clear the `forceExecutionEnvironment` flag