### PR TITLE
add webpack-dev-server dependency to expo/webpack-config

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -68,6 +68,7 @@
     "terser-webpack-plugin": "^3.0.6",
     "url-loader": "~4.1.0",
     "webpack": "4.43.0",
+    "webpack-dev-server": "3.11.0",
     "webpack-manifest-plugin": "~2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

Versioned expo CLI will require webpack-dev-server to be installed in the project, adding the dependency to `@expo/webpack-config` enables us to ensure all Webpack dependencies are versioned with the config.