### PR TITLE
[config-plugins] Remove warning when permissions config is empty when using blockedPermissions

### DIFF
--- a/packages/config-plugins/src/android/Permissions.ts
+++ b/packages/config-plugins/src/android/Permissions.ts
@@ -29,10 +29,6 @@ export const withBlockedPermissions: ConfigPlugin<string[] | string> = (config, 
     Boolean
   );
 
-  if (!resolvedPermissions.length) {
-    WarningAggregator.addWarningAndroid('block-permissions', 'No permissions provided');
-  }
-
   if (config?.android?.permissions && Array.isArray(config.android.permissions)) {
     // Remove any static config permissions
     config.android.permissions = config.android.permissions.filter(

--- a/packages/config-plugins/src/android/Permissions.ts
+++ b/packages/config-plugins/src/android/Permissions.ts
@@ -2,7 +2,6 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidManifest } from '../plugins/android-plugins';
-import * as WarningAggregator from '../utils/warnings';
 import { AndroidManifest, ensureToolsAvailable, ManifestUsesPermission } from './Manifest';
 
 const USES_PERMISSION = 'uses-permission';


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/17380

[The `expo-image-picker` config plugin uses `withBlockedPermissions`](https://github.com/expo/expo/blob/091d1acebb5cdaacaf45decc1fb179ce6770d082/packages/expo-image-picker/plugin/src/withImagePicker.ts#L56-L62), but it's possible that at the time that this plugin runs the `permissions` config is empty - depending on the order the plugins are executed. So we shouldn't show this warning in this case.

# How

Remove the warning

# Test Plan

Make the change manually in `node_modules` and verify there is no warning in [this repro](https://github.com/expo/expo/issues/17380#issuecomment-1120195369).

# Open questions

Does it matter that we might have a permission listed in both the `permissions` and `blockedPermission` key? Should we update the permissions config plugin to skip adding a permission if it's listed in `blockedPermissions`?