### PR TITLE
Upgrade `babel-preset-expo`

### DIFF
--- a/packages/next-adapter/package.json
+++ b/packages/next-adapter/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@expo/package-manager": "0.0.47",
     "@expo/webpack-config": "0.16.7",
-    "babel-preset-expo": "^8.4.1",
+    "babel-preset-expo": "^9.0.2",
     "chalk": "^4.0.0",
     "commander": "^4.0.1",
     "fs-extra": "9.0.0",


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Next adapter's babel plugin is out of date. I wonder if this should be a peer dependency instead to avoid clashes.

# How

n/a

# Test Plan

Using it in my app.