### PR TITLE
[config-plugins] Unescape values when reading strings.xml

### DIFF
--- a/packages/config-plugins/src/utils/XML.ts
+++ b/packages/config-plugins/src/utils/XML.ts
@@ -29,6 +29,17 @@ export async function readXMLAsync(options: {
   }
   const parser = new Parser();
   const manifest = await parser.parseStringPromise(contents || options.fallback || '');
+
+  // For strings.xml
+  if (Array.isArray(manifest?.resources?.string)) {
+    for (const string of manifest?.resources?.string) {
+      if (string.$.translatable === 'false' || string.$.translatable === false) {
+        continue;
+      }
+      string._ = unescapeAndroidString(string._);
+    }
+  }
+
   return manifest;
 }
 
@@ -121,4 +132,8 @@ export function escapeAndroidString(value: string): string {
     value = '"' + value + '"';
   }
   return value;
+}
+
+export function unescapeAndroidString(value: string): string {
+  return value.replace(/\\(.)/g, '$1');
 }

--- a/packages/config-plugins/src/utils/__tests__/XML-test.ts
+++ b/packages/config-plugins/src/utils/__tests__/XML-test.ts
@@ -1,52 +1,90 @@
+import fs from 'fs-extra';
 import { vol } from 'memfs';
 
 import { buildResourceItem, readResourcesXMLAsync } from '../../android/Resources';
 import { setStringItem } from '../../android/Strings';
-import { escapeAndroidString, format } from '../XML';
+import { escapeAndroidString, format, unescapeAndroidString, writeXMLAsync } from '../XML';
 
 jest.mock('fs');
 
 export const sampleStringsXML = `
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <resources>
-  <string name="app_name">expo &amp;bo&lt;y&gt;&apos;</string>
+  <string name="app_name">exp\\'o &amp;bo&lt;y&gt;&apos;</string>
 </resources>`;
 
-beforeAll(async () => {
-  const directoryJSON = {
-    './android/app/src/main/res/values/strings.xml': sampleStringsXML,
-  };
-  vol.fromJSON(directoryJSON, '/app');
+describe(readResourcesXMLAsync, () => {
+  beforeAll(async () => {
+    const directoryJSON = {
+      './android/app/src/main/res/values/strings.xml': sampleStringsXML,
+    };
+    vol.fromJSON(directoryJSON, '/app');
+  });
+
+  afterAll(async () => {
+    vol.reset();
+  });
+
+  it(`can write the escaped name and then read it back in unescaped format`, async () => {
+    const stringsPath = '/app/android/app/src/main/res/values/strings.xml';
+    let stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
+    expect(stringsJSON.resources.string.filter(e => e.$.name === 'app_name')[0]._).toBe(
+      `exp'o &bo<y>'`
+    );
+    stringsJSON = setStringItem(
+      [buildResourceItem({ name: 'app_name', value: `'E&x<p>o"@\n` })],
+      stringsJSON
+    );
+
+    // Test that it's written in escaped form
+    // expect(format(stringsJSON)).toBe(true);
+    expect(format(stringsJSON).includes(`\\'E&amp;x&lt;p&gt;o\\"\\@\\n`)).toBe(true);
+
+    // And parsed in unescaped form
+    expect(stringsJSON.resources.string.filter(e => e.$.name === 'app_name')[0]._).toBe(
+      `\\'E&x<p>o\\"\\@\\n`
+    );
+  });
 });
 
-afterAll(async () => {
-  vol.reset();
+describe('read and write', () => {
+  // reading removes
+  // <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+  const example = `<resources>
+  <string name="app_name">exp\\'o</string>
+</resources>`;
+  beforeAll(async () => {
+    const directoryJSON = {
+      './android/app/src/main/res/values/strings.xml': example,
+    };
+    vol.fromJSON(directoryJSON, '/app');
+  });
+
+  afterAll(async () => {
+    vol.reset();
+  });
+
+  it(`can write the escaped name and then read it back in unescaped format`, async () => {
+    const stringsPath = '/app/android/app/src/main/res/values/strings.xml';
+    const stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
+    console.log(stringsJSON);
+    await writeXMLAsync({ path: stringsPath, xml: stringsJSON });
+    expect(await fs.readFile(stringsPath, 'utf-8')).toBe(example);
+  });
 });
 
-it(`can write the escaped name and then read it back in unescaped format`, async () => {
-  const stringsPath = '/app/android/app/src/main/res/values/strings.xml';
-  let stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
-  expect(stringsJSON.resources.string.filter(e => e.$.name === 'app_name')[0]._).toBe(
-    `expo &bo<y>'`
-  );
-  stringsJSON = setStringItem(
-    [buildResourceItem({ name: 'app_name', value: `'E&x<p>o"@\n` })],
-    stringsJSON
-  );
-
-  // Test that it's written in escaped form
-  // expect(format(stringsJSON)).toBe(true);
-  expect(format(stringsJSON).includes(`\\'E&amp;x&lt;p&gt;o\\"\\@\\n`)).toBe(true);
-
-  // And parsed in unescaped form
-  expect(stringsJSON.resources.string.filter(e => e.$.name === 'app_name')[0]._).toBe(
-    `\\'E&x<p>o\\"\\@\\n`
-  );
-});
 describe(escapeAndroidString, () => {
   it(`can escape Android strings`, () => {
     expect(escapeAndroidString(`@`)).toBe(`\\@`);
     expect(escapeAndroidString(`'''`)).toBe(`\\'\\'\\'`);
     expect(escapeAndroidString('"E&x<p>o"@\n\r\t')).toBe(`\\"E&x<p>o\\"\\@\\n\\r\\t`);
+  });
+});
+
+describe(unescapeAndroidString, () => {
+  it(`can remove escape sequences from Android strings`, () => {
+    expect(unescapeAndroidString(`test\\test`)).toBe('testtest');
+    expect(unescapeAndroidString(`test\\'test`)).toBe("test'test");
+    expect(unescapeAndroidString(`test\\\\'test`)).toBe("test\\'test");
   });
 });


### PR DESCRIPTION
# Why

reading and writing string resources is escaping characters twice.

# How

This is not a proper fix, the correct approach would be to remove escaping from `writeXMLAsync`, but there is probably a bunch of places that rely on this behavior.

this PR is attempting to revert changes that `escapeAndroidString` will do on write

# Test Plan

added test
verified with local builds by applying a similar patch in eas-build code directly
https://github.com/expo/eas-build/pull/76