### PR TITLE
[install-expo-modules] Add react-native 0.68 and expo sdk 45 support

### DIFF
--- a/packages/config-plugins/src/android/codeMod.ts
+++ b/packages/config-plugins/src/android/codeMod.ts
@@ -40,7 +40,7 @@ export function findNewInstanceCodeBlock(
   // ```
   const nextBrace = contents.indexOf('{', end + 1);
   const isAnonymousClass =
-    nextBrace >= end && !!contents.substring(end + 1, nextBrace).match(/^\s*$/m);
+    nextBrace >= end && !!contents.substring(end + 1, nextBrace).match(/^\s*$/);
   if (isAnonymousClass) {
     end = findMatchingBracketPosition(contents, '{', end);
   }

--- a/packages/install-expo-modules/package.json
+++ b/packages/install-expo-modules/package.json
@@ -46,6 +46,7 @@
     "find-up": "^5.0.0",
     "glob": "7.1.6",
     "prompts": "^2.3.2",
+    "resolve-from": "^5.0.0",
     "semver": "7.3.2"
   },
   "devDependencies": {

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -2,17 +2,15 @@
 
 import { getConfig } from '@expo/config';
 import { compileModsAsync, ModPlatform } from '@expo/config-plugins';
-import * as PackageManager from '@expo/package-manager';
 import chalk from 'chalk';
 import { Command } from 'commander';
-import path from 'path';
 import prompts from 'prompts';
-import semver from 'semver';
 
 import { withAndroidModules } from './plugins/android/withAndroidModules';
 import { withIosDeploymentTarget } from './plugins/ios/withIosDeploymentTarget';
 import { withIosModules } from './plugins/ios/withIosModules';
 import { getDefaultSdkVersion, getVersionInfo, VersionInfo } from './utils/expoVersionMappings';
+import { installExpoPackageAsync, installPodsAsync } from './utils/packageInstaller';
 import { normalizeProjectRoot } from './utils/projectRoot';
 
 const packageJSON = require('../package.json');
@@ -83,15 +81,10 @@ async function runAsync(programName: string) {
   });
 
   console.log('\u203A Installing expo packages...');
-  const packageManager = PackageManager.createForProject(projectRoot);
-  // e.g. `expo@>=43.0.0-0 <44.0.0`, this will cover prerelease version for beta testing.
-  await packageManager.addAsync(`expo@>=${sdkVersion}-0 <${semver.inc(sdkVersion, 'major')}`);
+  await installExpoPackageAsync(projectRoot, sdkVersion);
 
   console.log('\u203A Installing ios pods...');
-  const podPackageManager = new PackageManager.CocoaPodsPackageManager({
-    cwd: path.join(projectRoot, 'ios'),
-  });
-  await podPackageManager.installAsync();
+  await installPodsAsync(projectRoot);
 
   console.log(chalk.bold('\u203A Installation completed!'));
 }

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-anonymous-delegate-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-anonymous-delegate-updated.java
@@ -1,0 +1,29 @@
+package com.helloworld;
+import expo.modules.ReactActivityDelegateWrapper;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegateWrapper(this, new ReactActivityDelegate(this, getMainComponentName()) {
+      @Override
+      protected ReactRootView createRootView() {
+        return new RNGestureHandlerEnabledRootView(MainActivity.this);
+      }
+    });
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-anonymous-delegate-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-anonymous-delegate-updated.kt
@@ -1,0 +1,26 @@
+package com.helloworld
+import expo.modules.ReactActivityDelegateWrapper
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactRootView
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return ReactActivityDelegateWrapper(this, object : ReactActivityDelegate(this, mainComponentName) {
+      override fun createRootView(): ReactRootView {
+        return RNGestureHandlerEnabledRootView(this@MainActivity)
+      }
+    })
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-anonymous-delegate.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-anonymous-delegate.java
@@ -1,0 +1,28 @@
+package com.helloworld;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegate(this, getMainComponentName()) {
+      @Override
+      protected ReactRootView createRootView() {
+        return new RNGestureHandlerEnabledRootView(MainActivity.this);
+      }
+    };
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-anonymous-delegate.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-anonymous-delegate.kt
@@ -1,0 +1,25 @@
+package com.helloworld
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactRootView
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return object : ReactActivityDelegate(this, mainComponentName) {
+      override fun createRootView(): ReactRootView {
+        return RNGestureHandlerEnabledRootView(this@MainActivity)
+      }
+    }
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.java
@@ -1,0 +1,24 @@
+package com.helloworld;
+import expo.modules.ReactActivityDelegateWrapper;
+import com.facebook.react.ReactActivityDelegate;
+
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegateWrapper(this,
+      new ReactActivityDelegate(this, getMainComponentName())
+    );
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.kt
@@ -1,0 +1,22 @@
+package com.helloworld
+import expo.modules.ReactActivityDelegateWrapper
+import com.facebook.react.ReactActivityDelegate
+
+import com.facebook.react.ReactActivity
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return ReactActivityDelegateWrapper(this,
+      ReactActivityDelegate(this, getMainComponentName())
+    );
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate.java
@@ -1,0 +1,15 @@
+package com.helloworld;
+
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate.kt
@@ -1,0 +1,14 @@
+package com.helloworld
+
+import com.facebook.react.ReactActivity
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn064-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn064-updated.java
@@ -1,0 +1,22 @@
+package com.helloworld;
+import expo.modules.ReactActivityDelegateWrapper;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegateWrapper(this, new ReactActivityDelegate(this, getMainComponentName()));
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn064-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn064-updated.kt
@@ -1,0 +1,20 @@
+package com.helloworld
+import expo.modules.ReactActivityDelegateWrapper
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return ReactActivityDelegateWrapper(this, ReactActivityDelegate(this, mainComponentName))
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn064.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn064.java
@@ -1,0 +1,21 @@
+package com.helloworld;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegate(this, getMainComponentName());
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn064.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn064.kt
@@ -1,0 +1,19 @@
+package com.helloworld
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return ReactActivityDelegate(this, mainComponentName)
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.java
@@ -1,0 +1,38 @@
+package com.helloworld;
+import expo.modules.ReactActivityDelegateWrapper;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is
+   * used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegateWrapper(this, new MainActivityDelegate(this, getMainComponentName()));
+  }
+
+  public static class MainActivityDelegate extends ReactActivityDelegate {
+    public MainActivityDelegate(ReactActivity activity, String mainComponentName) {
+      super(activity, mainComponentName);
+    }
+
+    @Override
+    protected ReactRootView createRootView() {
+      ReactRootView reactRootView = new ReactRootView(getContext());
+      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED);
+      return reactRootView;
+    }
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.kt
@@ -1,0 +1,31 @@
+package com.helloworld
+import expo.modules.ReactActivityDelegateWrapper
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactRootView
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return ReactActivityDelegateWrapper(this, MainActivityDelegate(this, mainComponentName))
+  }
+
+  class MainActivityDelegate(activity: ReactActivity?, mainComponentName: String?)
+    : ReactActivityDelegate(activity, mainComponentName) {
+    override fun createRootView(): ReactRootView {
+      val reactRootView = ReactRootView(context)
+      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
+      return reactRootView
+    }
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068.java
@@ -1,0 +1,37 @@
+package com.helloworld;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is
+   * used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new MainActivityDelegate(this, getMainComponentName());
+  }
+
+  public static class MainActivityDelegate extends ReactActivityDelegate {
+    public MainActivityDelegate(ReactActivity activity, String mainComponentName) {
+      super(activity, mainComponentName);
+    }
+
+    @Override
+    protected ReactRootView createRootView() {
+      ReactRootView reactRootView = new ReactRootView(getContext());
+      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED);
+      return reactRootView;
+    }
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068.kt
@@ -1,0 +1,30 @@
+package com.helloworld
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactRootView
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return MainActivityDelegate(this, mainComponentName)
+  }
+
+  class MainActivityDelegate(activity: ReactActivity?, mainComponentName: String?)
+    : ReactActivityDelegate(activity, mainComponentName) {
+    override fun createRootView(): ReactRootView {
+      val reactRootView = ReactRootView(context)
+      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
+      return reactRootView
+    }
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn064-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn064-updated.java
@@ -1,0 +1,55 @@
+package com.helloworld;
+import android.content.res.Configuration;
+import expo.modules.ApplicationLifecycleDispatcher;
+import expo.modules.ReactNativeHostWrapper;
+
+import android.app.Application;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.soloader.SoLoader;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHostWrapper(this, new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+  });
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+    // comment out initializeFlipper to keep test simpler
+    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+    ApplicationLifecycleDispatcher.onApplicationCreate(this);
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig);
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn064-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn064-updated.kt
@@ -1,0 +1,44 @@
+package com.helloworld
+import expo.modules.ApplicationLifecycleDispatcher
+import expo.modules.ReactNativeHostWrapper
+
+import android.app.Application
+import android.content.res.Configuration;
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.soloader.SoLoader
+
+class MainApplication : Application(), ReactApplication {
+  private val mReactNativeHost: ReactNativeHost = ReactNativeHostWrapper(this, object : ReactNativeHost(this) {
+    override fun getUseDeveloperSupport(): Boolean {
+      return BuildConfig.DEBUG
+    }
+
+    override fun getPackages(): List<ReactPackage> {
+      return PackageList(this).packages
+    }
+
+    override fun getJSMainModuleName(): String {
+      return "index"
+    }
+  })
+
+  override fun getReactNativeHost(): ReactNativeHost {
+    return mReactNativeHost
+  }
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this,  /* native exopackage */ false)
+    // comment out initializeFlipper to keep test simpler
+    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+    ApplicationLifecycleDispatcher.onApplicationCreate(this)
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn064.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn064.java
@@ -1,0 +1,45 @@
+package com.helloworld;
+
+import android.app.Application;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.soloader.SoLoader;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+  };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+    // comment out initializeFlipper to keep test simpler
+    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn064.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn064.kt
@@ -1,0 +1,40 @@
+package com.helloworld
+
+import android.app.Application
+import android.content.res.Configuration;
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.soloader.SoLoader
+
+class MainApplication : Application(), ReactApplication {
+  private val mReactNativeHost: ReactNativeHost = object : ReactNativeHost(this) {
+    override fun getUseDeveloperSupport(): Boolean {
+      return BuildConfig.DEBUG
+    }
+
+    override fun getPackages(): List<ReactPackage> {
+      return PackageList(this).packages
+    }
+
+    override fun getJSMainModuleName(): String {
+      return "index"
+    }
+  }
+
+  override fun getReactNativeHost(): ReactNativeHost {
+    return mReactNativeHost
+  }
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this,  /* native exopackage */ false)
+    // comment out initializeFlipper to keep test simpler
+    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn068-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn068-updated.java
@@ -1,0 +1,69 @@
+package com.helloworld;
+import android.content.res.Configuration;
+import expo.modules.ApplicationLifecycleDispatcher;
+import expo.modules.ReactNativeHostWrapper;
+
+import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.soloader.SoLoader;
+import com.helloworld.newarchitecture.MainApplicationReactNativeHost;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHostWrapper(this, new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+  });
+
+  private final ReactNativeHost mNewArchitectureNativeHost =
+      new ReactNativeHostWrapper(this, new MainApplicationReactNativeHost(this));
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      return mNewArchitectureNativeHost;
+    } else {
+      return mReactNativeHost;
+    }
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    // If you opted-in for the New Architecture, we enable the TurboModule system
+    ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+    SoLoader.init(this, /* native exopackage */ false);
+    // comment out initializeFlipper to keep test simpler
+    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+    ApplicationLifecycleDispatcher.onApplicationCreate(this);
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig);
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn068.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn068.java
@@ -1,0 +1,59 @@
+package com.helloworld;
+
+import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.soloader.SoLoader;
+import com.helloworld.newarchitecture.MainApplicationReactNativeHost;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+  };
+
+  private final ReactNativeHost mNewArchitectureNativeHost =
+      new MainApplicationReactNativeHost(this);
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      return mNewArchitectureNativeHost;
+    } else {
+      return mReactNativeHost;
+    }
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    // If you opted-in for the New Architecture, we enable the TurboModule system
+    ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+    SoLoader.init(this, /* native exopackage */ false);
+    // comment out initializeFlipper to keep test simpler
+    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
@@ -1,49 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+
 import { setModulesMainActivity } from '../withAndroidModulesMainActivity';
 
