### PR TITLE
feat(create-expo-app): fail on invalid template before prompting for the app name

### DIFF
--- a/packages/create-expo-app/src/Update.ts
+++ b/packages/create-expo-app/src/Update.ts
@@ -9,7 +9,7 @@ export default async function shouldUpdate(): Promise<void> {
     if (res?.latest) {
       console.log();
       console.log(chalk.yellow.bold(`A new version of \`${packageJson.name}\` is available`));
-      console.log(`You can update by running: {cyan npm install -g ${packageJson.name}}`);
+      console.log(chalk`You can update by running: {cyan npm install -g ${packageJson.name}}`);
       console.log();
     }
   } catch {

--- a/packages/create-expo-app/src/index.ts
+++ b/packages/create-expo-app/src/index.ts
@@ -35,6 +35,15 @@ const program = new Command(packageJSON.name)
 
 async function runAsync(): Promise<void> {
   try {
+    const resolvedTemplate: string | null = program.template;
+    // @ts-ignore: This guards against someone passing --template without a name after it.
+    if (resolvedTemplate === true) {
+      console.log();
+      console.log('Please specify the template, example: --template expo-template-blank');
+      console.log();
+      process.exit(1);
+    }
+
     let projectRoot: string;
     if (!inputPath && program.yes) {
       projectRoot = path.resolve(process.cwd());
@@ -43,14 +52,6 @@ async function runAsync(): Promise<void> {
       assertFolderEmpty(projectRoot, folderName);
     } else {
       projectRoot = await resolveProjectRootAsync(inputPath);
-    }
-    const resolvedTemplate: string | null = program.template;
-    // @ts-ignore: This guards against someone passing --template without a name after it.
-    if (resolvedTemplate === true) {
-      console.log();
-      console.log('Please specify the template, example: --template expo-template-blank');
-      console.log();
-      process.exit(1);
     }
 
     await fs.promises.mkdir(projectRoot, { recursive: true });

--- a/packages/create-expo-app/src/legacyTemplates.ts
+++ b/packages/create-expo-app/src/legacyTemplates.ts
@@ -1,0 +1,47 @@
+import chalk from 'chalk';
+import prompts from 'prompts';
+
+export const LEGACY_TEMPLATES = [
+  {
+    title: 'Blank',
+    value: 'expo-template-blank',
+    description: 'a minimal app as clean as an empty canvas',
+  },
+
+  {
+    title: 'Blank (TypeScript)',
+    value: 'expo-template-blank-typescript',
+    description: 'blank app with TypeScript enabled',
+  },
+  {
+    title: 'Navigation (TypeScript)',
+    value: 'expo-template-tabs',
+    description: 'several example screens and tabs using react-navigation and TypeScript',
+  },
+
+  {
+    title: 'Blank (Bare)',
+    value: 'expo-template-bare-minimum',
+    description: 'blank app with the native code exposed (expo prebuild)',
+  },
+];
+
+export const ALIASES = LEGACY_TEMPLATES.map(({ value }) => value);
+
+export async function promptTemplateAsync() {
+  const { answer } = await prompts({
+    type: 'select',
+    name: 'answer',
+    message: 'Choose a template:',
+    choices: LEGACY_TEMPLATES,
+  });
+
+  if (!answer) {
+    console.log();
+    console.log(chalk`Please specify the template, example: {cyan --template expo-template-blank}`);
+    console.log();
+    process.exit(1);
+  }
+
+  return answer;
+}

--- a/packages/create-expo-app/src/npm.ts
+++ b/packages/create-expo-app/src/npm.ts
@@ -9,6 +9,7 @@ import { promisify } from 'util';
 
 import { createEntryResolver, createFileTransform } from './createFileTransform';
 import { createFetch } from './fetch';
+import { ALIASES } from './legacyTemplates';
 
 type ExtractProps = {
   name: string;
@@ -16,13 +17,6 @@ type ExtractProps = {
   strip?: number;
   fileList?: string[];
 };
-
-const ALIASES = [
-  'expo-template-blank',
-  'expo-template-blank-typescript',
-  'expo-template-tabs',
-  'expo-template-bare-minimum',
-];
 
 function isBeta() {
   return getenv.boolish('EXPO_BETA', false);


### PR DESCRIPTION
- Fail faster
- Fix format
- Improve help
- Add template prompt