### PR TITLE
[cli] Cap Expo CLI at Node 16

### DIFF
--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/expo/expo-cli/tree/main/packages/expo-cli#readme",
   "engines": {
-    "node": ">=12"
+    "node": ">=12 <=16"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
# Why

It doesn't work with Node 17 right now. Make this clear in `engines`.

# Test Plan

Verified that `>=12 <=16` matches numbers like `12.4.5` and `16.1.2`.