### PR TITLE
feat(dev-server): support new API for Expo SDK 45

### DIFF
--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -38,7 +38,6 @@
     "@expo/bunyan": "4.0.0",
     "@expo/metro-config": "0.3.13",
     "@expo/osascript": "2.0.32",
-    "@react-native-community/cli-server-api": "^5.0.1",
     "body-parser": "1.19.0",
     "chalk": "^4.0.0",
     "connect": "^3.7.0",
@@ -52,6 +51,7 @@
   },
   "devDependencies": {
     "@types/connect": "^3.4.33",
+    "@react-native-community/cli-server-api": "^7.0.3",
     "metro-inspector-proxy": "^0.64.0"
   },
   "publishConfig": {

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -85,7 +85,16 @@ export async function runMetroDevServerAsync(
 
   const metroConfig = await ExpoMetroConfig.loadAsync(projectRoot, { reporter, ...options });
 
-  const { middleware, attachToServer } = createDevServerMiddleware({
+  const {
+    middleware,
+    attachToServer,
+
+    // RN +68 -- Expo SDK +45
+    debuggerProxyEndpoint,
+    messageSocketEndpoint,
+    eventsSocketEndpoint,
+    websocketEndpoints,
+  } = createDevServerMiddleware(projectRoot, {
     port: metroConfig.server.port,
     watchFolders: metroConfig.watchFolders,
     logger: options.logger,
@@ -100,16 +109,33 @@ export async function runMetroDevServerAsync(
     return middleware.use(metroMiddleware);
   };
 
-  const server = await Metro.runServer(metroConfig, { hmrEnabled: true });
+  const server = await Metro.runServer(metroConfig, {
+    hmrEnabled: true,
+    // @ts-expect-error: we know this is defined in newer version of metro.
+    websocketEndpoints,
+  });
 
-  const { messageSocket, eventsSocket } = attachToServer(server);
-  reporter.reportEvent = eventsSocket.reportEvent;
+  if (attachToServer) {
+    // Expo SDK 44 and lower
+    const { messageSocket, eventsSocket } = attachToServer(server);
+    reporter.reportEvent = eventsSocket.reportEvent;
 
-  return {
-    server,
-    middleware,
-    messageSocket,
-  };
+    return {
+      server,
+      middleware,
+      messageSocket,
+    };
+  } else {
+    // RN +68 -- Expo SDK +45
+    reporter.reportEvent = eventsSocketEndpoint.reportEvent;
+
+    return {
+      server,
+      middleware,
+      messageSocket: messageSocketEndpoint,
+      // debuggerProxyEndpoint,
+    };
+  }
 }
 
 let nextBuildID = 0;

--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -90,7 +90,6 @@ export async function runMetroDevServerAsync(
     attachToServer,
 
     // RN +68 -- Expo SDK +45
-    debuggerProxyEndpoint,
     messageSocketEndpoint,
     eventsSocketEndpoint,
     websocketEndpoints,
@@ -111,7 +110,6 @@ export async function runMetroDevServerAsync(
 
   const server = await Metro.runServer(metroConfig, {
     hmrEnabled: true,
-    // @ts-expect-error: we know this is defined in newer version of metro.
     websocketEndpoints,
   });
 

--- a/packages/dev-server/src/metro/importMetroFromProject.ts
+++ b/packages/dev-server/src/metro/importMetroFromProject.ts
@@ -45,6 +45,12 @@ export function importMetroServerFromProject(projectRoot: string): typeof Metro.
   return importFromProject(projectRoot, 'metro/src/Server');
 }
 
+export function importCliServerApiFromProject(
+  projectRoot: string
+): typeof import('@react-native-community/cli-server-api') {
+  return importFromProject(projectRoot, '@react-native-community/cli-server-api');
+}
+
 export function importInspectorProxyServerFromProject(
   projectRoot: string
 ): { InspectorProxy: any } {

--- a/packages/expo-cli/src/commands/start/parseStartOptions.ts
+++ b/packages/expo-cli/src/commands/start/parseStartOptions.ts
@@ -214,7 +214,7 @@ export function parseStartOptions(
   }
 
   // The SDK 41 client has web socket support.
-  if (Versions.gteSdkVersion(exp, '41.0.0')) {
+  if (!Versions.lteSdkVersion(exp, '40.0.0')) {
     startOpts.isRemoteReloadingEnabled = true;
     if (!startOpts.webOnly || Webpack.isTargetingNative()) {
       startOpts.isWebSocketsEnabled = true;

--- a/packages/xdl/src/Webpack.ts
+++ b/packages/xdl/src/Webpack.ts
@@ -149,7 +149,7 @@ function createNativeDevServerMiddleware(
   if (!isTargetingNative()) {
     return null;
   }
-  const nativeMiddleware = createDevServerMiddleware({
+  const nativeMiddleware = createDevServerMiddleware(projectRoot, {
     logger: ProjectUtils.getLogger(projectRoot),
     port,
     watchFolders: [projectRoot],
@@ -179,30 +179,40 @@ function attachNativeDevServerMiddlewareToDevServer(
   {
     server,
     middleware,
-    attachToServer,
     logger,
+    // Expo SDK 44 and lower
+    attachToServer,
+    // React Native +68 -- Expo SDK 45 and higher
+    messageSocketEndpoint,
+    eventsSocketEndpoint,
   }: { server: http.Server } & ReturnType<typeof createNativeDevServerMiddleware>
 ) {
-  // Hook up the React Native WebSockets to the Webpack dev server.
-  const { messageSocket, debuggerProxy, eventsSocket } = attachToServer(server);
+  if (attachToServer) {
+    // Hook up the React Native WebSockets to the Webpack dev server.
+    const { messageSocket, eventsSocket } = attachToServer(server);
 
-  customMessageSocketBroadcaster = messageSocket.broadcast;
+    customMessageSocketBroadcaster = messageSocket.broadcast;
 
-  const logReporter = new LogReporter(logger);
-  logReporter.reportEvent = eventsSocket.reportEvent;
+    const logReporter = new LogReporter(logger);
+    logReporter.reportEvent = eventsSocket.reportEvent;
 
-  const { inspectorProxy } = attachInspectorProxy(projectRoot, {
-    middleware,
-    server,
-  });
+    attachInspectorProxy(projectRoot, {
+      middleware,
+      server,
+    });
+  } else {
+    // React Native +68
+    const logReporter = new LogReporter(logger);
 
-  return {
-    messageSocket,
-    eventsSocket,
-    debuggerProxy,
-    logReporter,
-    inspectorProxy,
-  };
+    logReporter.reportEvent = eventsSocketEndpoint.reportEvent;
+
+    customMessageSocketBroadcaster = messageSocketEndpoint.broadcast;
+
+    attachInspectorProxy(projectRoot, {
+      middleware,
+      server,
+    });
+  }
 }
 
 export async function startAsync(
@@ -494,7 +504,7 @@ async function getAvailablePortAsync(options: {
       throw new Error(`Port ${defaultPort} not available.`);
     }
     return port;
-  } catch (error) {
+  } catch (error: any) {
     throw new XDLError('NO_PORT_FOUND', error.message);
   }
 }
@@ -677,7 +687,7 @@ async function openProjectAsync(
     }
     openBrowserAsync(url);
     return { success: true, url };
-  } catch (e) {
+  } catch (e: any) {
     Logger.global.error(`Couldn't start project on web: ${e.message}`);
     return { success: false, error: e };
   }

--- a/ts-declarations/metro/index.d.ts
+++ b/ts-declarations/metro/index.d.ts
@@ -170,6 +170,7 @@ declare module 'metro' {
     secure?: boolean;
     secureCert?: string;
     secureKey?: string;
+    websocketEndpoints?: object;
   };
 
   type BuildGraphOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2866,6 +2866,13 @@
   dependencies:
     serve-static "^1.13.1"
 
+"@react-native-community/cli-debugger-ui@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-7.0.3.tgz#3eeeacc5a43513cbcae56e5e965d77726361bcb4"
+  integrity sha512-G4SA6jFI0j22o+j+kYP8/7sxzbCDqSp2QiHA/X5E0lsGEd2o9qN2zbIjiFr8b8k+VVAYSUONhoC0+uKuINvmkA==
+  dependencies:
+    serve-static "^1.13.1"
+
 "@react-native-community/cli-hermes@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-5.0.1.tgz#039d064bf2dcd5043beb7dcd6cdf5f5cdd51e7fc"
@@ -2921,6 +2928,21 @@
     serve-static "^1.13.1"
     ws "^1.1.0"
 
+"@react-native-community/cli-server-api@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-7.0.3.tgz#ba9695a2fdfef22750d141153efd94baf641129b"
+  integrity sha512-JDrLsrkBgNxbG2u3fouoVGL9tKrXUrTsaNwr+oCV+3XyMwbVe42r/OaQ681/iW/7mHXjuVkDnMcp7BMg7e2yJg==
+  dependencies:
+    "@react-native-community/cli-debugger-ui" "^7.0.3"
+    "@react-native-community/cli-tools" "^6.2.0"
+    compression "^1.7.1"
+    connect "^3.6.5"
+    errorhandler "^1.5.0"
+    nocache "^2.1.0"
+    pretty-format "^26.6.2"
+    serve-static "^1.13.1"
+    ws "^7.5.1"
+
 "@react-native-community/cli-tools@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-5.0.1.tgz#9ee564dbe20448becd6bce9fbea1b59aa5797919"
@@ -2931,6 +2953,20 @@
     mime "^2.4.1"
     node-fetch "^2.6.0"
     open "^6.2.0"
+    shell-quote "1.6.1"
+
+"@react-native-community/cli-tools@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-6.2.0.tgz#8f4adc2d83ab96e5654348533c8fa602742c4fce"
+  integrity sha512-08ssz4GMEnRxC/1FgTTN/Ud7mExQi5xMphItPjfHiTxpZPhrFn+IMx6mya0ncFEhhxQ207wYlJMRLPRRdBZ8oA==
+  dependencies:
+    appdirsjs "^1.2.4"
+    chalk "^4.1.2"
+    lodash "^4.17.15"
+    mime "^2.4.1"
+    node-fetch "^2.6.0"
+    open "^6.2.0"
+    semver "^6.3.0"
     shell-quote "1.6.1"
 
 "@react-native-community/cli-types@^5.0.1":
@@ -18571,10 +18607,10 @@ ws@^6.1.4, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7, ws@^7.2.3:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.2.tgz#09cc8fea3bec1bc5ed44ef51b42f945be36900f6"
-  integrity sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==
+ws@^7, ws@^7.2.3, ws@^7.5.1:
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
+  integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
 
 xcode@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
# Why

- React Native community CLI broke the public interface for setting up the dev server across versions. Since our implementation is global we need to support both versions. https://github.com/react-native-community/cli/pull/1560
- Replaces https://github.com/expo/expo-cli/pull/4305

# How

- Import `@react-native-community/cli-server-api` from the project instead of vendoring. This will ensure the installed version works with the installed `metro` package.
- If `attachToServer` exists, then attach using the legacy API, otherwise use the new API.
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Sanity: I created a new React Native project using `npx react-native init`, a couple hours later I was able to run `npx react-native run-ios` then `npx react-native start` -- pressing `r` works but pressing `d` does not work.
- Test: in the new project I ran `expo start --dev-client` then pressed `r` to reload -- `d` didn't work in Expo CLI either.
- In an older Expo project I ran `expo start` to ensure pressing `r` and `d` still worked as expected.
- Wasn't able to test experimental webpack native support but I imagine it's partially broken now.
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->