### PR TITLE
[expo-cli]: pick correct scheme for open android app

### DIFF
--- a/packages/config-plugins/src/android/Scheme.ts
+++ b/packages/config-plugins/src/android/Scheme.ts
@@ -82,11 +82,11 @@ function propertiesFromIntentFilter(intentFilter: any): IntentFilterProps {
   const categories = intentFilter?.category?.map((data: any) => data?.$?.['android:name']) ?? [];
   const data =
     intentFilter?.data
+      ?.filter((data: any) => data?.$?.['android:scheme'])
       ?.map((data: any) => ({
         scheme: data?.$?.['android:scheme'],
         host: data?.$?.['android:host'],
-      }))
-      ?.filter((v: any) => v !== undefined) ?? [];
+      })) ?? [];
   return {
     actions,
     categories,

--- a/packages/config-plugins/src/android/Scheme.ts
+++ b/packages/config-plugins/src/android/Scheme.ts
@@ -86,7 +86,7 @@ function propertiesFromIntentFilter(intentFilter: any): IntentFilterProps {
         scheme: data?.$?.['android:scheme'],
         host: data?.$?.['android:host'],
       }))
-      ?.filter(v => v !== undefined) ?? [];
+      ?.filter((v: any) => v !== undefined) ?? [];
   return {
     actions,
     categories,

--- a/packages/config-plugins/src/android/Scheme.ts
+++ b/packages/config-plugins/src/android/Scheme.ts
@@ -124,7 +124,7 @@ export function getSchemesFromManifest(
     const properties = propertiesFromIntentFilter(intentFilter);
     if (isValidRedirectIntentFilter(properties) && properties.data) {
       for (const { scheme, host } of properties.data) {
-        if (!requestedHost || !host || host === requestedHost) {
+        if (requestedHost === null || !host || host === requestedHost) {
           outputSchemes.push(scheme);
         }
       }

--- a/packages/config-plugins/src/android/Scheme.ts
+++ b/packages/config-plugins/src/android/Scheme.ts
@@ -8,6 +8,7 @@ export type IntentFilterProps = {
   actions: string[];
   categories: string[];
   schemes: string[];
+  hosts: string[];
 };
 
 export const withScheme = createAndroidManifestPlugin(setScheme, 'withScheme');
@@ -78,10 +79,12 @@ function propertiesFromIntentFilter(intentFilter: any): IntentFilterProps {
   const actions = intentFilter?.action?.map((data: any) => data?.$?.['android:name']) ?? [];
   const categories = intentFilter?.category?.map((data: any) => data?.$?.['android:name']) ?? [];
   const schemes = intentFilter?.data?.map((data: any) => data?.$?.['android:scheme']) ?? [];
+  const hosts = intentFilter?.data?.map((data: any) => data?.$?.['android:host']) ?? [];
   return {
     schemes,
     actions,
     categories,
+    hosts,
   };
 }
 
@@ -104,13 +107,19 @@ function getSingleTaskIntentFilters(androidManifest: AndroidManifest): any[] {
   return outputSchemes;
 }
 
-export function getSchemesFromManifest(androidManifest: AndroidManifest): string[] {
+export function getSchemesFromManifest(
+  androidManifest: AndroidManifest,
+  host: string | null = null
+): string[] {
   const outputSchemes: IntentFilterProps[] = [];
 
   const singleTaskIntentFilters = getSingleTaskIntentFilters(androidManifest);
   for (const intentFilter of singleTaskIntentFilters) {
     const properties = propertiesFromIntentFilter(intentFilter);
-    if (isValidRedirectIntentFilter(properties)) {
+    if (
+      isValidRedirectIntentFilter(properties) &&
+      (host === null || properties.hosts.length === 0 || properties.hosts.includes(host))
+    ) {
       outputSchemes.push(properties);
     }
   }

--- a/packages/config-plugins/src/android/__tests__/Scheme-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Scheme-test.ts
@@ -13,6 +13,10 @@ import {
 
 const fixturesPath = resolve(__dirname, 'fixtures');
 const sampleManifestPath = resolve(fixturesPath, 'react-native-AndroidManifest.xml');
+const sampleManifestWithHostPath = resolve(
+  fixturesPath,
+  'react-native-AndroidManifest-with-host.xml'
+);
 
 describe('scheme', () => {
   it(`returns empty array if no scheme is provided`, () => {
@@ -106,6 +110,21 @@ describe('Schemes', () => {
     expect(schemes).toContain('myapp.test');
     const removedManifest = removeScheme('myapp.test', manifest);
     expect(getSchemesFromManifest(removedManifest)).not.toContain('myapp.test');
+  });
+
+  it(`get all schemes for the host`, async () => {
+    const manifest = await readAndroidManifestAsync(sampleManifestWithHostPath);
+    ensureManifestHasValidIntentFilter(manifest);
+
+    const modifiedManifest = appendScheme('myapp.test', manifest);
+    let schemes = getSchemesFromManifest(modifiedManifest, 'any-host');
+    expect(schemes).toContain('myapp.test');
+    expect(schemes).not.toContain('longestschemewiththehost');
+    expect(hasScheme('longestschemewiththehost', manifest)).toBe(true);
+
+    schemes = getSchemesFromManifest(modifiedManifest, 'expo-development-client');
+    expect(schemes).toContain('myapp.test');
+    expect(schemes).toContain('longestschemewiththehost');
   });
 
   it(`detect when a duplicate might be added`, async () => {

--- a/packages/config-plugins/src/android/__tests__/Scheme-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Scheme-test.ts
@@ -115,12 +115,12 @@ describe('Schemes', () => {
   it(`get all schemes for the host`, async () => {
     const manifest = await readAndroidManifestAsync(sampleManifestWithHostPath);
     ensureManifestHasValidIntentFilter(manifest);
+    expect(hasScheme('longestschemewiththehost', manifest)).toBe(true);
 
     const modifiedManifest = appendScheme('myapp.test', manifest);
     let schemes = getSchemesFromManifest(modifiedManifest, 'any-host');
     expect(schemes).toContain('myapp.test');
     expect(schemes).not.toContain('longestschemewiththehost');
-    expect(hasScheme('longestschemewiththehost', manifest)).toBe(true);
 
     schemes = getSchemesFromManifest(modifiedManifest, 'expo-development-client');
     expect(schemes).toContain('myapp.test');

--- a/packages/config-plugins/src/android/__tests__/fixtures/react-native-AndroidManifest-with-host.xml
+++ b/packages/config-plugins/src/android/__tests__/fixtures/react-native-AndroidManifest-with-host.xml
@@ -1,0 +1,42 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.expo.mycoolapp">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <queries>
+      <!-- Support checking for http(s) links via the Linking API -->
+      <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https" />
+      </intent>
+    </queries>
+
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="true"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:launchMode="singleTask"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW"/>
+            <category android:name="android.intent.category.DEFAULT"/>
+            <category android:name="android.intent.category.BROWSABLE"/>
+            <data android:scheme="longestschemewiththehost" android:host="expo-development-client" />
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+
+</manifest>

--- a/packages/expo-cli/src/commands/run/utils/schemes.ts
+++ b/packages/expo-cli/src/commands/run/utils/schemes.ts
@@ -26,7 +26,9 @@ export async function getSchemesForAndroidAsync(projectRoot: string) {
   try {
     const configPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectRoot);
     const manifest = await AndroidConfig.Manifest.readAndroidManifestAsync(configPath);
-    return sortLongest(await AndroidConfig.Scheme.getSchemesFromManifest(manifest));
+    return sortLongest(
+      await AndroidConfig.Scheme.getSchemesFromManifest(manifest, 'expo-development-client')
+    );
   } catch {
     // No android folder or some other error
     return [];


### PR DESCRIPTION
Expo CLI should pick the scheme with the empty host
or it's much exactly matched to `expo-development-client`

# Why

close https://github.com/expo/expo-cli/issues/4227

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
- Unittests