### PR TITLE
[expo init] Skip parsing font files on init

### DIFF
--- a/packages/expo-cli/src/commands/utils/createFileTransform.ts
+++ b/packages/expo-cli/src/commands/utils/createFileTransform.ts
@@ -79,6 +79,10 @@ export function createFileTransform(name: string) {
         '.svg',
         '.jar',
         '.keystore',
+
+        // Font files
+        '.otf',
+        '.ttf',
       ].includes(extension) &&
       name
     ) {


### PR DESCRIPTION
# Why


Fixes regression introduced here https://github.com/expo/expo-cli/pull/4088/files#diff-380dbe5016dbdaea46a5d3b7680df2e3ece26d1f0b728044ef75467278d98664L56 that corrupts font files on initialization