### PR TITLE
Upgrade `babel-preset-expo`

### DIFF
--- a/packages/next-adapter/package.json
+++ b/packages/next-adapter/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@expo/package-manager": "0.0.54",
     "@expo/webpack-config": "0.16.24",
-    "babel-preset-expo": "^8.4.1",
+    "babel-preset-expo": "^9.1.0",
     "chalk": "^4.0.0",
     "commander": "^4.0.1",
     "fs-extra": "9.0.0",


### PR DESCRIPTION
# Why

The current version is outdated:

<img width="843" alt="Screen Shot 2022-05-16 at 10 37 38 AM" src="https://user-images.githubusercontent.com/13172299/168618118-22c1a861-f961-4158-9ee7-38d29ca4ddd4.png">


# How

Version upgrade in `package.json`

# Test Plan

I had mismatching versions in my monorepo that broke `yarn install` on SDK 45, so I had to use a yarn resolution in my root `package.json`:

```json
{
  "resolutions": {
    "babel-preset-expo": "9.1.0"
  },
}
```

This is an issue in general with the tooling dependencies in a monorepo. Not sure what the best strategy is to handle it – perhaps make `babel-preset-expo` a peer dependency instead? 🤷‍♂️

As a similar issue, `expo upgrade` doesn't work in monorepos, since it only upgrades packages in the app folder, so there are tons of mismatches across the repo. It also doesn't detect lingering incorrect versions, such as `babel-preset-expo`.

I think it would be good for `expo upgrade` to run `yarn why` for every package it wants to upgrade, starting at the root of a monorepo (if it's in one), and indicate any packages that have the wrong versions based on the result of `yarn why` – not just the explicitly mentioned versions in `package.json`. I know that this issue is separate, but I thought it could be worth mentioning.