### PR TITLE
[Interstitial page] Improving user experience

### DIFF
--- a/packages/expo-cli/src/commands/start/TerminalUI.ts
+++ b/packages/expo-cli/src/commands/start/TerminalUI.ts
@@ -5,6 +5,8 @@ import chalk from 'chalk';
 import wrapAnsi from 'wrap-ansi';
 import {
   Android,
+  Env,
+  isDevClientPackageInstalled,
   Project,
   ProjectSettings,
   Prompts,
@@ -180,7 +182,20 @@ const printServerInfo = async (
     try {
       const url = await UrlUtils.constructDeepLinkAsync(projectRoot);
 
-      urlOpts.printQRCode(url);
+      const getURLForQR = async () => {
+        const { devClient } = await ProjectSettings.readAsync(projectRoot);
+        if (
+          Env.isInterstitiaLPageEnabled() &&
+          !devClient &&
+          (await isDevClientPackageInstalled(projectRoot))
+        ) {
+          return await UrlUtils.constructLoadingUrlAsync(projectRoot, null);
+        } else {
+          return url;
+        }
+      };
+
+      urlOpts.printQRCode(await getURLForQR());
       Log.nested(item(`Metro waiting on ${u(url)}`));
       // Log.newLine();
       // TODO: if development build, change this message!

--- a/packages/xdl/src/Android.ts
+++ b/packages/xdl/src/Android.ts
@@ -794,7 +794,7 @@ async function openUrlAsync({
         // The development build isn't available. So let's fall back to Expo Go.
         Logger.global.warn(
           `\u203A The 'expo-dev-client' package is installed, but a development build isn't available.\nYour app will open in Expo Go instead. If you want to use the development build, please install it on the simulator first.\n${learnMore(
-            'https://docs.expo.dev/clients/distribution-for-ios/#building-for-ios'
+            'https://docs.expo.dev/development/build/'
           )}`
         );
 

--- a/packages/xdl/src/Simulator.ts
+++ b/packages/xdl/src/Simulator.ts
@@ -647,7 +647,7 @@ async function openUrlInSimulatorSafeAsync({
         // The development build isn't available. So let's fall back to Expo Go.
         Logger.global.warn(
           `\u203A The 'expo-dev-client' package is installed, but a development build isn't available.\nYour app will open in Expo Go instead. If you want to use the development build, please install it on the simulator first.\n${learnMore(
-            'https://docs.expo.dev/clients/distribution-for-ios/#building-for-ios'
+            'https://docs.expo.dev/development/build/'
           )}`
         );
 

--- a/packages/xdl/src/UrlUtils.ts
+++ b/packages/xdl/src/UrlUtils.ts
@@ -100,11 +100,12 @@ export async function constructLogUrlAsync(
 
 export async function constructLoadingUrlAsync(
   projectRoot: string,
-  platform: 'ios' | 'android',
+  platform: 'ios' | 'android' | null,
   requestHostname?: string
 ): Promise<string> {
   const baseUrl = await constructUrlAsync(projectRoot, { urlType: 'http' }, false, requestHostname);
-  return `${baseUrl}/_expo/loading?platform=${platform}`;
+  const query = platform ? `?platform=${platform}` : '';
+  return `${baseUrl}/_expo/loading${query}`;
 }
 
 export async function constructUrlWithExtensionAsync(

--- a/packages/xdl/static/loading-page/index.html
+++ b/packages/xdl/static/loading-page/index.html
@@ -243,7 +243,7 @@
     <p class="bottom-bar-header">
       How would you like to open this project?
     </p>
-    <a id="expo-dev-client-link" href="/_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development App</a>
+    <a id="expo-dev-client-link" href="/_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development Build</a>
     <a id="expo-go-link" href="/_expo/link?choice=expo-go" class="bottom-bar-button bottom-bar-button-grey">Expo Go</a>
   </div>
   


### PR DESCRIPTION
# Why

Adjusting a couple of things according to the feedback https://www.notion.so/expo/Interstitial-page-testing-c4ee6e71e936460c8df786410d33e3fe

# How

- Replaced the link in the warning with the new one. 
- Detected the platform from the user-agent header if the get parameter wasn't provided 
- `Development App` -> `Development Build`
- Update QR code to point to the interstitial page if needed. 
- The deep links generated by the interstitial page aren't local anymore. 

# Test Plan

Test scenarios:

- app without dev-client
- check if the expo go will be installed if not present
- check what happens if the development build isn't present
- check what happens if both development build and expo go isn't available
- test QR code