### PR TITLE
[config-plugins] Added support for `AppDelegate.mm`

### DIFF
--- a/packages/config-plugins/src/ios/Maps.ts
+++ b/packages/config-plugins/src/ios/Maps.ts
@@ -180,7 +180,7 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
 
 const withGoogleMapsAppDelegate: ConfigPlugin<{ apiKey: string | null }> = (config, { apiKey }) => {
   return withAppDelegate(config, config => {
-    if (['objc', 'cxx'].includes(config.modResults.language)) {
+    if (['objc', 'objcpp'].includes(config.modResults.language)) {
       if (
         apiKey &&
         isReactNativeMapsAutolinked(config) &&

--- a/packages/config-plugins/src/ios/Maps.ts
+++ b/packages/config-plugins/src/ios/Maps.ts
@@ -180,7 +180,7 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
 
 const withGoogleMapsAppDelegate: ConfigPlugin<{ apiKey: string | null }> = (config, { apiKey }) => {
   return withAppDelegate(config, config => {
-    if (config.modResults.language === 'objc') {
+    if (['objc', 'cxx'].includes(config.modResults.language)) {
       if (
         apiKey &&
         isReactNativeMapsAutolinked(config) &&
@@ -194,7 +194,7 @@ const withGoogleMapsAppDelegate: ConfigPlugin<{ apiKey: string | null }> = (conf
             config.modResults.contents,
             apiKey
           ).contents;
-        } catch (error) {
+        } catch (error: any) {
           if (error.code === 'ERR_NO_MATCH') {
             throw new Error(
               `Cannot add Google Maps to the project's AppDelegate because it's malformed. Please report this with a copy of your project AppDelegate.`
@@ -211,7 +211,9 @@ const withGoogleMapsAppDelegate: ConfigPlugin<{ apiKey: string | null }> = (conf
         ).contents;
       }
     } else {
-      throw new Error('Cannot setup Google Maps because the AppDelegate is not Objective C');
+      throw new Error(
+        `Cannot setup Google Maps because the project AppDelegate is not a supported language: ${config.modResults.language}`
+      );
     }
     return config;
   });

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -13,7 +13,9 @@ interface ProjectFile<L extends string = string> {
   contents: string;
 }
 
-export type AppDelegateProjectFile = ProjectFile<'objc' | 'swift'>;
+type AppleLanguage = 'objc' | 'cxx' | 'swift';
+
+export type AppDelegateProjectFile = ProjectFile<AppleLanguage>;
 
 export function getAppDelegateHeaderFilePath(projectRoot: string): string {
   const [using, ...extra] = globSync('ios/*/AppDelegate.h', {
@@ -42,7 +44,7 @@ export function getAppDelegateHeaderFilePath(projectRoot: string): string {
 }
 
 export function getAppDelegateFilePath(projectRoot: string): string {
-  const [using, ...extra] = globSync('ios/*/AppDelegate.@(m|swift)', {
+  const [using, ...extra] = globSync('ios/*/AppDelegate.@(m|mm|swift)', {
     absolute: true,
     cwd: projectRoot,
     ignore: ignoredPaths,
@@ -89,9 +91,11 @@ export function getAppDelegateObjcHeaderFilePath(projectRoot: string): string {
   return using;
 }
 
-function getLanguage(filePath: string): 'objc' | 'swift' {
+function getLanguage(filePath: string): AppleLanguage {
   const extension = path.extname(filePath);
   switch (extension) {
+    case '.mm':
+      return 'cxx';
     case '.m':
     case '.h':
       return 'objc';

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -13,7 +13,7 @@ interface ProjectFile<L extends string = string> {
   contents: string;
 }
 
-type AppleLanguage = 'objc' | 'cxx' | 'swift';
+type AppleLanguage = 'objc' | 'objcpp' | 'swift';
 
 export type AppDelegateProjectFile = ProjectFile<AppleLanguage>;
 
@@ -95,7 +95,7 @@ function getLanguage(filePath: string): AppleLanguage {
   const extension = path.extname(filePath);
   switch (extension) {
     case '.mm':
-      return 'cxx';
+      return 'objcpp';
     case '.m':
     case '.h':
       return 'objc';

--- a/packages/config-plugins/src/ios/__tests__/Paths-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Paths-test.ts
@@ -118,7 +118,7 @@ describe(getAppDelegate, () => {
     });
   });
 
-  it(`returns C++ (cxx) path`, () => {
+  it(`returns C++ (objcpp) path`, () => {
     vol.fromJSON(
       {
         'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
@@ -136,7 +136,7 @@ describe(getAppDelegate, () => {
     expect(getAppDelegate('/')).toStrictEqual({
       contents: '',
       path: '/ios/testproject/AppDelegate.mm',
-      language: 'cxx',
+      language: 'objcpp',
     });
   });
 

--- a/packages/config-plugins/src/ios/__tests__/Paths-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Paths-test.ts
@@ -89,7 +89,14 @@ describe(getXcodeProjectPath, () => {
 });
 
 describe(getAppDelegate, () => {
-  beforeAll(async () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it(`returns objc path`, () => {
     vol.fromJSON(
       {
         'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
@@ -104,6 +111,36 @@ describe(getAppDelegate, () => {
       '/objc'
     );
 
+    expect(getAppDelegate('/objc')).toStrictEqual({
+      contents: '',
+      path: '/objc/ios/testproject/AppDelegate.m',
+      language: 'objc',
+    });
+  });
+
+  it(`returns C++ (cxx) path`, () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ) as string,
+        'ios/Podfile': 'content',
+        'ios/TestPod.podspec': 'noop',
+        'ios/testproject/AppDelegate.mm': '',
+        'ios/testproject/AppDelegate.h': '',
+      },
+      '/'
+    );
+
+    expect(getAppDelegate('/')).toStrictEqual({
+      contents: '',
+      path: '/ios/testproject/AppDelegate.mm',
+      language: 'cxx',
+    });
+  });
+
+  it(`returns swift path`, () => {
     vol.fromJSON(
       {
         'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
@@ -117,6 +154,14 @@ describe(getAppDelegate, () => {
       '/swift'
     );
 
+    expect(getAppDelegate('/swift')).toStrictEqual({
+      contents: '',
+      path: '/swift/ios/testproject/AppDelegate.swift',
+      language: 'swift',
+    });
+  });
+
+  it(`throws on invalid project`, () => {
     vol.fromJSON(
       {
         'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
@@ -129,6 +174,11 @@ describe(getAppDelegate, () => {
       '/invalid'
     );
 
+    expect(() => getAppDelegate('/invalid')).toThrow(UnexpectedError);
+    expect(() => getAppDelegate('/invalid')).toThrow(/AppDelegate/);
+  });
+
+  it(`warns when multiple paths are found`, () => {
     vol.fromJSON(
       {
         'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
@@ -143,33 +193,7 @@ describe(getAppDelegate, () => {
       },
       '/confusing'
     );
-  });
 
-  afterAll(() => {
-    vol.reset();
-  });
-
-  it(`returns objc path`, () => {
-    expect(getAppDelegate('/objc')).toStrictEqual({
-      contents: '',
-      path: '/objc/ios/testproject/AppDelegate.m',
-      language: 'objc',
-    });
-  });
-  it(`returns swift path`, () => {
-    expect(getAppDelegate('/swift')).toStrictEqual({
-      contents: '',
-      path: '/swift/ios/testproject/AppDelegate.swift',
-      language: 'swift',
-    });
-  });
-
-  it(`throws on invalid project`, () => {
-    expect(() => getAppDelegate('/invalid')).toThrow(UnexpectedError);
-    expect(() => getAppDelegate('/invalid')).toThrow(/AppDelegate/);
-  });
-
-  it(`warns when multiple paths are found`, () => {
     expect(getAppDelegate('/confusing')).toStrictEqual({
       contents: '',
       path: '/confusing/ios/testproject/AppDelegate.m',


### PR DESCRIPTION
# Why

- React Native 68 uses `AppDelegate.mm` instead of `AppDelegate.m` which means the existing prebuild check would assert that vital project files are missing and the Google Maps dangerous plugin would fail.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Add `objcpp` which is returned when the AppDelegate file extension is `.mm`.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- In a local project, rename `AppDelegate.m` to `AppDelegate.mm` and rerun `expo prebuild -p ios --no-install` -- no error should be thrown.
- It's unclear what the new template file will look like so we don't have a continuous test in place for the Maps plugin.
- Added a FS unit test.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->