### PR TITLE
fix(create-expo-app): use hidden directory for home cache

### DIFF
--- a/packages/create-expo-app/src/fetch.ts
+++ b/packages/create-expo-app/src/fetch.ts
@@ -9,7 +9,7 @@ const debug = require('debug')('create-expo-app:fetch') as typeof console.log;
 
 export function getCacheFilePath(subdir: string = 'template-cache') {
   // TODO: Revisit
-  return path.join(os.homedir(), 'create-expo-app', subdir);
+  return path.join(os.homedir(), '.create-expo-app', subdir);
 }
 
 export function createFetch({


### PR DESCRIPTION
# Why

Make the cache use a hidden directory in the home folder