+const fixturesPath = path.resolve(__dirname, 'fixtures');
+
 describe(setModulesMainActivity, () => {
-  it(`should add createReactActivityDelegate code block if not overridden yet - java`, () => {
-    const rawContents = `
-package com.helloworld;
-
-import com.facebook.react.ReactActivity;
-
-public class MainActivity extends ReactActivity {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "HelloWorld";
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld;
-import expo.modules.ReactActivityDelegateWrapper;
-import com.facebook.react.ReactActivityDelegate;
-
-import com.facebook.react.ReactActivity;
-
-public class MainActivity extends ReactActivity {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "HelloWorld";
-  }
-
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this,
-      new ReactActivityDelegate(this, getMainComponentName())
-    );
-  }
-}`;
+  it(`should add createReactActivityDelegate code block if not overridden yet - java`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-no-delegate.java'), 'utf8'),
+      fs.promises.readFile(
+        path.join(fixturesPath, 'MainActivity-no-delegate-updated.java'),
+        'utf8'
+      ),
+    ]);
 
     const contents = setModulesMainActivity(rawContents, 'java');
     expect(contents).toEqual(expectContents);
@@ -52,46 +22,11 @@ public class MainActivity extends ReactActivity {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add createReactActivityDelegate code block if not overridden yet - kotlin`, () => {
-    const rawContents = `
-package com.helloworld
-
-import com.facebook.react.ReactActivity
-
-class MainActivity : ReactActivity() {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun mainComponentName: String {
-    return "HelloWorld"
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld
-import expo.modules.ReactActivityDelegateWrapper
-import com.facebook.react.ReactActivityDelegate
-
-import com.facebook.react.ReactActivity
-
-class MainActivity : ReactActivity() {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun mainComponentName: String {
-    return "HelloWorld"
-  }
-
-  override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this,
-      ReactActivityDelegate(this, getMainComponentName())
-    );
-  }
-}`;
+  it(`should add createReactActivityDelegate code block if not overridden yet - kotlin`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-no-delegate.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-no-delegate-updated.kt'), 'utf8'),
+    ]);
 
     const contents = setModulesMainActivity(rawContents, 'kt');
     expect(contents).toEqual(expectContents);
@@ -100,83 +35,11 @@ class MainActivity : ReactActivity() {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - java`, () => {
-    const rawContents = `
-package com.helloworld;
-
-import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactActivityDelegate;
-import com.facebook.react.ReactRootView;
-
-public class MainActivity extends ReactActivity {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "HelloWorld";
-  }
-
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new MainActivityDelegate(this, getMainComponentName());
-  }
-
-  public static class MainActivityDelegate extends ReactActivityDelegate {
-    public MainActivityDelegate(ReactActivity activity, String mainComponentName) {
-      super(activity, mainComponentName);
-    }
-
-    @Override
-    protected ReactRootView createRootView() {
-      ReactRootView reactRootView = new ReactRootView(getContext());
-      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
-      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED);
-      return reactRootView;
-    }
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld;
-import expo.modules.ReactActivityDelegateWrapper;
-
-import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactActivityDelegate;
-import com.facebook.react.ReactRootView;
-
-public class MainActivity extends ReactActivity {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "HelloWorld";
-  }
-
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this, new MainActivityDelegate(this, getMainComponentName()));
-  }
-
-  public static class MainActivityDelegate extends ReactActivityDelegate {
-    public MainActivityDelegate(ReactActivity activity, String mainComponentName) {
-      super(activity, mainComponentName);
-    }
-
-    @Override
-    protected ReactRootView createRootView() {
-      ReactRootView reactRootView = new ReactRootView(getContext());
-      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
-      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED);
-      return reactRootView;
-    }
-  }
-}`;
+  it(`should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - java`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn068.java'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn068-updated.java'), 'utf8'),
+    ]);
 
     const contents = setModulesMainActivity(rawContents, 'java');
     expect(contents).toEqual(expectContents);
@@ -185,71 +48,11 @@ public class MainActivity extends ReactActivity {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - kotlin`, () => {
-    const rawContents = `
-package com.helloworld
-
-import com.facebook.react.ReactActivity
-import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.ReactRootView
-
-class MainActivity : ReactActivity() {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun mainComponentName: String {
-    return "HelloWorld"
-  }
-
-  override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return MainActivityDelegate(this, mainComponentName)
-  }
-
-  class MainActivityDelegate(activity: ReactActivity?, mainComponentName: String?)
-    : ReactActivityDelegate(activity, mainComponentName) {
-    override fun createRootView(): ReactRootView {
-      val reactRootView = ReactRootView(context)
-      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
-      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
-      return reactRootView
-    }
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld
-import expo.modules.ReactActivityDelegateWrapper
-
-import com.facebook.react.ReactActivity
-import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.ReactRootView
-
-class MainActivity : ReactActivity() {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun mainComponentName: String {
-    return "HelloWorld"
-  }
-
-  override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this, MainActivityDelegate(this, mainComponentName))
-  }
-
-  class MainActivityDelegate(activity: ReactActivity?, mainComponentName: String?)
-    : ReactActivityDelegate(activity, mainComponentName) {
-    override fun createRootView(): ReactRootView {
-      val reactRootView = ReactRootView(context)
-      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
-      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
-      return reactRootView
-    }
-  }
-}`;
+  it(`should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - kotlin`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn068.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn068-updated.kt'), 'utf8'),
+    ]);
 
     const contents = setModulesMainActivity(rawContents, 'kt');
     expect(contents).toEqual(expectContents);
@@ -258,53 +61,11 @@ class MainActivity : ReactActivity() {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add ReactActivityDelegateWrapper for react-native@<0.68.0 - java`, () => {
-    const rawContents = `
-package com.helloworld;
-
-import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactActivityDelegate;
-
-public class MainActivity extends ReactActivity {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "HelloWorld";
-  }
-
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegate(this, getMainComponentName());
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld;
-import expo.modules.ReactActivityDelegateWrapper;
-
-import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactActivityDelegate;
-
-public class MainActivity extends ReactActivity {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "HelloWorld";
-  }
-
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this, new ReactActivityDelegate(this, getMainComponentName()));
-  }
-}`;
+  it(`should add ReactActivityDelegateWrapper for react-native@<0.68.0 - java`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn064.java'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn064-updated.java'), 'utf8'),
+    ]);
 
     const contents = setModulesMainActivity(rawContents, 'java');
     expect(contents).toEqual(expectContents);
