### PR TITLE
[cli] update supported Node version warning to reflect current LTS schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🎉 New features
 
 ### 🧹 Chores
+- [expo-cli] update supported Node version warning to reflect current LTS schema ([#4261](https://github.com/expo/expo-cli/pull/4261))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -13,9 +13,8 @@ const minor = parseInt(match[2], 10);
 
 const supportedVersions =
   'expo-cli supports following Node.js versions:\n' +
-  '* >=12.13.0 <13.0.0 (Maintenance LTS)\n' +
-  '* >=14.0.0 <15.0.0 (Active LTS)\n' +
-  '* >=15.0.0 <17.0.0 (Current Release)\n';
+  '* >=12.13.0 <15.0.0 (Maintenance LTS)\n' +
+  '* >=16.0.0 <17.0.0 (Active LTS)\n';
 
 // If newer than the current release
 if (major > 16) {


### PR DESCRIPTION
# Why

The Node.js versions warning doesn't reflect the current version scheme (https://nodejs.org/en/about/releases/).

# How

Changed the warning copy.

# Test Plan

- Select different node version with `nvm`
- View warning