### PR TITLE
[config plugins] support android.blockedPermissions

### DIFF
--- a/packages/config-plugins/src/android/Manifest.ts
+++ b/packages/config-plugins/src/android/Manifest.ts
@@ -346,3 +346,33 @@ export function prefixAndroidKeys<T extends Record<string, any> = Record<string,
     {} as T
   );
 }
+
+/**
+ * Ensure the `tools:*` namespace is available in the manifest.
+ *
+ * @param manifest AndroidManifest.xml
+ * @returns manifest with the `tools:*` namespace available
+ */
+export function ensureToolsAvailable(manifest: AndroidManifest) {
+  return ensureManifestHasNamespace(manifest, {
+    namespace: 'xmlns:tools',
+    url: 'http://schemas.android.com/tools',
+  });
+}
+
+/**
+ * Ensure a particular namespace is available in the manifest.
+ *
+ * @param manifest `AndroidManifest.xml`
+ * @returns manifest with the provided namespace available
+ */
+function ensureManifestHasNamespace(
+  manifest: AndroidManifest,
+  { namespace, url }: { namespace: string; url: string }
+) {
+  if (manifest?.manifest?.$?.[namespace]) {
+    return manifest;
+  }
+  manifest.manifest.$[namespace] = url;
+  return manifest;
+}

--- a/packages/config-plugins/src/android/Permissions.ts
+++ b/packages/config-plugins/src/android/Permissions.ts
@@ -1,9 +1,9 @@
 import { ExpoConfig } from '@expo/config-types';
-import assert from 'assert';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidManifest } from '../plugins/android-plugins';
-import { AndroidManifest, ManifestUsesPermission } from './Manifest';
+import * as WarningAggregator from '../utils/warnings';
+import { AndroidManifest, ensureToolsAvailable, ManifestUsesPermission } from './Manifest';
 
 const USES_PERMISSION = 'uses-permission';
 
@@ -23,37 +23,39 @@ export const withPermissions: ConfigPlugin<string[] | void> = (config, permissio
   });
 };
 
