### PR TITLE
[expo-cli] Deprecate the `--name` argument of the init command.

### DIFF
--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -54,7 +54,7 @@ test('init react-native should exit', async () => {
 
   expect(stripAnsi(stderr)).toEqual(
     expect.stringMatching(
-      /Cannot create an app named \"react-native\" because it would conflict with a dependency of the same name/
+      /Cannot create an app named "react-native" because it would conflict with a dependency of the same name/
     )
   );
 });

--- a/packages/expo-cli/e2e/__tests__/init-test.ts
+++ b/packages/expo-cli/e2e/__tests__/init-test.ts
@@ -27,7 +27,7 @@ test('init', async () => {
 
   const cwd = temporary.directory();
   const { stdout } = await runAsync(
-    ['init', 'hello-world', '--template', 'blank', '--name', 'hello-world', '--no-install'],
+    ['init', 'hello-world', '--template', 'blank', '--no-install'],
     { cwd, env: { ...process.env, YARN_CACHE_FOLDER: path.join(cwd, 'yarn-cache') } }
   );
   expect(stdout).toMatch(`Your project is ready!`);
@@ -47,10 +47,26 @@ test('init', async () => {
 
 test('init react-native should exit', async () => {
   const cwd = temporary.directory();
-  const { stdout } = await tryRunAsync(
-    ['init', 'react-native', '--template', 'blank', '--name', 'react-native', '--no-install'],
+  const { stderr } = await tryRunAsync(
+    ['init', 'react-native', '--template', 'blank', '--no-install'],
     { cwd, env: { ...process.env, YARN_CACHE_FOLDER: path.join(cwd, 'yarn-cache') } }
   );
 
-  expect(stdout).toBe('');
+  expect(stripAnsi(stderr)).toEqual(
+    expect.stringMatching(
+      /Cannot create an app named \"react-native\" because it would conflict with a dependency of the same name/
+    )
+  );
+});
+
+test('init with the deprecated --name argument should exit', async () => {
+  const cwd = temporary.directory();
+  const { stderr } = await tryRunAsync(['init', 'foobar', '--name', 'foobar-name'], {
+    cwd,
+    env: { ...process.env, YARN_CACHE_FOLDER: path.join(cwd, 'yarn-cache') },
+  });
+
+  expect(stripAnsi(stderr)).toEqual(
+    expect.stringMatching(/Deprecated: Use expo init \[name\] instead of --name \[name\]/)
+  );
 });

--- a/packages/expo-cli/e2e/__tests__/start-test.ts
+++ b/packages/expo-cli/e2e/__tests__/start-test.ts
@@ -10,7 +10,7 @@ const projectRoot = path.join(tempDir, 'my-app');
 
 beforeAll(async () => {
   // jest.setTimeout(60000);
-  // await runAsync(['init', projectDir, '--template', 'blank', '--name', 'My App'], {
+  // await runAsync(['init', projectDir, '--template', 'blank'], {
   //   env: { ...process.env, YARN_CACHE_FOLDER: path.join(tempDir, 'yarn-cache') },
   // });
 });

--- a/packages/expo-cli/src/commands/init.ts
+++ b/packages/expo-cli/src/commands/init.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type { Command } from 'commander';
 
 import { applyAsyncAction } from './utils/applyAsyncAction';
@@ -14,10 +15,10 @@ export default function (program: Command) {
         'Specify which template to use. Valid options are "blank", "tabs", "bare-minimum" or a package on npm (e.g. "expo-template-bare-minimum") that includes an Expo project template.'
       )
       .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
-      .option('--yarn', 'Use Yarn to install dependencies. (default when Yarn is installed)')
       .option('--no-install', 'Skip installing npm packages or CocoaPods.')
-      .option('--name [name]', 'The name of your app visible on the home screen.')
-      .option('--yes', 'Use default options. Same as "expo init . --template blank'),
+      .option('--name <name>', chalk`{yellow Deprecated}: Use {bold expo init [name]} instead.`)
+      .option('--yes', 'Use default options. Same as "expo init . --template blank')
+      .option('--yarn', 'Use Yarn to install dependencies. (default when Yarn is installed)'),
     () => import('./initAsync')
   );
 }

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -349,7 +349,9 @@ Command.prototype.asyncAction = function (asyncFn: Action) {
       // This allows node js to exit immediately
       await Promise.all([Analytics.flush(), UnifiedAnalytics.flush()]);
     } catch (err) {
-      await handleErrorsAsync(err, { command: this.name() });
+      // If the `--name` property is being used then we can be sure that the error is coming from `expo init`.
+      const commandName = typeof this.name === 'string' ? 'init (probably)' : this.name();
+      await handleErrorsAsync(err, { command: commandName });
       process.exit(1);
     }
   });


### PR DESCRIPTION
# Why

When the `--name` parameter is used (and the CLI throws), the CLI fails with:

```
/Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/src/exp.ts:352
      await handleErrorsAsync(err, { command: this.name() });
                                                   ^
TypeError: this.name is not a function
    at Command.<anonymous> (/Users/evanbacon/.nvm/versions/node/v16.13.0/lib/node_modules/expo-cli/src/exp.ts:352:52)
```

Commander doesn't support using the `--name` argument since it is reserved internally. We always recommend users do `expo init [my-app]` since this plays nicely with the working directory paradigm.

Also fixes the test from https://github.com/expo/expo-cli/pull/4025 which doesn't test the output at all.

# How

- Add deprecation notice to `expo init --name` and force exit. 
- Drop the use of `--name` in the tests.

# Test Plan

- E2E tests