@@ -313,49 +74,11 @@ public class MainActivity extends ReactActivity {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add ReactActivityDelegateWrapper for react-native@<0.68.0 - kotlin`, () => {
-    const rawContents = `
-package com.helloworld
-
-import com.facebook.react.ReactActivity
-import com.facebook.react.ReactActivityDelegate
-
-class MainActivity : ReactActivity() {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun mainComponentName: String {
-    return "HelloWorld"
-  }
-
-  override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegate(this, mainComponentName)
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld
-import expo.modules.ReactActivityDelegateWrapper
-
-import com.facebook.react.ReactActivity
-import com.facebook.react.ReactActivityDelegate
-
-class MainActivity : ReactActivity() {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun mainComponentName: String {
-    return "HelloWorld"
-  }
-
-  override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this, ReactActivityDelegate(this, mainComponentName))
-  }
-}`;
+  it(`should add ReactActivityDelegateWrapper for react-native@<0.68.0 - kotlin`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn064.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn064-updated.kt'), 'utf8'),
+    ]);
 
     const contents = setModulesMainActivity(rawContents, 'kt');
     expect(contents).toEqual(expectContents);
@@ -364,67 +87,14 @@ class MainActivity : ReactActivity() {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add ReactActivityDelegateWrapper for anonymous class - java`, () => {
-    const rawContents = `
-package com.helloworld;
-
-import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactActivityDelegate;
-import com.facebook.react.ReactRootView
-import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
-
-public class MainActivity extends ReactActivity {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "HelloWorld";
-  }
-
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegate(this, getMainComponentName()) {
-      @Override
-      protected ReactRootView createRootView() {
-        return new RNGestureHandlerEnabledRootView(MainActivity.this);
-      }
-    };
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld;
-import expo.modules.ReactActivityDelegateWrapper;
-
-import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactActivityDelegate;
-import com.facebook.react.ReactRootView
-import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
-
-public class MainActivity extends ReactActivity {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "HelloWorld";
-  }
-
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this, new ReactActivityDelegate(this, getMainComponentName()) {
-      @Override
-      protected ReactRootView createRootView() {
-        return new RNGestureHandlerEnabledRootView(MainActivity.this);
-      }
-    });
-  }
-}`;
+  it(`should add ReactActivityDelegateWrapper for anonymous class - java`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-anonymous-delegate.java'), 'utf8'),
+      fs.promises.readFile(
+        path.join(fixturesPath, 'MainActivity-anonymous-delegate-updated.java'),
+        'utf8'
+      ),
+    ]);
 
     const contents = setModulesMainActivity(rawContents, 'java');
     expect(contents).toEqual(expectContents);