-export const withBlockedPermissions: ConfigPlugin<string[]> = (config, permissions) => {
-  assert(Array.isArray(permissions), 'permissions prop must be an array');
+/** Given a permission or list of permissions, block permissions in the final `AndroidManifest.xml` to ensure no installed library or plugin can add them. */
+export const withBlockedPermissions: ConfigPlugin<string[] | string> = (config, permissions) => {
+  const resolvedPermissions = (Array.isArray(permissions) ? permissions : [permissions]).filter(
+    Boolean
+  );
+
+  if (!resolvedPermissions.length) {
+    WarningAggregator.addWarningAndroid('block-permissions', 'No permissions provided');
+  }
 
   if (config?.android?.permissions && Array.isArray(config.android.permissions)) {
     // Remove any static config permissions
     config.android.permissions = config.android.permissions.filter(
-      permission => !permissions.includes(permission)
+      permission => !resolvedPermissions.includes(permission)
     );
   }
 
   return withAndroidManifest(config, async config => {
     config.modResults = ensureToolsAvailable(config.modResults);
-    config.modResults = addBlockedPermissions(config.modResults, permissions);
-
+    config.modResults = addBlockedPermissions(config.modResults, resolvedPermissions);
     return config;
   });
 };
 
-/**
- * Ensure the `tools:*` namespace is available in the manifest.
- *
- * @param manifest AndroidManifest.xml
- * @returns manifest with the `tools:*` namespace available
- */
-function ensureToolsAvailable(manifest: AndroidManifest) {
-  if (manifest?.manifest?.$?.['xmlns:tools']) {
-    return manifest;
+export const withInternalBlockedPermissions: ConfigPlugin = config => {
+  // Only add permissions if the user defined the property and added some values
+  // this ensures we don't add the `tools:*` namespace extraneously.
+  if (config.android?.blockedPermissions?.length) {
+    return withBlockedPermissions(config, config.android.blockedPermissions);
   }
-  manifest.manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
-  return manifest;
-}
+
+  return config;
+};
 
 export function addBlockedPermissions(androidManifest: AndroidManifest, permissions: string[]) {
   if (!Array.isArray(androidManifest.manifest['uses-permission'])) {

--- a/packages/config-plugins/src/android/__tests__/Manifest-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Manifest-test.ts
@@ -1,8 +1,10 @@
 import { resolve } from 'path';
 
+import * as XML from '../../utils/XML';
 import {
   addMetaDataItemToMainApplication,
   addUsesLibraryItemToMainApplication,
+  ensureToolsAvailable,
   findMetaDataItem,
   findUsesLibraryItem,
   getMainActivity,
@@ -83,5 +85,24 @@ describe(prefixAndroidKeys, () => {
       'android:bacon': 'pancake',
       'android:required': true,
     });
+  });
+});
+
+describe(ensureToolsAvailable, () => {
+  it(`ensures tools are available`, async () => {
+    const manifest = await readAndroidManifestAsync(sampleManifestPath);
+    expect(XML.format(manifest)).not.toMatch(/xmlns:tools="http:\/\/schemas\.android\.com\/tools"/);
+
+    // ensure idempotent
+    for (let i = 0; i < 2; i++) {
+      const firstFewLines = XML.format(ensureToolsAvailable(manifest))
+        .split('\n')
+        .splice(0, 1)
+        .join('\n');
+      expect(firstFewLines).toMatchInlineSnapshot(
+        `"<manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\" package=\\"com.expo.mycoolapp\\" xmlns:tools=\\"http://schemas.android.com/tools\\">"`
+      );
+      expect(firstFewLines).toMatch(/xmlns:tools="http:\/\/schemas\.android\.com\/tools"/);
+    }
   });
 });

--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -42,11 +42,14 @@ export interface ExpoConfig {
    * The runtime version associated with this manifest.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?:
+  runtimeVersion?: (
     | string
     | {
         policy: 'nativeVersion' | 'sdkVersion';
-      };
+      }
+  ) & {
+    [k: string]: any;
+  };
   /**
    * Your app version. In addition to this field, you'll also use `ios.buildNumber` and `android.versionCode` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). On iOS this corresponds to `CFBundleShortVersionString`, and on Android, this corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
    */
@@ -491,11 +494,14 @@ export interface IOS {
    * The runtime version associated with this manifest for the iOS platform. If provided, this will override the top level runtimeVersion key.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?:
+  runtimeVersion?: (
     | string
     | {
         policy: 'nativeVersion' | 'sdkVersion';
-      };
+      }
+  ) & {
+    [k: string]: any;
+  };
 }
 /**
  * Configuration that is specific to the Android platform.
@@ -588,6 +594,8 @@ export interface Android {
    * - `WRITE_SETTINGS`
    * - `VIBRATE`
    * - `READ_PHONE_STATE`
+   * - `FOREGROUND_SERVICE`
+   * - `WAKE_LOCK`
    * - `com.anddoes.launcher.permission.UPDATE_COUNT`
    * - `com.android.launcher.permission.INSTALL_SHORTCUT`
    * - `com.google.android.c2dm.permission.RECEIVE`
@@ -602,6 +610,10 @@ export interface Android {
    *
    */
   permissions?: string[];
+  /**
+   * List of permissions to block in the final `AndroidManifest.xml`. This is useful for removing permissions that are added by native package `AndroidManifest.xml` files which are merged into the final manifest. Not available in the classic `expo build:android` or Expo Go.
+   */
+  blockedPermissions?: string[];
   /**
    * [Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase. Including this key automatically enables FCM in your standalone app.
    */
