### PR TITLE
[expo-cli] Publish command correctly passes max-workers option through to metro

### DIFF
--- a/packages/expo-cli/src/commands/publish/publishAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishAsync.ts
@@ -99,6 +99,7 @@ export async function actionAsync(
   const result = await Project.publishAsync(projectRoot, {
     releaseChannel: options.releaseChannel,
     quiet: options.quiet,
+    maxWorkers: options.maxWorkers,
     target,
     resetCache: options.clear,
   });

--- a/packages/xdl/src/project/__tests__/createBundlesAsync-test.ts
+++ b/packages/xdl/src/project/__tests__/createBundlesAsync-test.ts
@@ -1,0 +1,61 @@
+import { getConfig, isLegacyImportsEnabled, ProjectTarget } from '@expo/config';
+import { bundleAsync } from '@expo/dev-server';
+
+import { getLogger } from '../ProjectUtils';
+import { createBundlesAsync } from '../createBundlesAsync';
+
+jest.mock('@expo/dev-server');
+jest.mock('@expo/config');
+jest.mock('../../tools/resolveEntryPoint');
+jest.mock('../ProjectUtils');
+
+describe(createBundlesAsync, () => {
+  const expoConfig = {
+    name: 'my-app',
+    slug: 'my-app',
+    sdkVersion: '100.0.0',
+  };
+  const mockLogger = jest.fn();
+
+  beforeAll(() => {
+    (getConfig as any).mockImplementation(() => ({ exp: expoConfig }));
+    (isLegacyImportsEnabled as any).mockImplementation(() => true);
+    (bundleAsync as any).mockImplementation(() => []);
+    (getLogger as any).mockImplementation(() => mockLogger);
+  });
+
+  it('passes expected options to devServer', async () => {
+    const publishOptions = {
+      target: 'managed' as ProjectTarget,
+      maxWorkers: 123,
+      resetCache: false,
+      quiet: true,
+    };
+
+    await createBundlesAsync('/', publishOptions, {
+      platforms: ['ios'],
+      useDevServer: true,
+      dev: false,
+    });
+
+    expect(bundleAsync).toHaveBeenCalledWith(
+      '/',
+      expoConfig,
+      {
+        target: 'managed',
+        resetCache: false,
+        quiet: true,
+        logger: mockLogger,
+        maxWorkers: 123,
+        unversioned: false,
+      },
+      [
+        {
+          dev: false,
+          entryPoint: undefined,
+          platform: 'ios',
+        },
+      ]
+    );
+  });
+});

--- a/packages/xdl/src/project/createBundlesAsync.ts
+++ b/packages/xdl/src/project/createBundlesAsync.ts
@@ -104,6 +104,7 @@ export async function createBundlesAsync(
       // If not legacy, ignore the target option to prevent warnings from being thrown.
       target: !isLegacy ? undefined : publishOptions.target,
       resetCache: publishOptions.resetCache,
+      maxWorkers: publishOptions.maxWorkers,
       logger: ProjectUtils.getLogger(projectRoot),
       quiet: publishOptions.quiet,
       unversioned: !config.exp.sdkVersion || config.exp.sdkVersion === 'UNVERSIONED',


### PR DESCRIPTION
# Why

```
expo publish --max-workers 1
``` 

In the publish command the `max-workers` option is not being passed through to metro causing it to ignore the option and always use the default.

This is causing our CI build to run out of memory when attempting to publish even when specifying to use `--max-workers 1`

# Test Plan

This area of the code did not appear to be tested so I took a stab at adding a test for at least part of it. Happy to add more tests or change or remove it.