### PR TITLE
feat: new --fix-dependencies option for doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
-- [expo-cli] Aew `--fix-dependencies` option for `doctor` ([#4153](https://github.com/expo/expo-cli/issues/4153))
+- [expo-cli] New `--fix-dependencies` option for `doctor` ([#4153](https://github.com/expo/expo-cli/issues/4153))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🎉 New features
 
+- [expo-cli] Aew `--fix-dependencies` option for `doctor` ([#4153](https://github.com/expo/expo-cli/issues/4153))
+
 ### 🧹 Chores
 
 - [expo-cli] updated markdown formatting in introspection script ([#4141)(https://github.com/expo/expo-cli/pull/4141))

--- a/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
+++ b/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
@@ -7,14 +7,19 @@ import { profileMethod } from '../../utils/profileMethod';
 import { validateDependenciesVersionsAsync } from '../../utils/validateDependenciesVersions';
 import { warnUponCmdExe } from './windows';
 
-export async function actionAsync(projectRoot: string) {
+type Options = {
+  fixDependencies?: boolean;
+};
+
+export async function actionAsync(projectRoot: string, options: Options) {
   await warnUponCmdExe();
 
   const { exp, pkg } = profileMethod(getConfig)(projectRoot);
   const areDepsValid = await profileMethod(validateDependenciesVersionsAsync)(
     projectRoot,
     exp,
-    pkg
+    pkg,
+    options.fixDependencies
   );
 
   // note: this currently only warns when something isn't right, it doesn't fail

--- a/packages/expo-cli/src/commands/info/doctor/index.ts
+++ b/packages/expo-cli/src/commands/info/doctor/index.ts
@@ -8,7 +8,7 @@ export default function (program: Command) {
       .command('doctor')
       .description('Diagnose issues with the project')
       .helpGroup('info')
-      .option('--fix-dependencies', 'Fix dependencies versions'),
+      .option('--fix-dependencies', 'Fix incompatible dependency versions'),
     () => import('./doctorAsync')
   );
 }

--- a/packages/expo-cli/src/commands/info/doctor/index.ts
+++ b/packages/expo-cli/src/commands/info/doctor/index.ts
@@ -5,9 +5,10 @@ import { applyAsyncActionProjectDir } from '../../utils/applyAsyncAction';
 export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
-      .command('doctor [path]')
+      .command('doctor')
       .description('Diagnose issues with the project')
-      .helpGroup('info'),
+      .helpGroup('info')
+      .option('--fix-dependencies', 'Fix dependencies versions'),
     () => import('./doctorAsync')
   );
 }

--- a/packages/expo-cli/src/commands/info/doctor/index.ts
+++ b/packages/expo-cli/src/commands/info/doctor/index.ts
@@ -5,7 +5,7 @@ import { applyAsyncActionProjectDir } from '../../utils/applyAsyncAction';
 export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
-      .command('doctor')
+      .command('doctor [path]')
       .description('Diagnose issues with the project')
       .helpGroup('info')
       .option('--fix-dependencies', 'Fix incompatible dependency versions'),


### PR DESCRIPTION
# Why

- https://github.com/expo/expo-cli/issues/2221

# How

Added option to `doctor` command, internally using the `install` command for the installation.

# Test Plan

Tested manually.