### PR TITLE
[config-plugins] handle missing targetattributes in project file when setting provisioning profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 - [cli] suppress unauthorized warning on login and logout commands after logging out of all sessions on the website ([#4120](https://github.com/expo/expo-cli/issues/4120))
 - [cli] fix reading EAS project ID from app.json during start ([#4155](https://github.com/expo/expo-cli/issues/4155))
+- [config-plugins] handle missing targetattributes edge case when setting provisioning profile for multitarget projects 
 
 ## [Wed, 22 Dec 2021 14:05:44 +0800](https://github.com/expo/expo-cli/commit/de947a91dfc3aa5c4b92330c3c03ec6649e0129f)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 - [cli] suppress unauthorized warning on login and logout commands after logging out of all sessions on the website ([#4120](https://github.com/expo/expo-cli/issues/4120))
 - [cli] fix reading EAS project ID from app.json during start ([#4155](https://github.com/expo/expo-cli/issues/4155))
-- [config-plugins] handle missing targetattributes edge case when setting provisioning profile for multitarget projects 
+- [config-plugins] handle missing targetattributes edge case when setting provisioning profile for multitarget projects ([#4175](https://github.com/expo/expo-cli/issues/4175))
 
 ## [Wed, 22 Dec 2021 14:05:44 +0800](https://github.com/expo/expo-cli/commit/de947a91dfc3aa5c4b92330c3c03ec6649e0129f)
 

--- a/packages/config-plugins/src/ios/ProvisioningProfile.ts
+++ b/packages/config-plugins/src/ios/ProvisioningProfile.ts
@@ -47,6 +47,9 @@ export function setProvisioningProfileForPbxproj(
   Object.entries(getProjectSection(project))
     .filter(isNotComment)
     .forEach(([, item]: ProjectSectionEntry) => {
+      if (!item.attributes.TargetAttributes[nativeTargetId]) {
+        item.attributes.TargetAttributes[nativeTargetId] = {};
+      }
       item.attributes.TargetAttributes[nativeTargetId].DevelopmentTeam = quotedAppleTeamId;
       item.attributes.TargetAttributes[nativeTargetId].ProvisioningStyle = 'Manual';
     });

--- a/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
@@ -13,6 +13,45 @@ describe('ProvisioningProfile module', () => {
     const projectRoot = '/testproject';
     const pbxProjPath = 'ios/testproject.xcodeproj/project.pbxproj';
 
+    afterEach(() => {
+      vol.reset();
+    });
+
+    it('configures the project.pbxproj file for multitarget projects', () => {
+      vol.fromJSON(
+        {
+          [pbxProjPath]: originalFs.readFileSync(
+            path.join(__dirname, 'fixtures/project-multitarget.pbxproj'),
+            'utf-8'
+          ),
+        },
+        projectRoot
+      );
+      setProvisioningProfileForPbxproj(projectRoot, {
+        profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+        appleTeamId: 'J5FM626PE2',
+      });
+      const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+      expect(pbxprojContents).toMatchSnapshot();
+    });
+    it('configures the project.pbxproj file for multitarget projects without existing target attributes', () => {
+      vol.fromJSON(
+        {
+          [pbxProjPath]: originalFs.readFileSync(
+            path.join(__dirname, 'fixtures/project-multitarget-missing-targetattributes.pbxproj'),
+            'utf-8'
+          ),
+        },
+        projectRoot
+      );
+      setProvisioningProfileForPbxproj(projectRoot, {
+        profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+        appleTeamId: 'J5FM626PE2',
+      });
+      const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+      expect(pbxprojContents).toMatchSnapshot();
+    });
+
     beforeEach(() => {
       vol.fromJSON(
         {
@@ -23,9 +62,6 @@ describe('ProvisioningProfile module', () => {
         },
         projectRoot
       );
-    });
-    afterEach(() => {
-      vol.reset();
     });
 
     it('configures the project.pbxproj file with the profile name and apple team id', () => {

--- a/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
@@ -17,77 +17,84 @@ describe('ProvisioningProfile module', () => {
       vol.reset();
     });
 
-    it('configures the project.pbxproj file for multitarget projects', () => {
-      vol.fromJSON(
-        {
-          [pbxProjPath]: originalFs.readFileSync(
-            path.join(__dirname, 'fixtures/project-multitarget.pbxproj'),
-            'utf-8'
-          ),
-        },
-        projectRoot
-      );
-      setProvisioningProfileForPbxproj(projectRoot, {
-        profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
-        appleTeamId: 'J5FM626PE2',
-      });
-      const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
-      expect(pbxprojContents).toMatchSnapshot();
-    });
-    it('configures the project.pbxproj file for multitarget projects without existing target attributes', () => {
-      vol.fromJSON(
-        {
-          [pbxProjPath]: originalFs.readFileSync(
-            path.join(__dirname, 'fixtures/project-multitarget-missing-targetattributes.pbxproj'),
-            'utf-8'
-          ),
-        },
-        projectRoot
-      );
-      setProvisioningProfileForPbxproj(projectRoot, {
-        profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
-        appleTeamId: 'J5FM626PE2',
-      });
-      const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
-      expect(pbxprojContents).toMatchSnapshot();
-    });
-
-    beforeEach(() => {
-      vol.fromJSON(
-        {
-          [pbxProjPath]: originalFs.readFileSync(
-            path.join(__dirname, 'fixtures/project.pbxproj'),
-            'utf-8'
-          ),
-        },
-        projectRoot
-      );
-    });
-
-    it('configures the project.pbxproj file with the profile name and apple team id', () => {
-      setProvisioningProfileForPbxproj(projectRoot, {
-        profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
-        appleTeamId: 'J5FM626PE2',
-      });
-      const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
-      expect(pbxprojContents).toMatchSnapshot();
-    });
-    it('configures the project.pbxproj file with the profile name and apple team id', () => {
-      setProvisioningProfileForPbxproj(projectRoot, {
-        profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
-        appleTeamId: 'Something Spaced',
-      });
-      const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
-      expect(pbxprojContents).toMatch(/DevelopmentTeam = "Something Spaced";/);
-    });
-    it('throws descriptive error when target name does not exist', () => {
-      expect(() =>
+    describe('multitarget', () => {
+      it('configures the project.pbxproj file for multitarget projects', () => {
+        vol.fromJSON(
+          {
+            [pbxProjPath]: originalFs.readFileSync(
+              path.join(__dirname, 'fixtures/project-multitarget.pbxproj'),
+              'utf-8'
+            ),
+          },
+          projectRoot
+        );
         setProvisioningProfileForPbxproj(projectRoot, {
-          targetName: 'faketargetname',
+          targetName: 'multitarget',
           profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
           appleTeamId: 'J5FM626PE2',
-        })
-      ).toThrow("Could not find target 'faketargetname' in project.pbxproj");
+        });
+        const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+        expect(pbxprojContents).toMatchSnapshot();
+      });
+
+      it('configures the project.pbxproj file for multitarget projects without existing target attributes', () => {
+        vol.fromJSON(
+          {
+            [pbxProjPath]: originalFs.readFileSync(
+              path.join(__dirname, 'fixtures/project-multitarget-missing-targetattributes.pbxproj'),
+              'utf-8'
+            ),
+          },
+          projectRoot
+        );
+        setProvisioningProfileForPbxproj(projectRoot, {
+          targetName: 'multitarget',
+          profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+          appleTeamId: 'J5FM626PE2',
+        });
+        const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+        expect(pbxprojContents).toMatchSnapshot();
+      });
+    });
+
+    describe('single target', () => {
+      beforeEach(() => {
+        vol.fromJSON(
+          {
+            [pbxProjPath]: originalFs.readFileSync(
+              path.join(__dirname, 'fixtures/project.pbxproj'),
+              'utf-8'
+            ),
+          },
+          projectRoot
+        );
+      });
+
+      it('configures the project.pbxproj file with the profile name and apple team id', () => {
+        setProvisioningProfileForPbxproj(projectRoot, {
+          profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+          appleTeamId: 'J5FM626PE2',
+        });
+        const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+        expect(pbxprojContents).toMatchSnapshot();
+      });
+      it('configures the project.pbxproj file with the profile name and apple team id', () => {
+        setProvisioningProfileForPbxproj(projectRoot, {
+          profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+          appleTeamId: 'Something Spaced',
+        });
+        const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+        expect(pbxprojContents).toMatch(/DevelopmentTeam = "Something Spaced";/);
+      });
+      it('throws descriptive error when target name does not exist', () => {
+        expect(() =>
+          setProvisioningProfileForPbxproj(projectRoot, {
+            targetName: 'faketargetname',
+            profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+            appleTeamId: 'J5FM626PE2',
+          })
+        ).toThrow("Could not find target 'faketargetname' in project.pbxproj");
+      });
     });
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures the project.pbxproj file for multitarget projects 1`] = `
+exports[`ProvisioningProfile module setProvisioningProfileForPbxproj multitarget configures the project.pbxproj file for multitarget projects 1`] = `
 "// !$*UTF8*$!
 {
 	archiveVersion = 1;
@@ -660,7 +660,7 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures 
 "
 `;
 
-exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures the project.pbxproj file for multitarget projects without existing target attributes 1`] = `
+exports[`ProvisioningProfile module setProvisioningProfileForPbxproj multitarget configures the project.pbxproj file for multitarget projects without existing target attributes 1`] = `
 "// !$*UTF8*$!
 {
 	archiveVersion = 1;
@@ -1314,7 +1314,7 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures 
 "
 `;
 
-exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures the project.pbxproj file with the profile name and apple team id 1`] = `
+exports[`ProvisioningProfile module setProvisioningProfileForPbxproj single target configures the project.pbxproj file with the profile name and apple team id 1`] = `
 "// !$*UTF8*$!
 {
 	archiveVersion = 1;

--- a/packages/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
+++ b/packages/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
@@ -1,5 +1,1319 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures the project.pbxproj file for multitarget projects 1`] = `
+"// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		6ADAD6E626493A420001F56E /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ADAD6E526493A420001F56E /* ShareViewController.m */; };
+		6ADAD6E926493A420001F56E /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6ADAD6E726493A420001F56E /* MainInterface.storyboard */; };
+		6ADAD6ED26493A420001F56E /* shareextension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6ADAD6E226493A420001F56E /* shareextension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		96905EF65AED1B983A6B3ABC /* libPods-multitarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6ADAD6EB26493A420001F56E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6ADAD6E126493A420001F56E;
+			remoteInfo = shareextension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		6ADAD6F126493A420001F56E /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = \\"\\";
+			dstSubfolderSpec = 13;
+			files = (
+				6ADAD6ED26493A420001F56E /* shareextension.appex in Embed App Extensions */,
+			);
+			name = \\"Embed App Extensions\\";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = \\"<group>\\"; };
+		13B07F961A680F5B00A75B9A /* multitarget.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = multitarget.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = multitarget/AppDelegate.h; sourceTree = \\"<group>\\"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = multitarget/AppDelegate.m; sourceTree = \\"<group>\\"; };
+		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = \\"<group>\\"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = multitarget/Images.xcassets; sourceTree = \\"<group>\\"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = multitarget/Info.plist; sourceTree = \\"<group>\\"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = multitarget/main.m; sourceTree = \\"<group>\\"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = \\"libPods-multitarget.a\\"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADAD6E226493A420001F56E /* shareextension.appex */ = {isa = PBXFileReference; explicitFileType = \\"wrapper.app-extension\\"; includeInIndex = 0; path = shareextension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADAD6E426493A420001F56E /* ShareViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = \\"<group>\\"; };
+		6ADAD6E526493A420001F56E /* ShareViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = \\"<group>\\"; };
+		6ADAD6E826493A420001F56E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = \\"<group>\\"; };
+		6ADAD6EA26493A420001F56E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = \\"<group>\\"; };
+		6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = \\"Pods-multitarget.debug.xcconfig\\"; path = \\"Target Support Files/Pods-multitarget/Pods-multitarget.debug.xcconfig\\"; sourceTree = \\"<group>\\"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = \\"Pods-multitarget.release.xcconfig\\"; path = \\"Target Support Files/Pods-multitarget/Pods-multitarget.release.xcconfig\\"; sourceTree = \\"<group>\\"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = multitarget/SplashScreen.storyboard; sourceTree = \\"<group>\\"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = \\"<group>\\"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-multitarget.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6DF26493A420001F56E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* multitarget */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+			);
+			name = multitarget;
+			sourceTree = \\"<group>\\";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */,
+			);
+			name = Frameworks;
+			sourceTree = \\"<group>\\";
+		};
+		6ADAD6E326493A420001F56E /* shareextension */ = {
+			isa = PBXGroup;
+			children = (
+				6ADAD6E426493A420001F56E /* ShareViewController.h */,
+				6ADAD6E526493A420001F56E /* ShareViewController.m */,
+				6ADAD6E726493A420001F56E /* MainInterface.storyboard */,
+				6ADAD6EA26493A420001F56E /* Info.plist */,
+			);
+			path = shareextension;
+			sourceTree = \\"<group>\\";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = \\"<group>\\";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* multitarget */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				6ADAD6E326493A420001F56E /* shareextension */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = \\"<group>\\";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* multitarget.app */,
+				6ADAD6E226493A420001F56E /* shareextension.appex */,
+			);
+			name = Products;
+			sourceTree = \\"<group>\\";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = multitarget/Supporting;
+			sourceTree = \\"<group>\\";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* multitarget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget \\"multitarget\\" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				FD10A7F022414F080027D42C /* Start Packager */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */,
+				6ADAD6F126493A420001F56E /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6ADAD6EC26493A420001F56E /* PBXTargetDependency */,
+			);
+			name = multitarget;
+			productName = multitarget;
+			productReference = 13B07F961A680F5B00A75B9A /* multitarget.app */;
+			productType = \\"com.apple.product-type.application\\";
+		};
+		6ADAD6E126493A420001F56E /* shareextension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6ADAD6EE26493A420001F56E /* Build configuration list for PBXNativeTarget \\"shareextension\\" */;
+			buildPhases = (
+				6ADAD6DE26493A420001F56E /* Sources */,
+				6ADAD6DF26493A420001F56E /* Frameworks */,
+				6ADAD6E026493A420001F56E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = shareextension;
+			productName = shareextension;
+			productReference = 6ADAD6E226493A420001F56E /* shareextension.appex */;
+			productType = \\"com.apple.product-type.app-extension\\";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = \\"J5FM626PE2\\";
+						LastSwiftMigration = 1120;
+						ProvisioningStyle = Manual;
+					};
+					6ADAD6E126493A420001F56E = {
+						CreatedOnToolsVersion = 12.5;
+						DevelopmentTeam = QL76XYH73P;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject \\"multitarget\\" */;
+			compatibilityVersion = \\"Xcode 3.2\\";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = \\"\\";
+			projectRoot = \\"\\";
+			targets = (
+				13B07F861A680F5B00A75B9A /* multitarget */,
+				6ADAD6E126493A420001F56E /* shareextension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6E026493A420001F56E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ADAD6E926493A420001F56E /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = \\"Bundle React Native code and images\\";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"if [[ -f /Users/dsokal/.volta/bin/node ]]; then\\\\n  export NODE_BINARY=/Users/dsokal/.volta/bin/node\\\\nelse\\\\n  export NODE_BINARY=node\\\\nfi\\\\n../node_modules/react-native/scripts/react-native-xcode.sh\\\\n../node_modules/expo-constants/scripts/get-app-config-ios.sh\\\\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\\\\n\\";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				\\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\",
+				\\"\${PODS_ROOT}/Manifest.lock\\",
+			);
+			name = \\"[CP] Check Pods Manifest.lock\\";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				\\"$(DERIVED_FILE_DIR)/Pods-multitarget-checkManifestLockResult.txt\\",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"diff \\\\\\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\\\\\" \\\\\\"\${PODS_ROOT}/Manifest.lock\\\\\\" > /dev/null\\\\nif [ $? != 0 ] ; then\\\\n    # print error to STDERR\\\\n    echo \\\\\\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\\\\\" >&2\\\\n    exit 1\\\\nfi\\\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\\\necho \\\\\\"SUCCESS\\\\\\" > \\\\\\"\${SCRIPT_OUTPUT_FILE_0}\\\\\\"\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+		AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				\\"\${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh\\",
+				\\"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle\\",
+			);
+			name = \\"[CP] Copy Pods Resources\\";
+			outputPaths = (
+				\\"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle\\",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"\\\\\\"\${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh\\\\\\"\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+		FD10A7F022414F080027D42C /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = \\"Start Packager\\";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"export RCT_METRO_PORT=\\\\\\"\${RCT_METRO_PORT:=8081}\\\\\\"\\\\necho \\\\\\"export RCT_METRO_PORT=\${RCT_METRO_PORT}\\\\\\" > \\\\\\"\${SRCROOT}/../node_modules/react-native/scripts/.packager.env\\\\\\"\\\\nif [ -z \\\\\\"\${RCT_NO_LAUNCH_PACKAGER+xxx}\\\\\\" ] ; then\\\\n  if nc -w 5 -z localhost \${RCT_METRO_PORT} ; then\\\\n    if ! curl -s \\\\\\"http://localhost:\${RCT_METRO_PORT}/status\\\\\\" | grep -q \\\\\\"packager-status:running\\\\\\" ; then\\\\n      echo \\\\\\"Port \${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\\\\\\"\\\\n      exit 2\\\\n    fi\\\\n  else\\\\n    open \\\\\\"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\\\\\\" || echo \\\\\\"Can't start packager automatically\\\\\\"\\\\n  fi\\\\nfi\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6DE26493A420001F56E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ADAD6E626493A420001F56E /* ShareViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6ADAD6EC26493A420001F56E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6ADAD6E126493A420001F56E /* shareextension */;
+			targetProxy = 6ADAD6EB26493A420001F56E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13B07FB21A68108700A75B9A /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = multitarget;
+			sourceTree = \\"<group>\\";
+		};
+		6ADAD6E726493A420001F56E /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6ADAD6E826493A420001F56E /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"$(inherited)\\",
+					\\"FB_SONARKIT_ENABLED=1\\",
+				);
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks\\";
+				OTHER_LDFLAGS = (
+					\\"$(inherited)\\",
+					\\"-ObjC\\",
+					\\"-lc++\\",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.debug;
+				PRODUCT_NAME = multitarget;
+				SWIFT_OPTIMIZATION_LEVEL = \\"-Onone\\";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = \\"apple-generic\\";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = \\"iPhone Distribution\\";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = \\"J5FM626PE2\\";
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks\\";
+				OTHER_LDFLAGS = (
+					\\"$(inherited)\\",
+					\\"-ObjC\\",
+					\\"-lc++\\",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget;
+				PRODUCT_NAME = multitarget;
+				PROVISIONING_PROFILE_SPECIFIER = \\"*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z\\";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = \\"apple-generic\\";
+			};
+			name = Release;
+		};
+		6ADAD6EF26493A420001F56E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++14\\";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks\\";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = \\"$(TARGET_NAME)\\";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = \\"1,2\\";
+			};
+			name = Debug;
+		};
+		6ADAD6F026493A420001F56E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++14\\";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = \\"dwarf-with-dsym\\";
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks\\";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = \\"$(TARGET_NAME)\\";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = \\"1,2\\";
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				\\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\\" = \\"iPhone Developer\\";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"DEBUG=1\\",
+					\\"$(inherited)\\",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"/usr/lib/swift $(inherited)\\";
+				LIBRARY_SEARCH_PATHS = (
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(inherited)\\\\\\"\\",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				\\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\\" = \\"iPhone Developer\\";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"/usr/lib/swift $(inherited)\\";
+				LIBRARY_SEARCH_PATHS = (
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(inherited)\\\\\\"\\",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget \\"multitarget\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6ADAD6EE26493A420001F56E /* Build configuration list for PBXNativeTarget \\"shareextension\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6ADAD6EF26493A420001F56E /* Debug */,
+				6ADAD6F026493A420001F56E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject \\"multitarget\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}
+"
+`;
+
+exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures the project.pbxproj file for multitarget projects without existing target attributes 1`] = `
+"// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		6ADAD6E626493A420001F56E /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ADAD6E526493A420001F56E /* ShareViewController.m */; };
+		6ADAD6E926493A420001F56E /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6ADAD6E726493A420001F56E /* MainInterface.storyboard */; };
+		6ADAD6ED26493A420001F56E /* shareextension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6ADAD6E226493A420001F56E /* shareextension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		96905EF65AED1B983A6B3ABC /* libPods-multitarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6ADAD6EB26493A420001F56E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6ADAD6E126493A420001F56E;
+			remoteInfo = shareextension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		6ADAD6F126493A420001F56E /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = \\"\\";
+			dstSubfolderSpec = 13;
+			files = (
+				6ADAD6ED26493A420001F56E /* shareextension.appex in Embed App Extensions */,
+			);
+			name = \\"Embed App Extensions\\";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = \\"<group>\\"; };
+		13B07F961A680F5B00A75B9A /* multitarget.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = multitarget.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = multitarget/AppDelegate.h; sourceTree = \\"<group>\\"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = multitarget/AppDelegate.m; sourceTree = \\"<group>\\"; };
+		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = \\"<group>\\"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = multitarget/Images.xcassets; sourceTree = \\"<group>\\"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = multitarget/Info.plist; sourceTree = \\"<group>\\"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = multitarget/main.m; sourceTree = \\"<group>\\"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = \\"libPods-multitarget.a\\"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADAD6E226493A420001F56E /* shareextension.appex */ = {isa = PBXFileReference; explicitFileType = \\"wrapper.app-extension\\"; includeInIndex = 0; path = shareextension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADAD6E426493A420001F56E /* ShareViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = \\"<group>\\"; };
+		6ADAD6E526493A420001F56E /* ShareViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = \\"<group>\\"; };
+		6ADAD6E826493A420001F56E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = \\"<group>\\"; };
+		6ADAD6EA26493A420001F56E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = \\"<group>\\"; };
+		6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = \\"Pods-multitarget.debug.xcconfig\\"; path = \\"Target Support Files/Pods-multitarget/Pods-multitarget.debug.xcconfig\\"; sourceTree = \\"<group>\\"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = \\"Pods-multitarget.release.xcconfig\\"; path = \\"Target Support Files/Pods-multitarget/Pods-multitarget.release.xcconfig\\"; sourceTree = \\"<group>\\"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = multitarget/SplashScreen.storyboard; sourceTree = \\"<group>\\"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = \\"<group>\\"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-multitarget.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6DF26493A420001F56E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* multitarget */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+			);
+			name = multitarget;
+			sourceTree = \\"<group>\\";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */,
+			);
+			name = Frameworks;
+			sourceTree = \\"<group>\\";
+		};
+		6ADAD6E326493A420001F56E /* shareextension */ = {
+			isa = PBXGroup;
+			children = (
+				6ADAD6E426493A420001F56E /* ShareViewController.h */,
+				6ADAD6E526493A420001F56E /* ShareViewController.m */,
+				6ADAD6E726493A420001F56E /* MainInterface.storyboard */,
+				6ADAD6EA26493A420001F56E /* Info.plist */,
+			);
+			path = shareextension;
+			sourceTree = \\"<group>\\";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = \\"<group>\\";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* multitarget */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				6ADAD6E326493A420001F56E /* shareextension */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = \\"<group>\\";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* multitarget.app */,
+				6ADAD6E226493A420001F56E /* shareextension.appex */,
+			);
+			name = Products;
+			sourceTree = \\"<group>\\";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = multitarget/Supporting;
+			sourceTree = \\"<group>\\";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* multitarget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget \\"multitarget\\" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				FD10A7F022414F080027D42C /* Start Packager */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */,
+				6ADAD6F126493A420001F56E /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6ADAD6EC26493A420001F56E /* PBXTargetDependency */,
+			);
+			name = multitarget;
+			productName = multitarget;
+			productReference = 13B07F961A680F5B00A75B9A /* multitarget.app */;
+			productType = \\"com.apple.product-type.application\\";
+		};
+		6ADAD6E126493A420001F56E /* shareextension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6ADAD6EE26493A420001F56E /* Build configuration list for PBXNativeTarget \\"shareextension\\" */;
+			buildPhases = (
+				6ADAD6DE26493A420001F56E /* Sources */,
+				6ADAD6DF26493A420001F56E /* Frameworks */,
+				6ADAD6E026493A420001F56E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = shareextension;
+			productName = shareextension;
+			productReference = 6ADAD6E226493A420001F56E /* shareextension.appex */;
+			productType = \\"com.apple.product-type.app-extension\\";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = \\"J5FM626PE2\\";
+						ProvisioningStyle = Manual;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject \\"multitarget\\" */;
+			compatibilityVersion = \\"Xcode 3.2\\";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = \\"\\";
+			projectRoot = \\"\\";
+			targets = (
+				13B07F861A680F5B00A75B9A /* multitarget */,
+				6ADAD6E126493A420001F56E /* shareextension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6E026493A420001F56E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ADAD6E926493A420001F56E /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = \\"Bundle React Native code and images\\";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"if [[ -f /Users/dsokal/.volta/bin/node ]]; then\\\\n  export NODE_BINARY=/Users/dsokal/.volta/bin/node\\\\nelse\\\\n  export NODE_BINARY=node\\\\nfi\\\\n../node_modules/react-native/scripts/react-native-xcode.sh\\\\n../node_modules/expo-constants/scripts/get-app-config-ios.sh\\\\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\\\\n\\";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				\\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\",
+				\\"\${PODS_ROOT}/Manifest.lock\\",
+			);
+			name = \\"[CP] Check Pods Manifest.lock\\";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				\\"$(DERIVED_FILE_DIR)/Pods-multitarget-checkManifestLockResult.txt\\",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"diff \\\\\\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\\\\\" \\\\\\"\${PODS_ROOT}/Manifest.lock\\\\\\" > /dev/null\\\\nif [ $? != 0 ] ; then\\\\n    # print error to STDERR\\\\n    echo \\\\\\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\\\\\" >&2\\\\n    exit 1\\\\nfi\\\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\\\necho \\\\\\"SUCCESS\\\\\\" > \\\\\\"\${SCRIPT_OUTPUT_FILE_0}\\\\\\"\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+		AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				\\"\${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh\\",
+				\\"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle\\",
+			);
+			name = \\"[CP] Copy Pods Resources\\";
+			outputPaths = (
+				\\"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle\\",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"\\\\\\"\${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh\\\\\\"\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+		FD10A7F022414F080027D42C /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = \\"Start Packager\\";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = \\"export RCT_METRO_PORT=\\\\\\"\${RCT_METRO_PORT:=8081}\\\\\\"\\\\necho \\\\\\"export RCT_METRO_PORT=\${RCT_METRO_PORT}\\\\\\" > \\\\\\"\${SRCROOT}/../node_modules/react-native/scripts/.packager.env\\\\\\"\\\\nif [ -z \\\\\\"\${RCT_NO_LAUNCH_PACKAGER+xxx}\\\\\\" ] ; then\\\\n  if nc -w 5 -z localhost \${RCT_METRO_PORT} ; then\\\\n    if ! curl -s \\\\\\"http://localhost:\${RCT_METRO_PORT}/status\\\\\\" | grep -q \\\\\\"packager-status:running\\\\\\" ; then\\\\n      echo \\\\\\"Port \${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\\\\\\"\\\\n      exit 2\\\\n    fi\\\\n  else\\\\n    open \\\\\\"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\\\\\\" || echo \\\\\\"Can't start packager automatically\\\\\\"\\\\n  fi\\\\nfi\\\\n\\";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6DE26493A420001F56E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ADAD6E626493A420001F56E /* ShareViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6ADAD6EC26493A420001F56E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6ADAD6E126493A420001F56E /* shareextension */;
+			targetProxy = 6ADAD6EB26493A420001F56E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13B07FB21A68108700A75B9A /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = multitarget;
+			sourceTree = \\"<group>\\";
+		};
+		6ADAD6E726493A420001F56E /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6ADAD6E826493A420001F56E /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = \\"<group>\\";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"$(inherited)\\",
+					\\"FB_SONARKIT_ENABLED=1\\",
+				);
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks\\";
+				OTHER_LDFLAGS = (
+					\\"$(inherited)\\",
+					\\"-ObjC\\",
+					\\"-lc++\\",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.debug;
+				PRODUCT_NAME = multitarget;
+				SWIFT_OPTIMIZATION_LEVEL = \\"-Onone\\";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = \\"apple-generic\\";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = \\"iPhone Distribution\\";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = \\"J5FM626PE2\\";
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks\\";
+				OTHER_LDFLAGS = (
+					\\"$(inherited)\\",
+					\\"-ObjC\\",
+					\\"-lc++\\",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget;
+				PRODUCT_NAME = multitarget;
+				PROVISIONING_PROFILE_SPECIFIER = \\"*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z\\";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = \\"apple-generic\\";
+			};
+			name = Release;
+		};
+		6ADAD6EF26493A420001F56E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++14\\";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks\\";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = \\"$(TARGET_NAME)\\";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = \\"1,2\\";
+			};
+			name = Debug;
+		};
+		6ADAD6F026493A420001F56E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++14\\";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = \\"dwarf-with-dsym\\";
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = \\"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks\\";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = \\"$(TARGET_NAME)\\";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = \\"1,2\\";
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				\\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\\" = \\"iPhone Developer\\";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					\\"DEBUG=1\\",
+					\\"$(inherited)\\",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"/usr/lib/swift $(inherited)\\";
+				LIBRARY_SEARCH_PATHS = (
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(inherited)\\\\\\"\\",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = \\"gnu++0x\\";
+				CLANG_CXX_LIBRARY = \\"libc++\\";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				\\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\\" = \\"iPhone Developer\\";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = \\"/usr/lib/swift $(inherited)\\";
+				LIBRARY_SEARCH_PATHS = (
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\\\\\"\\",
+					\\"\\\\\\"$(inherited)\\\\\\"\\",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget \\"multitarget\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6ADAD6EE26493A420001F56E /* Build configuration list for PBXNativeTarget \\"shareextension\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6ADAD6EF26493A420001F56E /* Debug */,
+				6ADAD6F026493A420001F56E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject \\"multitarget\\" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}
+"
+`;
+
 exports[`ProvisioningProfile module setProvisioningProfileForPbxproj configures the project.pbxproj file with the profile name and apple team id 1`] = `
 "// !$*UTF8*$!
 {

--- a/packages/config-plugins/src/ios/__tests__/fixtures/project-multitarget-missing-targetattributes.pbxproj
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/project-multitarget-missing-targetattributes.pbxproj
@@ -1,0 +1,645 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		6ADAD6E626493A420001F56E /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ADAD6E526493A420001F56E /* ShareViewController.m */; };
+		6ADAD6E926493A420001F56E /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6ADAD6E726493A420001F56E /* MainInterface.storyboard */; };
+		6ADAD6ED26493A420001F56E /* shareextension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6ADAD6E226493A420001F56E /* shareextension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		96905EF65AED1B983A6B3ABC /* libPods-multitarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6ADAD6EB26493A420001F56E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6ADAD6E126493A420001F56E;
+			remoteInfo = shareextension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		6ADAD6F126493A420001F56E /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				6ADAD6ED26493A420001F56E /* shareextension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		13B07F961A680F5B00A75B9A /* multitarget.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = multitarget.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = multitarget/AppDelegate.h; sourceTree = "<group>"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = multitarget/AppDelegate.m; sourceTree = "<group>"; };
+		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = multitarget/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = multitarget/Info.plist; sourceTree = "<group>"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = multitarget/main.m; sourceTree = "<group>"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-multitarget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADAD6E226493A420001F56E /* shareextension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = shareextension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		6ADAD6E426493A420001F56E /* ShareViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = "<group>"; };
+		6ADAD6E526493A420001F56E /* ShareViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = "<group>"; };
+		6ADAD6E826493A420001F56E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		6ADAD6EA26493A420001F56E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-multitarget.debug.xcconfig"; path = "Target Support Files/Pods-multitarget/Pods-multitarget.debug.xcconfig"; sourceTree = "<group>"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-multitarget.release.xcconfig"; path = "Target Support Files/Pods-multitarget/Pods-multitarget.release.xcconfig"; sourceTree = "<group>"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = multitarget/SplashScreen.storyboard; sourceTree = "<group>"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-multitarget.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6DF26493A420001F56E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* multitarget */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+			);
+			name = multitarget;
+			sourceTree = "<group>";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-multitarget.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6ADAD6E326493A420001F56E /* shareextension */ = {
+			isa = PBXGroup;
+			children = (
+				6ADAD6E426493A420001F56E /* ShareViewController.h */,
+				6ADAD6E526493A420001F56E /* ShareViewController.m */,
+				6ADAD6E726493A420001F56E /* MainInterface.storyboard */,
+				6ADAD6EA26493A420001F56E /* Info.plist */,
+			);
+			path = shareextension;
+			sourceTree = "<group>";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* multitarget */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				6ADAD6E326493A420001F56E /* shareextension */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* multitarget.app */,
+				6ADAD6E226493A420001F56E /* shareextension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = multitarget/Supporting;
+			sourceTree = "<group>";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* multitarget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "multitarget" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				FD10A7F022414F080027D42C /* Start Packager */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */,
+				6ADAD6F126493A420001F56E /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6ADAD6EC26493A420001F56E /* PBXTargetDependency */,
+			);
+			name = multitarget;
+			productName = multitarget;
+			productReference = 13B07F961A680F5B00A75B9A /* multitarget.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6ADAD6E126493A420001F56E /* shareextension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6ADAD6EE26493A420001F56E /* Build configuration list for PBXNativeTarget "shareextension" */;
+			buildPhases = (
+				6ADAD6DE26493A420001F56E /* Sources */,
+				6ADAD6DF26493A420001F56E /* Frameworks */,
+				6ADAD6E026493A420001F56E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = shareextension;
+			productName = shareextension;
+			productReference = 6ADAD6E226493A420001F56E /* shareextension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "multitarget" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* multitarget */,
+				6ADAD6E126493A420001F56E /* shareextension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6E026493A420001F56E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ADAD6E926493A420001F56E /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f /Users/dsokal/.volta/bin/node ]]; then\n  export NODE_BINARY=/Users/dsokal/.volta/bin/node\nelse\n  export NODE_BINARY=node\nfi\n../node_modules/react-native/scripts/react-native-xcode.sh\n../node_modules/expo-constants/scripts/get-app-config-ios.sh\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\n";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-multitarget-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FD10A7F022414F080027D42C /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Start Packager";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6ADAD6DE26493A420001F56E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ADAD6E626493A420001F56E /* ShareViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6ADAD6EC26493A420001F56E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6ADAD6E126493A420001F56E /* shareextension */;
+			targetProxy = 6ADAD6EB26493A420001F56E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13B07FB21A68108700A75B9A /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = multitarget;
+			sourceTree = "<group>";
+		};
+		6ADAD6E726493A420001F56E /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6ADAD6E826493A420001F56E /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-multitarget.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.debug;
+				PRODUCT_NAME = multitarget;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-multitarget.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget;
+				PRODUCT_NAME = multitarget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		6ADAD6EF26493A420001F56E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6ADAD6F026493A420001F56E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "multitarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6ADAD6EE26493A420001F56E /* Build configuration list for PBXNativeTarget "shareextension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6ADAD6EF26493A420001F56E /* Debug */,
+				6ADAD6F026493A420001F56E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "multitarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/eas-cli/issues/948.

# How

Create target attributes object first if missing.

# Test Plan

Added two test cases for the provisioning profile logic, one for a multitarget project with existing target attributes, and one without, and recorded snapshots to verify the functionality.