### PR TITLE
Expose `@expo/config-plugins/android/block-permissions` as a utility function

### DIFF
--- a/packages/config-plugins/android/block-permissions.js
+++ b/packages/config-plugins/android/block-permissions.js
@@ -1,0 +1,1 @@
+module.exports = require('../build/android/Permissions').withBlockedPermissions;

--- a/packages/config-plugins/package.json
+++ b/packages/config-plugins/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://docs.expo.dev/guides/config-plugins/",
   "files": [
+    "android",
     "build",
     "paths"
   ],

--- a/packages/config-plugins/src/android/Manifest.ts
+++ b/packages/config-plugins/src/android/Manifest.ts
@@ -346,3 +346,33 @@ export function prefixAndroidKeys<T extends Record<string, any> = Record<string,
     {} as T
   );
 }
+
+/**
+ * Ensure the `tools:*` namespace is available in the manifest.
+ *
+ * @param manifest AndroidManifest.xml
+ * @returns manifest with the `tools:*` namespace available
+ */
+export function ensureToolsAvailable(manifest: AndroidManifest) {
+  return ensureManifestHasNamespace(manifest, {
+    namespace: 'xmlns:tools',
+    url: 'http://schemas.android.com/tools',
+  });
+}
+
+/**
+ * Ensure a particular namespace is available in the manifest.
+ *
+ * @param manifest `AndroidManifest.xml`
+ * @returns manifest with the provided namespace available
+ */
+function ensureManifestHasNamespace(
+  manifest: AndroidManifest,
+  { namespace, url }: { namespace: string; url: string }
+) {
+  if (manifest?.manifest?.$?.[namespace]) {
+    return manifest;
+  }
+  manifest.manifest.$[namespace] = url;
+  return manifest;
+}

--- a/packages/config-plugins/src/android/Permissions.ts
+++ b/packages/config-plugins/src/android/Permissions.ts
@@ -1,9 +1,9 @@
 import { ExpoConfig } from '@expo/config-types';
-import assert from 'assert';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidManifest } from '../plugins/android-plugins';
-import { AndroidManifest, ManifestUsesPermission } from './Manifest';
+import * as WarningAggregator from '../utils/warnings';
+import { AndroidManifest, ensureToolsAvailable, ManifestUsesPermission } from './Manifest';
 
 const USES_PERMISSION = 'uses-permission';
 
@@ -23,37 +23,29 @@ export const withPermissions: ConfigPlugin<string[] | void> = (config, permissio
   });
 };
 
-export const withBlockedPermissions: ConfigPlugin<string[]> = (config, permissions) => {
-  assert(Array.isArray(permissions), 'permissions prop must be an array');
+/** Given a permission or list of permissions, block permissions in the final `AndroidManifest.xml` to ensure no installed library or plugin can add them. */
+export const withBlockedPermissions: ConfigPlugin<string[] | string> = (config, permissions) => {
+  const resolvedPermissions = (Array.isArray(permissions) ? permissions : [permissions]).filter(
+    Boolean
+  );
+
+  if (!resolvedPermissions.length) {
+    WarningAggregator.addWarningAndroid('block-permissions', 'No permissions provided');
+  }
 
   if (config?.android?.permissions && Array.isArray(config.android.permissions)) {
     // Remove any static config permissions
     config.android.permissions = config.android.permissions.filter(
-      permission => !permissions.includes(permission)
+      permission => !resolvedPermissions.includes(permission)
     );
   }
 
   return withAndroidManifest(config, async config => {
     config.modResults = ensureToolsAvailable(config.modResults);
-    config.modResults = addBlockedPermissions(config.modResults, permissions);
-
+    config.modResults = addBlockedPermissions(config.modResults, resolvedPermissions);
     return config;
   });
 };
-
-/**
- * Ensure the `tools:*` namespace is available in the manifest.
- *
- * @param manifest AndroidManifest.xml
- * @returns manifest with the `tools:*` namespace available
- */
-function ensureToolsAvailable(manifest: AndroidManifest) {
-  if (manifest?.manifest?.$?.['xmlns:tools']) {
-    return manifest;
-  }
-  manifest.manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
-  return manifest;
-}
 
 export function addBlockedPermissions(androidManifest: AndroidManifest, permissions: string[]) {
   if (!Array.isArray(androidManifest.manifest['uses-permission'])) {

--- a/packages/config-plugins/src/android/__tests__/Manifest-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Manifest-test.ts
@@ -1,8 +1,10 @@
 import { resolve } from 'path';
 
+import * as XML from '../../utils/XML';
 import {
   addMetaDataItemToMainApplication,
   addUsesLibraryItemToMainApplication,
+  ensureToolsAvailable,
   findMetaDataItem,
   findUsesLibraryItem,
   getMainActivity,
@@ -83,5 +85,24 @@ describe(prefixAndroidKeys, () => {
       'android:bacon': 'pancake',
       'android:required': true,
     });
+  });
+});
+
+describe(ensureToolsAvailable, () => {
+  it(`ensures tools are available`, async () => {
+    const manifest = await readAndroidManifestAsync(sampleManifestPath);
+    expect(XML.format(manifest)).not.toMatch(/xmlns:tools="http:\/\/schemas\.android\.com\/tools"/);
+
+    // ensure idempotent
+    for (let i = 0; i < 2; i++) {
+      const firstFewLines = XML.format(ensureToolsAvailable(manifest))
+        .split('\n')
+        .splice(0, 1)
+        .join('\n');
+      expect(firstFewLines).toMatchInlineSnapshot(
+        `"<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\" package=\\"com.expo.mycoolapp\\" xmlns:tools=\\"http://schemas.android.com/tools\\">"`
+      );
+      expect(firstFewLines).toMatch(/xmlns:tools="http:\/\/schemas\.android\.com\/tools"/);
+    }
   });
 });


### PR DESCRIPTION
# Why

Too many people need the ability to quickly block a few permissions, this makes it quick and easy to do that. [Example](https://github.com/expo/expo/pull/17168), here people still can't block permissions because they're used in the [library `AndroidManifest.xml`](https://github.com/expo/expo/blob/main/packages/expo-image-picker/android/src/main/AndroidManifest.xml#L4-L9).

This PR is **NOT** an invitation to add endless utility methods that fix one-off issues. We may drop this PR altogether in favor of `android.blockedPermissions: []` in the `app.json`.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Expose the ability to do:

```json

{
  "expo": {
    "plugins": [
      [
        "@expo/config-plugins/android/block-permissions", 
        ["android.permission.WRITE_EXTERNAL_STORAGE"]
      ]
    ]
  }
}

```

# Test Plan


```json
{
  "expo": {
    "plugins": [
      ["../../cli/packages/config-plugins/android/block-permissions", [
        "android.permission.WRITE_EXTERNAL_STORAGE"
        ]]
    ],
  }
}
```

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->