@@ -433,61 +103,14 @@ public class MainActivity extends ReactActivity {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add ReactActivityDelegateWrapper for anonymous class - kotlin`, () => {
-    const rawContents = `
-package com.helloworld
-
-import com.facebook.react.ReactActivity
-import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.ReactRootView
-import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView
-
-class MainActivity : ReactActivity() {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun mainComponentName: String {
-    return "HelloWorld"
-  }
-
-  override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return object : ReactActivityDelegate(this, mainComponentName) {
-      override fun createRootView(): ReactRootView {
-        return RNGestureHandlerEnabledRootView(this@MainActivity)
-      }
-    }
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld
-import expo.modules.ReactActivityDelegateWrapper
-
-import com.facebook.react.ReactActivity
-import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.ReactRootView
-import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView
-
-class MainActivity : ReactActivity() {
-
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  override fun mainComponentName: String {
-    return "HelloWorld"
-  }
-
-  override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this, object : ReactActivityDelegate(this, mainComponentName) {
-      override fun createRootView(): ReactRootView {
-        return RNGestureHandlerEnabledRootView(this@MainActivity)
-      }
-    })
-  }
-}`;
+  it(`should add ReactActivityDelegateWrapper for anonymous class - kotlin`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-anonymous-delegate.kt'), 'utf8'),
+      fs.promises.readFile(
+        path.join(fixturesPath, 'MainActivity-anonymous-delegate-updated.kt'),
+        'utf8'
+      ),
+    ]);
 
     const contents = setModulesMainActivity(rawContents, 'kt');
     expect(contents).toEqual(expectContents);

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
@@ -100,7 +100,165 @@ class MainActivity : ReactActivity() {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add ReactActivityDelegateWrapper - java`, () => {
+  it(`should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - java`, () => {
+    const rawContents = `
+package com.helloworld;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new MainActivityDelegate(this, getMainComponentName());
+  }
+
+  public static class MainActivityDelegate extends ReactActivityDelegate {
+    public MainActivityDelegate(ReactActivity activity, String mainComponentName) {
+      super(activity, mainComponentName);
+    }
+
+    @Override
+    protected ReactRootView createRootView() {
+      ReactRootView reactRootView = new ReactRootView(getContext());
+      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED);
+      return reactRootView;
+    }
+  }
+}`;
+
+    const expectContents = `
+package com.helloworld;
+import expo.modules.ReactActivityDelegateWrapper;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegateWrapper(this, new MainActivityDelegate(this, getMainComponentName()));
+  }
+
+  public static class MainActivityDelegate extends ReactActivityDelegate {
+    public MainActivityDelegate(ReactActivity activity, String mainComponentName) {
+      super(activity, mainComponentName);
+    }
+
+    @Override
+    protected ReactRootView createRootView() {
+      ReactRootView reactRootView = new ReactRootView(getContext());
+      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED);
+      return reactRootView;
+    }
+  }
+}`;
+
+    const contents = setModulesMainActivity(rawContents, 'java');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainActivity(contents, 'java');
+    expect(nextContents).toEqual(expectContents);
+  });
+
+  it(`should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - kotlin`, () => {
+    const rawContents = `
+package com.helloworld
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactRootView
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return MainActivityDelegate(this, mainComponentName)
+  }
+
+  class MainActivityDelegate(activity: ReactActivity?, mainComponentName: String?)
+    : ReactActivityDelegate(activity, mainComponentName) {
+    override fun createRootView(): ReactRootView {
+      val reactRootView = ReactRootView(context)
+      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
+      return reactRootView
+    }
+  }
+}`;
+
+    const expectContents = `
+package com.helloworld
+import expo.modules.ReactActivityDelegateWrapper
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactRootView
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun mainComponentName: String {
+    return "HelloWorld"
+  }
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return ReactActivityDelegateWrapper(this, MainActivityDelegate(this, mainComponentName))
+  }
+
+  class MainActivityDelegate(activity: ReactActivity?, mainComponentName: String?)
+    : ReactActivityDelegate(activity, mainComponentName) {
+    override fun createRootView(): ReactRootView {
+      val reactRootView = ReactRootView(context)
+      // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+      reactRootView.setIsFabric(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
+      return reactRootView
+    }
+  }
+}`;
+
+    const contents = setModulesMainActivity(rawContents, 'kt');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainActivity(contents, 'kt');
+    expect(nextContents).toEqual(expectContents);
+  });
+
+  it(`should add ReactActivityDelegateWrapper for react-native@<0.68.0 - java`, () => {
     const rawContents = `
 package com.helloworld;
 
@@ -155,7 +313,7 @@ public class MainActivity extends ReactActivity {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it(`should add ReactActivityDelegateWrapper - kotlin`, () => {
+  it(`should add ReactActivityDelegateWrapper for react-native@<0.68.0 - kotlin`, () => {
     const rawContents = `
 package com.helloworld
 

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -1,7 +1,146 @@
 import { setModulesMainApplication } from '../withAndroidModulesMainApplication';
 
 describe(setModulesMainApplication, () => {
-  it('should able to update from react native template', () => {
+  it('should able to update from react-native@>=0.68.0 template', () => {
+    const rawContents = `
+package com.helloworld;
+
+import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.soloader.SoLoader;
+import com.helloworld.newarchitecture.MainApplicationReactNativeHost;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+  };
+
+  private final ReactNativeHost mNewArchitectureNativeHost =
+      new MainApplicationReactNativeHost(this);
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      return mNewArchitectureNativeHost;
+    } else {
+      return mReactNativeHost;
+    }
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    // If you opted-in for the New Architecture, we enable the TurboModule system
+    ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+    SoLoader.init(this, /* native exopackage */ false);
+    // comment out initializeFlipper to keep test simpler
+    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+}`;
+
+    const expectContents = `
+package com.helloworld;
+import android.content.res.Configuration;
+import expo.modules.ApplicationLifecycleDispatcher;
+import expo.modules.ReactNativeHostWrapper;
+
+import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.soloader.SoLoader;
+import com.helloworld.newarchitecture.MainApplicationReactNativeHost;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHostWrapper(this, new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+  });
+
+  private final ReactNativeHost mNewArchitectureNativeHost =
+      new ReactNativeHostWrapper(this, new MainApplicationReactNativeHost(this));
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      return mNewArchitectureNativeHost;
+    } else {
+      return mReactNativeHost;
+    }
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    // If you opted-in for the New Architecture, we enable the TurboModule system
+    ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+    SoLoader.init(this, /* native exopackage */ false);
+    // comment out initializeFlipper to keep test simpler
+    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+    ApplicationLifecycleDispatcher.onApplicationCreate(this);
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig);
+  }
+}`;
+    const contents = setModulesMainApplication(rawContents, 'java');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainApplication(contents, 'java');
+    expect(nextContents).toEqual(expectContents);
+  });
+
+  it('should able to update from react-native@<0.68.0 template', () => {
     const rawContents = `
 package com.helloworld;
 

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -1,138 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+
 import { setModulesMainApplication } from '../withAndroidModulesMainApplication';
 
+const fixturesPath = path.resolve(__dirname, 'fixtures');
+
 describe(setModulesMainApplication, () => {
-  it('should able to update from react-native@>=0.68.0 template', () => {
-    const rawContents = `
-package com.helloworld;
+  it('should able to update from react-native@>=0.68.0 template', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn068.java'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn068-updated.java'), 'utf8'),
+    ]);
 
-import android.app.Application;
-import android.content.Context;
-import com.facebook.react.PackageList;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactPackage;
-import com.facebook.react.config.ReactFeatureFlags;
-import com.facebook.soloader.SoLoader;
-import com.helloworld.newarchitecture.MainApplicationReactNativeHost;
-import java.lang.reflect.InvocationTargetException;
-import java.util.List;
-
-public class MainApplication extends Application implements ReactApplication {
-
-  private final ReactNativeHost mReactNativeHost =
-      new ReactNativeHost(this) {
-        @Override
-        public boolean getUseDeveloperSupport() {
-          return BuildConfig.DEBUG;
-        }
-
-        @Override
-        protected List<ReactPackage> getPackages() {
-          @SuppressWarnings("UnnecessaryLocalVariable")
-          List<ReactPackage> packages = new PackageList(this).getPackages();
-          return packages;
-        }
-
-        @Override
-        protected String getJSMainModuleName() {
-          return "index";
-        }
-  };
-
-  private final ReactNativeHost mNewArchitectureNativeHost =
-      new MainApplicationReactNativeHost(this);
-
-  @Override
-  public ReactNativeHost getReactNativeHost() {
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      return mNewArchitectureNativeHost;
-    } else {
-      return mReactNativeHost;
-    }
-  }
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    // If you opted-in for the New Architecture, we enable the TurboModule system
-    ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
-    SoLoader.init(this, /* native exopackage */ false);
-    // comment out initializeFlipper to keep test simpler
-    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld;
-import android.content.res.Configuration;
-import expo.modules.ApplicationLifecycleDispatcher;
-import expo.modules.ReactNativeHostWrapper;
-
-import android.app.Application;
-import android.content.Context;
-import com.facebook.react.PackageList;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactPackage;
-import com.facebook.react.config.ReactFeatureFlags;
-import com.facebook.soloader.SoLoader;
-import com.helloworld.newarchitecture.MainApplicationReactNativeHost;
-import java.lang.reflect.InvocationTargetException;
-import java.util.List;
-
-public class MainApplication extends Application implements ReactApplication {
-
-  private final ReactNativeHost mReactNativeHost =
-      new ReactNativeHostWrapper(this, new ReactNativeHost(this) {
-        @Override
-        public boolean getUseDeveloperSupport() {
-          return BuildConfig.DEBUG;
-        }
-
-        @Override
-        protected List<ReactPackage> getPackages() {
-          @SuppressWarnings("UnnecessaryLocalVariable")
-          List<ReactPackage> packages = new PackageList(this).getPackages();
-          return packages;
-        }
-
-        @Override
-        protected String getJSMainModuleName() {
-          return "index";
-        }
-  });
-
-  private final ReactNativeHost mNewArchitectureNativeHost =
-      new ReactNativeHostWrapper(this, new MainApplicationReactNativeHost(this));
-
-  @Override
-  public ReactNativeHost getReactNativeHost() {
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      return mNewArchitectureNativeHost;
-    } else {
-      return mReactNativeHost;
-    }
-  }
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    // If you opted-in for the New Architecture, we enable the TurboModule system
-    ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
-    SoLoader.init(this, /* native exopackage */ false);
-    // comment out initializeFlipper to keep test simpler
-    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-    ApplicationLifecycleDispatcher.onApplicationCreate(this);
-  }
-
-  @Override
-  public void onConfigurationChanged(Configuration newConfig) {
-    super.onConfigurationChanged(newConfig);
-    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig);
-  }
-}`;
     const contents = setModulesMainApplication(rawContents, 'java');
     expect(contents).toEqual(expectContents);
     // Try it twice...
@@ -140,110 +19,12 @@ public class MainApplication extends Application implements ReactApplication {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it('should able to update from react-native@<0.68.0 template', () => {
-    const rawContents = `
-package com.helloworld;
+  it('should able to update from react-native@<0.68.0 template', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn064.java'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn064-updated.java'), 'utf8'),
+    ]);
 
