### PR TITLE
[config-plugins] avoid duplicate CFBundleURLTypes

### DIFF
--- a/packages/config-plugins/src/ios/Scheme.ts
+++ b/packages/config-plugins/src/ios/Scheme.ts
@@ -40,18 +40,20 @@ export function setScheme(
   };
 }
 
-// TODO: update this to be idempotent!
 export function appendScheme(scheme: string | null, infoPlist: InfoPlist): InfoPlist {
   if (!scheme) {
     return infoPlist;
   }
 
-  const existingSchemes = infoPlist.CFBundleURLTypes;
+  const existingSchemes = infoPlist.CFBundleURLTypes ?? [];
+  if (existingSchemes.some(({ CFBundleURLSchemes }) => CFBundleURLSchemes.includes(scheme))) {
+    return infoPlist;
+  }
 
   return {
     ...infoPlist,
     CFBundleURLTypes: [
-      ...(existingSchemes ?? []),
+      ...existingSchemes,
       {
         CFBundleURLSchemes: [scheme],
       },

--- a/packages/config-plugins/src/ios/__tests__/Scheme-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Scheme-test.ts
@@ -1,4 +1,11 @@
-import { getScheme, getSchemesFromPlist, hasScheme, removeScheme, setScheme } from '../Scheme';
+import {
+  appendScheme,
+  getScheme,
+  getSchemesFromPlist,
+  hasScheme,
+  removeScheme,
+  setScheme,
+} from '../Scheme';
 
 describe('scheme', () => {
   it(`returns empty array if no scheme is provided`, () => {
@@ -53,6 +60,28 @@ describe('scheme', () => {
       ],
     };
     expect(getSchemesFromPlist(infoPlist).length).toBe(3);
+  });
+
+  it(`append a scheme`, () => {
+    const infoPlist = {
+      CFBundleURLTypes: [
+        { CFBundleURLSchemes: ['myapp1', 'myapp2'] },
+        { CFBundleURLSchemes: ['myapp3'] },
+      ],
+    };
+    expect(appendScheme('myapp3', infoPlist)).toStrictEqual({
+      CFBundleURLTypes: [
+        { CFBundleURLSchemes: ['myapp1', 'myapp2'] },
+        { CFBundleURLSchemes: ['myapp3'] },
+      ],
+    });
+    expect(appendScheme('myapp4', infoPlist)).toStrictEqual({
+      CFBundleURLTypes: [
+        { CFBundleURLSchemes: ['myapp1', 'myapp2'] },
+        { CFBundleURLSchemes: ['myapp3'] },
+        { CFBundleURLSchemes: ['myapp4'] },
+      ],
+    });
   });
 
   it(`removes a scheme`, () => {


### PR DESCRIPTION
# Why

- `appendScheme` insert the same schema twice if I call it twice. It should insert only once

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Exists test