### PR TITLE
[expo-cli] warn for outdated `@expo/config-plugins` in deps' deps

### DIFF
--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -46,7 +46,11 @@ export async function validateDependenciesVersionsAsync(
   // find incorrect dependencies by comparing the actual package versions with the bundled native module version ranges
   const incorrectDeps = findIncorrectDependencies(packageVersions, bundledNativeModules);
 
+  let issuesFound = false;
+
   if (incorrectDeps.length > 0) {
+    issuesFound = true;
+
     Log.warn('Some dependencies are incompatible with the installed expo package version:');
     incorrectDeps.forEach(({ packageName, expectedVersionOrRange, actualVersion }) => {
       Log.warn(
@@ -71,10 +75,39 @@ export async function validateDependenciesVersionsAsync(
           )}`
       );
     }
-
-    return false;
   }
-  return true;
+
+  if (Versions.gteSdkVersion(exp, '45.0.0')) {
+    try {
+      /* This will throw if the dependency looked for is not installed,
+       * but that doesn't apply here, so that error is ignored */
+      const packageVersionConfigPlugins = await resolvePackageVersionsAsync(projectRoot, [
+        '@expo/config-plugins',
+      ]);
+      if ('@expo/config-plugins' in packageVersionConfigPlugins) {
+        if (!semver.intersects('^4.1.0', packageVersionConfigPlugins['@expo/config-plugins'])) {
+          if (issuesFound) {
+            Log.addNewLineIfNone();
+          }
+          issuesFound = true;
+          Log.warn(`One or more dependencies reference an incompatible version of ${chalk.underline(
+            '@expo/config-plugins'
+          )}.
+- expected version: ${chalk.underline('^4.1.0')} - actual version installed: ${chalk.underline(
+            packageVersionConfigPlugins['@expo/config-plugins']
+          )}'`);
+          Log.warn(`To find out which dependency references ${chalk.underline(
+            '@expo/config-plugins'
+          )},
+run ${chalk.inverse(`yarn why @expo/config-plugins`)} or ${chalk.inverse(
+            `npm why @expo/config-plugins`
+          )}`);
+        }
+      }
+    } catch {}
+  }
+
+  return !issuesFound;
 }
 
 function getPackagesToCheck(

--- a/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
+++ b/packages/expo-cli/src/commands/utils/validateDependenciesVersions.ts
@@ -77,7 +77,7 @@ export async function validateDependenciesVersionsAsync(
     }
   }
 
-  if (Versions.gteSdkVersion(exp, '45.0.0')) {
+  if (Versions.gteSdkVersion(exp, '45.0.0') && !Versions.gteSdkVersion(exp, '46.0.0')) {
     try {
       /* This will throw if the dependency looked for is not installed,
        * but that doesn't apply here, so that error is ignored */


### PR DESCRIPTION
# Why

SDK 45 needs @expo/config-plugins@^4.1.0. Because the error when using older version is quite cryptic, an explicit warning is added to `expo doctor`

# How

The required version is hardcoded for now. The warning doesn't show which packages actually use which versions (like npm/yarn why) because that test is complex.

# Test Plan

Tested manually.
Combined output:
![WindowsTerminal_HjvllCM3Gy](https://user-images.githubusercontent.com/852069/167044738-8e1843c1-8ea5-4d74-ba7f-568989187d5d.png)
Solo output:
![WindowsTerminal_TWw0XQJ5W2](https://user-images.githubusercontent.com/852069/167044741-45f82c08-b529-42df-a610-ab603cdbf2c2.png)

