### PR TITLE
[expo-env-info] convert expo-env-info from CJS to ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🧹 Chores
 
+[expo-env-info] convert from CJS to ESM module.
+
 ### 🐛 Bug fixes
 
 ## [Tue, 19 Apr 2022 14:19:30 -0700](https://github.com/expo/expo-cli/commit/a61ddb4dcd27da86f74de9c7e9bd18570d8c2684)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🧹 Chores
 
-[expo-env-info] convert from CJS to ESM module.
+[expo-env-info] convert from CJS to ESM module. ([#4320](https://github.com/expo/expo-cli/pull/4320))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-env-info/jest.config.js
+++ b/packages/expo-env-info/jest.config.js
@@ -1,7 +1,12 @@
-const path = require('path');
+import fs from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
-module.exports = {
+export default {
   preset: '../../jest/unit-test-config',
-  rootDir: path.resolve(__dirname),
-  displayName: require('./package').name,
+  rootDir: resolve(__dirname),
+  displayName: JSON.parse(fs.readFileSync(join(__dirname, 'package.json'))).name,
+  extensionsToTreatAsEsm: ['.ts'],
 };

--- a/packages/expo-env-info/package.json
+++ b/packages/expo-env-info/package.json
@@ -2,6 +2,7 @@
   "name": "expo-env-info",
   "version": "1.0.2",
   "preferGlobal": true,
+  "type": "module",
   "keywords": [
     "expo",
     "ios",

--- a/packages/expo-env-info/tsconfig.json
+++ b/packages/expo-env-info/tsconfig.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "rootDir": "src",
     "declaration": false,
-    "composite": false
+    "composite": false,
+    "module": "es2020",
   },
   "exclude": [
     "**/__mocks__/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9755,10 +9755,10 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-engine@~0.7.0:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.7.2.tgz#303cd99d23f68e708b223aec2d49d5872985388b"
-  integrity sha512-E2DkRaO97gwL98LPhgfkMqhHiNsrAjIfEk3wWYn2Y31xdkdWn0572H7RnVcGujMJVqZNJvtknxlpsUb8Wzc3KA==
+hermes-engine@0.0.0, hermes-engine@~0.7.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.0.0.tgz#6a65954646b5e32c87aa998dee16152c0c904cd6"
+  integrity sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA==
 
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"
@@ -18891,7 +18891,7 @@ ws@^6.1.4, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7, ws@^7.2.3, ws@^7.5.1:
+ws@^7, ws@^7.4.6, ws@^7.5.1:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==


### PR DESCRIPTION
# Why

More and more modules that we use in our CLI tools are moving to ESM only. Which means that in order to continue to use them, our packages _also_ need to move to ESM. @dsokal reached out to me about `eas-cli`, but it seemed like a smaller package like this would be a good test case first.

# How

For `expo-env-info`, the only 'breaking' change is the engine specification `"node": "^12.20.0 || ^14.13.1 || >=16.0.0"`, which is slightly narrower than before, but given that we're dropping Node 12 support in expo-cli, still totally acceptable. All the other heavy lifting is taken care of by NCC/TypeScript/Jest, after properly configuring those.

# Test Plan

All tests are passing, also ran `expo-env-info` locally.