### PR TITLE
[expo-cli] update error message when publish is misconfigured

### DIFF
--- a/packages/expo-cli/src/commands/publish/publishAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishAsync.ts
@@ -163,7 +163,7 @@ function assertUpdateURLCorrectlyConfigured(exp: ExpoConfig): void {
   if (isMaybeAnEASUrl(configuredURL)) {
     throw new CommandError(
       ErrorCodes.INVALID_UPDATE_URL,
-      `It seems like your project is configured for EAS Update. Please use 'eas branch:publish' instead.`
+      `It seems like your project is configured for EAS Update. Please use 'eas update' instead.`
     );
   }
 }


### PR DESCRIPTION
# Why

`eas branch:publish` has been renamed `eas update`