-import android.app.Application;
-import com.facebook.react.PackageList;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactPackage;
-import com.facebook.soloader.SoLoader;
-import java.util.List;
-
-public class MainApplication extends Application implements ReactApplication {
-
-  private final ReactNativeHost mReactNativeHost =
-      new ReactNativeHost(this) {
-        @Override
-        public boolean getUseDeveloperSupport() {
-          return BuildConfig.DEBUG;
-        }
-
-        @Override
-        protected List<ReactPackage> getPackages() {
-          @SuppressWarnings("UnnecessaryLocalVariable")
-          List<ReactPackage> packages = new PackageList(this).getPackages();
-          return packages;
-        }
-
-        @Override
-        protected String getJSMainModuleName() {
-          return "index";
-        }
-  };
-
-  @Override
-  public ReactNativeHost getReactNativeHost() {
-    return mReactNativeHost;
-  }
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    SoLoader.init(this, /* native exopackage */ false);
-    // comment out initializeFlipper to keep test simpler
-    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld;
-import android.content.res.Configuration;
-import expo.modules.ApplicationLifecycleDispatcher;
-import expo.modules.ReactNativeHostWrapper;
-
-import android.app.Application;
-import com.facebook.react.PackageList;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactPackage;
-import com.facebook.soloader.SoLoader;
-import java.util.List;
-
-public class MainApplication extends Application implements ReactApplication {
-
-  private final ReactNativeHost mReactNativeHost =
-      new ReactNativeHostWrapper(this, new ReactNativeHost(this) {
-        @Override
-        public boolean getUseDeveloperSupport() {
-          return BuildConfig.DEBUG;
-        }
-
-        @Override
-        protected List<ReactPackage> getPackages() {
-          @SuppressWarnings("UnnecessaryLocalVariable")
-          List<ReactPackage> packages = new PackageList(this).getPackages();
-          return packages;
-        }
-
-        @Override
-        protected String getJSMainModuleName() {
-          return "index";
-        }
-  });
-
-  @Override
-  public ReactNativeHost getReactNativeHost() {
-    return mReactNativeHost;
-  }
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    SoLoader.init(this, /* native exopackage */ false);
-    // comment out initializeFlipper to keep test simpler
-    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-    ApplicationLifecycleDispatcher.onApplicationCreate(this);
-  }
-
-  @Override
-  public void onConfigurationChanged(Configuration newConfig) {
-    super.onConfigurationChanged(newConfig);
-    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig);
-  }
-}`;
     const contents = setModulesMainApplication(rawContents, 'java');
     expect(contents).toEqual(expectContents);
     // Try it twice...
@@ -251,94 +32,12 @@ public class MainApplication extends Application implements ReactApplication {
     expect(nextContents).toEqual(expectContents);
   });
 
-  it('should support another manually modified kotlin version MainApplication', () => {
-    const rawContents = `
-package com.helloworld
+  it('should support another manually modified kotlin version MainApplication', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn064.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn064-updated.kt'), 'utf8'),
+    ]);
 
