### PR TITLE
[ci] Set timeout to 2 minutes and remove check files on windows

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -1,11 +1,9 @@
 name: Test Packages Windows
-
 on:
   push:
     branches: [main]
   pull_request:
     types: [opened, synchronize]
-
 jobs:
   build:
     runs-on: windows-latest
@@ -21,9 +19,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: yarn config list
-      - run: echo "intentionally failing run"; exit 1
-      - run: yarn install --frozen-lockfile --check-files
+      - run: yarn install --frozen-lockfile --network-timeout 120000
       - run: yarn lerna run prepare --stream
       - run: yarn lint --max-warnings=0
       - uses: actions/cache@v2

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -1,4 +1,5 @@
 name: Test Packages Windows
+
 on:
   push:
     branches: [main]
@@ -20,6 +21,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
+      - run: yarn config list
+      - run: echo "intentionally failing run"; exit 1
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn lerna run prepare --stream
       - run: yarn lint --max-warnings=0


### PR DESCRIPTION
# Why

Windows tests are currently failing with socket timeout errors. This should fix it.

# How

- Confirmed we are not using a proxy/vpn ([see this run](https://github.com/expo/expo-cli/runs/6026912201?check_suite_focus=true#step:4:5))
  → mentioned in yarnpkg/yarn#4890
- Adding `--network-timeout` set to 2 minutes (120 000 ms)
  → mentioned in yarnpkg/yarn#4890
- Removing `--check-files`
  → mentioned in https://github.community/t/yarn-esockettimedout-on-windows/118776/8

# Test Plan

- See if CI passes