### PR TITLE
[expo-cli]: don't sanitize numbers from project names for npm package name on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [cli] don't sanitize numbers from project name for npm package name ([#4208])(https://github.com/expo/expo-cli/pull/4208))
+
 ## [Thu, 10 Feb 2022 12:37:31 -0800](https://github.com/expo/expo-cli/commit/82904c9641b22fdf0cc2b24b1cfd4ed33c4dfc33)
 
 ### 🎉 New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,38 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+## [Thu, 10 Feb 2022 12:37:31 -0800](https://github.com/expo/expo-cli/commit/82904c9641b22fdf0cc2b24b1cfd4ed33c4dfc33)
+
+### 🎉 New features
+
+- [cli] check expo-updates is installed before a publish ([#4179](https://github.com/expo/expo-cli/issues/4179))
+
+### 🧹 Chores
+
+- Publish @expo/config-types@44.0.0
+
+### 🐛 Bug fixes
+
+- [cli] Skip parsing font files on init ([#4202](https://github.com/expo/expo-cli/issues/4202))
+- [cli] fix project page param typo ([#4204](https://github.com/expo/expo-cli/issues/4204))
+
+### 📦 Packages updated
+
+- @expo/config-plugins@4.0.18
+- @expo/config@6.0.18
+- @expo/dev-server@0.1.105
+- @expo/dev-tools@0.13.143
+- expo-cli@5.1.2
+- expo-optimize@0.2.10
+- install-expo-modules@0.2.4
+- @expo/metro-config@0.3.11
+- @expo/next-adapter@3.1.19
+- @expo/prebuild-config@3.0.18
+- expo-pwa@0.0.113
+- uri-scheme@1.0.114
+- @expo/webpack-config@0.16.18
+- xdl@59.2.27
+
 ## [Tue, 8 Feb 2022 14:47:23 -0800](https://github.com/expo/expo-cli/commit/e68ec76f84d1ffe7691dbaf3d13de8cf1b7a264e)
 
 ### 🐛 Bug fixes

--- a/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
+++ b/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
@@ -6,7 +6,7 @@ Array [
   "dist/assetmap.json (size ignored)",
   "dist/assets (dir)",
   "dist/bundles (dir)",
-  "dist/bundles/android-XXX.js (837 kB)",
+  "dist/bundles/android-XXX.js (838 kB)",
   "dist/bundles/ios-XXX.js (836 kB)",
   "dist/ios-index.json (658 B)",
 ]
@@ -55,7 +55,7 @@ Array [
   "dist/assetmap.json (size ignored)",
   "dist/assets (dir)",
   "dist/bundles (dir)",
-  "dist/bundles/android-XXX.js (837 kB)",
+  "dist/bundles/android-XXX.js (838 kB)",
   "dist/bundles/ios-XXX.js (836 kB)",
   "dist/ios-index.json (658 B)",
 ]

--- a/packages/expo-cli/src/commands/utils/__tests__/npm-test.ts
+++ b/packages/expo-cli/src/commands/utils/__tests__/npm-test.ts
@@ -2,7 +2,7 @@ import { sanitizeNpmPackageName } from '../npm';
 
 describe(sanitizeNpmPackageName, () => {
   it(`leaves valid names`, () => {
-    for (const name of ['@bacon/app', 'my-app', 'my-a.pp']) {
+    for (const name of ['@bacon/app', 'my-app', 'my-a.pp', 'test123']) {
       expect(sanitizeNpmPackageName(name)).toBe(name);
     }
   });

--- a/packages/expo-cli/src/commands/utils/npm.ts
+++ b/packages/expo-cli/src/commands/utils/npm.ts
@@ -41,7 +41,7 @@ function applyKnownNpmPackageNameRules(name: string): string | null {
     name = name.substring(1);
   }
 
-  name = name.toLowerCase().replace(/[^a-zA-Z._\-/@]/g, '');
+  name = name.toLowerCase().replace(/[^a-zA-Z0-9._\-/@]/g, '');
 
   return (
     name


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo-cli/issues/4203.

# How

Adjusted regular expression used to sanitize package name to allow numbers as per npm specs (https://github.com/npm/validate-npm-package-name/#naming-rules)

# Test Plan

- Initialized a project with a number in the name
- Verified package.json to see the package name still contains the number
- Added a test case to automated tests for a package name with a number, used it to verify the old and the new behavior