### PR TITLE
chore(xdl): add new metro logging events

### DIFF
--- a/packages/xdl/src/logs/PackagerLogsStream.ts
+++ b/packages/xdl/src/logs/PackagerLogsStream.ts
@@ -147,6 +147,12 @@ type ReportableEvent =
       chunk: string;
     }
   | {
+      type: 'transformer_load_started';
+    }
+  | {
+      type: 'transformer_load_done';
+    }
+  | {
       type: 'hmr_client_error';
       error: MetroError;
     };
@@ -324,6 +330,8 @@ export default class PackagerLogsStream {
       case 'dep_graph_loading':
       case 'dep_graph_loaded':
       case 'global_cache_error':
+      case 'transformer_load_started':
+      case 'transformer_load_done':
         return;
       default:
         chunk.msg = `Unrecognized event: ${JSON.stringify(msg)}`;


### PR DESCRIPTION
# Why

Required for react-native 68 support [new events](https://github.com/facebook/metro/blob/4875f3df0af55f1c3e8caa7a714cd568381e4273/packages/metro/src/Bundler.js#L35-L41). Versioned CLI shouldn't have this issue since we extend all of the built-in logging. 
- Adds `transformer_load_started `, and `transformer_load_done` events -- doing nothing with them.