### PR TITLE
[package-manager] Separate and test yarn and npm package managers

### DIFF
--- a/packages/package-manager/src/NodePackageManagers.ts
+++ b/packages/package-manager/src/NodePackageManagers.ts
@@ -1,14 +1,8 @@
-import JsonFile from '@expo/json-file';
-import spawnAsync, { SpawnOptions } from '@expo/spawn-async';
-import ansiRegex from 'ansi-regex';
 import { existsSync } from 'fs';
-import npmPackageArg from 'npm-package-arg';
 import path from 'path';
-import rimraf from 'rimraf';
-import split from 'split';
-import { Transform } from 'stream';
 
-import { Logger, PackageManager } from './PackageManager';
+import { NpmPackageManager } from './NpmPackageManager';
+import { Logger } from './PackageManager';
 import { PnpmPackageManager } from './PnpmPackageManager';
 import { YarnPackageManager } from './YarnPackageManager';
 import { findWorkspaceRoot, resolvePackageManager } from './utils/nodeWorkspaces';
@@ -21,12 +15,6 @@ export type NodePackageManager = 'yarn' | 'npm' | 'pnpm';
  */
 export const DISABLE_ADS_ENV = { DISABLE_OPENCOLLECTIVE: '1', ADBLOCK: '1' };
 
-const ansi = `(?:${ansiRegex().source})*`;
-const npmPeerDependencyWarningPattern = new RegExp(
-  `${ansi}npm${ansi} ${ansi}WARN${ansi}.+You must install peer dependencies yourself\\.\n`,
-  'g'
-);
-
 /**
  * Returns true if the project is using yarn, false if the project is using npm.
  *
@@ -38,169 +26,6 @@ export function isUsingYarn(projectRoot: string): boolean {
     return existsSync(path.join(workspaceRoot, 'yarn.lock'));
   }
   return existsSync(path.join(projectRoot, 'yarn.lock'));
-}
-
-class NpmStderrTransform extends Transform {
-  _transform(
-    chunk: Buffer,
-    encoding: string,
-    callback: (error?: Error | null, data?: any) => void
-  ) {
-    this.push(chunk.toString().replace(npmPeerDependencyWarningPattern, ''));
-    callback();
-  }
-}
-
-export class NpmPackageManager implements PackageManager {
-  options: SpawnOptions;
-
-  private log: Logger;
-
-  constructor({ cwd, log, silent }: { cwd: string; log?: Logger; silent?: boolean }) {
-    this.log = log || console.log;
-    this.options = {
-      env: {
-        ...process.env,
-        ...DISABLE_ADS_ENV,
-      },
-      cwd,
-      ...(silent
-        ? { ignoreStdio: true }
-        : {
-            stdio: ['inherit', 'inherit', 'pipe'],
-          }),
-    };
-  }
-
-  get name() {
-    return 'npm';
-  }
-
-  async installAsync(parameters: string[] = []) {
-    await this._runAsync(['install', ...parameters]);
-  }
-
-  async addGlobalAsync(...names: string[]) {
-    if (!names.length) return this.installAsync();
-    await this._runAsync(['install', '--global', ...names]);
-  }
-
-  async addWithParametersAsync(names: string[], parameters: string[] = []) {
-    if (!names.length) return this.installAsync(parameters);
-
-    const { versioned, unversioned } = this._parseSpecs(names);
-    if (versioned.length) {
-      await this._patchAsync(versioned, 'dependencies');
-      await this.installAsync(parameters);
-    }
-    if (unversioned.length) {
-      await this._runAsync([
-        'install',
-        '--save',
-        ...unversioned.map(spec => spec.raw),
-        ...parameters,
-      ]);
-    }
-  }
-
-  async addAsync(...names: string[]) {
-    await this.addWithParametersAsync(names, []);
-  }
-
-  async addDevAsync(...names: string[]) {
-    if (!names.length) return this.installAsync();
-
-    const { versioned, unversioned } = this._parseSpecs(names);
-    if (versioned.length) {
-      await this._patchAsync(versioned, 'devDependencies');
-      await this._runAsync(['install']);
-    }
-    if (unversioned.length) {
-      await this._runAsync(['install', '--save-dev', ...unversioned.map(spec => spec.raw)]);
-    }
-  }
-
-  async removeAsync(...names: string[]) {
-    await this._runAsync(['uninstall', ...names]);
-  }
-
-  async versionAsync() {
-    const { stdout } = await spawnAsync('npm', ['--version'], { stdio: 'pipe' });
-    return stdout.trim();
-  }
-
-  async getConfigAsync(key: string) {
-    const { stdout } = await spawnAsync('npm', ['config', 'get', key], { stdio: 'pipe' });
-    return stdout.trim();
-  }
-
-  async removeLockfileAsync() {
-    if (!this.options.cwd) {
-      throw new Error('cwd required for NpmPackageManager.removeLockfileAsync');
-    }
-    const lockfilePath = path.join(this.options.cwd, 'package-lock.json');
-    if (existsSync(lockfilePath)) {
-      rimraf.sync(lockfilePath);
-    }
-  }
-
-  async cleanAsync() {
-    if (!this.options.cwd) {
-      throw new Error('cwd required for NpmPackageManager.cleanAsync');
-    }
-    const nodeModulesPath = path.join(this.options.cwd, 'node_modules');
-    if (existsSync(nodeModulesPath)) {
-      rimraf.sync(nodeModulesPath);
-    }
-  }
-
-  // Private
-  private async _runAsync(args: string[]) {
-    if (!this.options.ignoreStdio) {
-      this.log(`> npm ${args.join(' ')}`);
-    }
-
-    // Have spawnAsync consume stdio but we don't actually do anything with it if it's ignored
-    const promise = spawnAsync('npm', [...args], { ...this.options, ignoreStdio: false });
-    if (promise.child.stderr && !this.options.ignoreStdio) {
-      promise.child.stderr
-        .pipe(split(/\r?\n/, (line: string) => line + '\n'))
-        .pipe(new NpmStderrTransform())
-        .pipe(process.stderr);
-    }
-    return promise;
-  }
-
-  private _parseSpecs(names: string[]) {
-    const result: {
-      versioned: npmPackageArg.Result[];
-      unversioned: npmPackageArg.Result[];
-    } = { versioned: [], unversioned: [] };
-    names
-      .map(name => npmPackageArg(name))
-      .forEach(spec => {
-        if (spec.rawSpec) {
-          result.versioned.push(spec);
-        } else {
-          result.unversioned.push(spec);
-        }
-      });
-    return result;
-  }
-
-  private async _patchAsync(
-    specs: npmPackageArg.Result[],
-    packageType: 'dependencies' | 'devDependencies'
-  ) {
-    const pkgPath = path.join(this.options.cwd || '.', 'package.json');
-    const pkg = await JsonFile.readAsync(pkgPath);
-    specs.forEach(spec => {
-      pkg[packageType] = pkg[packageType] || {};
-      // @ts-ignore
-      pkg[packageType][spec.name!] = spec.rawSpec;
-    });
-    await JsonFile.writeAsync(pkgPath, pkg, { json5: false });
-  }
 }
 
 export type CreateForProjectOptions = Partial<Record<NodePackageManager, boolean>> & {

--- a/packages/package-manager/src/NpmPackageManager.ts
+++ b/packages/package-manager/src/NpmPackageManager.ts
@@ -1,0 +1,179 @@
+import JsonFile from '@expo/json-file';
+import spawnAsync, { SpawnOptions } from '@expo/spawn-async';
+import ansiRegex from 'ansi-regex';
+import assert from 'assert';
+import fs from 'fs';
+import npmPackageArg from 'npm-package-arg';
+import path from 'path';
+import rimraf from 'rimraf';
+import split from 'split';
+import { Transform } from 'stream';
+
+import { DISABLE_ADS_ENV } from './NodePackageManagers';
+import { Logger, PackageManager } from './PackageManager';
+
+const ansi = `(?:${ansiRegex().source})*`;
+const npmPeerDependencyWarningPattern = new RegExp(
+  `${ansi}npm${ansi} ${ansi}WARN${ansi}.+You must install peer dependencies yourself\\.\n`,
+  'g'
+);
+
+/** Exposed for testing */
+export class NpmStderrTransform extends Transform {
+  _transform(
+    chunk: Buffer,
+    encoding: string,
+    callback: (error?: Error | null, data?: any) => void
+  ) {
+    this.push(chunk.toString().replace(npmPeerDependencyWarningPattern, ''));
+    callback();
+  }
+}
+
+export class NpmPackageManager implements PackageManager {
+  options: SpawnOptions;
+
+  private log: Logger;
+
+  constructor({ cwd, log, silent }: { cwd: string; log?: Logger; silent?: boolean }) {
+    this.log = log || console.log;
+    this.options = {
+      env: {
+        ...process.env,
+        ...DISABLE_ADS_ENV,
+      },
+      cwd,
+      ...(silent
+        ? { ignoreStdio: true }
+        : {
+            stdio: ['inherit', 'inherit', 'pipe'],
+          }),
+    };
+  }
+
+  get name() {
+    return 'npm';
+  }
+
+  async installAsync(parameters: string[] = []) {
+    await this._runAsync(['install', ...parameters]);
+  }
+
+  async addGlobalAsync(...names: string[]) {
+    if (!names.length) return this.installAsync();
+    await this._runAsync(['install', '--global', ...names]);
+  }
+
+  async addWithParametersAsync(names: string[], parameters: string[] = []) {
+    if (!names.length) return this.installAsync(parameters);
+
+    const { versioned, unversioned } = this._parseSpecs(names);
+    if (versioned.length) {
+      await this._patchAsync(versioned, 'dependencies');
+      await this.installAsync(parameters);
+    }
+    if (unversioned.length) {
+      await this._runAsync([
+        'install',
+        '--save',
+        ...unversioned.map(spec => spec.raw),
+        ...parameters,
+      ]);
+    }
+  }
+
+  async addAsync(...names: string[]) {
+    await this.addWithParametersAsync(names, []);
+  }
+
+  async addDevAsync(...names: string[]) {
+    if (!names.length) return this.installAsync();
+
+    const { versioned, unversioned } = this._parseSpecs(names);
+    if (versioned.length) {
+      await this._patchAsync(versioned, 'devDependencies');
+      await this._runAsync(['install']);
+    }
+    if (unversioned.length) {
+      await this._runAsync(['install', '--save-dev', ...unversioned.map(spec => spec.raw)]);
+    }
+  }
+
+  async removeAsync(...names: string[]) {
+    await this._runAsync(['uninstall', ...names]);
+  }
+
+  async versionAsync() {
+    const { stdout } = await spawnAsync('npm', ['--version'], { stdio: 'pipe' });
+    return stdout.trim();
+  }
+
+  async getConfigAsync(key: string) {
+    const { stdout } = await spawnAsync('npm', ['config', 'get', key], { stdio: 'pipe' });
+    return stdout.trim();
+  }
+
+  async removeLockfileAsync() {
+    assert(this.options.cwd, 'cwd required for NpmPackageManager.removeLockfileAsync');
+    const lockfilePath = path.join(this.options.cwd, 'package-lock.json');
+    if (fs.existsSync(lockfilePath)) {
+      rimraf.sync(lockfilePath);
+    }
+  }
+
+  async cleanAsync() {
+    assert(this.options.cwd, 'cwd required for NpmPackageManager.cleanAsync');
+    const nodeModulesPath = path.join(this.options.cwd, 'node_modules');
+    if (fs.existsSync(nodeModulesPath)) {
+      rimraf.sync(nodeModulesPath);
+    }
+  }
+
+  // Private
+  private async _runAsync(args: string[]) {
+    if (!this.options.ignoreStdio) {
+      this.log(`> npm ${args.join(' ')}`);
+    }
+
+    // Have spawnAsync consume stdio but we don't actually do anything with it if it's ignored
+    const promise = spawnAsync('npm', [...args], { ...this.options, ignoreStdio: false });
+    if (promise.child.stderr && !this.options.ignoreStdio) {
+      promise.child.stderr
+        .pipe(split(/\r?\n/, (line: string) => line + '\n'))
+        .pipe(new NpmStderrTransform())
+        .pipe(process.stderr);
+    }
+    return promise;
+  }
+
+  private _parseSpecs(names: string[]) {
+    const result: {
+      versioned: npmPackageArg.Result[];
+      unversioned: npmPackageArg.Result[];
+    } = { versioned: [], unversioned: [] };
+    names
+      .map(name => npmPackageArg(name))
+      .forEach(spec => {
+        if (spec.rawSpec) {
+          result.versioned.push(spec);
+        } else {
+          result.unversioned.push(spec);
+        }
+      });
+    return result;
+  }
+
+  private async _patchAsync(
+    specs: npmPackageArg.Result[],
+    packageType: 'dependencies' | 'devDependencies'
+  ) {
+    const pkgPath = path.join(this.options.cwd || '.', 'package.json');
+    const pkg = await JsonFile.readAsync(pkgPath);
+    specs.forEach(spec => {
+      pkg[packageType] = pkg[packageType] || {};
+      // @ts-ignore
+      pkg[packageType][spec.name!] = spec.rawSpec;
+    });
+    await JsonFile.writeAsync(pkgPath, pkg, { json5: false });
+  }
+}

