### PR TITLE
[config-plugins] Handle quoted build configuration

### DIFF
--- a/packages/config-plugins/src/ios/ProvisioningProfile.ts
+++ b/packages/config-plugins/src/ios/ProvisioningProfile.ts
@@ -9,6 +9,7 @@ import {
   isNotComment,
   ProjectSectionEntry,
 } from './utils/Xcodeproj';
+import { trimQuotes } from './utils/string';
 
 type ProvisioningProfileSettings = {
   targetName?: string;
@@ -36,7 +37,7 @@ export function setProvisioningProfileForPbxproj(
   const quotedAppleTeamId = ensureQuotes(appleTeamId);
 
   getBuildConfigurationsForListId(project, nativeTarget.buildConfigurationList)
-    .filter(([, item]: ConfigurationSectionEntry) => item.name === buildConfiguration)
+    .filter(([, item]: ConfigurationSectionEntry) => trimQuotes(item.name) === buildConfiguration)
     .forEach(([, item]: ConfigurationSectionEntry) => {
       item.buildSettings.PROVISIONING_PROFILE_SPECIFIER = `"${profileName}"`;
       item.buildSettings.DEVELOPMENT_TEAM = quotedAppleTeamId;

--- a/packages/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -16,6 +16,7 @@ import pbxFile from 'xcode/lib/pbxFile';
 
 import { addWarningIOS } from '../../utils/warnings';
 import * as Paths from '../Paths';
+import { trimQuotes } from './string';
 
 export type ProjectSectionEntry = [string, PBXProject];
 
@@ -390,7 +391,7 @@ export function getBuildConfigurationForListIdAndName(
   const xcBuildConfigurationEntry = getBuildConfigurationsForListId(
     project,
     configurationListId
-  ).find(i => i[1].name === buildConfiguration);
+  ).find(i => trimQuotes(i[1].name) === buildConfiguration);
   if (!xcBuildConfigurationEntry) {
     throw new Error(
       `Build configuration '${buildConfiguration}' does not exist in list with id '${configurationListId}'`


### PR DESCRIPTION
# Why

If someone creates build configuration with space the middle e.g. `Release production` value in pbxproj will be in quotes which is not handled correctly in util functions that search for build configuration by name

# How

trim quotes when comparing

# Test Plan

- reproduce the issue described above (`eas build` fails with ` Error: Build configuration 'Release' does not exist in list with id '13B07F931A680F5B00A75B9A'`)
- yarn link config-plugins with above changes to eas-cli
- run build on eas (build works)