### PR TITLE
chore(config plugins): drop fs-extra

### DIFF
--- a/packages/config-plugins/__mocks__/fs/promises.ts
+++ b/packages/config-plugins/__mocks__/fs/promises.ts
@@ -1,0 +1,2 @@
+import { fs } from 'memfs';
+module.exports = fs.promises;

--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -40,7 +40,6 @@
     "chalk": "^4.1.2",
     "debug": "^4.3.1",
     "find-up": "~5.0.0",
-    "fs-extra": "9.0.0",
     "getenv": "^1.0.0",
     "glob": "7.1.6",
     "resolve-from": "^5.0.0",
@@ -52,7 +51,6 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/find-up": "^4.0.0",
-    "@types/fs-extra": "^9.0.1",
     "@types/xml2js": "^0.4.5"
   },
   "publishConfig": {

--- a/packages/config-plugins/src/android/EasBuild.ts
+++ b/packages/config-plugins/src/android/EasBuild.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 
 import gradleScript from './EasBuildGradleScript';
@@ -24,14 +24,17 @@ export async function configureEasBuildAsync(projectRoot: string): Promise<void>
   const buildGradlePath = Paths.getAppBuildGradleFilePath(projectRoot);
   const easGradlePath = getEasBuildGradlePath(projectRoot);
 
-  await fs.writeFile(easGradlePath, gradleScript);
+  await fs.promises.writeFile(easGradlePath, gradleScript);
 
-  const buildGradleContent = await fs.readFile(path.join(buildGradlePath), 'utf8');
+  const buildGradleContent = await fs.promises.readFile(path.join(buildGradlePath), 'utf8');
 
   const hasEasGradleApply = hasApplyLine(buildGradleContent, APPLY_EAS_GRADLE);
 
   if (!hasEasGradleApply) {
-    await fs.writeFile(buildGradlePath, `${buildGradleContent.trim()}\n${APPLY_EAS_GRADLE}\n`);
+    await fs.promises.writeFile(
+      buildGradlePath,
+      `${buildGradleContent.trim()}\n${APPLY_EAS_GRADLE}\n`
+    );
   }
 }
 
@@ -39,9 +42,9 @@ export async function isEasBuildGradleConfiguredAsync(projectRoot: string): Prom
   const buildGradlePath = Paths.getAppBuildGradleFilePath(projectRoot);
   const easGradlePath = getEasBuildGradlePath(projectRoot);
 
-  const hasEasGradleFile = await fs.pathExists(easGradlePath);
+  const hasEasGradleFile = await fs.existsSync(easGradlePath);
 
-  const buildGradleContent = await fs.readFile(path.join(buildGradlePath), 'utf8');
+  const buildGradleContent = await fs.promises.readFile(path.join(buildGradlePath), 'utf8');
   const hasEasGradleApply = hasApplyLine(buildGradleContent, APPLY_EAS_GRADLE);
 
   return hasEasGradleApply && hasEasGradleFile;

--- a/packages/config-plugins/src/android/GoogleServices.ts
+++ b/packages/config-plugins/src/android/GoogleServices.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config-types';
-import fs from 'fs-extra';
-import { resolve } from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAppBuildGradle, withProjectBuildGradle } from '../plugins/android-plugins';
@@ -70,17 +70,25 @@ export async function setGoogleServicesFile(
     return false;
   }
 
-  const completeSourcePath = resolve(projectRoot, partialSourcePath);
-  const destinationPath = resolve(projectRoot, targetPath);
+  const completeSourcePath = path.resolve(projectRoot, partialSourcePath);
+  const destinationPath = path.resolve(projectRoot, targetPath);
 
   try {
-    await fs.copy(completeSourcePath, destinationPath);
+    await copyFilePathToPath(completeSourcePath, destinationPath);
   } catch (e) {
     throw new Error(
       `Cannot copy google-services.json from ${completeSourcePath} to ${destinationPath}. Please make sure the source and destination paths exist.`
     );
   }
   return true;
