### PR TITLE
[expo-cli] check expo-updates is installed before a publish

### DIFF
--- a/packages/expo-cli/src/commands/publish/publishAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishAsync.ts
@@ -6,15 +6,18 @@ import {
   PackageJSONConfig,
   ProjectTarget,
 } from '@expo/config';
+import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import fs from 'fs';
 import { Ora } from 'ora';
 import path from 'path';
+import resolveFrom from 'resolve-from';
 import { Project, UserManager } from 'xdl';
 
 import CommandError, { ErrorCodes } from '../../CommandError';
 import Log from '../../log';
 import { logNewSection } from '../../utils/ora';
+import { confirmAsync } from '../../utils/prompts';
 import * as TerminalLink from '../utils/TerminalLink';
 import { formatNamedWarning } from '../utils/logConfigWarnings';
 import * as sendTo from '../utils/sendTo';
@@ -41,6 +44,7 @@ export async function actionAsync(
   const { exp, pkg } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
   });
+  await confirmExpoUpdatesInstalledAsync(projectRoot);
   assertUpdateURLCorrectlyConfigured(exp);
   const { sdkVersion, runtimeVersion } = exp;
 
@@ -146,6 +150,59 @@ function assertValidReleaseChannel(releaseChannel?: string): void {
   if (isInvalidReleaseChannel(releaseChannel)) {
     throw new CommandError(
       'Release channel name can only contain lowercase letters, numbers and special characters . _ and -'
+    );
+  }
+}
+
+async function isExpoUpdatesInstalledAsync(projectDir: string): Promise<boolean> {
+  try {
+    resolveFrom(projectDir, 'expo-updates/package.json');
+    return true;
+  } catch (err: any) {
+    Log.debug(err);
+    return false;
+  }
+}
+
+async function installExpoUpdatesAsync(projectDir: string): Promise<void> {
+  const expoCliPath = resolveFrom(projectDir, 'expo/bin/cli.js');
+
+  Log.newLine();
+  Log.log(`Running ${chalk.bold('expo install expo-updates')}`);
+  Log.newLine();
+  await spawnAsync(expoCliPath, ['install', 'expo-updates']);
+  Log.newLine();
+}
+
+async function confirmExpoUpdatesInstalledAsync(projectDir: string): Promise<void> {
+  if (await isExpoUpdatesInstalledAsync(projectDir)) {
+    return;
+  }
+
+  const isBare = getDefaultTarget(projectDir) === 'bare';
+  if (isBare) {
+    throw new CommandError(
+      `This project is missing ${chalk.bold(
+        'expo-updates'
+      )}. Please install it in order to publish an update. ${chalk.dim(
+        TerminalLink.learnMore('https://docs.expo.dev/bare/installing-updates/')
+      )}`
+    );
+  }
+
+  const install = await confirmAsync({
+    message: `In order to publish an update, ${chalk.bold(
+      'expo-updates'
+    )} needs to be installed. Do you want to install it now?`,
+  });
+
+  if (install) {
+    await installExpoUpdatesAsync(projectDir);
+  } else {
+    throw new CommandError(
+      `This project is missing ${chalk.bold(
+        'expo-updates'
+      )}. Please install it in order to publish an update.`
     );
   }
 }


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
As of sdk 44 we no longer include expo-updates.


# How

<!-- 
How did you build this feature or fix this bug and why? 
-->
Prevent accidental publishes.


# Test Plan

Tested in demo repo.


<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->