### PR TITLE
[expo-cli] fix project page param typo

### DIFF
--- a/packages/xdl/src/project/publishAsync.ts
+++ b/packages/xdl/src/project/publishAsync.ts
@@ -322,9 +322,9 @@ function createProjectPageURL({
     return null;
   }
 
-  const formattedProjectUrl = `${projectPageUrl}?serviceType=eas&distribution=expo-go`;
+  const formattedProjectUrl = `${projectPageUrl}?serviceType=classic&distribution=expo-go`;
   if (releaseChannel && releaseChannel !== 'default') {
-    return `${formattedProjectUrl}?release-channel=${releaseChannel}`;
+    return `${formattedProjectUrl}&release-channel=${releaseChannel}`;
   } else {
     return formattedProjectUrl;
   }


### PR DESCRIPTION
# Why

The project page url redirects to an eas QR code.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->
Fix typo

# Test Plan
navigated to page and loaded in expo-go.
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->