-import android.app.Application
-import android.content.res.Configuration;
-import com.facebook.react.PackageList
-import com.facebook.react.ReactApplication
-import com.facebook.react.ReactNativeHost
-import com.facebook.react.ReactPackage
-import com.facebook.soloader.SoLoader
-
-class MainApplication : Application(), ReactApplication {
-  private val mReactNativeHost: ReactNativeHost = object : ReactNativeHost(this) {
-    override fun getUseDeveloperSupport(): Boolean {
-      return BuildConfig.DEBUG
-    }
-
-    override fun getPackages(): List<ReactPackage> {
-      return PackageList(this).packages
-    }
-
-    override fun getJSMainModuleName(): String {
-      return "index"
-    }
-  }
-
-  override fun getReactNativeHost(): ReactNativeHost {
-    return mReactNativeHost
-  }
-
-  override fun onCreate() {
-    super.onCreate()
-    SoLoader.init(this,  /* native exopackage */ false)
-    // comment out initializeFlipper to keep test simpler
-    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-  }
-
-  override fun onConfigurationChanged(newConfig: Configuration) {
-    super.onConfigurationChanged(newConfig)
-  }
-}`;
-
-    const expectContents = `
-package com.helloworld
-import expo.modules.ApplicationLifecycleDispatcher
-import expo.modules.ReactNativeHostWrapper
-
-import android.app.Application
-import android.content.res.Configuration;
-import com.facebook.react.PackageList
-import com.facebook.react.ReactApplication
-import com.facebook.react.ReactNativeHost
-import com.facebook.react.ReactPackage
-import com.facebook.soloader.SoLoader
-
-class MainApplication : Application(), ReactApplication {
-  private val mReactNativeHost: ReactNativeHost = ReactNativeHostWrapper(this, object : ReactNativeHost(this) {
-    override fun getUseDeveloperSupport(): Boolean {
-      return BuildConfig.DEBUG
-    }
-
-    override fun getPackages(): List<ReactPackage> {
-      return PackageList(this).packages
-    }
-
-    override fun getJSMainModuleName(): String {
-      return "index"
-    }
-  })
-
-  override fun getReactNativeHost(): ReactNativeHost {
-    return mReactNativeHost
-  }
-
-  override fun onCreate() {
-    super.onCreate()
-    SoLoader.init(this,  /* native exopackage */ false)
-    // comment out initializeFlipper to keep test simpler
-    // initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-    ApplicationLifecycleDispatcher.onApplicationCreate(this)
-  }
-
-  override fun onConfigurationChanged(newConfig: Configuration) {
-    super.onConfigurationChanged(newConfig)
-    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
-  }
-}`;
     const contents = setModulesMainApplication(rawContents, 'kt');
     expect(contents).toEqual(expectContents);
     // Try it twice...

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn068-updated.mm
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn068-updated.mm
@@ -1,0 +1,109 @@
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+#import <React/RCTAppSetupUtils.h>
+
+#if RCT_NEW_ARCH_ENABLED
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTCxxBridgeDelegate.h>
+#import <React/RCTFabricSurfaceHostingProxyRootView.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+#import <react/config/ReactNativeConfig.h>
+
+@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
+  RCTTurboModuleManager *_turboModuleManager;
+  RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
+  std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
+  facebook::react::ContextContainer::Shared _contextContainer;
+}
+@end
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  RCTAppSetupPrepareApp(application);
+
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+
+#if RCT_NEW_ARCH_ENABLED
+  _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
+  _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+  _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
+  _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
+  bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
+#endif
+
+  UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"HelloWorld", nil);
+
+  if (@available(iOS 13.0, *)) {
+    rootView.backgroundColor = [UIColor systemBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+  return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+#if RCT_NEW_ARCH_ENABLED
+
+#pragma mark - RCTCxxBridgeDelegate
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                             delegate:self
+                                                            jsInvoker:bridge.jsCallInvoker];
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+}
+
+#pragma mark RCTTurboModuleManagerDelegate
+
+- (Class)getModuleClassFromName:(const char *)name
+{
+  return RCTCoreModulesClassProvider(name);
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  return nullptr;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:
+                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+}
+
+#endif
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn068.mm
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn068.mm
@@ -1,0 +1,108 @@
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+#import <React/RCTAppSetupUtils.h>
+
+#if RCT_NEW_ARCH_ENABLED
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTCxxBridgeDelegate.h>
+#import <React/RCTFabricSurfaceHostingProxyRootView.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+#import <react/config/ReactNativeConfig.h>
+
+@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
+  RCTTurboModuleManager *_turboModuleManager;
+  RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
+  std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
+  facebook::react::ContextContainer::Shared _contextContainer;
+}
+@end
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  RCTAppSetupPrepareApp(application);
+
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+
+#if RCT_NEW_ARCH_ENABLED
+  _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
+  _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+  _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
+  _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
+  bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
+#endif
+
+  UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"HelloWorld", nil);
+
+  if (@available(iOS 13.0, *)) {
+    rootView.backgroundColor = [UIColor systemBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+#if RCT_NEW_ARCH_ENABLED
+
+#pragma mark - RCTCxxBridgeDelegate
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                             delegate:self
+                                                            jsInvoker:bridge.jsCallInvoker];
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+}
+
+#pragma mark RCTTurboModuleManagerDelegate
+
+- (Class)getModuleClassFromName:(const char *)name
+{
+  return RCTCoreModulesClassProvider(name);
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  return nullptr;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:
+                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+}
+
+#endif
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-updated.h
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-updated.h
@@ -1,0 +1,9 @@
+#import <React/RCTBridgeDelegate.h>
+#import <Expo/Expo.h>
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate>
+
+@property (nonatomic, strong) UIWindow *window;
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-updated.m
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-updated.m
@@ -1,0 +1,40 @@
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#ifdef FB_SONARKIT_ENABLED
+  InitializeFlipper(application);
+#endif
+
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge
+                                               moduleName:@"RN0633"
+                                               initialProperties:nil];
+
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+  return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-updated.swift
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-updated.swift
@@ -1,0 +1,33 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: AppDelegateWrapper, RCTBridgeDelegate {
+  var window: UIWindow?
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    let bridge = reactDelegate.createBridge(delegate: self, launchOptions: launchOptions)!
+    let rootView = reactDelegate.createRootView(bridge: bridge, moduleName: "HelloWorld", initialProperties: nil)
+
+    if #available(iOS 13.0, *) {
+      rootView.backgroundColor = UIColor.systemBackground
+    } else {
+      rootView.backgroundColor = UIColor.white
+    }
+
+    self.window = UIWindow(frame: UIScreen.main.bounds);
+    let rootViewController = reactDelegate.createRootViewController()
+    rootViewController.view = rootView
+    self.window?.rootViewController = rootViewController
+    self.window?.makeKeyAndVisible()
+    super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    return true
+  }
+
+  func sourceURL(for bridge: RCTBridge!) -> URL! {
+    #if DEBUG
+    return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: "index", fallbackResource: nil)
+    #else
+    return Bundle.main.url(forResource: "main", withExtension: "jsBundle")
+    #endif
+  }
+}

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-updated
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-updated
@@ -1,0 +1,42 @@
+require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '10.0'
+
+target 'HelloWorld' do
+  use_expo_modules!
+  post_integrate do |installer|
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end
+  end
+  config = use_native_modules!
+
+  use_react_native!(:path => config["reactNativePath"])
+
+  target 'HelloWorldTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  # Enables Flipper.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work and
+  # you should disable these next few lines.
+  use_flipper!
+  post_install do |installer|
+    flipper_post_install(installer)
+  end
+end
+
+target 'HelloWorld-tvOS' do
+  # Pods for HelloWorld-tvOS
+
+  target 'HelloWorld-tvOSTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-with-post-integrate
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-with-post-integrate
@@ -1,0 +1,9 @@
+target 'HelloWorld' do
+  config = use_native_modules!
+
+  use_react_native!(:path => config["reactNativePath"])
+
+  post_integrate do |installer|
+    puts "Existing post_integrate hook"
+  end
+end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-with-post-integrate-updated
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-with-post-integrate-updated
@@ -1,0 +1,16 @@
+require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+target 'HelloWorld' do
+  use_expo_modules!
+  config = use_native_modules!
+
+  use_react_native!(:path => config["reactNativePath"])
+
+  post_integrate do |installer|
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end
+    puts "Existing post_integrate hook"
+  end
+end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
@@ -8,28 +8,14 @@ import {
   updateModulesAppDelegateSwift,
 } from '../withIosModulesAppDelegate';
 
+const fixturesPath = path.resolve(__dirname, 'fixtures');
+
 describe(updateModulesAppDelegateObjcHeader, () => {
-  it('should migrate from classic RN AppDelegate header', () => {
-    const rawContents = `
-#import <React/RCTBridgeDelegate.h>
-#import <UIKit/UIKit.h>
-
-@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
-
-@property (nonatomic, strong) UIWindow *window;
-
-@end`;
-
-    const expectContents = `
-#import <React/RCTBridgeDelegate.h>
-#import <Expo/Expo.h>
-#import <UIKit/UIKit.h>
-
-@interface AppDelegate : EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate>
-
-@property (nonatomic, strong) UIWindow *window;
-
-@end`;
+  it('should migrate from classic RN AppDelegate header', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate.h'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-updated.h'), 'utf8'),
+    ]);
 
     const sdkVersion = getLatestSdkVersion().expoSdkVersion;
     const contents = updateModulesAppDelegateObjcHeader(rawContents, sdkVersion);
@@ -41,89 +27,11 @@ describe(updateModulesAppDelegateObjcHeader, () => {
 });
 
 describe(updateModulesAppDelegateObjcImpl, () => {
-  it('should migrate from classic RN AppDelegate implementation', () => {
-    const rawContents = `
-#import "AppDelegate.h"
-
-#import <React/RCTBridge.h>
-#import <React/RCTBundleURLProvider.h>
-#import <React/RCTRootView.h>
-
-@implementation AppDelegate
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
-#ifdef FB_SONARKIT_ENABLED
-  InitializeFlipper(application);
-#endif
-
-  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                               moduleName:@"RN0633"
-                                               initialProperties:nil];
-
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
-
-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [UIViewController new];
-  rootViewController.view = rootView;
-  self.window.rootViewController = rootViewController;
-  [self.window makeKeyAndVisible];
-  return YES;
-}
-
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
-{
-#if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-#else
-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-#endif
-}
-
-@end`;
-
-    const expectContents = `
-#import "AppDelegate.h"
-
-#import <React/RCTBridge.h>
-#import <React/RCTBundleURLProvider.h>
-#import <React/RCTRootView.h>
-
-@implementation AppDelegate
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
-#ifdef FB_SONARKIT_ENABLED
-  InitializeFlipper(application);
-#endif
-
-  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
-  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge
-                                               moduleName:@"RN0633"
-                                               initialProperties:nil];
-
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
-
-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
-  rootViewController.view = rootView;
-  self.window.rootViewController = rootViewController;
-  [self.window makeKeyAndVisible];
-  [super application:application didFinishLaunchingWithOptions:launchOptions];
-  return YES;
-}
-
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
-{
-#if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-#else
-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-#endif
-}
-
-@end`;
+  it('should migrate from classic RN AppDelegate implementation', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate.m'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-updated.m'), 'utf8'),
+    ]);
 
     const sdkVersion = getLatestSdkVersion().expoSdkVersion;
     const contents = updateModulesAppDelegateObjcImpl(rawContents, sdkVersion);
@@ -135,96 +43,23 @@ describe(updateModulesAppDelegateObjcImpl, () => {
 });
 
 describe(updateModulesAppDelegateSwift, () => {
-  it('should migrate from basic RN AppDelegate.swift', () => {
-    const contents = `
-import UIKit
-
-@UIApplicationMain
-class AppDelegate: NSObject, UIApplicationDelegate, RCTBridgeDelegate {
-  var window: UIWindow?
-
-  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    let bridge = RCTBridge(delegate: self, launchOptions: launchOptions)!
-    let rootView = RCTRootView(bridge: bridge, moduleName: "HelloWorld", initialProperties: nil)
-
-    if #available(iOS 13.0, *) {
-      rootView.backgroundColor = UIColor.systemBackground
-    } else {
-      rootView.backgroundColor = UIColor.white
-    }
-
-    self.window = UIWindow(frame: UIScreen.main.bounds);
-    let rootViewController = UIViewController()
-    rootViewController.view = rootView
-    self.window?.rootViewController = rootViewController
-    self.window?.makeKeyAndVisible()
-    return true
-  }
-
-  func sourceURL(for bridge: RCTBridge!) -> URL! {
-    #if DEBUG
-    return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: "index", fallbackResource: nil)
-    #else
-    return Bundle.main.url(forResource: "main", withExtension: "jsBundle")
-    #endif
-  }
-}
-`;
-
-    const expectContents = `
-import UIKit
-
-@UIApplicationMain
-class AppDelegate: AppDelegateWrapper, RCTBridgeDelegate {
-  var window: UIWindow?
-
-  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    let bridge = reactDelegate.createBridge(delegate: self, launchOptions: launchOptions)!
-    let rootView = reactDelegate.createRootView(bridge: bridge, moduleName: "HelloWorld", initialProperties: nil)
-
-    if #available(iOS 13.0, *) {
-      rootView.backgroundColor = UIColor.systemBackground
-    } else {
-      rootView.backgroundColor = UIColor.white
-    }
-
-    self.window = UIWindow(frame: UIScreen.main.bounds);
-    let rootViewController = reactDelegate.createRootViewController()
-    rootViewController.view = rootView
-    self.window?.rootViewController = rootViewController
-    self.window?.makeKeyAndVisible()
-    super.application(application, didFinishLaunchingWithOptions: launchOptions)
-    return true
-  }
-
-  func sourceURL(for bridge: RCTBridge!) -> URL! {
-    #if DEBUG
-    return RCTBundleURLProvider.sharedSettings()?.jsBundleURL(forBundleRoot: "index", fallbackResource: nil)
-    #else
-    return Bundle.main.url(forResource: "main", withExtension: "jsBundle")
-    #endif
-  }
-}
-`;
+  it('should migrate from basic RN AppDelegate.swift', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate.swift'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-updated.swift'), 'utf8'),
+    ]);
 
     const sdkVersion = getLatestSdkVersion().expoSdkVersion;
-    expect(updateModulesAppDelegateSwift(contents, sdkVersion)).toEqual(expectContents);
+    expect(updateModulesAppDelegateSwift(rawContents, sdkVersion)).toEqual(expectContents);
   });
 });
 
 describe('withIosModulesAppDelegate sdkVersion snapshots', () => {
-  const objcHeaderFixture = fs.readFileSync(
-    path.join(__dirname, 'fixtures', 'AppDelegate.h'),
-    'utf-8'
-  );
-  const objcImplFixture = fs.readFileSync(
-    path.join(__dirname, 'fixtures', 'AppDelegate.m'),
-    'utf-8'
-  );
-  const swiftFixture = fs.readFileSync(
-    path.join(__dirname, 'fixtures', 'AppDelegate.swift'),
-    'utf-8'
-  );
+  const [objcHeaderFixture, objcImplFixture, swiftFixture] = [
+    fs.readFileSync(path.join(fixturesPath, 'AppDelegate.h'), 'utf8'),
+    fs.readFileSync(path.join(fixturesPath, 'AppDelegate.m'), 'utf8'),
+    fs.readFileSync(path.join(fixturesPath, 'AppDelegate.swift'), 'utf8'),
+  ];
 
   ['43.0.0', '44.0.0'].forEach(sdkVersion => {
     it(`sdkVersion ${sdkVersion}`, () => {

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { getDefaultVersion } from '../../../utils/expoVersionMappings';
+import { getLatestSdkVersion } from '../../../utils/expoVersionMappings';
 import {
   updateModulesAppDelegateObjcHeader,
   updateModulesAppDelegateObjcImpl,
@@ -31,15 +31,12 @@ describe(updateModulesAppDelegateObjcHeader, () => {
 
 @end`;
 