--- a/packages/package-manager/src/YarnPackageManager.ts
+++ b/packages/package-manager/src/YarnPackageManager.ts
@@ -1,0 +1,142 @@
+import spawnAsync, { SpawnOptions } from '@expo/spawn-async';
+import ansiRegex from 'ansi-regex';
+import fs from 'fs';
+import path from 'path';
+import rimraf from 'rimraf';
+import { Transform } from 'stream';
+
+import { DISABLE_ADS_ENV } from './NodePackageManagers';
+import { Logger, PackageManager } from './PackageManager';
+import isYarnOfflineAsync from './utils/isYarnOfflineAsync';
+
+const ansi = `(?:${ansiRegex().source})*`;
+const yarnPeerDependencyWarningPattern = new RegExp(
+  `${ansi}warning${ansi} "[^"]+" has (?:unmet|incorrect) peer dependency "[^"]+"\\.\n`,
+  'g'
+);
+
+/** Exposed for testing */
+export class YarnStderrTransform extends Transform {
+  _transform(
+    chunk: Buffer,
+    encoding: string,
+    callback: (error?: Error | null, data?: any) => void
+  ) {
+    this.push(chunk.toString().replace(yarnPeerDependencyWarningPattern, ''));
+    callback();
+  }
+}
+
+export class YarnPackageManager implements PackageManager {
+  options: SpawnOptions;
+  private log: Logger;
+
+  constructor({ cwd, log, silent }: { cwd: string; log?: Logger; silent?: boolean }) {
+    this.log = log || console.log;
+    this.options = {
+      env: {
+        ...process.env,
+        ...DISABLE_ADS_ENV,
+      },
+      cwd,
+      ...(silent
+        ? { ignoreStdio: true }
+        : {
+            stdio: ['inherit', 'inherit', 'pipe'],
+          }),
+    };
+  }
+
+  get name() {
+    return 'Yarn';
+  }
+
+  private async withOfflineSupportAsync(...args: string[]): Promise<string[]> {
+    if (await isYarnOfflineAsync()) {
+      args.push('--offline');
+    }
+    // TODO: Maybe prompt about being offline and using local yarn cache.
+    return args;
+  }
+
+  async installAsync() {
+    const args = await this.withOfflineSupportAsync('install');
+    await this._runAsync(args);
+  }
+
+  async addGlobalAsync(...names: string[]) {
+    if (!names.length) return this.installAsync();
+    const args = await this.withOfflineSupportAsync('global', 'add');
+    args.push(...names);
+
+    await this._runAsync(args);
+  }
+
+  async addWithParametersAsync(names: string[], parameters: string[] = []) {
+    if (!names.length) return this.installAsync();
+    const args = await this.withOfflineSupportAsync('add');
+    args.push(...names);
+    args.push(...parameters);
+
+    await this._runAsync(args);
+  }
+
+  async addAsync(...names: string[]) {
+    await this.addWithParametersAsync(names, []);
+  }
+
+  async addDevAsync(...names: string[]) {
+    if (!names.length) return this.installAsync();
+    const args = await this.withOfflineSupportAsync('add', '--dev');
+    args.push(...names);
+    await this._runAsync(args);
+  }
+
+  async removeAsync(...names: string[]) {
+    await this._runAsync(['remove', ...names]);
+  }
+
+  async versionAsync() {
+    const { stdout } = await spawnAsync('yarnpkg', ['--version'], { stdio: 'pipe' });
+    return stdout.trim();
+  }
+
+  async getConfigAsync(key: string) {
+    const { stdout } = await spawnAsync('yarnpkg', ['config', 'get', key], { stdio: 'pipe' });
+    return stdout.trim();
+  }
+
+  async removeLockfileAsync() {
+    if (!this.options.cwd) {
+      throw new Error('cwd required for YarnPackageManager.removeLockfileAsync');
+    }
+    const lockfilePath = path.join(this.options.cwd, 'yarn-lock.json');
+    if (fs.existsSync(lockfilePath)) {
+      rimraf.sync(lockfilePath);
+    }
+  }
+
+  async cleanAsync() {
+    if (!this.options.cwd) {
+      throw new Error('cwd required for YarnPackageManager.cleanAsync');
+    }
+    const nodeModulesPath = path.join(this.options.cwd, 'node_modules');
+    if (fs.existsSync(nodeModulesPath)) {
+      rimraf.sync(nodeModulesPath);
+    }
+  }
+
+  // Private
+  private async _runAsync(args: string[]) {
+    if (!this.options.ignoreStdio) {
+      this.log(`> yarn ${args.join(' ')}`);
+    }
+
+    // Have spawnAsync consume stdio but we don't actually do anything with it if it's ignored
+    const promise = spawnAsync('yarnpkg', args, { ...this.options, ignoreStdio: false });
+    if (promise.child.stderr && !this.options.ignoreStdio) {
+      promise.child.stderr.pipe(new YarnStderrTransform()).pipe(process.stderr);
+    }
+    return promise;
+  }
+}

