### PR TITLE
[Interstitial page] Fix QR on web UI & fallback to SDK version if the runtime version wasn't defined

### DIFF
--- a/packages/dev-tools/components/ProjectManager.js
+++ b/packages/dev-tools/components/ProjectManager.js
@@ -198,6 +198,7 @@ class ProjectManager extends React.Component {
         isPublishing={this.props.isPublishing}
         isActiveDeviceIOS={this.props.isActiveDeviceIOS}
         isActiveDeviceAndroid={this.props.isActiveDeviceAndroid}
+        interstitialPageUrl={this.props.project.interstitialPageUrl}
       />
     );
 

--- a/packages/dev-tools/components/ProjectManagerSidebarOptions.js
+++ b/packages/dev-tools/components/ProjectManagerSidebarOptions.js
@@ -237,7 +237,7 @@ export default class ProjectManagerSidebarOptions extends React.Component {
           </div>
 
           <div className={STYLES_QR_SECTION}>
-            <QRCode url={this.props.url} />
+            <QRCode url={this.props.interstitialPageUrl ?? this.props.url} />
           </div>
         </div>
       </div>

--- a/packages/dev-tools/pages/index.js
+++ b/packages/dev-tools/pages/index.js
@@ -59,6 +59,7 @@ const query = gql`
           lastCursor
         }
       }
+      interstitialPageUrl
     }
     userSettings {
       id

--- a/packages/dev-tools/server/graphql/GraphQLSchema.ts
+++ b/packages/dev-tools/server/graphql/GraphQLSchema.ts
@@ -5,7 +5,9 @@ import { $$asyncIterator } from 'iterall';
 import {
   Android,
   ConnectionStatus,
+  Env,
   Exp,
+  isDevClientPackageInstalled,
   Logger,
   Project,
   ProjectSettings,
@@ -52,6 +54,8 @@ const typeDefs = graphql`
     sources: [Source]
     # All messages from all sources
     messages: MessageConnection!
+    # Link to the loding page if available.
+    interstitialPageUrl: String
   }
 
   type ProjectSettings {
@@ -455,6 +459,17 @@ const resolvers = {
     },
     messages(project, args, context) {
       return context.getMessageConnection();
+    },
+    async interstitialPageUrl(project) {
+      const { devClient } = await ProjectSettings.readAsync(project.projectDir);
+      if (
+        Env.isInterstitiaLPageEnabled() &&
+        !devClient &&
+        isDevClientPackageInstalled(project.projectDir)
+      ) {
+        return UrlUtils.constructLoadingUrlAsync(project.projectDir, null);
+      }
+      return null;
     },
   },
   ProjectSettings: {

--- a/packages/xdl/src/start/LoadingPageHandler.ts
+++ b/packages/xdl/src/start/LoadingPageHandler.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig, getConfig, getNameFromConfig } from '@expo/config';
-import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
+import { getRuntimeVersionNullable, getSDKVersion } from '@expo/config-plugins/build/utils/Updates';
 import express from 'express';
 import { readFile } from 'fs-extra';
 import http from 'http';
@@ -44,10 +44,10 @@ function getPlatform(
 
 function getRuntimeVersion(exp: ExpoConfig, platform: 'android' | 'ios' | null) {
   if (!platform) {
-    return 'Undetected';
+    return null;
   }
 
-  return getRuntimeVersionNullable(exp, platform) ?? 'Undetected';
+  return getRuntimeVersionNullable(exp, platform);
 }
 
 export function noCacheMiddleware(
@@ -77,7 +77,17 @@ async function loadingEndpointHandler(
   const runtimeVersion = getRuntimeVersion(exp, platform);
 
   content = content.replace(/{{\s*AppName\s*}}/, appName ?? 'App');
-  content = content.replace(/{{\s*RuntimeVersion\s*}}/, runtimeVersion);
+
+  content = content.replace(
+    /{{\s*ProjectVersionType\s*}}/,
+    runtimeVersion ? 'Runtime version' : 'SDK version'
+  );
+
+  content = content.replace(
+    /{{\s*ProjectVersion\s*}}/,
+    runtimeVersion ? runtimeVersion : getSDKVersion(exp) ?? 'Undetected'
+  );
+
   content = content.replace(/{{\s*Path\s*}}/, projectRoot);
 
   res.end(content);

--- a/packages/xdl/static/loading-page/index.html
+++ b/packages/xdl/static/loading-page/index.html
@@ -220,8 +220,8 @@
       <div class="info-box-details">
         <p class="info-box-app-name">{{ AppName }}</p>
         <div class="info-box-details-record">
-          <p>Runtime version</p>
-          <p>{{ RuntimeVersion }}</p>
+          <p>{{ ProjectVersionType }}</p>
+          <p>{{ ProjectVersion }}</p>
         </div>
         <!-- <div class="info-box-details-record">
           <p>Branch</p>


### PR DESCRIPTION
# Why

Fixes that QR code on web UI pointed to the `Expo Go` directly instead of to the interstitial page.
Fallback to the SDK version if the runtime version wasn't defined. 

# How

- Extended the dev graphQL server to serve Interstitial page URL if available. 

# Test Plan

- runs the local version of the CLI and confirms that the web QR code points to the correct place.
- checks if the SDK version was detected when the runtime version isn't available.