### PR TITLE
[cli] fix reading EAS project ID from app.json during start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🐛 Bug fixes
 
 - [cli] suppress unauthorized warning on login and logout commands after logging out of all sessions on the website ([#4120](https://github.com/expo/expo-cli/issues/4120))
+- [cli] fix reading EAS project ID from app.json during start ([#4155](https://github.com/expo/expo-cli/issues/4155))
 
 ## [Wed, 22 Dec 2021 14:05:44 +0800](https://github.com/expo/expo-cli/commit/de947a91dfc3aa5c4b92330c3c03ec6649e0129f)
 

--- a/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
+++ b/packages/xdl/src/start/ExpoUpdatesManifestHandler.ts
@@ -136,7 +136,7 @@ export async function getManifestResponseAsync({
     },
   });
 
-  const easProjectId = expoConfig.extra?.eas.projectId;
+  const easProjectId = expoConfig.extra?.eas?.projectId;
   const shouldUseAnonymousManifest = await shouldUseAnonymousManifestAsync(easProjectId);
   const userAnonymousIdentifier = await UserSettings.getAnonymousIdentifierAsync();
   const scopeKey = shouldUseAnonymousManifest


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo-cli/issues/4129.

This is a leftover from https://github.com/expo/expo-cli/pull/3929.

# How

Fix case where extra key exists but eas key does not by using conditional property access.

# Test Plan

Same as https://github.com/expo/expo-cli/pull/3929.