-    const contents = updateModulesAppDelegateObjcHeader(rawContents, getDefaultVersion());
-    expect(updateModulesAppDelegateObjcHeader(contents, getDefaultVersion())).toEqual(
-      expectContents
-    );
+    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const contents = updateModulesAppDelegateObjcHeader(rawContents, sdkVersion);
+    expect(updateModulesAppDelegateObjcHeader(contents, sdkVersion)).toEqual(expectContents);
     // Try it twice...
-    const nextContents = updateModulesAppDelegateObjcHeader(contents, getDefaultVersion());
-    expect(updateModulesAppDelegateObjcHeader(nextContents, getDefaultVersion())).toEqual(
-      expectContents
-    );
+    const nextContents = updateModulesAppDelegateObjcHeader(contents, sdkVersion);
+    expect(updateModulesAppDelegateObjcHeader(nextContents, sdkVersion)).toEqual(expectContents);
   });
 });
 
@@ -128,10 +125,11 @@ describe(updateModulesAppDelegateObjcImpl, () => {
 
 @end`;
 
-    const contents = updateModulesAppDelegateObjcImpl(rawContents, getDefaultVersion());
+    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const contents = updateModulesAppDelegateObjcImpl(rawContents, sdkVersion);
     expect(contents).toEqual(expectContents);
     // Try it twice...
-    const nextContents = updateModulesAppDelegateObjcImpl(contents, getDefaultVersion());
+    const nextContents = updateModulesAppDelegateObjcImpl(contents, sdkVersion);
     expect(nextContents).toEqual(expectContents);
   });
 });
@@ -209,7 +207,8 @@ class AppDelegate: AppDelegateWrapper, RCTBridgeDelegate {
 }
 `;
 
-    expect(updateModulesAppDelegateSwift(contents, getDefaultVersion())).toEqual(expectContents);
+    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    expect(updateModulesAppDelegateSwift(contents, sdkVersion)).toEqual(expectContents);
   });
 });
 

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
@@ -27,7 +27,21 @@ describe(updateModulesAppDelegateObjcHeader, () => {
 });
 
 describe(updateModulesAppDelegateObjcImpl, () => {
-  it('should migrate from classic RN AppDelegate implementation', async () => {
+  it('should migrate from classic react-native@>=0.68.0 AppDelegate.mm implementation', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn068.mm'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn068-updated.mm'), 'utf8'),
+    ]);
+
+    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const contents = updateModulesAppDelegateObjcImpl(rawContents, sdkVersion);
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = updateModulesAppDelegateObjcImpl(contents, sdkVersion);
+    expect(nextContents).toEqual(expectContents);
+  });
+
+  it('should migrate from classic react-native@<0.68.0 AppDelegate.m implementation', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate.m'), 'utf8'),
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-updated.m'), 'utf8'),

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { getDefaultVersion } from '../../../utils/expoVersionMappings';
+import { getLatestSdkVersion } from '../../../utils/expoVersionMappings';
 import { updatePodfile } from '../withIosModulesPodfile';
 
 describe(updatePodfile, () => {
@@ -87,7 +87,8 @@ target 'HelloWorld-tvOS' do
 end
 `;
 
-    expect(updatePodfile(contents, 'HelloWorld', getDefaultVersion())).toEqual(expectContents);
+    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    expect(updatePodfile(contents, 'HelloWorld', sdkVersion)).toEqual(expectContents);
   });
 
   it('minimum support for existing post_integrate hook', () => {
@@ -122,7 +123,8 @@ target 'HelloWorld' do
 end
 `;
 
-    expect(updatePodfile(contents, 'HelloWorld', getDefaultVersion())).toEqual(expectContents);
+    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    expect(updatePodfile(contents, 'HelloWorld', sdkVersion)).toEqual(expectContents);
   });
 });
 

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
@@ -4,127 +4,27 @@ import path from 'path';
 import { getLatestSdkVersion } from '../../../utils/expoVersionMappings';
 import { updatePodfile } from '../withIosModulesPodfile';
 
+const fixturesPath = path.resolve(__dirname, 'fixtures');
+
 describe(updatePodfile, () => {
-  it('should support classic rn podfile', () => {
-    const contents = `\
-require_relative '../node_modules/react-native/scripts/react_native_pods'
-require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
-
-platform :ios, '10.0'
-
-target 'HelloWorld' do
-  config = use_native_modules!
-
-  use_react_native!(:path => config["reactNativePath"])
-
-  target 'HelloWorldTests' do
-    inherit! :complete
-    # Pods for testing
-  end
-
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable these next few lines.
-  use_flipper!
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
-end
-
-target 'HelloWorld-tvOS' do
-  # Pods for HelloWorld-tvOS
-
-  target 'HelloWorld-tvOSTests' do
-    inherit! :search_paths
-    # Pods for testing
-  end
-end
-`;
-
-    const expectContents = `\
-require File.join(File.dirname(\`node --print "require.resolve('expo/package.json')"\`), "scripts/autolinking")
-require_relative '../node_modules/react-native/scripts/react_native_pods'
-require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
-
-platform :ios, '10.0'
-
-target 'HelloWorld' do
-  use_expo_modules!
-  post_integrate do |installer|
-    begin
-      expo_patch_react_imports!(installer)
-    rescue => e
-      Pod::UI.warn e
-    end
-  end
-  config = use_native_modules!
-
-  use_react_native!(:path => config["reactNativePath"])
-
-  target 'HelloWorldTests' do
-    inherit! :complete
-    # Pods for testing
-  end
-
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable these next few lines.
-  use_flipper!
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
-end
-
-target 'HelloWorld-tvOS' do
-  # Pods for HelloWorld-tvOS
-
-  target 'HelloWorld-tvOSTests' do
-    inherit! :search_paths
-    # Pods for testing
-  end
-end
-`;
+  it('should support classic rn podfile', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'Podfile'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'Podfile-updated'), 'utf8'),
+    ]);
 
     const sdkVersion = getLatestSdkVersion().expoSdkVersion;
-    expect(updatePodfile(contents, 'HelloWorld', sdkVersion)).toEqual(expectContents);
+    expect(updatePodfile(rawContents, 'HelloWorld', sdkVersion)).toEqual(expectContents);
   });
 
-  it('minimum support for existing post_integrate hook', () => {
-    const contents = `\
-target 'HelloWorld' do
-  config = use_native_modules!
-
-  use_react_native!(:path => config["reactNativePath"])
-
-  post_integrate do |installer|
-    puts "Existing post_integrate hook"
-  end
-end
-`;
-
-    const expectContents = `\
-require File.join(File.dirname(\`node --print "require.resolve('expo/package.json')"\`), "scripts/autolinking")
-target 'HelloWorld' do
-  use_expo_modules!
-  config = use_native_modules!
-
-  use_react_native!(:path => config["reactNativePath"])
-
-  post_integrate do |installer|
-    begin
-      expo_patch_react_imports!(installer)
-    rescue => e
-      Pod::UI.warn e
-    end
-    puts "Existing post_integrate hook"
-  end
-end
-`;
+  it('minimum support for existing post_integrate hook', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'Podfile-with-post-integrate'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'Podfile-with-post-integrate-updated'), 'utf8'),
+    ]);
 
     const sdkVersion = getLatestSdkVersion().expoSdkVersion;
