### PR TITLE
[config-plugins] use relative path for locales

### DIFF
--- a/packages/config-plugins/src/ios/Locales.ts
+++ b/packages/config-plugins/src/ios/Locales.ts
@@ -57,15 +57,16 @@ export async function setLocalesAsync(
     // Write the file to the file system.
     await fs.writeFile(strings, buffer.join('\n'));
 
+    const groupName = `${projectName}/Supporting/${lang}.lproj`;
     // deep find the correct folder
-    const group = ensureGroupRecursively(project, `${projectName}/Supporting/${lang}.lproj`);
+    const group = ensureGroupRecursively(project, groupName);
 
     // Ensure the file doesn't already exist
     if (!group?.children.some(({ comment }) => comment === stringName)) {
       // Only write the file if it doesn't already exist.
       project = addResourceFileToGroup({
         filepath: relative(supportingDirectory, strings),
-        groupName: `${projectName}/Supporting/${lang}.lproj`,
+        groupName,
         project,
         isBuildFile: true,
         verbose: true,

--- a/packages/config-plugins/src/ios/Locales.ts
+++ b/packages/config-plugins/src/ios/Locales.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig } from '@expo/config-types';
 import JsonFile from '@expo/json-file';
 import * as fs from 'fs-extra';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { XcodeProject } from 'xcode';
 
 import { ConfigPlugin } from '../Plugin.types';
@@ -64,7 +64,7 @@ export async function setLocalesAsync(
     if (!group?.children.some(({ comment }) => comment === stringName)) {
       // Only write the file if it doesn't already exist.
       project = addResourceFileToGroup({
-        filepath: strings,
+        filepath: relative(supportingDirectory, strings),
         groupName: `${projectName}/Supporting/${lang}.lproj`,
         project,
         isBuildFile: true,


### PR DESCRIPTION
# Why

Close: https://github.com/expo/expo/issues/15441

If the user run `expo prebuild -p ios` in their local and submit a new build with `eas build`. Then, the absolute path to locales files becomes wrong.

# How

- This PR fixes the issue by using a relative path for them.