+}
+
+/** A basic function that copies a single file to another file location. */
+async function copyFilePathToPath(src: string, dest: string): Promise<void> {
+  const srcFile = await fs.promises.readFile(src);
+
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+  await fs.promises.writeFile(dest, srcFile);
 }
 
 /**

--- a/packages/config-plugins/src/android/GoogleServices.ts
+++ b/packages/config-plugins/src/android/GoogleServices.ts
@@ -1,10 +1,10 @@
 import { ExpoConfig } from '@expo/config-types';
-import fs from 'fs';
 import path from 'path';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAppBuildGradle, withProjectBuildGradle } from '../plugins/android-plugins';
 import { withDangerousMod } from '../plugins/withDangerousMod';
+import { copyFilePathToPathAsync } from '../utils/fs';
 import { addWarningAndroid } from '../utils/warnings';
 
 const DEFAULT_TARGET_PATH = './android/app/google-services.json';
@@ -74,21 +74,14 @@ export async function setGoogleServicesFile(
   const destinationPath = path.resolve(projectRoot, targetPath);
 
   try {
-    await copyFilePathToPath(completeSourcePath, destinationPath);
+    await copyFilePathToPathAsync(completeSourcePath, destinationPath);
   } catch (e) {
+    console.log(e);
     throw new Error(
       `Cannot copy google-services.json from ${completeSourcePath} to ${destinationPath}. Please make sure the source and destination paths exist.`
     );
   }
   return true;
-}
-
-/** A basic function that copies a single file to another file location. */
-async function copyFilePathToPath(src: string, dest: string): Promise<void> {
-  const srcFile = await fs.promises.readFile(src);
-
-  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
-  await fs.promises.writeFile(dest, srcFile);
 }
 
 /**

--- a/packages/config-plugins/src/android/Manifest.ts
+++ b/packages/config-plugins/src/android/Manifest.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 
 import * as XML from '../utils/XML';
@@ -155,8 +155,8 @@ export async function writeAndroidManifestAsync(
   androidManifest: AndroidManifest
 ): Promise<void> {
   const manifestXml = XML.format(androidManifest);
-  await fs.ensureDir(path.dirname(manifestPath));
-  await fs.writeFile(manifestPath, manifestXml);
+  await fs.promises.mkdir(path.dirname(manifestPath), { recursive: true });
+  await fs.promises.writeFile(manifestPath, manifestXml);
 }
 
 export async function readAndroidManifestAsync(manifestPath: string): Promise<AndroidManifest> {

--- a/packages/config-plugins/src/android/Package.ts
+++ b/packages/config-plugins/src/android/Package.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config-types';
 import Debug from 'debug';
-import fs from 'fs-extra';
+import fs from 'fs';
 import { sync as globSync } from 'glob';
 import path from 'path';
 
@@ -136,15 +136,15 @@ export async function renamePackageOnDiskForType({
   const newPackagePath = path.join(packageRoot, ...packageName.split('.'));
 
   // Create the new directory
-  fs.mkdirpSync(newPackagePath);
+  fs.mkdirSync(newPackagePath, { recursive: true });
 
   // Move everything from the old directory over
   globSync('**/*', { cwd: currentPackagePath }).forEach(relativePath => {
     const filepath = path.join(currentPackagePath, relativePath);
     if (fs.lstatSync(filepath).isFile()) {
-      fs.moveSync(filepath, path.join(newPackagePath, relativePath));
+      moveFileSync(filepath, path.join(newPackagePath, relativePath));
     } else {
-      fs.mkdirpSync(filepath);
+      fs.mkdirSync(filepath, { recursive: true });
     }
   });
 
@@ -182,6 +182,11 @@ export async function renamePackageOnDiskForType({
   });
 }
 
