### PR TITLE
Update ExpoConfig.ts from latest

### DIFF
--- a/packages/config-types/src/ExpoConfig.ts
+++ b/packages/config-types/src/ExpoConfig.ts
@@ -42,11 +42,14 @@ export interface ExpoConfig {
    * The runtime version associated with this manifest.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?:
+  runtimeVersion?: (
     | string
     | {
         policy: 'nativeVersion' | 'sdkVersion';
-      };
+      }
+  ) & {
+    [k: string]: any;
+  };
   /**
    * Your app version. In addition to this field, you'll also use `ios.buildNumber` and `android.versionCode` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). On iOS this corresponds to `CFBundleShortVersionString`, and on Android, this corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
    */
@@ -491,11 +494,14 @@ export interface IOS {
    * The runtime version associated with this manifest for the iOS platform. If provided, this will override the top level runtimeVersion key.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?:
+  runtimeVersion?: (
     | string
     | {
         policy: 'nativeVersion' | 'sdkVersion';
-      };
+      }
+  ) & {
+    [k: string]: any;
+  };
 }
 /**
  * Configuration that is specific to the Android platform.
@@ -588,6 +594,8 @@ export interface Android {
    * - `WRITE_SETTINGS`
    * - `VIBRATE`
    * - `READ_PHONE_STATE`
+   * - `FOREGROUND_SERVICE`
+   * - `WAKE_LOCK`
    * - `com.anddoes.launcher.permission.UPDATE_COUNT`
    * - `com.android.launcher.permission.INSTALL_SHORTCUT`
    * - `com.google.android.c2dm.permission.RECEIVE`
@@ -703,7 +711,7 @@ export interface Android {
    */
   intentFilters?: {
     /**
-     * You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](developer.android.com/training/app-links)
+     * You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](https://developer.android.com/training/app-links)
      */
     autoVerify?: boolean;
     action: string;
@@ -728,11 +736,14 @@ export interface Android {
    * The runtime version associated with this manifest for the Android platform. If provided, this will override the top level runtimeVersion key.
    * Set this to `{"policy": "nativeVersion"}` to generate it automatically.
    */
-  runtimeVersion?:
+  runtimeVersion?: (
     | string
     | {
         policy: 'nativeVersion' | 'sdkVersion';
-      };
+      }
+  ) & {
+    [k: string]: any;
+  };
 }
 export interface AndroidIntentFiltersData {
   /**


### PR DESCRIPTION
# Why

- There appears to be a type issue here (introduced in https://github.com/expo/universe/pull/9471)

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- `yarn generate --path ../../../universe/server/www/xdl-schemas/UNVERSIONED-schema.json` in `packages/config-types` while my git branch for universe is on the latest [(#f779fb6018)](https://github.com/expo/universe/commit/f779fb60183e8839cce9d76d85c439c0913946e6)

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->