### PR TITLE
fix(config-plugins): drop blockedPermissions warning

### DIFF
--- a/packages/config-plugins/src/android/Permissions.ts
+++ b/packages/config-plugins/src/android/Permissions.ts
@@ -29,10 +29,6 @@ export const withBlockedPermissions: ConfigPlugin<string[] | string> = (config, 
     Boolean
   );
 
-  if (!resolvedPermissions.length) {
-    WarningAggregator.addWarningAndroid('block-permissions', 'No permissions provided');
-  }
-
   if (config?.android?.permissions && Array.isArray(config.android.permissions)) {
     // Remove any static config permissions
     config.android.permissions = config.android.permissions.filter(

--- a/packages/config-plugins/src/android/Permissions.ts
+++ b/packages/config-plugins/src/android/Permissions.ts
@@ -2,7 +2,6 @@ import { ExpoConfig } from '@expo/config-types';
 
 import { ConfigPlugin } from '../Plugin.types';
 import { withAndroidManifest } from '../plugins/android-plugins';
-import * as WarningAggregator from '../utils/warnings';
 import { AndroidManifest, ensureToolsAvailable, ManifestUsesPermission } from './Manifest';
 
 const USES_PERMISSION = 'uses-permission';


### PR DESCRIPTION
# Why

Warning doesn't need to be shown for this. 