+function moveFileSync(src: string, dest: string) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.renameSync(src, dest);
+}
+
 export function setPackageInBuildGradle(config: Pick<ExpoConfig, 'android'>, buildGradle: string) {
   const packageName = getPackage(config);
   if (packageName === null) {
@@ -209,10 +214,10 @@ export function setPackageInAndroidManifest(
 
 export async function getApplicationIdAsync(projectRoot: string): Promise<string | null> {
   const buildGradlePath = getAppBuildGradleFilePath(projectRoot);
-  if (!(await fs.pathExists(buildGradlePath))) {
+  if (!fs.existsSync(buildGradlePath)) {
     return null;
   }
-  const buildGradle = await fs.readFile(buildGradlePath, 'utf8');
+  const buildGradle = await fs.promises.readFile(buildGradlePath, 'utf8');
   const matchResult = buildGradle.match(/applicationId ['"](.*)['"]/);
   // TODO add fallback for legacy cases to read from AndroidManifest.xml
   return matchResult?.[1] ?? null;

--- a/packages/config-plugins/src/android/Paths.ts
+++ b/packages/config-plugins/src/android/Paths.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import fs from 'fs-extra';
+import fs from 'fs';
 import { sync as globSync } from 'glob';
 import * as path from 'path';
 
@@ -68,8 +68,8 @@ export function getGradleFilePath(projectRoot: string, gradleName: string): stri
   const groovyPath = path.resolve(projectRoot, `${gradleName}.gradle`);
   const ktPath = path.resolve(projectRoot, `${gradleName}.gradle.kts`);
 
-  const isGroovy = fs.pathExistsSync(groovyPath);
-  const isKotlin = !isGroovy && fs.pathExistsSync(ktPath);
+  const isGroovy = fs.existsSync(groovyPath);
+  const isKotlin = !isGroovy && fs.existsSync(ktPath);
 
   if (!isGroovy && !isKotlin) {
     throw new Error(`Failed to find '${gradleName}.gradle' file for project: ${projectRoot}.`);

--- a/packages/config-plugins/src/android/__tests__/GoogleServices-test.ts
+++ b/packages/config-plugins/src/android/__tests__/GoogleServices-test.ts
@@ -8,7 +8,7 @@ import {
   setGoogleServicesFile,
 } from '../GoogleServices';
 
-jest.mock('fs-extra');
+jest.mock('fs');
 const fixturesPath = resolve(__dirname, 'fixtures');
 
 describe('google services file', () => {

--- a/packages/config-plugins/src/android/__tests__/Updates-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Updates-test.ts
@@ -1,6 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
 import fs from 'fs';
-import fsExtra from 'fs-extra';
 import { vol } from 'memfs';
 import path from 'path';
 
@@ -16,7 +15,7 @@ jest.mock('resolve-from');
 
 const { silent } = require('resolve-from');
 
-const fsReal = jest.requireActual('fs') as typeof fs;
+const fsReal = jest.requireActual('fs') as typeof import('fs');
 
 describe('Android Updates config', () => {
   beforeEach(() => {
@@ -119,7 +118,7 @@ describe('Android Updates config', () => {
         '/app'
       );
 
-      const contents = await fsExtra.readFile('/app/android/app/build.gradle', 'utf-8');
+      const contents = await fs.promises.readFile('/app/android/app/build.gradle', 'utf-8');
       const newContents = Updates.ensureBuildGradleContainsConfigurationScript('/app', contents);
       expect(newContents).toMatchSnapshot();
     });
@@ -146,7 +145,10 @@ describe('Android Updates config', () => {
         '/app'
       );
 
-      const contents = await fsExtra.readFile('/app/workspace/android/app/build.gradle', 'utf-8');
+      const contents = await fs.promises.readFile(
+        '/app/workspace/android/app/build.gradle',
+        'utf-8'
+      );
       const newContents = Updates.ensureBuildGradleContainsConfigurationScript(
         '/app/workspace',
         contents

--- a/packages/config-plugins/src/ios/BundleIdentifier.ts
+++ b/packages/config-plugins/src/ios/BundleIdentifier.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig } from '@expo/config-types';
 import plist, { PlistObject } from '@expo/plist';
 import assert from 'assert';
-import fs from 'fs-extra';
+import fs from 'fs';
 import xcode, { XCBuildConfiguration } from 'xcode';
 
 import { ConfigPlugin } from '../Plugin.types';

--- a/packages/config-plugins/src/ios/Entitlements.ts
+++ b/packages/config-plugins/src/ios/Entitlements.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config-types';
 import { JSONObject } from '@expo/json-file';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import slash from 'slash';
 
@@ -76,7 +76,7 @@ export function getEntitlementsPath(projectRoot: string): string {
       template = fs.readFileSync(last, 'utf8');
     }
 
-    fs.ensureDirSync(path.dirname(entitlementsPath));
+    fs.mkdirSync(path.dirname(entitlementsPath), { recursive: true });
     fs.writeFileSync(entitlementsPath, template);
 
     Object.entries(project.pbxXCBuildConfigurationSection())
@@ -97,7 +97,8 @@ export function getEntitlementsPath(projectRoot: string): string {
 
 function deleteEntitlementsFiles(entitlementsPaths: string[]) {
   for (const path of entitlementsPaths) {
-    fs.removeSync(path);
+    // fs.removeSync(path);
+    fs.rmdirSync(path, { recursive: true });
   }
 }
 

--- a/packages/config-plugins/src/ios/Entitlements.ts
+++ b/packages/config-plugins/src/ios/Entitlements.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import slash from 'slash';
 
 import { createEntitlementsPlugin } from '../plugins/ios-plugins';
+import { removeFile } from '../utils/fs';
 import * as Paths from './Paths';
 import {
   getPbxproj,
@@ -97,8 +98,7 @@ export function getEntitlementsPath(projectRoot: string): string {
 
 function deleteEntitlementsFiles(entitlementsPaths: string[]) {
   for (const path of entitlementsPaths) {
-    // fs.removeSync(path);
-    fs.rmdirSync(path, { recursive: true });
+    removeFile(path);
   }
 }
 

--- a/packages/config-plugins/src/ios/Google.ts
+++ b/packages/config-plugins/src/ios/Google.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig } from '@expo/config-types';
 import plist from '@expo/plist';
 import assert from 'assert';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import { XcodeProject } from 'xcode';
 

--- a/packages/config-plugins/src/ios/Locales.ts
+++ b/packages/config-plugins/src/ios/Locales.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config-types';
 import JsonFile from '@expo/json-file';
-import * as fs from 'fs-extra';
+import fs from 'fs';
 import { join, relative } from 'path';
 import { XcodeProject } from 'xcode';
 
@@ -48,14 +48,16 @@ export async function setLocalesAsync(
 
   for (const [lang, localizationObj] of Object.entries(localesMap)) {
     const dir = join(supportingDirectory, `${lang}.lproj`);
-    await fs.ensureDir(dir);
+    // await fs.ensureDir(dir);
+    await fs.promises.mkdir(dir, { recursive: true });
+
     const strings = join(dir, stringName);
     const buffer = [];
     for (const [plistKey, localVersion] of Object.entries(localizationObj)) {
       buffer.push(`${plistKey} = "${localVersion}";`);
     }
     // Write the file to the file system.
-    await fs.writeFile(strings, buffer.join('\n'));
+    await fs.promises.writeFile(strings, buffer.join('\n'));
 
     const groupName = `${projectName}/Supporting/${lang}.lproj`;
     // deep find the correct folder

--- a/packages/config-plugins/src/ios/Maps.ts
+++ b/packages/config-plugins/src/ios/Maps.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
@@ -147,7 +147,7 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
     'ios',
     async config => {
       const filePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
-      const contents = await fs.readFile(filePath, 'utf-8');
+      const contents = await fs.promises.readFile(filePath, 'utf-8');
       let results: MergeResults;
       // Only add the block if react-native-maps is installed in the project (best effort).
       // Generally prebuild runs after a yarn install so this should always work as expected.
@@ -171,7 +171,7 @@ const withMapsCocoaPods: ConfigPlugin<{ useGoogleMaps: boolean }> = (config, { u
         results = removeMapsCocoaPods(contents);
       }
       if (results.didMerge || results.didClear) {
-        await fs.writeFile(filePath, results.contents);
+        await fs.promises.writeFile(filePath, results.contents);
       }
       return config;
     },

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -1,4 +1,4 @@
-import { pathExistsSync, readFileSync } from 'fs-extra';
+import { existsSync, readFileSync } from 'fs';
 import { sync as globSync } from 'glob';
 import * as path from 'path';
 
@@ -176,7 +176,7 @@ export function getAllPBXProjectPaths(projectRoot: string): string[] {
   const projectPaths = getAllXcodeProjectPaths(projectRoot);
   const paths = projectPaths
     .map(value => path.join(value, 'project.pbxproj'))
-    .filter(value => pathExistsSync(value));
+    .filter(value => existsSync(value));
 
   if (!paths.length) {
     throw new UnexpectedError(

--- a/packages/config-plugins/src/ios/ProvisioningProfile.ts
+++ b/packages/config-plugins/src/ios/ProvisioningProfile.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 
 import { findFirstNativeTarget, findNativeTargetByName } from './Target';
 import {

--- a/packages/config-plugins/src/ios/Swift.ts
+++ b/packages/config-plugins/src/ios/Swift.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 
 import { ConfigPlugin, XcodeProject } from '../Plugin.types';

--- a/packages/config-plugins/src/ios/XcodeProjectFile.ts
+++ b/packages/config-plugins/src/ios/XcodeProjectFile.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 
 import { ConfigPlugin, XcodeProject } from '../Plugin.types';

--- a/packages/config-plugins/src/ios/__tests__/Entitlements-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Entitlements-test.ts
@@ -1,5 +1,5 @@
 import plist from '@expo/plist';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import { vol } from 'memfs';
 import * as path from 'path';
 
@@ -52,7 +52,7 @@ describe(getEntitlementsPath, () => {
     expect(entitlementsPath).toBe('/no-config/ios/testproject/testproject.entitlements');
 
     // New file has the contents of the old entitlements file
-    const data = plist.parse(await fs.readFile(entitlementsPath, 'utf8'));
+    const data = plist.parse(await fs.promises.readFile(entitlementsPath, 'utf8'));
     expect(data).toStrictEqual({
       // No entitlements enabled by default
     });
@@ -63,10 +63,10 @@ describe(getEntitlementsPath, () => {
     expect(entitlementsPath).toBe('/app/ios/testproject/testproject.entitlements');
 
     // New file has the contents of the old entitlements file
-    const data = plist.parse(await fs.readFile(entitlementsPath, 'utf8'));
+    const data = plist.parse(await fs.promises.readFile(entitlementsPath, 'utf8'));
     expect(data).toStrictEqual({ special: true });
 
     // Old file is deleted
-    expect(await fs.pathExists('/app/ios/testproject/old.entitlements')).toBe(false);
+    expect(fs.existsSync('/app/ios/testproject/old.entitlements')).toBe(false);
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs-extra';
+import fs from 'fs';
 import { vol } from 'memfs';
 import path from 'path';
 
@@ -6,7 +6,7 @@ import { setProvisioningProfileForPbxproj } from '../ProvisioningProfile';
 
 jest.mock('fs');
 
-const originalFs = jest.requireActual('fs') as typeof fs;
+const originalFs = jest.requireActual('fs') as typeof import('fs');
 
 describe('ProvisioningProfile module', () => {
   describe(setProvisioningProfileForPbxproj, () => {

--- a/packages/config-plugins/src/plugins/__tests__/android-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/android-plugins-test.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config';
-import fs from 'fs-extra';
+import fs from 'fs';
 import { vol } from 'memfs';
 import path from 'path';
 

--- a/packages/config-plugins/src/plugins/__tests__/mod-compiler-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/mod-compiler-test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import { vol } from 'memfs';
 
 import { ExportedConfig, Mod } from '../../Plugin.types';
@@ -133,7 +133,7 @@ describe(compileModsAsync, () => {
     expect(Object.values(config.mods.ios).every(value => typeof value === 'function')).toBe(true);
 
     // Test that the actual file was rewritten.
-    const data = await fs.readFile('/app/ios/ReactNativeProject/Info.plist', 'utf8');
+    const data = await fs.promises.readFile('/app/ios/ReactNativeProject/Info.plist', 'utf8');
     expect(data).toMatch(/CFBundleDevelopmentRegion-crazy-random-value/);
   });
 

--- a/packages/config-plugins/src/utils/XML.ts
+++ b/packages/config-plugins/src/utils/XML.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import { EOL } from 'os';
 import path from 'path';
 import { Builder, Parser } from 'xml2js';
@@ -13,8 +13,8 @@ export interface XMLObject {
 
 export async function writeXMLAsync(options: { path: string; xml: any }): Promise<void> {
   const xml = format(options.xml);
-  await fs.ensureDir(path.dirname(options.path));
-  await fs.writeFile(options.path, xml);
+  await fs.promises.mkdir(path.dirname(options.path), { recursive: true });
+  await fs.promises.writeFile(options.path, xml);
 }
 
 export async function readXMLAsync(options: {
@@ -23,7 +23,7 @@ export async function readXMLAsync(options: {
 }): Promise<XMLObject> {
   let contents: string = '';
   try {
-    contents = await fs.readFile(options.path, { encoding: 'utf8', flag: 'r' });
+    contents = await fs.promises.readFile(options.path, { encoding: 'utf8', flag: 'r' });
   } catch {
     // catch and use fallback
   }

--- a/packages/config-plugins/src/utils/__tests__/XML-test.ts
+++ b/packages/config-plugins/src/utils/__tests__/XML-test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import { vol } from 'memfs';
 
 import { buildResourceItem, readResourcesXMLAsync } from '../../android/Resources';
@@ -69,7 +69,7 @@ describe('read and write', () => {
     const stringsJSON = await readResourcesXMLAsync({ path: stringsPath });
     console.log(stringsJSON);
     await writeXMLAsync({ path: stringsPath, xml: stringsJSON });
-    expect(await fs.readFile(stringsPath, 'utf-8')).toBe(example);
+    expect(await fs.promises.readFile(stringsPath, 'utf-8')).toBe(example);
   });
 });
 

--- a/packages/config-plugins/src/utils/__tests__/fs-test.ts
+++ b/packages/config-plugins/src/utils/__tests__/fs-test.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import { vol } from 'memfs';
+
+import { copyFilePathToPathAsync } from '../fs';
+jest.mock('fs');
+
+describe(copyFilePathToPathAsync, () => {
+  beforeAll(() => {
+    jest.spyOn(fs.promises, 'readFile');
+    jest.spyOn(fs.promises, 'writeFile');
+  });
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it(`copies a single file into a nested location`, async () => {
+    const projectRoot = '/';
+    const CONTENTS = '{ foobar }';
+    vol.fromJSON(
+      {
+        'google-services.json': CONTENTS,
+      },
+      projectRoot
+    );
+
+    await copyFilePathToPathAsync('/google-services.json', '/android/app/google-services.json');
+
+    expect(fs.promises.readFile).toHaveBeenLastCalledWith('/google-services.json');
+
+    expect(fs.promises.writeFile).toHaveBeenLastCalledWith(
+      '/android/app/google-services.json',
+      expect.anything()
+    );
+
+    expect(vol.toJSON(projectRoot)).toEqual({
+      // New
+      '/android/app/google-services.json': CONTENTS,
+      // Old -- both should still exist
+      '/google-services.json': CONTENTS,
+    });
+  });
+});

--- a/packages/config-plugins/src/utils/__tests__/fs-test.ts
+++ b/packages/config-plugins/src/utils/__tests__/fs-test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { vol } from 'memfs';
 
-import { copyFilePathToPathAsync } from '../fs';
+import { copyFilePathToPathAsync, removeFile } from '../fs';
 jest.mock('fs');
 
 describe(copyFilePathToPathAsync, () => {
@@ -38,5 +38,42 @@ describe(copyFilePathToPathAsync, () => {
       // Old -- both should still exist
       '/google-services.json': CONTENTS,
     });
+  });
+});
+
+describe(removeFile, () => {
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it(`removes a single file`, () => {
+    const projectRoot = '/';
+    vol.fromJSON(
+      {
+        'google-services.json': '{ foobar }',
+      },
+      projectRoot
+    );
+
+    expect(removeFile('/google-services.json')).toBe(true);
+
+    expect(vol.toJSON(projectRoot)).toEqual({});
+  });
+  it(`returns false if the requested file is missing`, () => {
+    vol.fromJSON({}, '/');
+
+    expect(removeFile('/google-services.json')).toBe(false);
+  });
+
+  it(`does not remove non-empty directories`, async () => {
+    const projectRoot = '/';
+    vol.fromJSON(
+      {
+        '/android/app/file.txt': '{}',
+      },
+      projectRoot
+    );
+
+    expect(() => removeFile('/android/app')).toThrow(/Dir not empty/);
   });
 });

--- a/packages/config-plugins/src/utils/fs.ts
+++ b/packages/config-plugins/src/utils/fs.ts
@@ -7,3 +7,17 @@ export async function copyFilePathToPathAsync(src: string, dest: string): Promis
   await fs.promises.mkdir(path.dirname(dest), { recursive: true });
   await fs.promises.writeFile(dest, srcFile);
 }
+
+/** Remove a single file (not directory). Returns `true` if a file was actually deleted. */
+export function removeFile(filePath: string): boolean {
+  try {
+    fs.unlinkSync(filePath);
+    return true;
+  } catch (error: any) {
+    // Skip if the remove did nothing.
+    if (error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/packages/config-plugins/src/utils/fs.ts
+++ b/packages/config-plugins/src/utils/fs.ts
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+
+/** A basic function that copies a single file to another file location. */
+export async function copyFilePathToPathAsync(src: string, dest: string): Promise<void> {
+  const srcFile = await fs.promises.readFile(src);
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+  await fs.promises.writeFile(dest, srcFile);
+}


### PR DESCRIPTION
# Why

Noticing an increasing number of issues regarding `json-utils` this is due to a bug in node modules resolution where too many packages are nested in each other.

One way to mitigate the risk of this error occurring is by reducing the amount of copies of common libraries like `@expo/config-plugins` and `fs-extra`. When we migrate to the versioned CLI we should be able to reduce the copies of `@expo/config-plugins` and this PR address `fs-extra` by dropping it.

# Test Plan

- Tests should continue to pass.
- New tests should also work.