### PR TITLE
Add support for detecting Gemfile and using ruby bundler for cocoapods

### DIFF
--- a/packages/create-expo-app/src/Template.ts
+++ b/packages/create-expo-app/src/Template.ts
@@ -160,9 +160,11 @@ export async function installPodsAsync(projectRoot: string) {
     step.succeed('Skipped installing CocoaPods because operating system is not macOS.');
     return false;
   }
+  const useRubyBundler = PackageManager.CocoaPodsPackageManager.isUsingRubyBundler(projectRoot);
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
     silent: !env.EXPO_DEBUG,
+    shouldUseRubyBundler: useRubyBundler,
   });
 
   if (!(await packageManager.isCLIInstalledAsync())) {

--- a/packages/create-expo-app/src/Template.ts
+++ b/packages/create-expo-app/src/Template.ts
@@ -160,11 +160,9 @@ export async function installPodsAsync(projectRoot: string) {
     step.succeed('Skipped installing CocoaPods because operating system is not macOS.');
     return false;
   }
-  const useRubyBundler = PackageManager.CocoaPodsPackageManager.isUsingRubyBundler(projectRoot);
-  const packageManager = new PackageManager.CocoaPodsPackageManager({
+  const packageManager = PackageManager.CocoaPodsPackageManager.create(projectRoot, {
     cwd: path.join(projectRoot, 'ios'),
     silent: !env.EXPO_DEBUG,
-    shouldUseRubyBundler: useRubyBundler,
   });
 
   if (!(await packageManager.isCLIInstalledAsync())) {

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -165,11 +165,9 @@ export async function installCocoaPodsAsync(projectRoot: string) {
     return false;
   }
 
-  const useRubyBundler = PackageManager.CocoaPodsPackageManager.isUsingRubyBundler(projectRoot);
-  const packageManager = new PackageManager.CocoaPodsPackageManager({
+  const packageManager = PackageManager.CocoaPodsPackageManager.create(projectRoot, {
     cwd: path.join(projectRoot, 'ios'),
     silent: !EXPO_DEBUG,
-    shouldUseRubyBundler: useRubyBundler,
   });
 
   if (!(await packageManager.isCLIInstalledAsync())) {
@@ -177,10 +175,9 @@ export async function installCocoaPodsAsync(projectRoot: string) {
       // prompt user -- do you want to install cocoapods right now?
       step.text = 'CocoaPods CLI not found in your PATH, installing it now.';
       step.stopAndPersist();
-      const noisyPackageManager = new PackageManager.CocoaPodsPackageManager({
+      const noisyPackageManager = PackageManager.CocoaPodsPackageManager.create(projectRoot, {
         cwd: path.join(projectRoot, 'ios'),
         silent: !EXPO_DEBUG,
-        shouldUseRubyBundler: useRubyBundler,
         spawnOptions: {
           // Don't silence this part
           stdio: ['inherit', 'inherit', 'pipe'],

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -165,9 +165,11 @@ export async function installCocoaPodsAsync(projectRoot: string) {
     return false;
   }
 
+  const useRubyBundler = PackageManager.CocoaPodsPackageManager.isUsingRubyBundler(projectRoot);
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
     silent: !EXPO_DEBUG,
+    shouldUseRubyBundler: useRubyBundler,
   });
 
   if (!(await packageManager.isCLIInstalledAsync())) {
@@ -178,6 +180,7 @@ export async function installCocoaPodsAsync(projectRoot: string) {
       const noisyPackageManager = new PackageManager.CocoaPodsPackageManager({
         cwd: path.join(projectRoot, 'ios'),
         silent: !EXPO_DEBUG,
+        shouldUseRubyBundler: useRubyBundler,
         spawnOptions: {
           // Don't silence this part
           stdio: ['inherit', 'inherit', 'pipe'],

--- a/packages/expo-cli/src/commands/utils/CreateApp.ts
+++ b/packages/expo-cli/src/commands/utils/CreateApp.ts
@@ -175,14 +175,16 @@ export async function installCocoaPodsAsync(projectRoot: string) {
       // prompt user -- do you want to install cocoapods right now?
       step.text = 'CocoaPods CLI not found in your PATH, installing it now.';
       step.stopAndPersist();
-      await PackageManager.CocoaPodsPackageManager.installCLIAsync({
-        nonInteractive: true,
+      const noisyPackageManager = new PackageManager.CocoaPodsPackageManager({
+        cwd: path.join(projectRoot, 'ios'),
+        silent: !EXPO_DEBUG,
         spawnOptions: {
-          ...packageManager.options,
           // Don't silence this part
           stdio: ['inherit', 'inherit', 'pipe'],
         },
+        isNonInteractive: true,
       });
+      await noisyPackageManager.installCLIAsync();
       step.succeed('Installed CocoaPods CLI.');
       step = logNewSection('Running `pod install` in the `ios` directory.');
     } catch (e: any) {

--- a/packages/package-manager/src/__tests__/CocoaPodsPackageManager-test.ts
+++ b/packages/package-manager/src/__tests__/CocoaPodsPackageManager-test.ts
@@ -338,15 +338,15 @@ describe('isUsingRubyBundler', () => {
 describe('spawnPodCommandAsync', () => {
   it('supports no Gemfile', async () => {
     const { CocoaPodsPackageManager } = require('../CocoaPodsPackageManager');
-    const manager = new CocoaPodsPackageManager({ shouldUseRubyBundler: false });
+    const manager = new CocoaPodsPackageManager({ cwd: projectRoot });
 
     await manager.spawnPodCommandAsync(['install']);
     expect(spawnAsync).toBeCalledWith('pod', ['install'], undefined);
   });
 
   it('supports Gemfile', async () => {
-    const { CocoaPodsPackageManager } = require('../CocoaPodsPackageManager');
-    const manager = new CocoaPodsPackageManager({ shouldUseRubyBundler: true });
+    const { CocoaPodsBundlerPackageManager } = require('../CocoaPodsPackageManager');
+    const manager = new CocoaPodsBundlerPackageManager({ cwd: projectRoot });
 
     await manager.spawnPodCommandAsync(['install']);
     expect(spawnAsync).toBeCalledWith('bundle', ['exec', 'pod', 'install'], undefined);

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -39,20 +39,18 @@ async function runAsync(): Promise<void> {
     return;
   }
 
-  const useRubyBundler = CocoaPodsPackageManager.isUsingRubyBundler(projectRoot);
-
+  let podfileRoot = projectRoot;
   const possibleProjectRoot = CocoaPodsPackageManager.getPodProjectRoot(projectRoot);
   if (!possibleProjectRoot) {
     info(chalk.yellow('CocoaPods is not supported in this project'));
     return;
   } else {
-    projectRoot = possibleProjectRoot;
+    podfileRoot = possibleProjectRoot;
   }
 
-  const manager = new CocoaPodsPackageManager({
-    cwd: projectRoot,
+  const manager = CocoaPodsPackageManager.create(projectRoot, {
+    cwd: podfileRoot,
     isNonInteractive: program.nonInteractive,
-    shouldUseRubyBundler: useRubyBundler,
   });
   if (!(await manager.isCLIInstalledAsync())) {
     await manager.installCLIAsync();

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -39,6 +39,8 @@ async function runAsync(): Promise<void> {
     return;
   }
 
+  const useRubyBundler = CocoaPodsPackageManager.isUsingRubyBundler(projectRoot);
+
   const possibleProjectRoot = CocoaPodsPackageManager.getPodProjectRoot(projectRoot);
   if (!possibleProjectRoot) {
     info(chalk.yellow('CocoaPods is not supported in this project'));
@@ -47,10 +49,14 @@ async function runAsync(): Promise<void> {
     projectRoot = possibleProjectRoot;
   }
 
-  if (!(await CocoaPodsPackageManager.isCLIInstalledAsync())) {
-    await CocoaPodsPackageManager.installCLIAsync({ nonInteractive: program.nonInteractive });
+  const manager = new CocoaPodsPackageManager({
+    cwd: projectRoot,
+    isNonInteractive: program.nonInteractive,
+    shouldUseRubyBundler: useRubyBundler,
+  });
+  if (!(await manager.isCLIInstalledAsync())) {
+    await manager.installCLIAsync();
   }
-  const manager = new CocoaPodsPackageManager({ cwd: projectRoot });
   try {
     await manager.installAsync();
   } catch (error: any) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/compat-data@^7.11.0", "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0", "@babel/compat-data@^7.18.6", "@babel/compat-data@^7.18.8":
+"@babel/compat-data@^7.11.0", "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0", "@babel/compat-data@^7.18.8":
   version "7.18.8"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
   integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
@@ -174,7 +174,7 @@
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-"@babel/generator@^7.18.2", "@babel/generator@^7.18.7", "@babel/generator@^7.18.9", "@babel/generator@^7.5.0", "@babel/generator@^7.7.2", "@babel/generator@^7.7.7", "@babel/generator@^7.9.0":
+"@babel/generator@^7.18.2", "@babel/generator@^7.18.9", "@babel/generator@^7.5.0", "@babel/generator@^7.7.2", "@babel/generator@^7.7.7", "@babel/generator@^7.9.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
   integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
@@ -254,7 +254,7 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-function-name@^7.16.0", "@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.6", "@babel/helper-function-name@^7.18.9":
+"@babel/helper-function-name@^7.16.0", "@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz#940e6084a55dee867d33b4e487da2676365e86b0"
   integrity sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==
@@ -388,7 +388,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.7", "@babel/parser@^7.18.0", "@babel/parser@^7.18.6", "@babel/parser@^7.18.8", "@babel/parser@^7.18.9", "@babel/parser@^7.7.7", "@babel/parser@^7.9.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.7", "@babel/parser@^7.18.0", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9", "@babel/parser@^7.7.7", "@babel/parser@^7.9.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
   integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
@@ -1335,7 +1335,7 @@
     "@babel/parser" "^7.18.6"
     "@babel/types" "^7.18.6"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.18.2", "@babel/traverse@^7.18.6", "@babel/traverse@^7.18.8", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2", "@babel/traverse@^7.7.4", "@babel/traverse@^7.9.0":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.18.2", "@babel/traverse@^7.18.6", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2", "@babel/traverse@^7.7.4", "@babel/traverse@^7.9.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
   integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
@@ -1369,7 +1369,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.11.5", "@babel/types@^7.13.12", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.18.2", "@babel/types@^7.18.6", "@babel/types@^7.18.7", "@babel/types@^7.18.8", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.4", "@babel/types@^7.9.0":
+"@babel/types@^7.0.0", "@babel/types@^7.11.5", "@babel/types@^7.13.12", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.18.2", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.4", "@babel/types@^7.9.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
   integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
@@ -1736,6 +1736,23 @@
     sudo-prompt "^8.2.0"
     tmp "^0.0.33"
     tslib "^1.10.0"
+
+"@expo/image-utils@0.3.21":
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.21.tgz#dabe772135a66671939f87389e11f23e54341e1e"
+  integrity sha512-Ha7pNcpl52RJIeYz3gR1ajOgPPl7WLZWiLqtLi94s9J0a7FvmNBMqd/VKrfHNj8QmtZxXcmXr7y7tPhZbVFg7w==
+  dependencies:
+    "@expo/spawn-async" "1.5.0"
+    chalk "^4.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    jimp-compact "0.16.1"
+    mime "^2.4.4"
+    node-fetch "^2.6.0"
+    parse-png "^2.1.0"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    tempy "0.3.0"
 
 "@expo/metro-config@0.3.18":
   version "0.3.18"


### PR DESCRIPTION
# Why

Resolves #2206

Different developers are ended up with different cocoapods versions which causes problems with Podfile.lock being generated differently.

# Test Plan

~I need help with this. I'm not an experienced JS developer, I come from an iOS background. I can't seem to get anything to use my local `package-manager` package. I can point a project to my local `pod-install` package, but even that doesn't use the local `package-manager` (even when the dependency is overridden to a local path).~
- Tested against local project which uses a Gemfile.
- Added a few unit tests.