### PR TITLE
feat(config-plugins): add initial app clip support

### DIFF
--- a/packages/config-plugins/src/ios/BuildScheme.ts
+++ b/packages/config-plugins/src/ios/BuildScheme.ts
@@ -41,7 +41,14 @@ export function getRunnableSchemesFromXcodeproj(
     let osType = 'iOS';
     const type = unquote(target.productType);
 
-    if (type === TargetType.APPLICATION) {
+    if (type === TargetType.WATCH) {
+      osType = 'watchOS';
+    } else if (
+      // (apps) com.apple.product-type.application
+      // (app clips) com.apple.product-type.application.on-demand-install-capable
+      // NOTE(EvanBacon): This matches against `watchOS` as well so we check for watch first.
+      type.startsWith(TargetType.APPLICATION)
+    ) {
       // Attempt to resolve the platform SDK for each target so we can filter devices.
       const xcConfigurationList =
         project.hash.project.objects.XCConfigurationList[target.buildConfigurationList];
@@ -67,8 +74,6 @@ export function getRunnableSchemesFromXcodeproj(
           }
         }
       }
-    } else if (type === TargetType.WATCH) {
-      osType = 'watchOS';
     }
 
     return {

--- a/packages/config-plugins/src/ios/Target.ts
+++ b/packages/config-plugins/src/ios/Target.ts
@@ -13,6 +13,7 @@ export enum TargetType {
   APPLICATION = 'com.apple.product-type.application',
   EXTENSION = 'com.apple.product-type.app-extension',
   WATCH = 'com.apple.product-type.application.watchapp',
+  APP_CLIP = 'com.apple.product-type.application.on-demand-install-capable',
   STICKER_PACK_EXTENSION = 'com.apple.product-type.app-extension.messages-sticker-pack',
   OTHER = 'other',
 }
@@ -92,13 +93,23 @@ export function getNativeTargets(project: XcodeProject): NativeTargetSectionEntr
 
 export function findSignableTargets(project: XcodeProject): NativeTargetSectionEntry[] {
   const targets = getNativeTargets(project);
-  const applicationTargets = targets.filter(
-    ([, target]) =>
-      isTargetOfType(target, TargetType.APPLICATION) ||
-      isTargetOfType(target, TargetType.EXTENSION) ||
-      isTargetOfType(target, TargetType.WATCH) ||
-      isTargetOfType(target, TargetType.STICKER_PACK_EXTENSION)
-  );
+
+  const signableTargetTypes = [
+    TargetType.APPLICATION,
+    TargetType.APP_CLIP,
+    TargetType.EXTENSION,
+    TargetType.WATCH,
+    TargetType.STICKER_PACK_EXTENSION,
+  ];
+
+  const applicationTargets = targets.filter(([, target]) => {
+    for (const targetType of signableTargetTypes) {
+      if (isTargetOfType(target, targetType)) {
+        return true;
+      }
+    }
+    return false;
+  });
   if (applicationTargets.length === 0) {
     throw new Error(`Could not find any signable targets in project.pbxproj`);
   }

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -99,18 +99,21 @@ export function addResourceFileToGroup({
   isBuildFile,
   project,
   verbose,
+  targetUuid,
 }: {
   filepath: string;
   groupName: string;
   isBuildFile?: boolean;
   project: XcodeProject;
   verbose?: boolean;
+  targetUuid?: string;
 }): XcodeProject {
   return addFileToGroupAndLink({
     filepath,
     groupName,
     project,
     verbose,
+    targetUuid,
     addFileToProject({ project, file }) {
       project.addToPbxFileReferenceSection(file);
       if (isBuildFile) {
@@ -143,6 +146,7 @@ export function addBuildSourceFileToGroup({
     groupName,
     project,
     verbose,
+    targetUuid,
     addFileToProject({ project, file }) {
       project.addToPbxFileReferenceSection(file);
       project.addToPbxBuildFileSection(file);


### PR DESCRIPTION
# Why

- why not


<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

- `expo run:ios --scheme` -- this will prompt to choose any runnable scheme (which now includes app clips).

<img width="403" alt="Screen Shot 2022-04-24 at 4 58 14 PM" src="https://user-images.githubusercontent.com/9664363/164998392-5d66ce60-d01c-41ee-ab9c-d0fcb2fec9e7.png">