-    expect(updatePodfile(contents, 'HelloWorld', sdkVersion)).toEqual(expectContents);
+    expect(updatePodfile(rawContents, 'HelloWorld', sdkVersion)).toEqual(expectContents);
   });
 });
 

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
@@ -16,10 +16,9 @@ import xcode from 'xcode';
 
 export const withIosModulesAppDelegate: ConfigPlugin = config => {
   return withAppDelegate(config, config => {
-    config.modResults.contents =
-      config.modResults.language === 'objc'
-        ? updateModulesAppDelegateObjcImpl(config.modResults.contents, config.sdkVersion)
-        : updateModulesAppDelegateSwift(config.modResults.contents, config.sdkVersion);
+    config.modResults.contents = ['objc', 'objcpp'].includes(config.modResults.language)
+      ? updateModulesAppDelegateObjcImpl(config.modResults.contents, config.sdkVersion)
+      : updateModulesAppDelegateSwift(config.modResults.contents, config.sdkVersion);
     return config;
   });
 };

--- a/packages/install-expo-modules/src/utils/__tests__/expoVersionMappings-test.ts
+++ b/packages/install-expo-modules/src/utils/__tests__/expoVersionMappings-test.ts
@@ -1,0 +1,32 @@
+import resolveFrom from 'resolve-from';
+
+import { getDefaultSdkVersion } from '../expoVersionMappings';
+
+jest.mock('resolve-from');
+
+describe(getDefaultSdkVersion, () => {
+  function setupReactNativeVersionMock(version: string) {
+    const mockResolve = resolveFrom.silent as jest.MockedFunction<typeof resolveFrom.silent>;
+    mockResolve.mockReturnValueOnce('fs');
+    jest.doMock('fs', () => ({ version }));
+  }
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('should resolve as sdk 45 from react-native 0.68 project', async () => {
+    setupReactNativeVersionMock('0.68.0');
+    expect(getDefaultSdkVersion('/projectRoot').expoSdkVersion).toBe('45.0.0');
+  });
+
+  it('should resolve as sdk 45 from react-native 0.65 project', async () => {
+    setupReactNativeVersionMock('0.65.0');
+    expect(getDefaultSdkVersion('/projectRoot').expoSdkVersion).toBe('45.0.0');
+  });
+
+  it('should resolve as sdk 44 from react-native 0.64 project', async () => {
+    setupReactNativeVersionMock('0.64.3');
+    expect(getDefaultSdkVersion('/projectRoot').expoSdkVersion).toBe('44.0.0');
+  });
+});

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -1,26 +1,52 @@
-interface VersionInfo {
+import resolveFrom from 'resolve-from';
+import semver from 'semver';
+
+export interface VersionInfo {
+  expoSdkVersion: string;
   iosDeploymentTarget: string;
+  reactNativeVersionRange: string;
 }
 
-const DEFAULT_VERSION = '44.0.0';
-
-export const ExpoVersionMappings: Record<string, VersionInfo> = {
-  '44.0.0': {
+export const ExpoVersionMappings: VersionInfo[] = [
+  // Please keep sdk versions in sorted order (latest sdk first)
+  {
+    expoSdkVersion: '45.0.0',
     iosDeploymentTarget: '12.0',
+    reactNativeVersionRange: '>= 0.65.0',
   },
-  '43.0.0': {
+  {
+    expoSdkVersion: '44.0.0',
     iosDeploymentTarget: '12.0',
+    reactNativeVersionRange: '< 0.68.0',
   },
-};
+  {
+    expoSdkVersion: '43.0.0',
+    iosDeploymentTarget: '12.0',
+    reactNativeVersionRange: '< 0.68.0',
+  },
+];
 
-export function getDefaultVersion(): string {
-  return DEFAULT_VERSION;
+export function getDefaultSdkVersion(projectRoot: string): VersionInfo {
+  const reactNativePackageJsonPath = resolveFrom.silent(projectRoot, 'react-native/package.json');
+  if (!reactNativePackageJsonPath) {
+    throw new Error(`Unable to find react-native package - projectRoot[${projectRoot}]`);
+  }
+  const reactNativeVersion = require(reactNativePackageJsonPath).version;
+  const versionInfo = ExpoVersionMappings.find(info =>
+    semver.satisfies(reactNativeVersion, info.reactNativeVersionRange)
+  );
+  if (!versionInfo) {
+    throw new Error(
+      `Unable to find compatible expo sdk version - reactNativeVersion[${reactNativeVersion}]`
+    );
+  }
+  return versionInfo;
 }
 
-export function isSupportedVersion(version: string): boolean {
-  return !!ExpoVersionMappings[version];
+export function getLatestSdkVersion(): VersionInfo {
+  return ExpoVersionMappings[0];
 }
 
-export function getIosDeploymentTarget(version: string): string {
-  return ExpoVersionMappings[version]?.iosDeploymentTarget;
+export function getVersionInfo(sdkVersion: string): VersionInfo | null {
+  return ExpoVersionMappings.find(info => info.expoSdkVersion === sdkVersion) ?? null;
 }

--- a/packages/install-expo-modules/src/utils/packageInstaller.ts
+++ b/packages/install-expo-modules/src/utils/packageInstaller.ts
@@ -1,0 +1,51 @@
+import * as PackageManager from '@expo/package-manager';
+import path from 'path';
+import semver from 'semver';
+
+/**
+ * Install a node package non-interactively
+ *
+ * @param projectRoot target project root folder
+ * @param pkg package name
+ */
+function installPackageNonInteractiveAsync(projectRoot: string, pkg: string) {
+  const isYarn = PackageManager.isUsingYarn(projectRoot);
+  const packageManager = PackageManager.createForProject(projectRoot);
+  if (isYarn) {
+    return packageManager.addWithParametersAsync([pkg], ['--non-interactive']);
+  } else {
+    return packageManager.addAsync(pkg);
+  }
+}
+
+/**
+ * Install the `expo` package
+ *
+ * @param projectRoot target project root folder
+ * @param sdkVersion expo sdk version
+ */
+export async function installExpoPackageAsync(projectRoot: string, sdkVersion: string) {
+  try {
+    // First try to install from released versions, e.g. `expo@^45.0.0`
+    await installPackageNonInteractiveAsync(projectRoot, `expo@^${sdkVersion}`);
+  } catch {
+    // Fallback to install from prerelease versions,
+    // e.g. `expo@>=45.0.0-0 <46.0.0`, this will cover prerelease version for beta testing.
+    await installPackageNonInteractiveAsync(
+      projectRoot,
+      `expo@>=${sdkVersion}-0 <${semver.inc(sdkVersion, 'major')}`
+    );
+  }
+}
+
+/**
+ * Running `pod install` for the target project
+ *
+ * @param projectRoot target project root folder
+ */
+export async function installPodsAsync(projectRoot: string) {
+  const podPackageManager = new PackageManager.CocoaPodsPackageManager({
+    cwd: path.join(projectRoot, 'ios'),
+  });
+  await podPackageManager.installAsync();
+}


### PR DESCRIPTION
# Why

close ENG-4618

# How

- install expo sdk based on target project's react-native version
- will try to install `expo@^45.0.0` first and fallback to install `expo@>=45.0.0-0 <46.0.0` for prerelease version
- add react-native 0.68 template support

# Test Plan

#### Unit Test

```
 PASS   install-expo-modules  src/utils/__tests__/expoVersionMappings-test.ts
  getDefaultSdkVersion
    ✓ should resolve as sdk 45 from react-native 0.68 project (16 ms)
    ✓ should resolve as sdk 45 from react-native 0.65 project (1 ms)
    ✓ should resolve as sdk 44 from react-native 0.64 project

 PASS   install-expo-modules  src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
  setModulesMainApplication
    ✓ should able to update from react-native@>=0.68.0 template (2 ms)

 PASS   install-expo-modules  src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
  setModulesMainActivity
    ✓ should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - java (1 ms)
    ✓ should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - kotlin (1 ms)
```

#### Integration Test

```sh
$ npx react-native init RN068 --version 0.68
$ npx install-expo-modules

$ expo run:android

$ expo run:ios

$ export ORG_GRADLE_PROJECT_newArchEnabled=true ; expo run:android

$ cd ios; rm -rf Pods build; RCT_NEW_ARCH_ENABLED=1 pod install
$ expo run:ios
```