### PR TITLE
[test] re-enable codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,20 +67,20 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Test ${{ matrix.package }}
-        run: cd packages/${{ matrix.package }} && yarn test
-        # run: cd packages/${{ matrix.package }} && yarn test --coverage
+        # run: cd packages/${{ matrix.package }} && yarn test
+        run: cd packages/${{ matrix.package }} && yarn test --coverage
         env:
           CI: true
           EXPO_DEBUG: true
-      # - name: Get Test Flag Name
-      #   id: cov-flag-name
-      #   run: echo "::set-output name=flag::$(echo ${{ matrix.package }} | perl -pe 's/[^a-z]+([a-z])/\U\1/gi;s/^([A-Z])/\l\1/')"
-      # - uses: codecov/codecov-action@v1
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-      #     file: ./packages/${{ matrix.package }}/coverage/clover.xml # optional
-      #     flags: ${{ steps.cov-flag-name.outputs.flag }} # optional
-      #     fail_ci_if_error: true # optional (default = false)
+      - name: Get Test Flag Name
+        id: cov-flag-name
+        run: echo "::set-output name=flag::$(echo ${{ matrix.package }} | perl -pe 's/[^a-z]+([a-z])/\U\1/gi;s/^([A-Z])/\l\1/')"
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          file: ./packages/${{ matrix.package }}/coverage/clover.xml # optional
+          flags: ${{ steps.cov-flag-name.outputs.flag }} # optional
+          fail_ci_if_error: false # optional (default = false)
 
   puppeteer:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Get Test Flag Name
         id: cov-flag-name
         run: echo "::set-output name=flag::$(echo ${{ matrix.package }} | perl -pe 's/[^a-z]+([a-z])/\U\1/gi;s/^([A-Z])/\l\1/')"
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           file: ./packages/${{ matrix.package }}/coverage/clover.xml # optional

--- a/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
+++ b/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
@@ -6,7 +6,7 @@ Array [
   "dist/assetmap.json (size ignored)",
   "dist/assets (dir)",
   "dist/bundles (dir)",
-  "dist/bundles/android-XXX.js (838 kB)",
+  "dist/bundles/android-XXX.js (837 kB)",
   "dist/bundles/ios-XXX.js (836 kB)",
   "dist/ios-index.json (658 B)",
 ]
@@ -55,7 +55,7 @@ Array [
   "dist/assetmap.json (size ignored)",
   "dist/assets (dir)",
   "dist/bundles (dir)",
-  "dist/bundles/android-XXX.js (838 kB)",
+  "dist/bundles/android-XXX.js (837 kB)",
   "dist/bundles/ios-XXX.js (836 kB)",
   "dist/ios-index.json (658 B)",
 ]

--- a/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
+++ b/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
@@ -7,7 +7,7 @@ Array [
   "dist/assets (dir)",
   "dist/bundles (dir)",
   "dist/bundles/android-XXX.js (838 kB)",
-  "dist/bundles/ios-XXX.js (837 kB)",
+  "dist/bundles/ios-XXX.js (836 kB)",
   "dist/ios-index.json (658 B)",
 ]
 `;
@@ -56,7 +56,7 @@ Array [
   "dist/assets (dir)",
   "dist/bundles (dir)",
   "dist/bundles/android-XXX.js (838 kB)",
-  "dist/bundles/ios-XXX.js (837 kB)",
+  "dist/bundles/ios-XXX.js (836 kB)",
   "dist/ios-index.json (658 B)",
 ]
 `;

--- a/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
+++ b/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
@@ -6,8 +6,8 @@ Array [
   "dist/assetmap.json (size ignored)",
   "dist/assets (dir)",
   "dist/bundles (dir)",
-  "dist/bundles/android-XXX.js (837 kB)",
-  "dist/bundles/ios-XXX.js (836 kB)",
+  "dist/bundles/android-XXX.js (838 kB)",
+  "dist/bundles/ios-XXX.js (837 kB)",
   "dist/ios-index.json (658 B)",
 ]
 `;
@@ -55,8 +55,8 @@ Array [
   "dist/assetmap.json (size ignored)",
   "dist/assets (dir)",
   "dist/bundles (dir)",
-  "dist/bundles/android-XXX.js (837 kB)",
-  "dist/bundles/ios-XXX.js (836 kB)",
+  "dist/bundles/android-XXX.js (838 kB)",
+  "dist/bundles/ios-XXX.js (837 kB)",
   "dist/ios-index.json (658 B)",
 ]
 `;


### PR DESCRIPTION
# Why

As test coverage has improved over time, and the companion repo `expo/eas-cli` has code coverage enabled as well, we should look at re-enabling it again on `expo/expo-cli` as well.

# How

Reverted the change that was done to disable it in the past.

# Test Plan

Not sure if GH picks up on .github changes in PRs, so here's to hoping it will run in this PR.