--- a/packages/package-manager/src/YarnPackageManager.ts
+++ b/packages/package-manager/src/YarnPackageManager.ts
@@ -1,5 +1,6 @@
 import spawnAsync, { SpawnOptions } from '@expo/spawn-async';
 import ansiRegex from 'ansi-regex';
+import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
@@ -107,9 +108,7 @@ export class YarnPackageManager implements PackageManager {
   }
 
   async removeLockfileAsync() {
-    if (!this.options.cwd) {
-      throw new Error('cwd required for YarnPackageManager.removeLockfileAsync');
-    }
+    assert(this.options.cwd, 'cwd required for YarnPackageManager.removeLockfileAsync');
     const lockfilePath = path.join(this.options.cwd, 'yarn-lock.json');
     if (fs.existsSync(lockfilePath)) {
       rimraf.sync(lockfilePath);
@@ -117,9 +116,7 @@ export class YarnPackageManager implements PackageManager {
   }
 
   async cleanAsync() {
-    if (!this.options.cwd) {
-      throw new Error('cwd required for YarnPackageManager.cleanAsync');
-    }
+    assert(this.options.cwd, 'cwd required for YarnPackageManager.cleanAsync');
     const nodeModulesPath = path.join(this.options.cwd, 'node_modules');
     if (fs.existsSync(nodeModulesPath)) {
       rimraf.sync(nodeModulesPath);

--- a/packages/package-manager/src/YarnPackageManager.ts
+++ b/packages/package-manager/src/YarnPackageManager.ts
@@ -109,7 +109,7 @@ export class YarnPackageManager implements PackageManager {
 
   async removeLockfileAsync() {
     assert(this.options.cwd, 'cwd required for YarnPackageManager.removeLockfileAsync');
-    const lockfilePath = path.join(this.options.cwd, 'yarn-lock.json');
+    const lockfilePath = path.join(this.options.cwd, 'yarn.lock');
     if (fs.existsSync(lockfilePath)) {
       rimraf.sync(lockfilePath);
     }

--- a/packages/package-manager/src/__tests__/NpmPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/NpmPackageManager-test.ts
@@ -1,0 +1,500 @@
+/* eslint-env jest */
+import spawnAsync from '@expo/spawn-async';
+import { vol } from 'memfs';
+import path from 'path';
+import split from 'split';
+import { PassThrough } from 'stream';
+
+import { NpmPackageManager, NpmStderrTransform } from '../NpmPackageManager';
+
+jest.mock('fs');
+jest.mock('@expo/spawn-async', () => {
+  const actualModule = jest.requireActual('@expo/spawn-async');
+
+  return {
+    __esModule: true,
+    ...actualModule,
+    // minimal implementation is needed here because the packager manager depends on the child property to exist.
+    default: jest.fn((_command, _args, _options) => {
+      const promise = new Promise((resolve, _reject) => resolve({}));
+      // @ts-ignore: TypeScript isn't aware the Promise constructor argument runs synchronously
+      promise.child = {};
+      return promise;
+    }),
+  };
+});
+
+const mockedSpawnAsync = spawnAsync as jest.MockedFunction<typeof spawnAsync>;
+
+describe('NpmPackageManager', () => {
+  // Default options for all instances, logger is disabled to prevent spamming jest results
+  const cwd = '/project/with-npm';
+  const log = jest.fn();
+
+  afterEach(() => {
+    vol.reset();
+    mockedSpawnAsync.mockClear();
+  });
+
+  describe('installAsync', () => {
+    it('runs normal installation', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.installAsync();
+
+      expect(spawnAsync).toBeCalledWith('npm', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    // Note, passing parameters to install is only for npm itself.
+    it('runs install with paramenters', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.installAsync(['--save-optional']);
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save-optional'],
+        expect.objectContaining({ cwd })
+      );
+    });
+  });
+
+  describe('addWithParametersAsync', () => {
+    it('adds a single package with custom parameters', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addWithParametersAsync(['@babel/core'], ['--save-exact']);
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save', '@babel/core', '--save-exact'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('adds multiple packages with custom parameters', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addWithParametersAsync(['@babel/core', '@babel/runtime'], ['--save-exact']);
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save', '@babel/core', '@babel/runtime', '--save-exact'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('installs project without packages', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addWithParametersAsync([], ['--save-optional']);
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save-optional'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('adds single package with exact version', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: JSON.stringify({
+          name: 'expo-app',
+          version: '1.0.0',
+          dependencies: {
+            expo: '^45.0.0',
+          },
+        }),
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addWithParametersAsync(['@babel/core@7.17.10'], ['--save-exact']);
+
+      const { dependencies } = JSON.parse(
+        vol.readFileSync(path.join(cwd, 'package.json'), 'utf8').toString()
+      );
+
+      expect(dependencies).toHaveProperty('@babel/core', '7.17.10');
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save-exact'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('adds multiple packages with exact versions', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: JSON.stringify({
+          name: 'expo-app',
+          version: '1.0.0',
+          dependencies: {
+            expo: '^45.0.0',
+          },
+        }),
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addWithParametersAsync(
+        ['@babel/core@7.17.10', '@babel/runtime@7.17.9'],
+        ['--save-exact']
+      );
+
+      const { dependencies } = JSON.parse(
+        vol.readFileSync(path.join(cwd, 'package.json'), 'utf8').toString()
+      );
+
+      expect(dependencies).toHaveProperty('@babel/core', '7.17.10');
+      expect(dependencies).toHaveProperty('@babel/runtime', '7.17.9');
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save-exact'],
+        expect.objectContaining({ cwd })
+      );
+    });
+  });
+
+  describe('addAsync', () => {
+    it('adds a single package to dependencies', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addAsync('@react-navigation/native');
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save', '@react-navigation/native'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('adds multiple packages to dependencies', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addAsync('@react-navigation/native', '@react-navigation/drawer');
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save', '@react-navigation/native', '@react-navigation/drawer'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('installs project without packages', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addAsync();
+
+      expect(spawnAsync).toBeCalledWith('npm', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    it('adds a single package with exact version', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: JSON.stringify({
+          name: 'expo-app',
+          version: '1.0.0',
+          dependencies: {
+            expo: '^45.0.0',
+          },
+        }),
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addAsync('@react-navigation/native@^6.0.10');
+
+      const { dependencies } = JSON.parse(
+        vol.readFileSync(path.join(cwd, 'package.json'), 'utf8').toString()
+      );
+
+      expect(dependencies).toHaveProperty('@react-navigation/native', '^6.0.10');
+      expect(spawnAsync).toBeCalledWith('npm', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    it('adds multiple packages with exact versions', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: JSON.stringify({
+          name: 'expo-app',
+          version: '1.0.0',
+          dependencies: {
+            expo: '^45.0.0',
+          },
+        }),
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addAsync('@react-navigation/native@^6.0.10', '@react-navigation/drawer@^6.4.1');
+
+      const { dependencies } = JSON.parse(
+        vol.readFileSync(path.join(cwd, 'package.json'), 'utf8').toString()
+      );
+
+      expect(dependencies).toHaveProperty('@react-navigation/native', '^6.0.10');
+      expect(dependencies).toHaveProperty('@react-navigation/drawer', '^6.4.1');
+      expect(spawnAsync).toBeCalledWith('npm', ['install'], expect.objectContaining({ cwd }));
+    });
+  });
+
+  describe('addDevAsync', () => {
+    it('adds a single package to dev dependencies', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addDevAsync('eslint');
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save-dev', 'eslint'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('adds multiple packages to dev dependencies', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addDevAsync('eslint', 'prettier');
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--save-dev', 'eslint', 'prettier'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('installs project without packages', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addDevAsync();
+
+      expect(spawnAsync).toBeCalledWith('npm', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    it('adds a single package with exact version', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: JSON.stringify({
+          name: 'expo-app',
+          version: '1.0.0',
+          dependencies: {
+            expo: '^45.0.0',
+          },
+          devDependencies: {},
+        }),
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addDevAsync('eslint@^8.0.0');
+
+      const { devDependencies } = JSON.parse(
+        vol.readFileSync(path.join(cwd, 'package.json'), 'utf8').toString()
+      );
+
+      expect(devDependencies).toHaveProperty('eslint', '^8.0.0');
+      expect(spawnAsync).toBeCalledWith('npm', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    it('adds multiple packages with exact versions', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: JSON.stringify({
+          name: 'expo-app',
+          version: '1.0.0',
+          dependencies: {
+            expo: '^45.0.0',
+          },
+          devDependencies: {},
+        }),
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addDevAsync('eslint@^8.0.0', 'eslint-config-universe@^11.0.0');
+
+      const { devDependencies } = JSON.parse(
+        vol.readFileSync(path.join(cwd, 'package.json'), 'utf8').toString()
+      );
+
+      expect(devDependencies).toHaveProperty('eslint', '^8.0.0');
+      expect(devDependencies).toHaveProperty('eslint-config-universe', '^11.0.0');
+      expect(spawnAsync).toBeCalledWith('npm', ['install'], expect.objectContaining({ cwd }));
+    });
+  });
+
+  describe('addGlobalAsync', () => {
+    it('adds a single package globally', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addGlobalAsync('expo-cli@^5');
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--global', 'expo-cli@^5'],
+        expect.anything()
+      );
+    });
+
+    it('adds multiple packages globally', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.addGlobalAsync('expo-cli@^5', 'eas-cli');
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['install', '--global', 'expo-cli@^5', 'eas-cli'],
+        expect.anything()
+      );
+    });
+  });
+
+  describe('removeAsync', () => {
+    it('removes a single package', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.removeAsync('metro');
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['uninstall', 'metro'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('removes multiple packages', async () => {
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.removeAsync('metro', 'jest-haste-map');
+
+      expect(spawnAsync).toBeCalledWith(
+        'npm',
+        ['uninstall', 'metro', 'jest-haste-map'],
+        expect.objectContaining({ cwd })
+      );
+    });
+  });
+
+  describe('versionAsync', () => {
+    it('returns version from npm', async () => {
+      mockedSpawnAsync.mockResolvedValue({ stdout: '8.9.0\n' } as any);
+
+      const npm = new NpmPackageManager({ log, cwd });
+
+      expect(await npm.versionAsync()).toBe('8.9.0');
+      expect(spawnAsync).toBeCalledWith('npm', ['--version'], expect.anything());
+    });
+  });
+
+  describe('getConfigAsync', () => {
+    it('returns a configuration key from npm', async () => {
+      mockedSpawnAsync.mockResolvedValue({ stdout: 'https://registry.npmjs.org/\n' } as any);
+
+      const npm = new NpmPackageManager({ log, cwd });
+
+      expect(await npm.getConfigAsync('registry')).toBe('https://registry.npmjs.org/');
+      expect(spawnAsync).toBeCalledWith('npm', ['config', 'get', 'registry'], expect.anything());
+    });
+  });
+
+  describe('removeLockfileAsync', () => {
+    it('removes package-lock.json file relative to cwd', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: '{}',
+        [path.join(cwd, 'package-lock.json')]: '{}',
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.removeLockfileAsync();
+
+      expect(vol.existsSync(path.join(cwd, 'package-lock.json'))).toBe(false);
+    });
+
+    it('skips removing non-existing npm.lock', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: '{}',
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.removeLockfileAsync();
+
+      expect(vol.existsSync(path.join(cwd, 'package-lock.json'))).toBe(false);
+    });
+
+    it('fails when no cwd is provided', async () => {
+      const npm = new NpmPackageManager({ log, cwd: undefined });
+      await expect(npm.removeLockfileAsync()).rejects.toThrow('cwd required');
+    });
+  });
+
+  describe('cleanAsync', () => {
+    afterEach(() => vol.reset());
+
+    it('removes node_modules folder relative to cwd', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: '{}',
+        [path.join(cwd, 'node_modules/expo/package.json')]: '{}',
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.cleanAsync();
+
+      expect(vol.existsSync(path.join(cwd, 'node_modules'))).toBe(false);
+    });
+
+    it('skips removing non-existing node_modules folder', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: '{}',
+      });
+
+      const npm = new NpmPackageManager({ log, cwd });
+      await npm.cleanAsync();
+
+      expect(vol.existsSync(path.join(cwd, 'node_modules'))).toBe(false);
+    });
+
+    it('fails when no cwd is provided', async () => {
+      const npm = new NpmPackageManager({ log, cwd: undefined });
+      await expect(npm.cleanAsync()).rejects.toThrow('cwd required');
+    });
+  });
+});
+
+describe('NpmStderrTransform', () => {
+  const installNormal = `
+  npm [33mWARN[39m optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.2 (node_modules\fsevents):
+  npm [33mWARN[39m notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})
+  
+  added 1006 packages from 692 contributors and audited 1008 packages in 22.785s
+  
+  53 packages are looking for funding
+    run \`npm fund\` for details
+  
+  found 0 vulnerabilities
+  `;
+
+  const installPeerDepsWarning = `
+  npm [33mWARN[39m eslint-config-prettier@8.5.0 requires a peer of eslint@>=7.0.0 but none is installed. You must install peer dependencies yourself.
+  npm [33mWARN[39m eslint-config-universe@11.0.0 requires a peer of eslint@>=8.10 but none is installed. You must install peer dependencies yourself.
+  npm [33mWARN[39m eslint-plugin-react@7.29.4 requires a peer of eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 but none is installed. You must install peer dependencies yourself.
+  npm [33mWARN[39m eslint-utils@3.0.0 requires a peer of eslint@>=5 but none is installed. You must install peer dependencies yourself.
+  npm [33mWARN[39m optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.2 (node_modules\fsevents):
+  npm [33mWARN[39m notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})
+  
+  audited 1100 packages in 3.462s
+  
+  98 packages are looking for funding
+    run \`npm fund\` for details
+  
+  found 0 vulnerabilities
+  `;
+
+  it('does not filter normal output', () => {
+    const stream = new PassThrough()
+      .pipe(split(/\r?\n/, (line: string) => line + '\n'))
+      .pipe(new NpmStderrTransform())
+      .on('data', (data: Buffer) => {
+        expect(installNormal).toContain(data.toString());
+      });
+
+    stream.write(installNormal);
+    stream.end();
+
+    return new Promise<void>((resolve, reject) => {
+      stream.on('error', reject);
+      stream.on('end', resolve);
+    });
+  });
+
+  it('filters peer dependency warnings', () => {
+    const stream = new PassThrough()
+      .pipe(split(/\r?\n/, (line: string) => line + '\n'))
+      .pipe(new NpmStderrTransform())
+      .on('data', (data: Buffer) => {
+        expect(data.toString()).not.toContain('peer dependencies');
+      });
+
+    stream.write(installPeerDepsWarning);
+    stream.end();
+
+    return new Promise<void>((resolve, reject) => {
+      stream.on('error', reject);
+      stream.on('end', resolve);
+    });
+  });
+});

