### PR TITLE
[next-adapter] revert webpack5 detection

### DIFF
--- a/packages/next-adapter/src/withExpo.ts
+++ b/packages/next-adapter/src/withExpo.ts
@@ -19,7 +19,7 @@ export default function withExpo(nextConfig: any = {}): any {
         },
         {
           supportsFontLoading: false,
-          webpack5: webpack5 && webpack5 !== false,
+          webpack5: webpack5 !== false,
         }
       );
       // Use original public path


### PR DESCRIPTION
# Why

Quoting comment from https://github.com/expo/expo-cli/pull/4058

> This PR did the opposite of its intention and actually broke `withExpo` by causing it to default to `webpack5: undefined` instead of `webpack5: true`
> 
> The idea of the previous logic was to default to passing `webpack5: true` to `withUnimodules` if `next.config.js` had a truthy value or it wasn't declared (undefined)
> 
> It should only pass `false` to `withUnimodules` if the user explicitly set `webpack5: false` in their `next.config.js`
> 
> ```
> const webpack5 = undefined
> const previous = webpack5 !== false // previous === true
> const current = webpack5 && webpack5 !== false // current === undefined
> ```
> 

Reverting this change will fix [Issue using turborepo and @expo/next-adapter #4066](https://github.com/expo/expo-cli/issues/4066)
