### PR TITLE
[package-manager] Prefer yarn over npm if both lockfiles exists

### DIFF
--- a/packages/package-manager/src/utils/nodeWorkspaces.ts
+++ b/packages/package-manager/src/utils/nodeWorkspaces.ts
@@ -9,7 +9,7 @@ export const NPM_LOCK_FILE = 'package-lock.json';
 export const YARN_LOCK_FILE = 'yarn.lock';
 export const PNPM_LOCK_FILE = 'pnpm-lock.yaml';
 export const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml';
-export const managerResolutionOrder: NodePackageManager[] = ['npm', 'yarn', 'pnpm'];
+export const managerResolutionOrder: NodePackageManager[] = ['yarn', 'npm', 'pnpm'];
 
 /**
  * Find the `pnpm-workspace.yaml` file that represents the root of the monorepo.


### PR DESCRIPTION
# Why

https://github.com/expo/eas-build/pull/96#issuecomment-1122205110

EAS Build prioritized yarn when both lockfiles existed so if we don't want to introduce breaking changes and unify the logic change has to be here

# How

change order in which package managers are resolved

# Test Plan

CI