--- a/packages/package-manager/src/__tests__/PnpmPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/PnpmPackageManager-test.ts
@@ -27,129 +27,120 @@ jest.mock('@expo/spawn-async', () => {
 const mockedSpawnAsync = spawnAsync as jest.MockedFunction<typeof spawnAsync>;
 
 describe('PnpmPackageManager', () => {
-  const projectRoot = '/project/with-pnpm';
+  // Default options for all instances, logger is disabled to prevent spamming jest results
+  const cwd = '/project/with-pnpm';
+  const log = jest.fn();
+
+  afterEach(() => {
+    vol.reset();
+    mockedSpawnAsync.mockClear();
+  });
 
   describe('installAsync', () => {
     it('runs normal installation', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.installAsync();
 
-      expect(spawnAsync).toBeCalledWith(
-        'pnpm',
-        ['install'],
-        expect.objectContaining({ cwd: projectRoot })
-      );
+      expect(spawnAsync).toBeCalledWith('pnpm', ['install'], expect.objectContaining({ cwd }));
     });
   });
 
   describe('addWithParametersAsync', () => {
     it('adds a single package with custom parameters', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addWithParametersAsync(['@babel/core'], ['--save-peer']);
 
       expect(spawnAsync).toBeCalledWith(
         'pnpm',
         ['add', '--save-peer', '@babel/core'],
-        expect.objectContaining({ cwd: projectRoot })
+        expect.objectContaining({ cwd })
       );
     });
 
     it('adds multiple packages with custom parameters', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addWithParametersAsync(['@babel/core', '@babel/runtime'], ['--save-peer']);
 
       expect(spawnAsync).toBeCalledWith(
         'pnpm',
         ['add', '--save-peer', '@babel/core', '@babel/runtime'],
-        expect.objectContaining({ cwd: projectRoot })
+        expect.objectContaining({ cwd })
       );
     });
 
     it('installs project without packages', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addWithParametersAsync([], ['--save-optional']);
 
-      expect(spawnAsync).toBeCalledWith(
-        'pnpm',
-        ['install'],
-        expect.objectContaining({ cwd: projectRoot })
-      );
+      expect(spawnAsync).toBeCalledWith('pnpm', ['install'], expect.objectContaining({ cwd }));
     });
   });
 
   describe('addAsync', () => {
     it('adds a single package to dependencies', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addAsync('@react-navigation/native');
 
       expect(spawnAsync).toBeCalledWith(
         'pnpm',
         ['add', '@react-navigation/native'],
-        expect.objectContaining({ cwd: projectRoot })
+        expect.objectContaining({ cwd })
       );
     });
 
     it('adds multiple packages to dependencies', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addAsync('@react-navigation/native', '@react-navigation/drawer');
 
       expect(spawnAsync).toBeCalledWith(
         'pnpm',
         ['add', '@react-navigation/native', '@react-navigation/drawer'],
-        expect.objectContaining({ cwd: projectRoot })
+        expect.objectContaining({ cwd })
       );
     });
 
     it('installs project without packages', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addAsync();
 
-      expect(spawnAsync).toBeCalledWith(
-        'pnpm',
-        ['install'],
-        expect.objectContaining({ cwd: projectRoot })
-      );
+      expect(spawnAsync).toBeCalledWith('pnpm', ['install'], expect.objectContaining({ cwd }));
     });
   });
 
   describe('addDevAsync', () => {
     it('adds a single package to dev dependencies', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addDevAsync('eslint');
 
       expect(spawnAsync).toBeCalledWith(
         'pnpm',
         ['add', '--save-dev', 'eslint'],
-        expect.objectContaining({ cwd: projectRoot })
+        expect.objectContaining({ cwd })
       );
     });
 
     it('adds multiple packages to dev dependencies', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addDevAsync('eslint', 'prettier');
 
       expect(spawnAsync).toBeCalledWith(
         'pnpm',
         ['add', '--save-dev', 'eslint', 'prettier'],
-        expect.objectContaining({ cwd: projectRoot })
+        expect.objectContaining({ cwd })
       );
     });
 
     it('installs project without packages', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addDevAsync();
 
-      expect(spawnAsync).toBeCalledWith(
-        'pnpm',
-        ['install'],
-        expect.objectContaining({ cwd: projectRoot })
-      );
+      expect(spawnAsync).toBeCalledWith('pnpm', ['install'], expect.objectContaining({ cwd }));
     });
   });
 
   describe('addGlobalAsync', () => {
     it('adds a single package globally', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addGlobalAsync('expo-cli@^5');
 
       expect(spawnAsync).toBeCalledWith(
@@ -160,7 +151,7 @@ describe('PnpmPackageManager', () => {
     });
 
     it('adds multiple packages globally', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.addGlobalAsync('expo-cli@^5', 'eas-cli');
 
       expect(spawnAsync).toBeCalledWith(
@@ -173,24 +164,24 @@ describe('PnpmPackageManager', () => {
 
   describe('removeAsync', () => {
     it('removes a single package', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.removeAsync('metro');
 
       expect(spawnAsync).toBeCalledWith(
         'pnpm',
         ['remove', 'metro'],
-        expect.objectContaining({ cwd: projectRoot })
+        expect.objectContaining({ cwd })
       );
     });
 
     it('removes multiple packages', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.removeAsync('metro', 'jest-haste-map');
 
       expect(spawnAsync).toBeCalledWith(
         'pnpm',
         ['remove', 'metro', 'jest-haste-map'],
-        expect.objectContaining({ cwd: projectRoot })
+        expect.objectContaining({ cwd })
       );
     });
   });
@@ -199,7 +190,7 @@ describe('PnpmPackageManager', () => {
     it('returns version from pnpm', async () => {
       mockedSpawnAsync.mockResolvedValue({ stdout: '7.0.0\n' } as any);
 
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
 
       expect(await pnpm.versionAsync()).toBe('7.0.0');
       expect(spawnAsync).toBeCalledWith('pnpm', ['--version'], expect.anything());
@@ -210,7 +201,7 @@ describe('PnpmPackageManager', () => {
     it('returns a configuration key from pnpm', async () => {
       mockedSpawnAsync.mockResolvedValue({ stdout: 'https://custom.registry.org/\n' } as any);
 
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
 
       expect(await pnpm.getConfigAsync('registry')).toBe('https://custom.registry.org/');
       expect(spawnAsync).toBeCalledWith('pnpm', ['config', 'get', 'registry'], expect.anything());
@@ -218,65 +209,61 @@ describe('PnpmPackageManager', () => {
   });
 
   describe('removeLockfileAsync', () => {
-    afterEach(() => vol.reset());
-
     it('removes pnpm-lock.yaml file relative to cwd', async () => {
       vol.fromJSON({
-        [path.join(projectRoot, 'package.json')]: '{}',
-        [path.join(projectRoot, 'pnpm-lock.yaml')]: '',
+        [path.join(cwd, 'package.json')]: '{}',
+        [path.join(cwd, 'pnpm-lock.yaml')]: '',
       });
 
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.removeLockfileAsync();
 
-      expect(vol.existsSync(path.join(projectRoot, 'pnpm-lock.yaml'))).toBe(false);
+      expect(vol.existsSync(path.join(cwd, 'pnpm-lock.yaml'))).toBe(false);
     });
 
     it('skips removing non-existing pnpm-lock.yaml', async () => {
       vol.fromJSON({
-        [path.join(projectRoot, 'package.json')]: '{}',
+        [path.join(cwd, 'package.json')]: '{}',
       });
 
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.removeLockfileAsync();
 
-      expect(vol.existsSync(path.join(projectRoot, 'pnpm-lock.yaml'))).toBe(false);
+      expect(vol.existsSync(path.join(cwd, 'pnpm-lock.yaml'))).toBe(false);
     });
 
     it('fails when no cwd is provided', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: undefined });
+      const pnpm = new PnpmPackageManager({ log, cwd: undefined });
       await expect(pnpm.removeLockfileAsync()).rejects.toThrow('cwd required');
     });
   });
 
   describe('cleanAsync', () => {
-    afterEach(() => vol.reset());
-
     it('removes node_modules folder relative to cwd', async () => {
       vol.fromJSON({
-        [path.join(projectRoot, 'package.json')]: '{}',
-        [path.join(projectRoot, 'node_modules/expo/package.json')]: '{}',
+        [path.join(cwd, 'package.json')]: '{}',
+        [path.join(cwd, 'node_modules/expo/package.json')]: '{}',
       });
 
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.cleanAsync();
 
-      expect(vol.existsSync(path.join(projectRoot, 'node_modules'))).toBe(false);
+      expect(vol.existsSync(path.join(cwd, 'node_modules'))).toBe(false);
     });
 
     it('skips removing non-existing node_modules folder', async () => {
       vol.fromJSON({
-        [path.join(projectRoot, 'package.json')]: '{}',
+        [path.join(cwd, 'package.json')]: '{}',
       });
 
-      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      const pnpm = new PnpmPackageManager({ log, cwd });
       await pnpm.cleanAsync();
 
-      expect(vol.existsSync(path.join(projectRoot, 'node_modules'))).toBe(false);
+      expect(vol.existsSync(path.join(cwd, 'node_modules'))).toBe(false);
     });
 
     it('fails when no cwd is provided', async () => {
-      const pnpm = new PnpmPackageManager({ cwd: undefined });
+      const pnpm = new PnpmPackageManager({ log, cwd: undefined });
       await expect(pnpm.cleanAsync()).rejects.toThrow('cwd required');
     });
   });
@@ -323,10 +310,7 @@ Progress: resolved 340, reused 340, downloaded 0, added 0, done
         expect(installNormal).toContain(data.toString());
       });
 
-    for (const line of installNormal.split('\n')) {
-      stream.write(line);
-    }
-
+    stream.write(installNormal);
     stream.end();
 
     return new Promise<void>((resolve, reject) => {
@@ -343,10 +327,7 @@ Progress: resolved 340, reused 340, downloaded 0, added 0, done
         expect(data.toString()).not.toContain('peer dependencies');
       });
 
-    for (const line of installPeerDepsWarning.split('\n')) {
-      stream.write(line);
-    }
-
+    stream.write(installPeerDepsWarning);
     stream.end();
 
     return new Promise<void>((resolve, reject) => {

--- a/packages/package-manager/src/__tests__/YarnPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/YarnPackageManager-test.ts
@@ -1,0 +1,488 @@
+/* eslint-env jest */
+import spawnAsync from '@expo/spawn-async';
+import { vol } from 'memfs';
+import path from 'path';
+import { PassThrough } from 'stream';
+
+import { YarnPackageManager, YarnStderrTransform } from '../YarnPackageManager';
+import isYarnOfflineAsync from '../utils/isYarnOfflineAsync';
+
+jest.mock('../utils/isYarnOfflineAsync');
+jest.mock('fs');
+jest.mock('@expo/spawn-async', () => {
+  const actualModule = jest.requireActual('@expo/spawn-async');
+
+  return {
+    __esModule: true,
+    ...actualModule,
+    // minimal implementation is needed here because the packager manager depends on the child property to exist.
+    default: jest.fn((_command, _args, _options) => {
+      const promise = new Promise((resolve, _reject) => resolve({}));
+      // @ts-ignore: TypeScript isn't aware the Promise constructor argument runs synchronously
+      promise.child = {};
+      return promise;
+    }),
+  };
+});
+
+const mockedSpawnAsync = spawnAsync as jest.MockedFunction<typeof spawnAsync>;
+const mockedIsYarnOfflineAsync = isYarnOfflineAsync as jest.MockedFunction<
+  typeof isYarnOfflineAsync
+>;
+
+describe('YarnPackageManager', () => {
+  // Default options for all instances, logger is disabled to prevent spamming jest results
+  const cwd = '/project/with-yarn';
+  const log = jest.fn();
+
+  afterEach(() => {
+    mockedIsYarnOfflineAsync.mockReset();
+  });
+
+  describe('installAsync', () => {
+    it('runs normal installation', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.installAsync();
+
+      expect(spawnAsync).toBeCalledWith('yarnpkg', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    describe('offline', () => {
+      beforeEach(() => {
+        mockedIsYarnOfflineAsync.mockResolvedValue(true);
+      });
+
+      it('runs installation when offline', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.installAsync();
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['install', '--offline'],
+          expect.objectContaining({ cwd })
+        );
+      });
+    });
+  });
+
+  describe('addWithParametersAsync', () => {
+    it('adds a single package with custom parameters', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addWithParametersAsync(['@babel/core'], ['--cache-folder=/tmp']);
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['add', '@babel/core', '--cache-folder=/tmp'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('adds multiple packages with custom parameters', async () => {
+      const pnpm = new YarnPackageManager({ log, cwd });
+      await pnpm.addWithParametersAsync(['@babel/core', '@babel/runtime'], ['--cache-folder=/tmp']);
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['add', '@babel/core', '@babel/runtime', '--cache-folder=/tmp'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('installs project without packages', async () => {
+      const pnpm = new YarnPackageManager({ log, cwd });
+      await pnpm.addWithParametersAsync([], ['--cache-folder=/tmp']);
+
+      expect(spawnAsync).toBeCalledWith('yarnpkg', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    describe('offline', () => {
+      beforeEach(() => {
+        mockedIsYarnOfflineAsync.mockResolvedValue(true);
+      });
+
+      it('adds a single package with custom parameters when offline', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addWithParametersAsync(['@babel/core'], ['--cache-folder=/tmp']);
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['add', '--offline', '@babel/core', '--cache-folder=/tmp'],
+          expect.objectContaining({ cwd })
+        );
+      });
+
+      it('adds multiple packages with custom parameters when offline', async () => {
+        const pnpm = new YarnPackageManager({ log, cwd });
+        await pnpm.addWithParametersAsync(
+          ['@babel/core', '@babel/runtime'],
+          ['--cache-folder=/tmp']
+        );
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['add', '--offline', '@babel/core', '@babel/runtime', '--cache-folder=/tmp'],
+          expect.objectContaining({ cwd })
+        );
+      });
+
+      it('installs project without packages', async () => {
+        const pnpm = new YarnPackageManager({ log, cwd });
+        await pnpm.addWithParametersAsync([], ['--cache-folder=/tmp']);
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['install', '--offline'],
+          expect.objectContaining({ cwd })
+        );
+      });
+    });
+  });
+
+  describe('addAsync', () => {
+    it('adds a single package to dependencies', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addAsync('@react-navigation/native');
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['add', '@react-navigation/native'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('adds multiple packages to dependencies', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addAsync('@react-navigation/native', '@react-navigation/drawer');
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['add', '@react-navigation/native', '@react-navigation/drawer'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('installs project without packages', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addAsync();
+
+      expect(spawnAsync).toBeCalledWith('yarnpkg', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    describe('offline', () => {
+      beforeEach(() => {
+        mockedIsYarnOfflineAsync.mockResolvedValue(true);
+      });
+
+      it('adds a single package to dependencies when offline', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addAsync('@react-navigation/native');
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['add', '--offline', '@react-navigation/native'],
+          expect.objectContaining({ cwd })
+        );
+      });
+
+      it('adds multiple packages to dependencies when offline', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addAsync('@react-navigation/native', '@react-navigation/drawer');
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['add', '--offline', '@react-navigation/native', '@react-navigation/drawer'],
+          expect.objectContaining({ cwd })
+        );
+      });
+
+      it('installs project without packages when offline', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addAsync();
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['install', '--offline'],
+          expect.objectContaining({ cwd })
+        );
+      });
+    });
+  });
+
+  describe('addDevAsync', () => {
+    it('adds a single package to dev dependencies', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addDevAsync('eslint');
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['add', '--dev', 'eslint'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('adds multiple packages to dev dependencies', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addDevAsync('eslint', 'prettier');
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['add', '--dev', 'eslint', 'prettier'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('installs project without packages', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addDevAsync();
+
+      expect(spawnAsync).toBeCalledWith('yarnpkg', ['install'], expect.objectContaining({ cwd }));
+    });
+
+    describe('offline', () => {
+      beforeEach(() => {
+        mockedIsYarnOfflineAsync.mockResolvedValue(true);
+      });
+
+      it('adds a single package to dev dependencies when offline', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addDevAsync('eslint');
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['add', '--dev', '--offline', 'eslint'],
+          expect.objectContaining({ cwd })
+        );
+      });
+
+      it('adds multiple packages to dev dependencies when offline', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addDevAsync('eslint', 'prettier');
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['add', '--dev', '--offline', 'eslint', 'prettier'],
+          expect.objectContaining({ cwd })
+        );
+      });
+
+      it('installs project without packages when offline', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addDevAsync();
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['install', '--offline'],
+          expect.objectContaining({ cwd })
+        );
+      });
+    });
+  });
+
+  describe('addGlobalAsync', () => {
+    it('adds a single package globally', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addGlobalAsync('expo-cli@^5');
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['global', 'add', 'expo-cli@^5'],
+        expect.anything()
+      );
+    });
+
+    it('adds multiple packages globally', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addGlobalAsync('expo-cli@^5', 'eas-cli');
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['global', 'add', 'expo-cli@^5', 'eas-cli'],
+        expect.anything()
+      );
+    });
+
+    describe('offline', () => {
+      beforeEach(() => {
+        mockedIsYarnOfflineAsync.mockResolvedValue(true);
+      });
+
+      it('adds a single package globally', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addGlobalAsync('expo-cli@^5');
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['global', 'add', '--offline', 'expo-cli@^5'],
+          expect.anything()
+        );
+      });
+
+      it('adds multiple packages globally', async () => {
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addGlobalAsync('expo-cli@^5', 'eas-cli');
+
+        expect(spawnAsync).toBeCalledWith(
+          'yarnpkg',
+          ['global', 'add', '--offline', 'expo-cli@^5', 'eas-cli'],
+          expect.anything()
+        );
+      });
+    });
+  });
+
+  describe('removeAsync', () => {
+    it('removes a single package', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.removeAsync('metro');
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['remove', 'metro'],
+        expect.objectContaining({ cwd })
+      );
+    });
+
+    it('removes multiple packages', async () => {
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.removeAsync('metro', 'jest-haste-map');
+
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['remove', 'metro', 'jest-haste-map'],
+        expect.objectContaining({ cwd })
+      );
+    });
+  });
+
+  describe('versionAsync', () => {
+    it('returns version from yarn', async () => {
+      mockedSpawnAsync.mockResolvedValue({ stdout: '1.22.15\n' } as any);
+
+      const yarn = new YarnPackageManager({ log, cwd });
+
+      expect(await yarn.versionAsync()).toBe('1.22.15');
+      expect(spawnAsync).toBeCalledWith('yarnpkg', ['--version'], expect.anything());
+    });
+  });
+
+  describe('getConfigAsync', () => {
+    it('returns a configuration key from yarn', async () => {
+      mockedSpawnAsync.mockResolvedValue({ stdout: 'https://registry.yarnpkg.com\n' } as any);
+
+      const yarn = new YarnPackageManager({ log, cwd });
+
+      expect(await yarn.getConfigAsync('registry')).toBe('https://registry.yarnpkg.com');
+      expect(spawnAsync).toBeCalledWith(
+        'yarnpkg',
+        ['config', 'get', 'registry'],
+        expect.anything()
+      );
+    });
+  });
+
+  describe('removeLockfileAsync', () => {
+    afterEach(() => vol.reset());
+
+    it('removes yarn.lock file relative to cwd', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: '{}',
+        [path.join(cwd, 'yarn.lock')]: '',
+      });
+
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.removeLockfileAsync();
+
+      expect(vol.existsSync(path.join(cwd, 'yarn.lock'))).toBe(false);
+    });
+
+    it('skips removing non-existing yarn.lock', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: '{}',
+      });
+
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.removeLockfileAsync();
+
+      expect(vol.existsSync(path.join(cwd, 'yarn.lock'))).toBe(false);
+    });
+
+    it('fails when no cwd is provided', async () => {
+      const yarn = new YarnPackageManager({ log, cwd: undefined });
+      await expect(yarn.removeLockfileAsync()).rejects.toThrow('cwd required');
+    });
+  });
+
+  describe('cleanAsync', () => {
+    afterEach(() => vol.reset());
+
+    it('removes node_modules folder relative to cwd', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: '{}',
+        [path.join(cwd, 'node_modules/expo/package.json')]: '{}',
+      });
+
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.cleanAsync();
+
+      expect(vol.existsSync(path.join(cwd, 'node_modules'))).toBe(false);
+    });
+
+    it('skips removing non-existing node_modules folder', async () => {
+      vol.fromJSON({
+        [path.join(cwd, 'package.json')]: '{}',
+      });
+
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.cleanAsync();
+
+      expect(vol.existsSync(path.join(cwd, 'node_modules'))).toBe(false);
+    });
+
+    it('fails when no cwd is provided', async () => {
+      const yarn = new YarnPackageManager({ log, cwd: undefined });
+      await expect(yarn.cleanAsync()).rejects.toThrow('cwd required');
+    });
+  });
+});
+
+describe('YarnStderrTransform', () => {
+  const installNormal = `
+yarn install v1.22.15
+[1/4] Resolving packages...
+success Already up-to-date.
+Done in 0.06s.
+  `;
+
+  const installPeerDepsWarning = `
+warning "react-native > react-native-codegen > jscodeshift@0.13.1" has unmet peer dependency "@babel/preset-env@^7.1.6".
+  `;
+
+  it('does not filter normal output', () => {
+    const stream = new PassThrough().pipe(new YarnStderrTransform()).on('data', (data: Buffer) => {
+      expect(installNormal).toContain(data.toString());
+    });
+
+    stream.write(installNormal);
+    stream.end();
+
+    return new Promise<void>((resolve, reject) => {
+      stream.on('error', reject);
+      stream.on('end', resolve);
+    });
+  });
+
+  it('filters peer dependency warnings', () => {
+    const stream = new PassThrough().pipe(new YarnStderrTransform()).on('data', (data: Buffer) => {
+      expect(data.toString()).not.toContain('peer dependency');
+    });
+
+    stream.write(installNormal);
+    stream.write(installPeerDepsWarning);
+    stream.end();
+
+    return new Promise<void>((resolve, reject) => {
+      stream.on('error', reject);
+      stream.on('end', resolve);
+    });
+  });
+});

