### PR TITLE
[expo-cli] set non-zero exit code when expo doctor fails

### DIFF
--- a/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
+++ b/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
@@ -27,5 +27,7 @@ export async function actionAsync(projectRoot: string, options: Options) {
 
   if ((await Doctor.validateWithNetworkAsync(projectRoot)) === Doctor.NO_ISSUES && areDepsValid) {
     Log.log(chalk.green(`🎉 Didn't find any issues with the project!`));
+  } else {
+    process.exitCode = 1;
   }
 }


### PR DESCRIPTION
# Why

Follow-up to https://linear.app/expo/issue/ENG-4643/improve-error-reporting-for-expo-doctor-phase

On the website, we want to make it clear to the user that the `expo doctor` returned some warnings/errors. For that, currently, I decided to detect whether `Didn't find any issues with the project` was printed. It's not perfect because it'll break when we change the log message here.

We need a deterministic way to know if `expo doctor` failed.

# How

Set exit code to 1 if there are validation errors.

@EvanBacon do you think this is fine or you'd prefer to do sth different? If we end up not doing this (because this could break people's workflows), @wkozyra95 proposed that we could have an env var (sth like `EXPO_DOCTOR_FAIL_ON_VALIDATION_ERROR`) and we'd set the exit code only in this case.

# Test Plan

I ran `expo doctor` for a project that has some warnings, exit code was set properly.