### PR TITLE
[config-plugins] resolve target specific entitlement files

### DIFF
--- a/packages/config-plugins/src/ios/Entitlements.ts
+++ b/packages/config-plugins/src/ios/Entitlements.ts
@@ -56,13 +56,6 @@ export function getEntitlementsPath(
   return entitlementsPath && fs.existsSync(entitlementsPath) ? entitlementsPath : null;
 }
 
-export function getDefaultEntitlementsPath(projectRoot: string) {
-  const project = getPbxproj(projectRoot);
-  const projectName = getProjectName(projectRoot);
-  const productName = getProductName(project);
-  return path.normalize(path.join(projectRoot, 'ios', projectName, `${productName}.entitlements`));
-}
-
 function getEntitlementsPathFromBuildConfiguration(
   projectRoot: string,
   xcBuildConfiguration: XCBuildConfiguration
@@ -82,13 +75,13 @@ export function ensureApplicationTargetEntitlementsFileConfigured(projectRoot: s
   const projectName = getProjectName(projectRoot);
   const productName = getProductName(project);
 
-  const [, nativeTarget] = findFirstNativeTarget(project);
+  const [, applicationTarget] = findFirstNativeTarget(project);
   const buildConfigurations = getBuildConfigurationsForListId(
     project,
-    nativeTarget.buildConfigurationList
+    applicationTarget.buildConfigurationList
   );
   let hasChangesToWrite = false;
-  buildConfigurations.forEach(([, xcBuildConfiguration]) => {
+  for (const [, xcBuildConfiguration] of buildConfigurations) {
     const oldEntitlementPath = getEntitlementsPathFromBuildConfiguration(
       projectRoot,
       xcBuildConfiguration
@@ -107,7 +100,7 @@ export function ensureApplicationTargetEntitlementsFileConfigured(projectRoot: s
       fs.writeFileSync(entitlementsPath, ENTITLEMENTS_TEMPLATE);
     }
     xcBuildConfiguration.buildSettings.CODE_SIGN_ENTITLEMENTS = entitlementsRelativePath;
-  });
+  }
   if (hasChangesToWrite) {
     fs.writeFileSync(project.filepath, project.writeSync());
   }

--- a/packages/config-plugins/src/ios/Entitlements.ts
+++ b/packages/config-plugins/src/ios/Entitlements.ts
@@ -3,18 +3,17 @@ import { JSONObject } from '@expo/json-file';
 import fs from 'fs';
 import path from 'path';
 import slash from 'slash';
+import { XCBuildConfiguration } from 'xcode';
 
 import { createEntitlementsPlugin } from '../plugins/ios-plugins';
-import { removeFile } from '../utils/fs';
-import * as Paths from './Paths';
+import { findFirstNativeTarget, getXCBuildConfigurationFromPbxproj } from './Target';
 import {
+  getBuildConfigurationsForListId,
   getPbxproj,
   getProductName,
   getProjectName,
-  isBuildConfig,
-  isNotComment,
-  isNotTestHost,
 } from './utils/Xcodeproj';
+import { trimQuotes } from './utils/string';
 
 export const withAssociatedDomains = createEntitlementsPlugin(
   setAssociatedDomains,
@@ -35,70 +34,82 @@ export function setAssociatedDomains(
   return entitlementsPlist;
 }
 
-export function getEntitlementsPath(projectRoot: string): string {
-  const paths = Paths.getAllEntitlementsPaths(projectRoot);
-  let targetPath: string | null = null;
+export function getEntitlementsPath(
+  projectRoot: string,
+  {
+    targetName,
+    buildConfiguration = 'Release',
+  }: { targetName?: string; buildConfiguration?: string } = {}
+): string | null {
+  const project = getPbxproj(projectRoot);
+  const xcBuildConfiguration = getXCBuildConfigurationFromPbxproj(project, {
+    targetName,
+    buildConfiguration,
+  });
+  if (!xcBuildConfiguration) {
+    return null;
+  }
+  const entitlementsPath = getEntitlementsPathFromBuildConfiguration(
+    projectRoot,
+    xcBuildConfiguration
+  );
+  return entitlementsPath && fs.existsSync(entitlementsPath) ? entitlementsPath : null;
+}
 
-  /**
-   * Add file to pbxproj under CODE_SIGN_ENTITLEMENTS
-   */
+export function getDefaultEntitlementsPath(projectRoot: string) {
+  const project = getPbxproj(projectRoot);
+  const projectName = getProjectName(projectRoot);
+  const productName = getProductName(project);
+  return path.normalize(path.join(projectRoot, 'ios', projectName, `${productName}.entitlements`));
+}
+
+function getEntitlementsPathFromBuildConfiguration(
+  projectRoot: string,
+  xcBuildConfiguration: XCBuildConfiguration
+): string | null {
+  const entitlementsPathRaw = xcBuildConfiguration?.buildSettings?.CODE_SIGN_ENTITLEMENTS as
+    | string
+    | undefined;
+  if (entitlementsPathRaw) {
+    return path.normalize(path.join(projectRoot, 'ios', trimQuotes(entitlementsPathRaw)));
+  } else {
+    return null;
+  }
+}
+
+export function ensureApplicationTargetEntitlementsFileConfigured(projectRoot: string): void {
   const project = getPbxproj(projectRoot);
   const projectName = getProjectName(projectRoot);
   const productName = getProductName(project);
 
-  // Use posix formatted path, even on Windows
-  const entitlementsRelativePath = slash(path.join(projectName, `${productName}.entitlements`));
-  const entitlementsPath = slash(
-    path.normalize(path.join(projectRoot, 'ios', entitlementsRelativePath))
+  const [, nativeTarget] = findFirstNativeTarget(project);
+  const buildConfigurations = getBuildConfigurationsForListId(
+    project,
+    nativeTarget.buildConfigurationList
   );
-
-  const pathsToDelete: string[] = [];
-
-  while (paths.length) {
-    const last = slash(path.normalize(paths.pop()!));
-    if (last !== entitlementsPath) {
-      pathsToDelete.push(last);
-    } else {
-      targetPath = last;
+  let hasChangesToWrite = false;
+  buildConfigurations.forEach(([, xcBuildConfiguration]) => {
+    const oldEntitlementPath = getEntitlementsPathFromBuildConfiguration(
+      projectRoot,
+      xcBuildConfiguration
+    );
+    if (oldEntitlementPath && fs.existsSync(oldEntitlementPath)) {
+      return;
     }
-  }
-
-  // Create a new entitlements file
-  if (!targetPath) {
-    targetPath = entitlementsPath;
-
-    // Use the default template
-    let template = ENTITLEMENTS_TEMPLATE;
-
-    // If an old entitlements file exists, copy it's contents into the new file.
-    if (pathsToDelete.length) {
-      // Get the last entitlements file and use it as the template
-      const last = pathsToDelete[pathsToDelete.length - 1]!;
-      template = fs.readFileSync(last, 'utf8');
-    }
-
+    hasChangesToWrite = true;
+    // Use posix formatted path, even on Windows
+    const entitlementsRelativePath = slash(path.join(projectName, `${productName}.entitlements`));
+    const entitlementsPath = path.normalize(
+      path.join(projectRoot, 'ios', entitlementsRelativePath)
+    );
     fs.mkdirSync(path.dirname(entitlementsPath), { recursive: true });
-    fs.writeFileSync(entitlementsPath, template);
-
-    Object.entries(project.pbxXCBuildConfigurationSection())
-      .filter(isNotComment)
-      .filter(isBuildConfig)
-      .filter(isNotTestHost)
-      .forEach(({ 1: { buildSettings } }: any) => {
-        buildSettings.CODE_SIGN_ENTITLEMENTS = `"${entitlementsRelativePath}"`;
-      });
+    if (!fs.existsSync(entitlementsPath)) {
+      fs.writeFileSync(entitlementsPath, ENTITLEMENTS_TEMPLATE);
+    }
+    xcBuildConfiguration.buildSettings.CODE_SIGN_ENTITLEMENTS = entitlementsRelativePath;
+  });
+  if (hasChangesToWrite) {
     fs.writeFileSync(project.filepath, project.writeSync());
-  }
-
-  // Clean up others
-  deleteEntitlementsFiles(pathsToDelete);
-
-  return entitlementsPath;
-}
-
-function deleteEntitlementsFiles(entitlementsPaths: string[]) {
-  for (const path of entitlementsPaths) {
-    removeFile(path);
   }
 }
 

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 
 import { UnexpectedError } from '../utils/errors';
 import { addWarningIOS } from '../utils/warnings';
+import * as Entitlements from './Entitlements';
 
 const ignoredPaths = ['**/@(Carthage|Pods|vendor|node_modules)/**'];
 
@@ -251,6 +252,13 @@ export function getAllEntitlementsPaths(projectRoot: string): string[] {
     ignore: ignoredPaths,
   });
   return paths;
+}
+
+/**
+ * @deprecated: use Entitlements.getEntitlementsPath instead
+ */
+export function getEntitlementsPath(projectRoot: string): string | null {
+  return Entitlements.getEntitlementsPath(projectRoot);
 }
 
 export function getSupportingPath(projectRoot: string): string {

--- a/packages/config-plugins/src/ios/Paths.ts
+++ b/packages/config-plugins/src/ios/Paths.ts
@@ -253,27 +253,6 @@ export function getAllEntitlementsPaths(projectRoot: string): string[] {
   return paths;
 }
 
-/**
- * Get the entitlements file path if it exists.
- *
- * @param projectRoot
- */
-export function getEntitlementsPath(projectRoot: string): string | null {
-  const [using, ...extra] = getAllEntitlementsPaths(projectRoot);
-
-  if (extra.length) {
-    warnMultipleFiles({
-      tag: 'entitlements',
-      fileName: '*.entitlements',
-      projectRoot,
-      using,
-      extra,
-    });
-  }
-
-  return using ?? null;
-}
-
 export function getSupportingPath(projectRoot: string): string {
   return path.resolve(projectRoot, 'ios', path.basename(getSourceRoot(projectRoot)), 'Supporting');
 }

--- a/packages/config-plugins/src/ios/__tests__/Entitlements-test.ts
+++ b/packages/config-plugins/src/ios/__tests__/Entitlements-test.ts
@@ -3,34 +3,32 @@ import * as fs from 'fs';
 import { vol } from 'memfs';
 import * as path from 'path';
 
-import { getEntitlementsPath } from '../Entitlements';
+import {
+  ensureApplicationTargetEntitlementsFileConfigured,
+  getEntitlementsPath,
+} from '../Entitlements';
 
 const fsReal = jest.requireActual('fs') as typeof fs;
 
 jest.mock('fs');
 
-describe(getEntitlementsPath, () => {
-  const projectRoot = '/app';
-  const projectRootNone = '/no-config';
-  beforeAll(async () => {
-    vol.fromJSON(
-      {
-        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
-          path.join(__dirname, 'fixtures/project.pbxproj'),
-          'utf-8'
-        ),
-        'ios/testproject/old.entitlements': `<?xml version="1.0" encoding="UTF-8"?>
+const exampleEntitlements = `<?xml version="0.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>special</key>
 	<true/>
 </dict>
-</plist>`,
-        'ios/testproject/AppDelegate.m': '',
-      },
-      projectRoot
-    );
+</plist>`;
+
+describe(ensureApplicationTargetEntitlementsFileConfigured, () => {
+  const projectRoot = '/app';
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('creates a new entitlements file when none exists', async () => {
     vol.fromJSON(
       {
         'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
@@ -39,17 +37,13 @@ describe(getEntitlementsPath, () => {
         ),
         'ios/testproject/AppDelegate.m': '',
       },
-      projectRootNone
+      projectRoot
     );
-  });
-
-  afterAll(() => {
-    vol.reset();
-  });
-
-  it('creates a new entitlements file when none exists', async () => {
-    const entitlementsPath = getEntitlementsPath(projectRootNone);
-    expect(entitlementsPath).toBe('/no-config/ios/testproject/testproject.entitlements');
+    const entitlementsPathBefore = getEntitlementsPath(projectRoot);
+    ensureApplicationTargetEntitlementsFileConfigured(projectRoot);
+    const entitlementsPath = getEntitlementsPath(projectRoot);
+    expect(entitlementsPathBefore).toBeNull();
+    expect(entitlementsPath).toBe('/app/ios/testproject/testproject.entitlements');
 
     // New file has the contents of the old entitlements file
     const data = plist.parse(await fs.promises.readFile(entitlementsPath, 'utf8'));
@@ -58,15 +52,87 @@ describe(getEntitlementsPath, () => {
     });
   });
 
-  it('creates a new entitlements file and copies the contents of the older one before deleting it', async () => {
+  it('creates a new entitlements file if file in XCBuildConfiguration does not exists', async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project-with-entitlements.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject/AppDelegate.m': '',
+      },
+      projectRoot
+    );
+    ensureApplicationTargetEntitlementsFileConfigured(projectRoot);
     const entitlementsPath = getEntitlementsPath(projectRoot);
     expect(entitlementsPath).toBe('/app/ios/testproject/testproject.entitlements');
 
     // New file has the contents of the old entitlements file
     const data = plist.parse(await fs.promises.readFile(entitlementsPath, 'utf8'));
+    expect(data).toStrictEqual({});
+  });
+
+  it('does not create any entitlements files if it already exists', async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project-with-entitlements.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testapp/example.entitlements': exampleEntitlements,
+        'ios/testproject/AppDelegate.m': '',
+      },
+      projectRoot
+    );
+    ensureApplicationTargetEntitlementsFileConfigured(projectRoot);
+    const entitlementsPath = getEntitlementsPath(projectRoot);
+    expect(entitlementsPath).toBe('/app/ios/testapp/example.entitlements');
+
+    // New file has the contents of the old entitlements file
+    const data = plist.parse(await fs.promises.readFile(entitlementsPath, 'utf8'));
     expect(data).toStrictEqual({ special: true });
 
-    // Old file is deleted
-    expect(fs.existsSync('/app/ios/testproject/old.entitlements')).toBe(false);
+    // entitlement file in default location does not exist
+    expect(fs.existsSync('/app/ios/testproject/testproject.entitlements')).toBe(false);
+  });
+});
+
+describe(getEntitlementsPath, () => {
+  const projectRoot = '/app';
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('returns null if CODE_SIGN_ENTITLEMENTS is not specified', async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testproject/AppDelegate.m': '',
+      },
+      projectRoot
+    );
+
+    const entitlementsPath = getEntitlementsPath(projectRoot);
+    expect(entitlementsPath).toBeNull();
+  });
+  it('returns path if CODE_SIGN_ENTITLEMENTS is specified and file exists', async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj': fsReal.readFileSync(
+          path.join(__dirname, 'fixtures/project-with-entitlements.pbxproj'),
+          'utf-8'
+        ),
+        'ios/testapp/example.entitlements': exampleEntitlements,
+        'ios/testproject/AppDelegate.m': '',
+      },
+      projectRoot
+    );
+
+    const entitlementsPath = getEntitlementsPath(projectRoot);
+    expect(entitlementsPath).toBe('/app/ios/testapp/example.entitlements');
   });
 });

--- a/packages/config-plugins/src/ios/__tests__/fixtures/project-with-entitlements.pbxproj
+++ b/packages/config-plugins/src/ios/__tests__/fixtures/project-with-entitlements.pbxproj
@@ -1,0 +1,462 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		96905EF65AED1B983A6B3ABC /* libPods-testproject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		13B07F961A680F5B00A75B9A /* testproject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = testproject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = testproject/AppDelegate.h; sourceTree = "<group>"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = testproject/AppDelegate.m; sourceTree = "<group>"; };
+		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = testproject/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = testproject/Info.plist; sourceTree = "<group>"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = testproject/main.m; sourceTree = "<group>"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-testproject.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-testproject.debug.xcconfig"; path = "Target Support Files/Pods-testproject/Pods-testproject.debug.xcconfig"; sourceTree = "<group>"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-testproject.release.xcconfig"; path = "Target Support Files/Pods-testproject/Pods-testproject.release.xcconfig"; sourceTree = "<group>"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = testproject/SplashScreen.storyboard; sourceTree = "<group>"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-testproject.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* testproject */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+			);
+			name = testproject;
+			sourceTree = "<group>";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-testproject.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* testproject */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* testproject.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = testproject/Supporting;
+			sourceTree = "<group>";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* testproject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "testproject" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				FD10A7F022414F080027D42C /* Start Packager */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = testproject;
+			productName = testproject;
+			productReference = 13B07F961A680F5B00A75B9A /* testproject.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1120;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "testproject" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* testproject */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\n";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-testproject-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FD10A7F022414F080027D42C /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Start Packager";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13B07FB21A68108700A75B9A /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = testproject;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-testproject.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = testproject/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				CODE_SIGN_ENTITLEMENTS = testapp/example.entitlements;
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.testproject;
+				PRODUCT_NAME = testproject;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-testproject.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = testproject/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				CODE_SIGN_ENTITLEMENTS = testapp/example.entitlements;
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.testproject;
+				PRODUCT_NAME = testproject;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
+					"\"$(inherited)\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "testproject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "testproject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -205,10 +205,8 @@ const defaultProviders = {
 
     async getFilePath(config) {
       try {
-        return (
-          Entitlements.getEntitlementsPath(config.modRequest.projectRoot) ??
-          Entitlements.getDefaultEntitlementsPath(config.modRequest.projectRoot)
-        );
+        ensureApplicationTargetEntitlementsFileConfigured(config.modRequest.projectRoot);
+        return Entitlements.getEntitlementsPath(config.modRequest.projectRoot) ?? '';
       } catch (error: any) {
         if (config.modRequest.introspect) {
           // fallback to an empty string in introspection mode.
@@ -262,7 +260,6 @@ const defaultProviders = {
         return;
       }
 
-      ensureApplicationTargetEntitlementsFileConfigured(config.modRequest.projectRoot);
       await writeFile(filePath, plist.build(sortObject(config.modResults)));
     },
   }),

--- a/packages/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/config-plugins/src/plugins/withIosBaseMods.ts
@@ -1,12 +1,13 @@
 import JsonFile, { JSONObject, JSONValue } from '@expo/json-file';
 import plist from '@expo/plist';
 import assert from 'assert';
-import { promises } from 'fs';
+import fs, { promises } from 'fs';
 import path from 'path';
 import xcode, { XcodeProject } from 'xcode';
 
 import { ExportedConfig, ModConfig } from '../Plugin.types';
 import { Entitlements, Paths } from '../ios';
+import { ensureApplicationTargetEntitlementsFileConfigured } from '../ios/Entitlements';
 import { InfoPlist } from '../ios/IosConfig.types';
 import { getPbxproj } from '../ios/utils/Xcodeproj';
 import { getInfoPlistPathFromPbxproj } from '../ios/utils/getInfoPlistPath';
@@ -204,8 +205,10 @@ const defaultProviders = {
 
     async getFilePath(config) {
       try {
-        // Fallback on glob...
-        return await Entitlements.getEntitlementsPath(config.modRequest.projectRoot);
+        return (
+          Entitlements.getEntitlementsPath(config.modRequest.projectRoot) ??
+          Entitlements.getDefaultEntitlementsPath(config.modRequest.projectRoot)
+        );
       } catch (error: any) {
         if (config.modRequest.introspect) {
           // fallback to an empty string in introspection mode.
@@ -218,9 +221,13 @@ const defaultProviders = {
     async read(filePath, config) {
       let modResults: JSONObject;
       try {
-        const contents = await readFile(filePath, 'utf8');
-        assert(contents, 'Entitlements plist is empty');
-        modResults = plist.parse(contents);
+        if (fs.existsSync(filePath)) {
+          const contents = await readFile(filePath, 'utf8');
+          assert(contents, 'Entitlements plist is empty');
+          modResults = plist.parse(contents);
+        } else {
+          modResults = getEntitlementsPlistTemplate();
+        }
       } catch (error: any) {
         // Throw errors in introspection mode.
         if (!config.modRequest.introspect) {
@@ -255,6 +262,7 @@ const defaultProviders = {
         return;
       }
 
+      ensureApplicationTargetEntitlementsFileConfigured(config.modRequest.projectRoot);
       await writeFile(filePath, plist.build(sortObject(config.modResults)));
     },
   }),

--- a/packages/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
+++ b/packages/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
@@ -490,7 +490,6 @@ describe('built-in plugins', () => {
       'ios/ReactNativeProject/Base.lproj/LaunchScreen.xib',
       'ios/ReactNativeProject/Images.xcassets/AppIcon.appiconset/Contents.json',
       'ios/ReactNativeProject/Images.xcassets/Contents.json',
-      'ios/ReactNativeProject/ReactNativeProject.entitlements',
       'ios/ReactNativeProject.xcodeproj/project.pbxproj',
       'ios/Podfile.properties.json',
       'ios/Podfile',
@@ -508,10 +507,6 @@ describe('built-in plugins', () => {
     ]);
 
     // unmodified
-    expect(after['ios/ReactNativeProject/ReactNativeProject.entitlements']).not.toMatch(
-      'com.apple.developer.associated-domains'
-    );
-
     expect(after['ios/ReactNativeProject/Info.plist']).toBe(
       rnFixture['ios/ReactNativeProject/Info.plist']
     );

--- a/packages/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
+++ b/packages/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
@@ -490,6 +490,7 @@ describe('built-in plugins', () => {
       'ios/ReactNativeProject/Base.lproj/LaunchScreen.xib',
       'ios/ReactNativeProject/Images.xcassets/AppIcon.appiconset/Contents.json',
       'ios/ReactNativeProject/Images.xcassets/Contents.json',
+      'ios/ReactNativeProject/ReactNativeProject.entitlements',
       'ios/ReactNativeProject.xcodeproj/project.pbxproj',
       'ios/Podfile.properties.json',
       'ios/Podfile',
@@ -507,6 +508,10 @@ describe('built-in plugins', () => {
     ]);
 
     // unmodified
+    expect(after['ios/ReactNativeProject/ReactNativeProject.entitlements']).not.toMatch(
+      'com.apple.developer.associated-domains'
+    );
+
     expect(after['ios/ReactNativeProject/Info.plist']).toBe(
       rnFixture['ios/ReactNativeProject/Info.plist']
     );


### PR DESCRIPTION
# Why

Pick entitlements files for specific targets based on pbxproj values, necessary to support app extensions (both for manged and bare projects)

# How

- getEntitlementsPath does not modify or delete files anymore
- ensureApplicationTargetEntitlementsFileConfigured exists for legacy reason
  - it ensures that CODE_SIGN_ENTITLEMENTS is defined for the default application target
  - it ensures that the file specified by that value exists
  - if CODE_SIGN_ENTITLEMENTS points to a file that does not exist new entitlements file is created in the default location and value CODE_SIGN_ENTITLEMENTS is changed

### Changes (as far as I see not breaking)
- if the entitlement file is not in the default location we are not doing anything, this is a supported case
- do not delete any entitlement files
- files should not be modified at all in introspect mode

# Test Plan

- added some tests
- run prebuild
- rename entitlements file and value in pbxproj and run prebuild again