### PR TITLE
[metro-config] Add missing resolve-from dependency

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -40,6 +40,7 @@
     "debug": "^4.3.2",
     "find-yarn-workspace-root": "~2.0.0",
     "getenv": "^1.0.0",
+    "resolve-from": "^5.0.0",
     "sucrase": "^3.20.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

It's imported here: https://github.com/expo/expo-cli/blob/34bc461a9a81bdab198e10b14d77dd0cda8d7d54/packages/metro-config/src/ExpoMetroConfig.ts#L10

But it's not included in the package.json for @expo/metro-config

May be related to https://forums.expo.dev/t/expo-environment-setup-problem/61363/9 - not clear why it's only happening to this user though.

# How

--

# Test Plan

--