### PR TITLE
[xdl] send request to close dev session when server is closed

### DIFF
--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -152,7 +152,7 @@ export async function stopAsync(projectRoot: string): Promise<void> {
   try {
     const result = await Promise.race([
       stopInternalAsync(projectRoot),
-      new Promise(resolve => setTimeout(resolve, 5000, 'stopFailed')),
+      new Promise(resolve => setTimeout(resolve, 2000, 'stopFailed')),
     ]);
     if (result === 'stopFailed') {
       await forceQuitAsync(projectRoot);

--- a/packages/xdl/src/start/startAsync.ts
+++ b/packages/xdl/src/start/startAsync.ts
@@ -105,9 +105,8 @@ async function stopDevServerAsync() {
 }
 
 async function stopInternalAsync(projectRoot: string): Promise<void> {
-  DevSession.stopSession();
-
   await Promise.all([
+    DevSession.stopSession(projectRoot),
     Webpack.stopAsync(projectRoot),
     stopDevServerAsync(),
     stopExpoServerAsync(projectRoot),
@@ -153,7 +152,7 @@ export async function stopAsync(projectRoot: string): Promise<void> {
   try {
     const result = await Promise.race([
       stopInternalAsync(projectRoot),
-      new Promise(resolve => setTimeout(resolve, 2000, 'stopFailed')),
+      new Promise(resolve => setTimeout(resolve, 5000, 'stopFailed')),
     ]);
     if (result === 'stopFailed') {
       await forceQuitAsync(projectRoot);


### PR DESCRIPTION
# Why

Development Sessions shown in Expo Go can be "stale" (saying that they show up in the app when the Expo CLI session has been closed) for up to 3 minutes.

# How

Expo CLI dev sessions can feel more up-to-date by calling `/notify-close`, which tells `www` to remove the dev session after the process is closed. This will update in Expo Go in the next polling request or when a user pull-to-refreshes like how it does for Snacks.

I also increased the force quit delay to account for the added network calls.

# Test Plan

Open a project with a locally built copy of Expo CLI on this branch, observe that it shows up in Expo Go, then close the dev server, refresh Expo Go, and see that it doesn't show up anymore:

https://user-images.githubusercontent.com/12488826/164531590-da8d7da3-33b8-4229-9703-bc87383e4133.mp4