--- a/packages/package-manager/src/__tests__/YarnPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/YarnPackageManager-test.ts
@@ -78,8 +78,8 @@ describe('YarnPackageManager', () => {
     });
 
     it('adds multiple packages with custom parameters', async () => {
-      const pnpm = new YarnPackageManager({ log, cwd });
-      await pnpm.addWithParametersAsync(['@babel/core', '@babel/runtime'], ['--cache-folder=/tmp']);
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addWithParametersAsync(['@babel/core', '@babel/runtime'], ['--cache-folder=/tmp']);
 
       expect(spawnAsync).toBeCalledWith(
         'yarnpkg',
@@ -89,8 +89,8 @@ describe('YarnPackageManager', () => {
     });
 
     it('installs project without packages', async () => {
-      const pnpm = new YarnPackageManager({ log, cwd });
-      await pnpm.addWithParametersAsync([], ['--cache-folder=/tmp']);
+      const yarn = new YarnPackageManager({ log, cwd });
+      await yarn.addWithParametersAsync([], ['--cache-folder=/tmp']);
 
       expect(spawnAsync).toBeCalledWith('yarnpkg', ['install'], expect.objectContaining({ cwd }));
     });
@@ -112,8 +112,8 @@ describe('YarnPackageManager', () => {
       });
 
       it('adds multiple packages with custom parameters when offline', async () => {
-        const pnpm = new YarnPackageManager({ log, cwd });
-        await pnpm.addWithParametersAsync(
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addWithParametersAsync(
           ['@babel/core', '@babel/runtime'],
           ['--cache-folder=/tmp']
         );
@@ -126,8 +126,8 @@ describe('YarnPackageManager', () => {
       });
 
       it('installs project without packages', async () => {
-        const pnpm = new YarnPackageManager({ log, cwd });
-        await pnpm.addWithParametersAsync([], ['--cache-folder=/tmp']);
+        const yarn = new YarnPackageManager({ log, cwd });
+        await yarn.addWithParametersAsync([], ['--cache-folder=/tmp']);
 
         expect(spawnAsync).toBeCalledWith(
           'yarnpkg',

--- a/packages/package-manager/src/__tests__/YarnPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/YarnPackageManager-test.ts
@@ -36,6 +36,7 @@ describe('YarnPackageManager', () => {
   const log = jest.fn();
 
   afterEach(() => {
+    mockedSpawnAsync.mockClear();
     mockedIsYarnOfflineAsync.mockReset();
   });
 
@@ -449,12 +450,19 @@ describe('YarnStderrTransform', () => {
   const installNormal = `
 yarn install v1.22.15
 [1/4] Resolving packages...
-success Already up-to-date.
+[32msuccess[39m Already up-to-date.
 Done in 0.06s.
   `;
 
   const installPeerDepsWarning = `
-warning "react-native > react-native-codegen > jscodeshift@0.13.1" has unmet peer dependency "@babel/preset-env@^7.1.6".
+yarn install v1.22.15
+[1/4] Resolving packages...
+[2/4] Fetching packages...
+[34minfo[39m fsevents@2.3.2: The platform "win32" is incompatible with this module.
+[34minfo[39m "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
+[3/4] Linking dependencies...
+[33mwarning[39m "react-native > react-native-codegen > jscodeshift@0.13.1" has unmet peer dependency "@babel/preset-env@^7.1.6".
+[4/4] Building fresh packages...
   `;
 
   it('does not filter normal output', () => {
@@ -476,7 +484,6 @@ warning "react-native > react-native-codegen > jscodeshift@0.13.1" has unmet pee
       expect(data.toString()).not.toContain('peer dependency');
     });
 
-    stream.write(installNormal);
     stream.write(installPeerDepsWarning);
     stream.end();
 

--- a/packages/package-manager/src/index.ts
+++ b/packages/package-manager/src/index.ts
@@ -1,6 +1,7 @@
 export * from './PackageManager';
 export * from './NodePackageManagers';
 export { PnpmPackageManager } from './PnpmPackageManager';
+export { YarnPackageManager } from './YarnPackageManager';
 export * from './CocoaPodsPackageManager';
 export { default as shouldUseYarn } from './utils/shouldUseYarn';
 export { default as isYarnOfflineAsync } from './utils/isYarnOfflineAsync';

--- a/packages/package-manager/src/index.ts
+++ b/packages/package-manager/src/index.ts
@@ -1,5 +1,6 @@
 export * from './PackageManager';
 export * from './NodePackageManagers';
+export { NpmPackageManager } from './NpmPackageManager';
 export { PnpmPackageManager } from './PnpmPackageManager';
 export { YarnPackageManager } from './YarnPackageManager';
 export * from './CocoaPodsPackageManager';


### PR DESCRIPTION
# Why

This should add some missing tests for the `YarnPackageManager` and `NpmPackageManager`, and make it on par with the `PnpmPackageManager`.

# How

- Split the package managers outside the `NodePackageManager` file into their own
- Copied and modified the tests from `PnpmPackageManager` for both `yarn` and `npm`

# Test Plan

- See tests