### PR TITLE
[xdl] drop IP from track context

### DIFF
--- a/packages/xdl/src/Analytics.ts
+++ b/packages/xdl/src/Analytics.ts
@@ -2,8 +2,6 @@ import RudderAnalytics from '@expo/rudder-sdk-node';
 import os from 'os';
 import { URL } from 'url';
 
-import { ip } from './internal';
-
 const PLATFORM_TO_ANALYTICS_PLATFORM: { [platform: string]: string } = {
   darwin: 'Mac',
   win32: 'Windows',
@@ -73,7 +71,6 @@ export class AnalyticsClient {
   private getContext(): any {
     const platform = PLATFORM_TO_ANALYTICS_PLATFORM[os.platform()] || os.platform();
     const context = {
-      ip: ip.address(),
       device: {
         model: platform,
         brand: platform,


### PR DESCRIPTION
# Why

We'd like to remove personal data from all track calls as much as possible due to GDPR regulations.

# How

Removed IP from the context object of the track call.

# Test Plan

N/A