### PR TITLE
[config-plugin] append scheme REVERSED_CLIENT_ID from GoogleService-Info.plist

### DIFF
--- a/packages/config-plugins/src/ios/Google.ts
+++ b/packages/config-plugins/src/ios/Google.ts
@@ -6,13 +6,18 @@ import path from 'path';
 import { XcodeProject } from 'xcode';
 
 import { ConfigPlugin, ModProps } from '../Plugin.types';
-import { createInfoPlistPlugin, withXcodeProject } from '../plugins/ios-plugins';
+import { withInfoPlist, withXcodeProject } from '../plugins/ios-plugins';
 import { InfoPlist } from './IosConfig.types';
 import { getSourceRoot } from './Paths';
 import { appendScheme } from './Scheme';
 import { addResourceFileToGroup, getProjectName } from './utils/Xcodeproj';
 
-export const withGoogle = createInfoPlistPlugin(setGoogleConfig, 'withGoogle');
+export const withGoogle: ConfigPlugin = config => {
+  return withInfoPlist(config, config => {
+    config.modResults = setGoogleConfig(config, config.modResults, config.modRequest);
+    return config;
+  });
+};
 
 export const withGoogleServicesFile: ConfigPlugin = config => {
   return withXcodeProject(config, config => {

--- a/packages/config-plugins/src/ios/Google.ts
+++ b/packages/config-plugins/src/ios/Google.ts
@@ -33,14 +33,10 @@ function readGoogleServicesInfoPlist(
   relativePath: string,
   { projectRoot }: { projectRoot: string }
 ) {
-  try {
-    const googleServiceFilePath = path.resolve(projectRoot, relativePath);
-    const contents = fs.readFileSync(googleServiceFilePath, 'utf8');
-    assert(contents, 'GoogleService-Info.plist is empty');
-    return plist.parse(contents);
-  } catch (error) {
-    throw error;
-  }
+  const googleServiceFilePath = path.resolve(projectRoot, relativePath);
+  const contents = fs.readFileSync(googleServiceFilePath, 'utf8');
+  assert(contents, 'GoogleService-Info.plist is empty');
+  return plist.parse(contents);
 }
 
 export function getGoogleSignInReservedClientId(

--- a/packages/config-plugins/src/ios/Google.ts
+++ b/packages/config-plugins/src/ios/Google.ts
@@ -31,7 +31,7 @@ export const withGoogleServicesFile: ConfigPlugin = config => {
 
 function readGoogleServicesInfoPlist(
   relativePath: string,
-  { introspect, projectRoot }: { introspect: boolean; projectRoot: string }
+  { projectRoot }: { projectRoot: string }
 ) {
   try {
     const googleServiceFilePath = path.resolve(projectRoot, relativePath);
@@ -39,16 +39,13 @@ function readGoogleServicesInfoPlist(
     assert(contents, 'GoogleService-Info.plist is empty');
     return plist.parse(contents);
   } catch (error) {
-    if (introspect) {
-      return {};
-    }
     throw error;
   }
 }
 
 export function getGoogleSignInReservedClientId(
   config: Pick<ExpoConfig, 'ios'>,
-  modRequest: Pick<ModProps<InfoPlist>, 'projectRoot' | 'introspect'>
+  modRequest: Pick<ModProps<InfoPlist>, 'projectRoot'>
 ): string | null {
   const reservedClientId = config.ios?.config?.googleSignIn?.reservedClientId ?? null;
   if (reservedClientId) {
@@ -72,7 +69,7 @@ export function getGoogleServicesFile(config: Pick<ExpoConfig, 'ios'>) {
 export function setGoogleSignInReservedClientId(
   config: Pick<ExpoConfig, 'ios'>,
   infoPlist: InfoPlist,
-  modRequest: Pick<ModProps<InfoPlist>, 'projectRoot' | 'introspect'>
+  modRequest: Pick<ModProps<InfoPlist>, 'projectRoot'>
 ): InfoPlist {
   const reservedClientId = getGoogleSignInReservedClientId(config, modRequest);
 

--- a/packages/config-plugins/src/ios/Google.ts
+++ b/packages/config-plugins/src/ios/Google.ts
@@ -43,7 +43,7 @@ function readGoogleServicesInfoPlist(
 
 export function getGoogleSignInReservedClientId(
   config: Pick<ExpoConfig, 'ios'>,
-  { introspect, projectRoot }: { introspect: boolean; projectRoot: string }
+  modRequest: Pick<ModProps<InfoPlist>, 'projectRoot' | 'introspect'>
 ): string | null {
   const reservedClientId = config.ios?.config?.googleSignIn?.reservedClientId ?? null;
   if (reservedClientId) {
@@ -55,10 +55,7 @@ export function getGoogleSignInReservedClientId(
     return null;
   }
 
-  const infoPlist = readGoogleServicesInfoPlist(googleServicesFileRelativePath, {
-    introspect,
-    projectRoot,
-  });
+  const infoPlist = readGoogleServicesInfoPlist(googleServicesFileRelativePath, modRequest);
 
   return infoPlist.REVERSED_CLIENT_ID ?? null;
 }

--- a/packages/config-plugins/src/ios/__tests__/Google-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Google-test.ts
@@ -19,15 +19,7 @@ describe('ios google config', () => {
   afterEach(() => vol.reset());
 
   it(`returns null from all getters if no value provided`, () => {
-    expect(
-      getGoogleSignInReservedClientId(
-        {},
-        {
-          introspect: false,
-          projectRoot: null,
-        }
-      )
-    ).toBe(null);
+    expect(getGoogleSignInReservedClientId({}, { projectRoot: null })).toBe(null);
     expect(getGoogleServicesFile({})).toBe(null);
   });
 
@@ -37,10 +29,7 @@ describe('ios google config', () => {
         {
           ios: { config: { googleSignIn: { reservedClientId: '000' } } },
         },
-        {
-          introspect: false,
-          projectRoot: null,
-        }
+        { projectRoot: null }
       )
     ).toBe('000');
     expect(
@@ -68,10 +57,7 @@ describe('ios google config', () => {
         },
       },
       infoPlist,
-      {
-        introspect: false,
-        projectRoot: null,
-      }
+      { projectRoot }
     );
 
     expect(appendScheme).toHaveBeenCalledWith('client-id-scheme', infoPlist);
@@ -94,10 +80,7 @@ describe('ios google config', () => {
         ios: { googleServicesFile: './path/to/GoogleService-Info.plist' },
       },
       infoPlist,
-      {
-        introspect: false,
-        projectRoot,
-      }
+      { projectRoot }
     );
 
     expect(appendScheme).toHaveBeenCalledWith(

--- a/packages/config-plugins/src/ios/__tests__/Google-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Google-test.ts
@@ -1,3 +1,6 @@
+import { vol } from 'memfs';
+import path from 'path';
+
 import {
   getGoogleServicesFile,
   getGoogleSignInReservedClientId,
@@ -5,19 +8,40 @@ import {
 } from '../Google';
 import { appendScheme } from '../Scheme';
 
+jest.mock('fs');
 jest.mock('../Scheme');
 
+const originalFs = jest.requireActual('fs');
+
 describe('ios google config', () => {
+  const projectRoot = '/testproject';
+
+  afterEach(() => vol.reset());
+
   it(`returns null from all getters if no value provided`, () => {
-    expect(getGoogleSignInReservedClientId({})).toBe(null);
+    expect(
+      getGoogleSignInReservedClientId(
+        {},
+        {
+          introspect: false,
+          projectRoot: null,
+        }
+      )
+    ).toBe(null);
     expect(getGoogleServicesFile({})).toBe(null);
   });
 
   it(`returns the correct values from all getters if a value is provided`, () => {
     expect(
-      getGoogleSignInReservedClientId({
-        ios: { config: { googleSignIn: { reservedClientId: '000' } } },
-      })
+      getGoogleSignInReservedClientId(
+        {
+          ios: { config: { googleSignIn: { reservedClientId: '000' } } },
+        },
+        {
+          introspect: false,
+          projectRoot: null,
+        }
+      )
     ).toBe('000');
     expect(
       getGoogleServicesFile({ ios: { googleServicesFile: './path/to/GoogleService-Info.plist' } })
@@ -25,13 +49,60 @@ describe('ios google config', () => {
   });
 
   it(`adds the reserved client id to scheme if provided`, () => {
+    vol.fromJSON(
+      {
+        'path/to/GoogleService-Info.plist': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/GoogleService-Info.plist'),
+          'utf-8'
+        ),
+      },
+      projectRoot
+    );
+
     const infoPlist = {};
     setGoogleSignInReservedClientId(
       {
-        ios: { config: { googleSignIn: { reservedClientId: 'client-id-scheme' } } },
+        ios: {
+          config: { googleSignIn: { reservedClientId: 'client-id-scheme' } },
+          googleServicesFile: './path/to/GoogleService-Info.plist',
+        },
       },
+      infoPlist,
+      {
+        introspect: false,
+        projectRoot: null,
+      }
+    );
+
+    expect(appendScheme).toHaveBeenCalledWith('client-id-scheme', infoPlist);
+  });
+
+  it(`adds the reserved client id to scheme from GoogleService-Info.Plist`, () => {
+    vol.fromJSON(
+      {
+        'path/to/GoogleService-Info.plist': originalFs.readFileSync(
+          path.join(__dirname, 'fixtures/GoogleService-Info.plist'),
+          'utf-8'
+        ),
+      },
+      projectRoot
+    );
+
+    const infoPlist = {};
+    setGoogleSignInReservedClientId(
+      {
+        ios: { googleServicesFile: './path/to/GoogleService-Info.plist' },
+      },
+      infoPlist,
+      {
+        introspect: false,
+        projectRoot,
+      }
+    );
+
+    expect(appendScheme).toHaveBeenCalledWith(
+      'com.googleusercontent.apps.1234567890123-abcdef',
       infoPlist
     );
-    expect(appendScheme).toHaveBeenCalledWith('client-id-scheme', infoPlist);
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/fixtures/GoogleService-Info.plist
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/GoogleService-Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>1234567890123-abcdef.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.1234567890123-abcdef</string>
+	<key>API_KEY</key>
+	<string>1234567890abcdef</string>
+	<key>GCM_SENDER_ID</key>
+	<string>1234567890123</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>dev.bacon.app</string>
+	<key>PROJECT_ID</key>
+	<string>abcdef</string>
+	<key>STORAGE_BUCKET</key>
+	<string>abcdef.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:1234567890123:ios:cc1778371ad8b329a1550f</string>
+</dict>
+</plist>

--- a/packages/config-plugins/src/plugins/ios-plugins.ts
+++ b/packages/config-plugins/src/plugins/ios-plugins.ts
@@ -2,12 +2,16 @@ import type { ExpoConfig } from '@expo/config-types';
 import type { JSONObject, JSONValue } from '@expo/json-file';
 import type { XcodeProject } from 'xcode';
 
-import type { ConfigPlugin, Mod } from '../Plugin.types';
+import type { ConfigPlugin, Mod, ModProps } from '../Plugin.types';
 import type { ExpoPlist, InfoPlist } from '../ios/IosConfig.types';
 import type { AppDelegateProjectFile } from '../ios/Paths';
 import { withMod } from './withMod';
 
-type MutateInfoPlistAction = (expo: ExpoConfig, infoPlist: InfoPlist) => InfoPlist;
+type MutateInfoPlistAction = (
+  expo: ExpoConfig,
+  infoPlist: InfoPlist,
+  modRequest: ModProps<InfoPlist>
+) => Promise<InfoPlist> | InfoPlist;
 
 /**
  * Helper method for creating mods from existing config functions.
@@ -17,7 +21,7 @@ type MutateInfoPlistAction = (expo: ExpoConfig, infoPlist: InfoPlist) => InfoPli
 export function createInfoPlistPlugin(action: MutateInfoPlistAction, name?: string): ConfigPlugin {
   const withUnknown: ConfigPlugin = config =>
     withInfoPlist(config, async config => {
-      config.modResults = await action(config, config.modResults);
+      config.modResults = await action(config, config.modResults, config.modRequest);
       return config;
     });
   if (name) {

--- a/packages/config-plugins/src/plugins/ios-plugins.ts
+++ b/packages/config-plugins/src/plugins/ios-plugins.ts
@@ -2,15 +2,14 @@ import type { ExpoConfig } from '@expo/config-types';
 import type { JSONObject, JSONValue } from '@expo/json-file';
 import type { XcodeProject } from 'xcode';
 
-import type { ConfigPlugin, Mod, ModProps } from '../Plugin.types';
+import type { ConfigPlugin, Mod } from '../Plugin.types';
 import type { ExpoPlist, InfoPlist } from '../ios/IosConfig.types';
 import type { AppDelegateProjectFile } from '../ios/Paths';
 import { withMod } from './withMod';
 
 type MutateInfoPlistAction = (
   expo: ExpoConfig,
-  infoPlist: InfoPlist,
-  modRequest: ModProps<InfoPlist>
+  infoPlist: InfoPlist
 ) => Promise<InfoPlist> | InfoPlist;
 
 /**
@@ -21,7 +20,7 @@ type MutateInfoPlistAction = (
 export function createInfoPlistPlugin(action: MutateInfoPlistAction, name?: string): ConfigPlugin {
   const withUnknown: ConfigPlugin = config =>
     withInfoPlist(config, async config => {
-      config.modResults = await action(config, config.modResults, config.modRequest);
+      config.modResults = await action(config, config.modResults);
       return config;
     });
   if (name) {


### PR DESCRIPTION
# Why

While writing a new plug-in for Google Sign In, I noticed that `ios.config.googleSignIn.reservedClientId` is used to add a new scheme to the iOS configuration.

We can do this automatically by reading the `REVERSED_CLIENT_ID` field from the `GoogleService-Info.plist` file

# How

- Update `withGoogle` plugin to read the field from the `GoogleService-Info.plist` file.
- We still respect the old `ios.config.googleSignIn.reservedClientId` config for backward compatible.
- *Next step*: Update the Google SignIn module to remove mention about `ios.config.googleSignIn.reservedClientId`.

# Test Plan

- Unit test