### PR TITLE
[chore] switch issue template to `expo-env-info`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
       required: true
     attributes:
       label: Environment
-      placeholder: Run `expo diagnostics` and paste the output here
+      placeholder: Run `npx expo-env-info` and paste the output here
   - type: input
     validations:
       required: true


### PR DESCRIPTION
# Why

`expo diagnostics` is deprecated in favor of `npx expo-env-info`

# How

Updated issue template

# Test Plan

N/A