### PR TITLE
[package-manager] Disable frozen lockfiles for pnpm in CI

### DIFF
--- a/packages/package-manager/src/PnpmPackageManager.ts
+++ b/packages/package-manager/src/PnpmPackageManager.ts
@@ -66,6 +66,12 @@ export class PnpmPackageManager {
   }
 
   async installAsync() {
+    if (this.options.env?.['CI']) {
+      // When running in EAS, we need to disable this to run install after prebuild
+      // see: https://pnpm.io/cli/install#--frozen-lockfile
+      await this._runAsync(['install', '--no-frozen-lockfile']);
+    }
+
     await this._runAsync(['install']);
   }
 

--- a/packages/package-manager/src/__tests__/PnpmPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/PnpmPackageManager-test.ts
@@ -40,6 +40,22 @@ describe('PnpmPackageManager', () => {
         expect.objectContaining({ cwd: projectRoot })
       );
     });
+
+    it('runs with --no-froze-lockfile on CI environments', async () => {
+      const originalCI = process.env.CI;
+      process.env.CI = 'true';
+
+      const pnpm = new PnpmPackageManager({ cwd: projectRoot });
+      await pnpm.installAsync();
+
+      expect(spawnAsync).toBeCalledWith(
+        'pnpm',
+        ['install', '--no-frozen-lockfile'],
+        expect.objectContaining({ cwd: projectRoot })
+      );
+
+      process.env.CI = originalCI;
+    });
   });
 
   describe('addWithParametersAsync', () => {


### PR DESCRIPTION
# Why

This is required in EAS to run installAsync after running prebuild. Some packages might have changed, and thus changes the lockfile.

[Pnpm automatically enables this on CI environments.](https://pnpm.io/cli/install#--frozen-lockfile)

I think we can also just run this every time instead of just on CI environments though.

# How

- Added `--no-frozen-lockfile` for CI only
- Added test

# Test Plan

See test