### PR TITLE
[expo-cli] Move `expo eject` to the deprecated help group

### DIFF
--- a/packages/expo-cli/src/commands/eject/eject.ts
+++ b/packages/expo-cli/src/commands/eject/eject.ts
@@ -1,22 +1,17 @@
 import chalk from 'chalk';
-import type { Command } from 'commander';
+import { Command } from 'commander';
 
-import { learnMore } from '../utils/TerminalLink';
 import { applyAsyncActionProjectDir } from '../utils/applyAsyncAction';
 
 export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('eject [path]')
-      .description(
-        `Create native iOS and Android project files. ${chalk.dim(
-          learnMore('https://docs.expo.dev/workflow/customizing/')
-        )}`
-      )
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`expo prebuild`}`)
       .longDescription(
         'Create Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.'
       )
-      .helpGroup('eject')
+      .helpGroup('deprecated')
       .option('--no-install', 'Skip installing npm packages and CocoaPods.')
       .option('--npm', 'Use npm to install dependencies. (default when Yarn is not installed)')
       .option(


### PR DESCRIPTION

<img width="566" alt="Screen Shot 2022-03-08 at 12 21 10 PM" src="https://user-images.githubusercontent.com/9664363/157309748-d2abf2a7-7715-4e8d-88d5-83eca5119325.png">


# Why

- Update the description to reflect that users should move to expo prebuild instead.
- We want to deprecate `expo eject` but we can do this naturally by waiting until the `expo-cli` package is deprecated in favor of `npx expo`.
- Waiting until `npx expo` is in beta ready adding a proper notice that would detect the SDK version and prompt the user to use `npx expo prebuild` instead.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