@@ -703,7 +715,7 @@ export interface Android {
    */
   intentFilters?: {
     /**
-     * You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](developer.android.com/training/app-links)
+     * You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](https://developer.android.com/training/app-links)
      */
     autoVerify?: boolean;
     action: string;
@@ -728,11 +740,14 @@ export interface Android {
    * The runtime version associated with this manifest for the Android platform. If provided, this will override the top level runtimeVersion key.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?:
+  runtimeVersion?: (
     | string
     | {
         policy: 'nativeVersion' | 'sdkVersion';
-      };
+      }
+  ) & {
+    [k: string]: any;
+  };
 }
 export interface AndroidIntentFiltersData {
   /**

--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -42,14 +42,7 @@ export interface ExpoConfig {
    * The runtime version associated with this manifest.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?: (
-    | string
-    | {
-        policy: 'nativeVersion' | 'sdkVersion';
-      }
-  ) & {
-    [k: string]: any;
-  };
+  runtimeVersion?: string | { policy: 'nativeVersion' | 'sdkVersion' };
   /**
    * Your app version. In addition to this field, you'll also use `ios.buildNumber` and `android.versionCode` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). On iOS this corresponds to `CFBundleShortVersionString`, and on Android, this corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
    */
@@ -494,14 +487,7 @@ export interface IOS {
    * The runtime version associated with this manifest for the iOS platform. If provided, this will override the top level runtimeVersion key.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?: (
-    | string
-    | {
-        policy: 'nativeVersion' | 'sdkVersion';
-      }
-  ) & {
-    [k: string]: any;
-  };
+  runtimeVersion?: string | { policy: 'nativeVersion' | 'sdkVersion' };
 }
 /**
  * Configuration that is specific to the Android platform.
@@ -611,7 +597,7 @@ export interface Android {
    */
   permissions?: string[];
   /**
-   * List of permissions to block in the final `AndroidManifest.xml`. This is useful for removing permissions that are added by native package `AndroidManifest.xml` files which are merged into the final manifest. Not available in the classic `expo build:android` or Expo Go.
+   * List of permissions to block in the final `AndroidManifest.xml`. This is useful for removing permissions that are added by native package `AndroidManifest.xml` files which are merged into the final manifest. Internally this feature uses the `tools:node="remove"` XML attribute to remove permissions. Not available in the classic `expo build:android` or Expo Go.
    */
   blockedPermissions?: string[];
   /**
@@ -740,14 +726,7 @@ export interface Android {
    * The runtime version associated with this manifest for the Android platform. If provided, this will override the top level runtimeVersion key.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?: (
-    | string
-    | {
-        policy: 'nativeVersion' | 'sdkVersion';
-      }
-  ) & {
-    [k: string]: any;
-  };
+  runtimeVersion?: string | { policy: 'nativeVersion' | 'sdkVersion' };
 }
 export interface AndroidIntentFiltersData {
   /**

--- a/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -62,6 +62,10 @@ Object {
     },
     "allowBackup": true,
     "backgroundColor": "#ff0000",
+    "blockedPermissions": Array [
+      "android.permission.RECORD_AUDIO",
+      "android.permission.ACCESS_FINE_LOCATION",
+    ],
     "config": Object {
       "branch": Object {
         "apiKey": "MY_BRANCH_ANDROID_KEY",
@@ -92,7 +96,6 @@ Object {
       "CAMERA",
       "com.sec.android.provider.badge.permission.WRITE",
       "android.permission.ACCESS_COARSE_LOCATION",
-      "android.permission.ACCESS_FINE_LOCATION",
     ],
     "softwareKeyboardLayoutMode": "pan",
     "splash": Object {
@@ -474,6 +477,7 @@ Object {
             "$": Object {
               "package": "com.bacon.todo",
               "xmlns:android": "http://schemas.android.com/apk/res/android",
+              "xmlns:tools": "http://schemas.android.com/tools",
             },
             "application": Array [
               Object {
@@ -774,7 +778,14 @@ Object {
               },
               Object {
                 "$": Object {
+                  "android:name": "android.permission.RECORD_AUDIO",
+                  "tools:node": "remove",
+                },
+              },
+              Object {
+                "$": Object {
                   "android:name": "android.permission.ACCESS_FINE_LOCATION",
+                  "tools:node": "remove",
                 },
               },
             ],
@@ -1048,6 +1059,10 @@ Object {
     },
     "allowBackup": true,
     "backgroundColor": "#ff0000",
+    "blockedPermissions": Array [
+      "android.permission.RECORD_AUDIO",
+      "android.permission.ACCESS_FINE_LOCATION",
+    ],
     "config": Object {
       "branch": Object {
         "apiKey": "MY_BRANCH_ANDROID_KEY",
@@ -1078,7 +1093,6 @@ Object {
       "CAMERA",
       "com.sec.android.provider.badge.permission.WRITE",
       "android.permission.ACCESS_COARSE_LOCATION",
-      "android.permission.ACCESS_FINE_LOCATION",
     ],
     "softwareKeyboardLayoutMode": "pan",
     "splash": Object {
@@ -1345,6 +1359,7 @@ Object {
             "$": Object {
               "package": "com.bacon.todo",
               "xmlns:android": "http://schemas.android.com/apk/res/android",
+              "xmlns:tools": "http://schemas.android.com/tools",
             },
             "application": Array [
               Object {
@@ -1664,7 +1679,14 @@ Object {
               },
               Object {
                 "$": Object {
+                  "android:name": "android.permission.RECORD_AUDIO",
+                  "tools:node": "remove",
+                },
+              },
+              Object {
+                "$": Object {
                   "android:name": "android.permission.ACCESS_FINE_LOCATION",
+                  "tools:node": "remove",
                 },
               },
             ],
@@ -1933,6 +1955,10 @@ Object {
     },
     "allowBackup": true,
     "backgroundColor": "#ff0000",
+    "blockedPermissions": Array [
+      "android.permission.RECORD_AUDIO",
+      "android.permission.ACCESS_FINE_LOCATION",
+    ],
     "config": Object {
       "branch": Object {
         "apiKey": "MY_BRANCH_ANDROID_KEY",
@@ -1963,7 +1989,6 @@ Object {
       "CAMERA",
       "com.sec.android.provider.badge.permission.WRITE",
       "android.permission.ACCESS_COARSE_LOCATION",
-      "android.permission.ACCESS_FINE_LOCATION",
     ],
     "softwareKeyboardLayoutMode": "pan",
     "splash": Object {

--- a/packages/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
+++ b/packages/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
@@ -148,7 +148,15 @@ function getLargeConfig(): ExportedConfig {
           backgroundColor: '#00ffff',
         },
       },
-      permissions: ['CAMERA', 'com.sec.android.provider.badge.permission.WRITE'],
+      blockedPermissions: [
+        'android.permission.RECORD_AUDIO',
+        'android.permission.ACCESS_FINE_LOCATION',
+      ],
+      permissions: [
+        'CAMERA',
+        'com.sec.android.provider.badge.permission.WRITE',
+        'android.permission.RECORD_AUDIO',
+      ],
       googleServicesFile: './config/google-services.json',
       config: {
         branch: {

--- a/packages/prebuild-config/src/plugins/withDefaultPlugins.ts
+++ b/packages/prebuild-config/src/plugins/withDefaultPlugins.ts
@@ -102,6 +102,7 @@ export const withAndroidExpoPlugins: ConfigPlugin<{
     AndroidConfig.IntentFilters.withAndroidIntentFilters,
     AndroidConfig.Scheme.withScheme,
     AndroidConfig.Orientation.withOrientation,
+    AndroidConfig.Permissions.withInternalBlockedPermissions,
     AndroidConfig.Permissions.withPermissions,
 
     // strings.xml


### PR DESCRIPTION
# Why


- Alternative to this lazy, bloated solution: https://github.com/expo/expo-cli/pull/4322
- Implements the new schema property proposed here: https://github.com/expo/universe/pull/9504

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- If the user defines `android.blockedPermissions`, then prebuild will apply the blocked permissions to the `AndroidManifest.xml`.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- Added tests.
