### PR TITLE
[pkcs12] upgrade node-forge

### DIFF
--- a/packages/pkcs12/package.json
+++ b/packages/pkcs12/package.json
@@ -27,7 +27,7 @@
     "build"
   ],
   "dependencies": {
-    "node-forge": "^0.10.0"
+    "node-forge": "^1.2.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pkcs12/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/pkcs12/src/__tests__/__snapshots__/index-test.ts.snap
@@ -1018,7 +1018,7 @@ Object {
       },
     ],
     "getField": [Function],
-    "hash": "b8c7850b7d3127608f8ea7f3ef9e853bd3095c3f",
+    "hash": "64d7ddd8b72851acedab0b6a26653ffc05c174c1",
   },
   "md": Object {
     "algorithm": "sha256",
@@ -1161,7 +1161,7 @@ Object {
       },
     ],
     "getField": [Function],
-    "hash": "b8c7850b7d3127608f8ea7f3ef9e853bd3095c3f",
+    "hash": "64d7ddd8b72851acedab0b6a26653ffc05c174c1",
   },
   "tbsCertificate": Object {
     "composed": true,
@@ -1626,7 +1626,7 @@ Object {
       },
     ],
     "getField": [Function],
-    "hash": "5ec7598c4767ee0eea22de9a8f56380406671b9f",
+    "hash": "38d78bf6a681a88363f0b2ceaeeac5bae8298245",
   },
   "md": Object {
     "algorithm": "sha256",
@@ -1796,7 +1796,7 @@ Object {
       },
     ],
     "getField": [Function],
-    "hash": "5ec7598c4767ee0eea22de9a8f56380406671b9f",
+    "hash": "38d78bf6a681a88363f0b2ceaeeac5bae8298245",
   },
   "tbsCertificate": Object {
     "composed": true,
@@ -2466,7 +2466,7 @@ Object {
       },
     ],
     "getField": [Function],
-    "hash": "5ec7598c4767ee0eea22de9a8f56380406671b9f",
+    "hash": "38d78bf6a681a88363f0b2ceaeeac5bae8298245",
   },
   "md": Object {
     "algorithm": "sha256",
@@ -2636,7 +2636,7 @@ Object {
       },
     ],
     "getField": [Function],
-    "hash": "5ec7598c4767ee0eea22de9a8f56380406671b9f",
+    "hash": "38d78bf6a681a88363f0b2ceaeeac5bae8298245",
   },
   "tbsCertificate": Object {
     "composed": true,
@@ -3306,7 +3306,7 @@ Object {
       },
     ],
     "getField": [Function],
-    "hash": "5ec7598c4767ee0eea22de9a8f56380406671b9f",
+    "hash": "38d78bf6a681a88363f0b2ceaeeac5bae8298245",
   },
   "md": Object {
     "algorithm": "sha256",
@@ -3480,7 +3480,7 @@ Object {
       },
     ],
     "getField": [Function],
-    "hash": "5ec7598c4767ee0eea22de9a8f56380406671b9f",
+    "hash": "38d78bf6a681a88363f0b2ceaeeac5bae8298245",
   },
   "tbsCertificate": Object {
     "composed": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9540,10 +9540,10 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@0.0.0, hermes-engine@~0.7.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
-  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
+hermes-engine@~0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.7.2.tgz#303cd99d23f68e708b223aec2d49d5872985388b"
+  integrity sha512-E2DkRaO97gwL98LPhgfkMqhHiNsrAjIfEk3wWYn2Y31xdkdWn0572H7RnVcGujMJVqZNJvtknxlpsUb8Wzc3KA==
 
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"
@@ -13119,7 +13119,7 @@ node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@0.10.0, node-forge@^0.10.0:
+node-forge@0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
@@ -13128,6 +13128,11 @@ node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
   integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
+
+node-forge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
+  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
 
 node-gyp@^5.0.2:
   version "5.0.5"


### PR DESCRIPTION
# Why

- To fix https://github.com/expo/eas-cli/security/dependabot/yarn.lock/node-forge/open
- Generally, to keep the `node-forge` dependency up-to-date.

# How

- Upgrade `node-forge` to the latest.
- Update test snapshot.

# Test Plan

- Existing tests 
- I had to update the snapshot but it seems there are only some node-forge internal changes there are the update is fine. 