### PR TITLE
[metro-config] Remove json assetExt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🛠 Breaking changes
 
-- [metro-config] Removes duplicate `json` extensions in metro `assetExts` and `sourceExts`. ([#4255](https://github.com/expo/expo-cli/issues/4255))
+- [metro-config] Removes duplicate `json` extensions in metro `assetExts` and `sourceExts`. ([#4255](https://github.com/expo/expo-cli/pull/4255))
 
   - If a project requires `json` assets as discreet assets, include a **metro.config.js** file at the root of the project and add `json` to the `assetExts` array. Example:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- [metro-config] Removes duplicate `json` extensions in metro `assetExts` and `sourceExts`. ([#4255](https://github.com/expo/expo-cli/issues/4255))
+
+  - If a project requires `json` assets as discreet assets, include a **metro.config.js** file at the root of the project and add `json` to the `assetExts` array. Example:
+
+  ```js
+  const { getDefaultConfig } = require('expo/metro-config');
+  const defaultConfig = getDefaultConfig(__dirname);
+
+  module.exports = {
+    resolver: {
+      assetExts: [...defaultConfig.resolver.assetExts, 'json'],
+    },
+  };
+  ```
+
 ### 🎉 New features
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 - [metro-config] Removes duplicate `json` extensions in metro `assetExts` and `sourceExts`. ([#4255](https://github.com/expo/expo-cli/pull/4255))
 
-  - If a project requires `json` assets as discreet assets, include a **metro.config.js** file at the root of the project and add `json` to the `assetExts` array. Example:
+  - If a project requires `json` assets as discrete assets, include a **metro.config.js** file at the root of the project and add `json` to the `assetExts` array. Example:
 
   ```js
   const { getDefaultConfig } = require('expo/metro-config');

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -224,7 +224,9 @@ export function getDefaultConfig(
     resolver: {
       resolverMainFields,
       platforms: ['ios', 'android', 'native', 'testing'],
-      assetExts: [...metroDefaultValues.resolver.assetExts.filter(assetExt => assetExt !== 'json')],
+      assetExts: metroDefaultValues.resolver.assetExts.filter(
+        assetExt => !sourceExts.includes(assetExt)
+      ),
       sourceExts,
       nodeModulesPaths,
     },

--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -223,7 +223,8 @@ export function getDefaultConfig(
     watchFolders,
     resolver: {
       resolverMainFields,
-      platforms: ['ios', 'android', 'native'],
+      platforms: ['ios', 'android', 'native', 'testing'],
+      assetExts: [...metroDefaultValues.resolver.assetExts.filter(assetExt => assetExt !== 'json')],
       sourceExts,
       nodeModulesPaths,
     },

--- a/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
+++ b/packages/metro-config/src/__tests__/ExpoMetroConfig-test.ts
@@ -3,13 +3,13 @@ import path from 'path';
 import { getDefaultConfig, loadAsync } from '../ExpoMetroConfig';
 
 const projectRoot = path.join(__dirname, '__fixtures__', 'hello-world');
-
 const consoleError = console.error;
 
 beforeEach(() => {
   delete process.env.EXPO_TARGET;
   delete process.env.EXPO_USE_EXOTIC;
 });
+
 describe('getDefaultConfig', () => {
   afterAll(() => {
     console.error = consoleError;
@@ -21,17 +21,15 @@ describe('getDefaultConfig', () => {
         projectRoot,
         resolver: expect.objectContaining({
           resolverMainFields: expect.arrayContaining(['react-native', 'browser', 'main']),
-          sourceExts: expect.not.arrayContaining([
-            'expo.ts',
-            'expo.tsx',
-            'expo.js',
-            'expo.jsx',
-            'jsx',
-          ]),
+          sourceExts:
+            expect.not.arrayContaining(['expo.ts', 'expo.tsx', 'expo.js', 'expo.jsx', 'jsx']) &&
+            expect.arrayContaining(['json']),
+          assetExts: expect.not.arrayContaining(['json']),
         }),
       })
     );
   });
+
   it('loads exotic configuration', () => {
     expect(getDefaultConfig(projectRoot, { mode: 'exotic' })).toEqual(
       expect.objectContaining({
@@ -58,6 +56,7 @@ describe('getDefaultConfig', () => {
       getDefaultConfig(projectRoot, { target: 'blooper' })
     ).not.toThrow();
   });
+
   it('logs an error if the environment variable is used', () => {
     console.error = jest.fn();
     process.env.EXPO_TARGET = 'bare';
@@ -73,14 +72,17 @@ describe('loadAsync', () => {
       resetCache: true,
       reporter: { update() {} },
       sourceExts: ['yml', 'toml', 'json'],
+      assetExts: ['json'],
     };
     const config = await loadAsync(projectRoot, options);
+
     expect(config).toMatchObject({
       maxWorkers: options.maxWorkers,
       resetCache: options.resetCache,
       reporter: options.reporter,
       resolver: {
         sourceExts: options.sourceExts,
+        assetExts: options.assetExts,
       },
     });
   });


### PR DESCRIPTION
# Why

When we create update bundles, metro includes all assets necessary to run the app in its output. Part of our metro `resolver` configuration includes `assetExts` and `sourceExts`. `assetExts` are file extensions that metro will include as discreet assets alongside the JS bundles. `sourceExts` are file extensions that metro will include inside the JS bundle, inline.

I noticed that we have `json` in both `assetExts` and `sourceExts`, which means we are inlining `json` files in the main JS bundle and then including them again as discreet assets. In other words, all `json` files in update bundles are duplicated.

With EAS Update, developers often have node modules that include many `json` files (like translations etc), which we then count against our 400 asset limit. This can make it hard for larger apps to publish. Since those apps do not need the extra `json` assets because they are also inlined, this PR removes `json` from `assetExts`. 

Below I ran `expod export --experimental-bundle` on a project:

## Before

```bash
saving /assets/fonts/SpaceMono-Regular.ttf
saving /node_modules/@react-navigation/elements/src/assets/back-icon@1x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@1.5x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@2x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@3x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@4x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon-mask.png
saving /node_modules/react-native/package.json
saving /node_modules/mdn-data/css/at-rules.json
saving /node_modules/mdn-data/css/properties.json
saving /node_modules/mdn-data/css/syntaxes.json
saving /node_modules/css-tree/data/patch.json
saving /node_modules/css-tree/package.json
saving /node_modules/entities/lib/maps/entities.json
saving /node_modules/entities/lib/maps/legacy.json
saving /node_modules/entities/lib/maps/xml.json
saving /node_modules/entities/lib/maps/decode.json
saving /node_modules/dom-serializer/foreignNames.json
saving /node_modules/css-select/lib/procedure.json
saving /assets/databases/CSW21.db
saving /assets/databases/NWL2020.db
saving /tailwind.json
saving /node_modules/@react-navigation/elements/src/assets/back-icon@1x.ios.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@1.5x.ios.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@2x.ios.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@3x.ios.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@4x.ios.png
```

## After

```bash
saving /assets/fonts/SpaceMono-Regular.ttf
saving /node_modules/@react-navigation/elements/src/assets/back-icon@1x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@1.5x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@2x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@3x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@4x.android.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon-mask.png
saving /assets/databases/CSW21.db
saving /assets/databases/NWL2020.db
saving /node_modules/@react-navigation/elements/src/assets/back-icon@1x.ios.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@1.5x.ios.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@2x.ios.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@3x.ios.png
saving /node_modules/@react-navigation/elements/src/assets/back-icon@4x.ios.png
```

# How

- In `getDefaultConfig()`, I filtered out `json` from the default `assetExts`, then added tests.

# Test Plan

This change affects development and production bundles. To see the result of this change, pull this branch, then run `yarn link` in **expo-cli/packages/metro-config**. Then, in an Expo project run `yarn link @expo/metro-config`. Back in **expo-cli**, run `yarn start` to build the packages.

Back in the Expo project, you can run `expod export --experimental-bundle` (I have `expod` as an alias: `alias expod="~/<your-file-path>/expo-cli/packages/expo-cli/bin/expo.js"`).

After running this, you should see that `json` files are not emitted as part of the bundle.

Also:
- Make sure that you can run `expod start` and see changes
- Make sure you can run `expod publish` and `eas update`. Make sure there are no json files in the **metadata.json** file.
- Make sure that when supplying a custom **metro.config.json** in a project, that if you add `json` in `assetExts`, that it does include `json` files in the outputted bundle as assets.