### PR TITLE
match `xcodeproj` in ios directory only

### DIFF
--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -143,7 +143,15 @@ export function getAllXcodeProjectPaths(projectRoot: string): string[] {
     .filter(project => !/test|example|sample/i.test(project) || path.dirname(project) === iosFolder)
     // sort alphabetically to ensure this works the same across different devices (Fail in CI (linux) without this)
     .sort()
-    .sort(project => (path.dirname(project) === iosFolder ? -1 : 1));
+    .sort((a, b) => {
+      const isAInIos = path.dirname(a) === iosFolder;
+      const isBInIos = path.dirname(b) === iosFolder;
+      // preserve previous sort order
+      if ((isAInIos && isBInIos) || (!isAInIos && !isBInIos)) {
+        return 0;
+      }
+      return isAInIos ? -1 : 1;
+    });
 
   if (!pbxprojPaths.length) {
     throw new UnexpectedError(

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -139,11 +139,11 @@ export function findSchemeNames(projectRoot: string): string[] {
 
 export function getAllXcodeProjectPaths(projectRoot: string): string[] {
   const iosFolder = 'ios';
-  const pbxprojPaths = globSync('**/*.xcodeproj', { cwd: projectRoot, ignore: ignoredPaths })
+  const pbxprojPaths = globSync('ios/**/*.xcodeproj', { cwd: projectRoot, ignore: ignoredPaths })
     .filter(project => !/test|example|sample/i.test(project) || path.dirname(project) === iosFolder)
-    .sort(project => (path.dirname(project) === iosFolder ? -1 : 1))
     // sort alphabetically to ensure this works the same across different devices (Fail in CI (linux) without this)
-    .sort();
+    .sort()
+    .sort(project => (path.dirname(project) === iosFolder ? -1 : 1));
 
   if (!pbxprojPaths.length) {
     throw new UnexpectedError(

--- a/packages/config-plugins/src/ios/__tests__/Paths-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Paths-test.ts
@@ -36,7 +36,11 @@ describe(findSchemeNames, () => {
 });
 
 describe(getXcodeProjectPath, () => {
-  beforeAll(async () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it(`returns project path`, () => {
     vol.fromJSON(
       {
         'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
@@ -49,8 +53,14 @@ describe(getXcodeProjectPath, () => {
       },
       '/app'
     );
+    expect(getXcodeProjectPath('/app')).toBe('/app/ios/testproject.xcodeproj');
+  });
 
-    // More than one
+  it(`throws when no paths are found`, () => {
+    expect(() => getXcodeProjectPath('/none')).toThrow(UnexpectedError);
+  });
+
+  it(`warns when multiple paths are found`, () => {
     vol.fromJSON(
       {
         'ios/otherproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
@@ -63,28 +73,80 @@ describe(getXcodeProjectPath, () => {
         ),
         'ios/testproject/AppDelegate.m': '',
       },
-      '/multiple'
+      '/app'
     );
-  });
 
-  afterAll(() => {
-    vol.reset();
-  });
-
-  it(`returns project path`, () => {
-    expect(getXcodeProjectPath('/app')).toBe('/app/ios/testproject.xcodeproj');
-  });
-
-  it(`throws when no paths are found`, () => {
-    expect(() => getXcodeProjectPath('/none')).toThrow(UnexpectedError);
-  });
-
-  it(`warns when multiple paths are found`, () => {
-    expect(getXcodeProjectPath('/multiple')).toBe('/multiple/ios/otherproject.xcodeproj');
+    expect(getXcodeProjectPath('/app')).toBe('/app/ios/otherproject.xcodeproj');
     expect(WarningAggregator.addWarningIOS).toHaveBeenLastCalledWith(
       'paths-xcodeproj',
       'Found multiple *.xcodeproj file paths, using "ios/otherproject.xcodeproj". Ignored paths: ["ios/testproject.xcodeproj"]'
     );
+  });
+
+  it(`selects xcodeproj based on alphabetical order, but picks direct children of ios directory first`, () => {
+    vol.fromJSON(
+      {
+        'ios/otherproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/aa/otherproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/botherproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject/AppDelegate.m': '',
+      },
+      '/app'
+    );
+
+    expect(getXcodeProjectPath('/app')).toBe('/app/ios/botherproject.xcodeproj');
+    expect(WarningAggregator.addWarningIOS).toHaveBeenLastCalledWith(
+      'paths-xcodeproj',
+      'Found multiple *.xcodeproj file paths, using "ios/botherproject.xcodeproj". Ignored paths: ["ios/otherproject.xcodeproj","ios/testproject.xcodeproj","ios/aa/otherproject.xcodeproj"]'
+    );
+  });
+
+  it(`warns when multiple paths are found`, () => {
+    vol.fromJSON(
+      {
+        'ios/otherproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject/AppDelegate.m': '',
+      },
+      '/app'
+    );
+
+    expect(getXcodeProjectPath('/app')).toBe('/app/ios/otherproject.xcodeproj');
+    expect(WarningAggregator.addWarningIOS).toHaveBeenLastCalledWith(
+      'paths-xcodeproj',
+      'Found multiple *.xcodeproj file paths, using "ios/otherproject.xcodeproj". Ignored paths: ["ios/testproject.xcodeproj"]'
+    );
+  });
+  it(`ignores xcodeproj outside of the ios directory`, () => {
+    vol.fromJSON(
+      {
+        'lib/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+      },
+      '/app'
+    );
+    expect(() => getXcodeProjectPath('/app')).toThrow(UnexpectedError);
   });
 });
 


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/1033

We use `getPBXProjectPath` to detect if the project is bare or managed in eas-cli (if the file is not gitingored)

# How

Changed the order of sort calls, I'm not sure what was the original intention but the current implementation does not make sense, the second sort would always override whatever the first one did. I'm assuming that the intention was to ensure order regardless of what glob returns.
With sort calls inverted the first sort  will order paths alphabetically and the second one will pick direct children of ios directory while still preserving alphabetical order in both groups

search files only in the ios directory

# Test Plan

verified that `'ios/**/*.xcodeproj` is matching `ios/something.xcodeproj` in separate script
tests that verify the order of xcodeproj values are passing