### PR TITLE
[package-manager] Add custom spawn option for node package managers

### DIFF
--- a/packages/package-manager/src/NodePackageManagers.ts
+++ b/packages/package-manager/src/NodePackageManagers.ts
@@ -1,3 +1,4 @@
+import spawnAsync from '@expo/spawn-async';
 import { existsSync } from 'fs';
 import path from 'path';
 
@@ -31,6 +32,7 @@ export function isUsingYarn(projectRoot: string): boolean {
 export type CreateForProjectOptions = Partial<Record<NodePackageManager, boolean>> & {
   log?: Logger;
   silent?: boolean;
+  spawner?: typeof spawnAsync;
 };
 
 export function createForProject(
@@ -52,7 +54,12 @@ export function createForProject(
     PackageManager = NpmPackageManager;
   }
 
-  return new PackageManager({ cwd: projectRoot, log: options.log, silent: options.silent });
+  return new PackageManager({
+    cwd: projectRoot,
+    log: options.log,
+    silent: options.silent,
+    spawner: options.spawner,
+  });
 }
 
 export function getModulesPath(projectRoot: string): string {

--- a/packages/package-manager/src/__tests__/NpmPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/NpmPackageManager-test.ts
@@ -36,6 +36,14 @@ describe('NpmPackageManager', () => {
     mockedSpawnAsync.mockClear();
   });
 
+  it('uses different spawners', async () => {
+    const spawner = jest.fn(mockedSpawnAsync);
+    const npm = new NpmPackageManager({ cwd, log, spawner });
+    await npm.installAsync();
+
+    expect(spawner).toBeCalledWith('npm', ['install'], expect.objectContaining({ cwd }));
+  });
+
   describe('installAsync', () => {
     it('runs normal installation', async () => {
       const npm = new NpmPackageManager({ log, cwd });

--- a/packages/package-manager/src/__tests__/PackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/PackageManager-test.ts
@@ -39,6 +39,12 @@ describe('createForProject', () => {
     const manager = createForProject(projectRoot);
     expect(manager.name).toBe('npm');
   });
+  it('creates pnpm package manager from options with custom spawner', async () => {
+    const spawner = jest.fn(spawnAsync);
+    const manager = createForProject(projectRoot, { pnpm: true, spawner });
+    await manager.installAsync();
+    expect(spawner).toHaveBeenCalled();
+  });
 });
 
 describe('getPossibleProjectRoot', () => {

--- a/packages/package-manager/src/__tests__/PnpmPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/PnpmPackageManager-test.ts
@@ -36,6 +36,14 @@ describe('PnpmPackageManager', () => {
     mockedSpawnAsync.mockClear();
   });
 
+  it('uses different spawners', async () => {
+    const spawner = jest.fn(mockedSpawnAsync);
+    const pnpm = new PnpmPackageManager({ cwd, log, spawner });
+    await pnpm.installAsync();
+
+    expect(spawner).toBeCalledWith('pnpm', ['install'], expect.objectContaining({ cwd }));
+  });
+
   describe('installAsync', () => {
     it('runs normal installation', async () => {
       const pnpm = new PnpmPackageManager({ log, cwd });

--- a/packages/package-manager/src/__tests__/YarnPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/YarnPackageManager-test.ts
@@ -40,6 +40,14 @@ describe('YarnPackageManager', () => {
     mockedIsYarnOfflineAsync.mockReset();
   });
 
+  it('uses different spawners', async () => {
+    const spawner = jest.fn(mockedSpawnAsync);
+    const yarn = new YarnPackageManager({ cwd, log, spawner });
+    await yarn.installAsync();
+
+    expect(spawner).toBeCalledWith('yarnpkg', ['install'], expect.objectContaining({ cwd }));
+  });
+
   describe('installAsync', () => {
     it('runs normal installation', async () => {
       const yarn = new YarnPackageManager({ log, cwd });


### PR DESCRIPTION
# Why

> Note, this is just a proposal. With this PR, we could move EAS and classic turtle back to use `@expo/package-manager` _and_ add support for pnpm.

In EAS we need to pipe the logs in a different way, [using a different logger](https://github.com/expo/eas-build/blob/f1abc21a3da8049a241edfc902e378ac8523f081/packages/build-tools/src/utils/project.ts#L116-L120) - [`@expo/turtle-spawn`](https://github.com/expo/eas-build/tree/f1abc21a3da8049a241edfc902e378ac8523f081/packages/turtle-spawn). This allows us to use that logger with just the package manager. It also should inherit the annoying peer-dep log filtering.

# How

- Added spawner option to the constructors
- Added tests to validate the new spawner for `installAsync`

# Test Plan

- See tests