### PR TITLE
[config-plugins] rename android jni java descriptors from prebuild

### DIFF
--- a/packages/config-plugins/src/android/__tests__/Package-test.ts
+++ b/packages/config-plugins/src/android/__tests__/Package-test.ts
@@ -1,11 +1,12 @@
 import { vol } from 'memfs';
 
-import { renamePackageOnDiskForType } from '../../../build/android/Package';
 import rnFixture from '../../plugins/__tests__/fixtures/react-native-project';
 import { readAndroidManifestAsync } from '../Manifest';
 import {
   getApplicationIdAsync,
   getPackage,
+  renameJniOnDiskForType,
+  renamePackageOnDiskForType,
   setPackageInAndroidManifest,
   setPackageInBuildGradle,
 } from '../Package';
@@ -109,6 +110,29 @@ describe(renamePackageOnDiskForType, () => {
     const results = vol.toJSON();
     expect(results['/android/app/src/debug/java/com/bacon/foobar/ReactNativeFlipper.java']).toMatch(
       /package com.bacon.foobar;/
+    );
+  });
+});
+
+describe(renameJniOnDiskForType, () => {
+  afterAll(async () => {
+    vol.reset();
+  });
+  it(`refactors a main project`, async () => {
+    const projectRoot = '/';
+    vol.fromJSON(rnFixture, projectRoot);
+
+    await renameJniOnDiskForType({
+      projectRoot,
+      type: 'main',
+      packageName: 'com.bacon.foobar',
+    });
+
+    const results = vol.toJSON();
+    expect(
+      results['/android/app/src/main/jni/MainApplicationTurboModuleManagerDelegate.h']
+    ).toMatch(
+      /"Lcom\/bacon\/foobar\/newarchitecture\/modules\/MainApplicationTurboModuleManagerDelegate;";/
     );
   });
 });

--- a/packages/config-plugins/src/plugins/__tests__/fixtures/react-native-project.ts
+++ b/packages/config-plugins/src/plugins/__tests__/fixtures/react-native-project.ts
@@ -1316,4 +1316,45 @@ include ':app'
       into 'libs'
   }
   apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)`,
+
+  'android/app/src/main/jni/MainApplicationTurboModuleManagerDelegate.h': `\
+  #include <memory>
+  #include <string>
+
+  #include <ReactCommon/TurboModuleManagerDelegate.h>
+  #include <fbjni/fbjni.h>
+
+  namespace facebook {
+  namespace react {
+
+  class MainApplicationTurboModuleManagerDelegate
+      : public jni::HybridClass<
+            MainApplicationTurboModuleManagerDelegate,
+            TurboModuleManagerDelegate> {
+   public:
+    // Adapt it to the package you used for your Java class.
+    static constexpr auto kJavaDescriptor =
+        "Lcom/reactnativeproject/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate;";
+
+    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject>);
+
+    static void registerNatives();
+
+    std::shared_ptr<TurboModule> getTurboModule(
+        const std::string name,
+        const std::shared_ptr<CallInvoker> jsInvoker) override;
+    std::shared_ptr<TurboModule> getTurboModule(
+        const std::string name,
+        const JavaTurboModule::InitParams &params) override;
+
+    /**
+     * Test-only method. Allows user to verify whether a TurboModule can be
+     * created by instances of this class.
+     */
+    bool canCreateTurboModule(std::string name);
+  };
+
+  } // namespace react
+  } // namespace facebook
+`,
 };


### PR DESCRIPTION
# Why

react-native 0.68 added jni code in templates for new architecture support. in the jni code, there are some java descriptors mapping to java class names. e.g.:

```c++
  static constexpr auto kJavaDescriptor =
      "Lcom/helloworld/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate;";
```

we should also rename these descriptors. otherwise apps will crash from new architecture mode.

# How

rename descriptors in jni folders

# Test Plan

#### Integration Tests

```sh
$ expo init -t blank sdk45
$ expo prebuild -p android # use package name other than com.sdk45
# set newArchEnabled=true in android/gradle.properties
$ expo run:android
```

also tested on a sdk 44 project to make sure the pr is backward compatible.

#### Unit Test

```
 PASS   @expo/config-plugins  src/android/__tests__/Package-test.ts
  renameJniOnDiskForType
    ✓ refactors a main project (5 ms)
```