### PR TITLE
fix: prevent throwing when an upper-level directory has an invalid package.json

### DIFF
--- a/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
+++ b/packages/expo-cli/src/commands/utils/deprecatedExtensionWarnings.ts
@@ -50,9 +50,21 @@ export async function assertProjectHasExpoExtensionFilesAsync(
   }
 }
 
+/** Wraps `findWorkspaceRoot` and guards against having an empty `package.json` file in an upper directory. */
+function getWorkspaceRoot(projectRoot: string): string | null {
+  try {
+    return findWorkspaceRoot(projectRoot);
+  } catch (error: any) {
+    if (error.message.includes('Unexpected end of JSON input')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function assertModulesHasExpoExtensionFilesAsync(projectRoot: string) {
   const spinner = ora('Checking project for deprecated features, this may take a moment.').start();
-  const root = findWorkspaceRoot(projectRoot) || projectRoot;
+  const root = getWorkspaceRoot(projectRoot) || projectRoot;
 
   Log.time('assertModulesHasExpoExtensionFilesAsync');
   let matches = await queryExpoExtensionFilesAsync(root, [

--- a/packages/metro-config/src/getModulesPaths.ts
+++ b/packages/metro-config/src/getModulesPaths.ts
@@ -1,12 +1,24 @@
 import findWorkspaceRoot from 'find-yarn-workspace-root';
 import path from 'path';
 
+/** Wraps `findWorkspaceRoot` and guards against having an empty `package.json` file in an upper directory. */
+export function getWorkspaceRoot(projectRoot: string): string | null {
+  try {
+    return findWorkspaceRoot(projectRoot);
+  } catch (error: any) {
+    if (error.message.includes('Unexpected end of JSON input')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 export function getModulesPaths(projectRoot: string): string[] {
   const paths: string[] = [];
 
   // Only add the project root if it's not the current working directory
   // this minimizes the chance of Metro resolver breaking on new Node.js versions.
-  const workspaceRoot = findWorkspaceRoot(path.resolve(projectRoot)); // Absolute path or null
+  const workspaceRoot = getWorkspaceRoot(path.resolve(projectRoot)); // Absolute path or null
   if (workspaceRoot) {
     paths.push(path.resolve(projectRoot));
     paths.push(path.resolve(workspaceRoot, 'node_modules'));

--- a/packages/metro-config/src/getWatchFolders.ts
+++ b/packages/metro-config/src/getWatchFolders.ts
@@ -1,8 +1,9 @@
 import JsonFile from '@expo/json-file';
 import assert from 'assert';
-import findWorkspaceRoot from 'find-yarn-workspace-root';
 import { sync as globSync } from 'glob';
 import path from 'path';
+
+import { getWorkspaceRoot } from './getModulesPaths';
 
 /**
  * @param workspaceProjectRoot Root file path for the yarn workspace
@@ -69,7 +70,7 @@ export function resolveAllWorkspacePackageJsonPaths(workspaceProjectRoot: string
  * @returns list of node module paths to watch in Metro bundler, ex: `['/Users/me/app/node_modules/', '/Users/me/app/apps/my-app/', '/Users/me/app/packages/my-package/']`
  */
 export function getWatchFolders(projectRoot: string): string[] {
-  const workspaceRoot = findWorkspaceRoot(path.resolve(projectRoot));
+  const workspaceRoot = getWorkspaceRoot(path.resolve(projectRoot));
   // Rely on default behavior in standard projects.
   if (!workspaceRoot) {
     return [];

--- a/packages/package-manager/src/utils/__tests__/nodeWorkspaces-test.ts
+++ b/packages/package-manager/src/utils/__tests__/nodeWorkspaces-test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import {
   findWorkspaceRoot,
+  findYarnOrNpmWorkspaceRootSafe,
   NPM_LOCK_FILE,
   PNPM_LOCK_FILE,
   PNPM_WORKSPACE_FILE,
@@ -11,6 +12,21 @@ import {
 } from '../nodeWorkspaces';
 
 jest.mock('fs');
+
+describe(findYarnOrNpmWorkspaceRootSafe, () => {
+  afterEach(() => vol.reset());
+  it(`doesn't throw when the upper level has a malformed package.json`, () => {
+    vol.fromJSON(
+      {
+        'packages/test/package.json': '{}',
+        'package.json': '',
+      },
+      '/'
+    );
+
+    expect(findYarnOrNpmWorkspaceRootSafe('/packages/test')).toBe(null);
+  });
+});
 
 describe(findWorkspaceRoot, () => {
   // Resolve these paths to avoid posix vs windows path issues when validating

--- a/packages/package-manager/src/utils/nodeWorkspaces.ts
+++ b/packages/package-manager/src/utils/nodeWorkspaces.ts
@@ -28,6 +28,18 @@ function findPnpmWorkspaceRoot(projectRoot: string) {
   return manifestLocation ? path.dirname(manifestLocation) : null;
 }
 
+/** Wraps `findYarnOrNpmWorkspaceRoot` and guards against having an empty `package.json` file in an upper directory. */
+export function findYarnOrNpmWorkspaceRootSafe(projectRoot: string): string | null {
+  try {
+    return findYarnOrNpmWorkspaceRoot(projectRoot);
+  } catch (error: any) {
+    if (error.message.includes('Unexpected end of JSON input')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 /**
  * Resolve the workspace root for a project, if its part of a monorepo.
  * Optionally, provide a specific packager to only resolve that one specifically.
@@ -42,8 +54,8 @@ export function findWorkspaceRoot(
   packageManager?: NodePackageManager
 ): string | null {
   const strategies: Record<NodePackageManager, (projectRoot: string) => string | null> = {
-    npm: findYarnOrNpmWorkspaceRoot,
-    yarn: findYarnOrNpmWorkspaceRoot,
+    npm: findYarnOrNpmWorkspaceRootSafe,
+    yarn: findYarnOrNpmWorkspaceRootSafe,
     pnpm: findPnpmWorkspaceRoot,
   };
 

--- a/packages/webpack-config/src/env/paths.ts
+++ b/packages/webpack-config/src/env/paths.ts
@@ -9,6 +9,18 @@ import url from 'url';
 import { Environment, FilePaths, InputEnvironment } from '../types';
 import getMode from './getMode';
 
+/** Wraps `findYarnOrNpmWorkspaceRoot` and guards against having an empty `package.json` file in an upper directory. */
+function findYarnOrNpmWorkspaceRootSafe(projectRoot: string): string | null {
+  try {
+    return findWorkspaceRoot(projectRoot);
+  } catch (error: any) {
+    if (error.message.includes('Unexpected end of JSON input')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 function getAbsolutePathWithProjectRoot(projectRoot: string, ...pathComponents: string[]): string {
   // Simple check if we are dealing with a URL.
   if (pathComponents?.length === 1 && pathComponents[0].startsWith('http')) {
@@ -19,7 +31,7 @@ function getAbsolutePathWithProjectRoot(projectRoot: string, ...pathComponents: 
 }
 
 function getModulesPath(projectRoot: string): string {
-  const workspaceRoot = findWorkspaceRoot(path.resolve(projectRoot)); // Absolute path or null
+  const workspaceRoot = findYarnOrNpmWorkspaceRootSafe(path.resolve(projectRoot)); // Absolute path or null
   if (workspaceRoot) {
     return path.resolve(workspaceRoot, 'node_modules');
   }


### PR DESCRIPTION
# Why

- fix ENG-4914

# Test Plan

- Added tests to the package-manager copy of the function.