### PR TITLE
[Interstitial page] Try to detect if a deep link succeed

### DIFF
--- a/packages/xdl/src/start/LoadingPageHandler.ts
+++ b/packages/xdl/src/start/LoadingPageHandler.ts
@@ -6,7 +6,7 @@ import http from 'http';
 import { resolve } from 'path';
 import { parse } from 'url';
 
-import { UrlUtils } from './../internal';
+import { ProjectSettings, UrlUtils } from './../internal';
 
 export const LoadingEndpoint = '/_expo/loading';
 export const DeepLinkEndpoint = '/_expo/link';
@@ -71,6 +71,7 @@ async function loadingEndpointHandler(
   ).toString('utf-8');
 
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const { scheme } = await ProjectSettings.readAsync(projectRoot);
   const { appName } = getNameFromConfig(exp);
   const { query } = parse(req.url!, true);
   const platform = getPlatform(query, req.headers['user-agent']);
@@ -79,6 +80,7 @@ async function loadingEndpointHandler(
   content = content.replace(/{{\s*AppName\s*}}/, appName ?? 'App');
   content = content.replace(/{{\s*RuntimeVersion\s*}}/, runtimeVersion);
   content = content.replace(/{{\s*Path\s*}}/, projectRoot);
+  content = content.replace(/{{\s*Scheme\s*}}/, scheme ?? 'Unknown');
 
   res.end(content);
 }

--- a/packages/xdl/static/loading-page/index.html
+++ b/packages/xdl/static/loading-page/index.html
@@ -270,10 +270,10 @@
 
   const showAlert = (isExpoGo) => {
     if (isExpoGo) {
-      alertElement.innerHTML = 'It seems that deep-link into your application failed. Make sure that you have the <b>Expo Go</b> installed.' + 
-      '<br><a href="https://docs.expo.dev/get-started/installation/#2-expo-go-app-for-ios-and">Learn more.</a>';
+      alertElement.innerHTML = 'Unable to open in Expo Go. Please install <b>Expo Go</b> to continue.' + 
+      '<br><a href="https://expo.dev/client">Learn more.</a>';
     } else {
-      alertElement.innerHTML = 'It seems that deep-link into your application failed. Make sure that you have the <b>Development Build</b> installed.' + 
+      alertElement.innerHTML = 'Unable to open in Development Build with the <b>{{ Scheme }}</b> scheme. Please build and install a compatible <b>Development Build</b> to continue.' + 
       '<br><a href="https://docs.expo.dev/development/build/">Learn more.</a>';
     }
 

--- a/packages/xdl/static/loading-page/index.html
+++ b/packages/xdl/static/loading-page/index.html
@@ -185,10 +185,28 @@
       color: var(--secondary-text-color);
     }
 
+    #alert {
+      background-color: #fff;
+      color: var(--secondary-text-color);
+
+      padding-top: 20px;
+      padding-bottom: 20px;
+      padding-left: 10px;
+      padding-right: 10px;
+      
+      text-align: center;
+      font-size: 16px;
+      letter-spacing: -0.0001em;
+      line-height: 150%;
+
+
+      display: none;
+    }
   </style>
   <title>Expo Start | Loading Page</title>
 </head>
 <body>
+  <div id="alert"></div>
   <div class="logo-box">
     <div class="logo-background-box">
 
@@ -248,6 +266,24 @@
   </div>
   
   <script>
+  const alertElement = document.getElementById("alert");
+
+  const showAlert = (isExpoGo) => {
+    if (isExpoGo) {
+      alertElement.innerHTML = 'It seems that deep-link into your application failed. Make sure that you have the <b>Expo Go</b> installed.' + 
+      '<br><a href="https://docs.expo.dev/get-started/installation/#2-expo-go-app-for-ios-and">Learn more.</a>';
+    } else {
+      alertElement.innerHTML = 'It seems that deep-link into your application failed. Make sure that you have the <b>Development Build</b> installed.' + 
+      '<br><a href="https://docs.expo.dev/development/build/">Learn more.</a>';
+    }
+
+    alertElement.style.display = "block";
+  }
+
+  const hideAlert = () => {
+    alertElement.style.display = "none";
+  }
+
   function findGetParameter(parameterName) {
     let result = null;
 
@@ -261,11 +297,69 @@
     return result;
   }
 
+  function tryToDetectDeepLinkFailure(isExpoGo) {
+    const waitForRedirect = 800;    
+    let didHide = false;
+    let didLoseFocuse = false;
+
+    const onVisibilitychange = (e) => { 
+      if (e.target.visibilityState === 'hidden') {
+        didHide = true;
+        hideAlert();
+      }
+    };
+
+    const clearOnFocus = () => {
+      hideAlert();
+      window.removeEventListener('focus', clearOnFocus);
+    };
+
+    const showErrorOnFocus = () => {
+      window.removeEventListener('focus', showErrorOnFocus);
+
+      setTimeout(() => {
+        window.addEventListener('focus', clearOnFocus);
+
+        if (!didHide) {
+          showAlert(isExpoGo);
+        }
+      }, waitForRedirect);
+    }
+
+    const onBlur = () => {
+      didLoseFocuse = true;
+      window.removeEventListener('blur', onBlur);
+      window.addEventListener('focus', showErrorOnFocus);
+    };
+
+    window.addEventListener('blur', onBlur);
+    document.addEventListener("visibilitychange", onVisibilitychange);
+    setTimeout(() => {
+      // A modal was shown. So we need to wait for a user input.
+      if (didLoseFocuse) {
+        return;
+      }
+
+      window.addEventListener('focus', clearOnFocus);
+      document.removeEventListener("visibilitychange", onVisibilitychange);
+
+      // deeplink seems to be working
+      if (didHide) {
+        return;
+      }
+
+      showAlert(isExpoGo);
+    }, waitForRedirect);
+  }
+  
+  const devClientLink = document.getElementById("expo-dev-client-link");
+  const goLink = document.getElementById("expo-go-link");
+
+  devClientLink.onclick = () => tryToDetectDeepLinkFailure(false); 
+  goLink.onclick = () => tryToDetectDeepLinkFailure(true);
+
   const platform = findGetParameter("platform");
   if (platform) {
-    const devClientLink = document.getElementById("expo-dev-client-link");
-    const goLink = document.getElementById("expo-go-link");
-
     devClientLink.href += "&platform=" + platform;
     goLink.href += "&platform=" + platform;
   }


### PR DESCRIPTION
# Why

Currently, if someone scans the QR code, we can't detect if the device can handle a deep link to `Expo Go` or `Development Build`. So we're trying to detect if the redirection was successful. If not we display a message. 

# How

When the user clicks, we trigger a timeout. After some time, we check if the document became inactive (if so, we know that the redirection was successful). This flow gets more complicated on iOS because the user will see a modal. In that case, we need to fire the timeout after the document will be focused. 

# Test Plan

- manual tests with Android device and iOS simulator.