### PR TITLE
[config plugins] allow overwriting Info.plist values

### DIFF
--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -68,7 +68,7 @@ export interface ExportedConfigWithProps<Data = any> extends ExportedConfig {
    * For example, you could infer that the user defined a certain
    * value explicitly and disable any automatic changes.
    */
-  readonly modOriginalConfig: ExpoConfig;
+  readonly modRawConfig: ExpoConfig;
 }
 
 /**

--- a/packages/config-plugins/src/Plugin.types.ts
+++ b/packages/config-plugins/src/Plugin.types.ts
@@ -61,6 +61,14 @@ export interface ExportedConfigWithProps<Data = any> extends ExportedConfig {
    */
   modResults: Data;
   modRequest: ModProps<Data>;
+  /**
+   * A frozen representation of the original file contents,
+   * this can be used as a reference into the user's original intent.
+   *
+   * For example, you could infer that the user defined a certain
+   * value explicitly and disable any automatic changes.
+   */
+  readonly modOriginalConfig: ExpoConfig;
 }
 
 /**

--- a/packages/config-plugins/src/ios/Name.ts
+++ b/packages/config-plugins/src/ios/Name.ts
@@ -2,7 +2,7 @@ import { ExpoConfig } from '@expo/config-types';
 import { XcodeProject } from 'xcode';
 
 import { ConfigPlugin } from '../Plugin.types';
-import { createInfoPlistPlugin, withXcodeProject } from '../plugins/ios-plugins';
+import { createInfoPlistPluginWithPropertyGuard, withXcodeProject } from '../plugins/ios-plugins';
 import { InfoPlist } from './IosConfig.types';
 import { findFirstNativeTarget } from './Target';
 import {
@@ -11,9 +11,23 @@ import {
   sanitizedName,
 } from './utils/Xcodeproj';
 
-export const withDisplayName = createInfoPlistPlugin(setDisplayName, 'withDisplayName');
+export const withDisplayName = createInfoPlistPluginWithPropertyGuard(
+  setDisplayName,
+  {
+    infoPlistProperty: 'CFBundleDisplayName',
+    expoConfigProperty: 'name',
+  },
+  'withDisplayName'
+);
 
-export const withName = createInfoPlistPlugin(setName, 'withName');
+export const withName = createInfoPlistPluginWithPropertyGuard(
+  setName,
+  {
+    infoPlistProperty: 'CFBundleName',
+    expoConfigProperty: 'name',
+  },
+  'withName'
+);
 
 /** Set the PRODUCT_NAME variable in the xcproj file based on the app.json name property. */
 export const withProductName: ConfigPlugin = config => {

--- a/packages/config-plugins/src/ios/Orientation.ts
+++ b/packages/config-plugins/src/ios/Orientation.ts
@@ -1,9 +1,16 @@
 import { ExpoConfig } from '@expo/config-types';
 
-import { createInfoPlistPlugin } from '../plugins/ios-plugins';
+import { createInfoPlistPluginWithPropertyGuard } from '../plugins/ios-plugins';
 import { InfoPlist, InterfaceOrientation } from './IosConfig.types';
 
-export const withOrientation = createInfoPlistPlugin(setOrientation, 'withOrientation');
+export const withOrientation = createInfoPlistPluginWithPropertyGuard(
+  setOrientation,
+  {
+    infoPlistProperty: 'UISupportedInterfaceOrientations',
+    expoConfigProperty: 'orientation',
+  },
+  'withOrientation'
+);
 
 export function getOrientation(config: Pick<ExpoConfig, 'orientation'>) {
   return config.orientation ?? null;

--- a/packages/config-plugins/src/ios/Scheme.ts
+++ b/packages/config-plugins/src/ios/Scheme.ts
@@ -1,9 +1,16 @@
 import { ExpoConfig } from '@expo/config-types';
 
-import { createInfoPlistPlugin } from '../plugins/ios-plugins';
+import { createInfoPlistPluginWithPropertyGuard } from '../plugins/ios-plugins';
 import { InfoPlist, URLScheme } from './IosConfig.types';
 
-export const withScheme = createInfoPlistPlugin(setScheme, 'withScheme');
+export const withScheme = createInfoPlistPluginWithPropertyGuard(
+  setScheme,
+  {
+    infoPlistProperty: 'CFBundleURLTypes',
+    expoConfigProperty: 'scheme',
+  },
+  'withScheme'
+);
 
 export function getScheme(config: { scheme?: string | string[] }): string[] {
   if (Array.isArray(config.scheme)) {

--- a/packages/config-plugins/src/ios/UsesNonExemptEncryption.ts
+++ b/packages/config-plugins/src/ios/UsesNonExemptEncryption.ts
@@ -1,10 +1,14 @@
 import { ExpoConfig } from '@expo/config-types';
 
-import { createInfoPlistPlugin } from '../plugins/ios-plugins';
+import { createInfoPlistPluginWithPropertyGuard } from '../plugins/ios-plugins';
 import { InfoPlist } from './IosConfig.types';
 
-export const withUsesNonExemptEncryption = createInfoPlistPlugin(
+export const withUsesNonExemptEncryption = createInfoPlistPluginWithPropertyGuard(
   setUsesNonExemptEncryption,
+  {
+    infoPlistProperty: 'ITSAppUsesNonExemptEncryption',
+    expoConfigProperty: 'ios.config.usesNonExemptEncryption',
+  },
   'withUsesNonExemptEncryption'
 );
 

--- a/packages/config-plugins/src/ios/Version.ts
+++ b/packages/config-plugins/src/ios/Version.ts
@@ -1,11 +1,28 @@
 import { ExpoConfig } from '@expo/config-types';
 
-import { createInfoPlistPlugin } from '../plugins/ios-plugins';
+import {
+  createInfoPlistPlugin,
+  createInfoPlistPluginWithPropertyGuard,
+} from '../plugins/ios-plugins';
 import { InfoPlist } from './IosConfig.types';
 
-export const withVersion = createInfoPlistPlugin(setVersion, 'withVersion');
+export const withVersion = createInfoPlistPluginWithPropertyGuard(
+  setVersion,
+  {
+    infoPlistProperty: 'CFBundleShortVersionString',
+    expoConfigProperty: 'version',
+  },
+  'withVersion'
+);
 
-export const withBuildNumber = createInfoPlistPlugin(setBuildNumber, 'withBuildNumber');
+export const withBuildNumber = createInfoPlistPluginWithPropertyGuard(
+  setBuildNumber,
+  {
+    infoPlistProperty: 'CFBundleVersion',
+    expoConfigProperty: 'ios.buildNumber',
+  },
+  'withBuildNumber'
+);
 
 export function getVersion(config: Pick<ExpoConfig, 'version'>) {
   return config.version || '1.0.0';

--- a/packages/config-plugins/src/plugins/__tests__/ios-plugins-test.ts
+++ b/packages/config-plugins/src/plugins/__tests__/ios-plugins-test.ts
@@ -1,0 +1,149 @@
+import { ExpoConfig } from '@expo/config-types';
+import { vol } from 'memfs';
+
+import { addWarningIOS } from '../../utils/warnings';
+import { createInfoPlistPluginWithPropertyGuard } from '../ios-plugins';
+import { evalModsAsync } from '../mod-compiler';
+import { getIosModFileProviders, withIosBaseMods } from '../withIosBaseMods';
+import rnFixture from './fixtures/react-native-project';
+
+jest.mock('../../utils/warnings', () => ({
+  addWarningIOS: jest.fn(),
+}));
+
+jest.mock('fs');
+
+export const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+describe(createInfoPlistPluginWithPropertyGuard, () => {
+  const projectRoot = '/app';
+
+  beforeEach(async () => {
+    asMock(addWarningIOS).mockClear();
+    vol.fromJSON(
+      {
+        ...rnFixture,
+      },
+      projectRoot
+    );
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it(`respects info plist manual values`, async () => {
+    const setter = jest.fn();
+    const withPlugin = createInfoPlistPluginWithPropertyGuard(setter, {
+      infoPlistProperty: 'CFFakeValue',
+      // Supports nesting
+      expoConfigProperty: 'ios.appStoreUrl',
+    });
+
+    let config: ExpoConfig = {
+      name: 'hey',
+      slug: '',
+      ios: {
+        appStoreUrl: 'underlying',
+        infoPlist: {
+          CFFakeValue: false,
+        },
+      },
+    };
+
+    config = withPlugin(config);
+
+    config = withIosBaseMods(config, {
+      providers: {
+        infoPlist: getIosModFileProviders().infoPlist,
+      },
+    });
+
+    const results = await evalModsAsync(config, {
+      projectRoot,
+      platforms: ['ios'],
+      introspect: true,
+      assertMissingModProviders: true,
+    });
+
+    expect(results.ios.infoPlist.CFFakeValue).toEqual(false);
+
+    expect(setter).not.toBeCalled();
+    expect(addWarningIOS).toBeCalledWith(
+      'ios.appStoreUrl',
+      '"ios.infoPlist.CFFakeValue" is set in the config. Ignoring abstract property "ios.appStoreUrl": underlying'
+    );
+  });
+
+  it(`does not warn about info plist overrides if the abstract value is not defined`, async () => {
+    const setter = jest.fn();
+    const withPlugin = createInfoPlistPluginWithPropertyGuard(setter, {
+      infoPlistProperty: 'CFFakeValue',
+      expoConfigProperty: 'foobar',
+    });
+
+    let config: ExpoConfig = {
+      name: 'hey',
+      slug: '',
+      ios: {
+        infoPlist: {
+          CFFakeValue: false,
+        },
+      },
+    };
+
+    config = withPlugin(config);
+
+    config = withIosBaseMods(config, {
+      providers: {
+        infoPlist: getIosModFileProviders().infoPlist,
+      },
+    });
+
+    const results = await evalModsAsync(config, {
+      projectRoot,
+      platforms: ['ios'],
+      introspect: true,
+      assertMissingModProviders: true,
+    });
+
+    expect(results.ios.infoPlist.CFFakeValue).toEqual(false);
+
+    expect(setter).not.toBeCalled();
+    expect(addWarningIOS).not.toBeCalled();
+  });
+
+  it(`uses default behavior when not overwritten`, async () => {
+    const setter = jest.fn();
+    const withPlugin = createInfoPlistPluginWithPropertyGuard(setter, {
+      infoPlistProperty: 'CFFakeValue',
+      expoConfigProperty: 'name',
+    });
+
+    let config: ExpoConfig = {
+      name: 'hey',
+      slug: '',
+      ios: {
+        infoPlist: {},
+      },
+    };
+
+    config = withPlugin(config);
+
+    config = withIosBaseMods(config, {
+      providers: {
+        infoPlist: getIosModFileProviders().infoPlist,
+      },
+    });
+
+    await evalModsAsync(config, {
+      projectRoot,
+      platforms: ['ios'],
+      introspect: true,
+      assertMissingModProviders: true,
+    });
+
+    expect(setter).toBeCalled();
+    expect(addWarningIOS).not.toBeCalled();
+  });
+});

--- a/packages/config-plugins/src/plugins/ios-plugins.ts
+++ b/packages/config-plugins/src/plugins/ios-plugins.ts
@@ -48,7 +48,7 @@ export function createInfoPlistPluginWithPropertyGuard(
         ? settings.expoPropertyGetter(config)
         : get(config, settings.expoConfigProperty);
       // If the user explicitly sets a value in the infoPlist, we should respect that.
-      if (config.modOriginalConfig.ios?.infoPlist?.[settings.infoPlistProperty] === undefined) {
+      if (config.modRawConfig.ios?.infoPlist?.[settings.infoPlistProperty] === undefined) {
         config.modResults = await action(config, config.modResults);
       } else if (existingProperty !== undefined) {
         // Only warn if there is a conflict.

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -128,6 +128,8 @@ export async function evalModsAsync(
     platforms?: ModPlatform[];
   }
 ): Promise<ExportedConfig> {
+  const modOriginalConfig = Object.freeze(config);
+
   for (const [platformName, platform] of Object.entries(config.mods ?? ({} as ModConfig))) {
     if (platforms && !platforms.includes(platformName as any)) {
       debug(`skip platform: ${platformName}`);
@@ -173,14 +175,17 @@ export async function evalModsAsync(
           ...config,
           modResults: null,
           modRequest,
+          modOriginalConfig,
         });
 
         // Sanity check to help locate non compliant mods.
         config = assertModResults(results, platformName, modName);
-        // @ts-ignore: data is added for modifications
+        // @ts-ignore: `modResults` is added for modifications
         delete config.modResults;
-        // @ts-ignore: info is added for modifications
+        // @ts-ignore: `modRequest` is added for modifications
         delete config.modRequest;
+        // @ts-ignore: `modOriginalConfig` is added for modifications
+        delete config.modOriginalConfig;
       }
     }
   }

--- a/packages/config-plugins/src/plugins/mod-compiler.ts
+++ b/packages/config-plugins/src/plugins/mod-compiler.ts
@@ -128,7 +128,7 @@ export async function evalModsAsync(
     platforms?: ModPlatform[];
   }
 ): Promise<ExportedConfig> {
-  const modOriginalConfig = Object.freeze(config);
+  const modRawConfig = Object.freeze(config);
 
   for (const [platformName, platform] of Object.entries(config.mods ?? ({} as ModConfig))) {
     if (platforms && !platforms.includes(platformName as any)) {
@@ -175,7 +175,7 @@ export async function evalModsAsync(
           ...config,
           modResults: null,
           modRequest,
-          modOriginalConfig,
+          modRawConfig,
         });
 
         // Sanity check to help locate non compliant mods.
@@ -184,8 +184,8 @@ export async function evalModsAsync(
         delete config.modResults;
         // @ts-ignore: `modRequest` is added for modifications
         delete config.modRequest;
-        // @ts-ignore: `modOriginalConfig` is added for modifications
-        delete config.modOriginalConfig;
+        // @ts-ignore: `modRawConfig` is added for modifications
+        delete config.modRawConfig;
       }
     }
   }

--- a/packages/config-plugins/src/utils/obj.ts
+++ b/packages/config-plugins/src/utils/obj.ts
@@ -1,0 +1,13 @@
+/** `lodash.get` */
+export function get(obj: any, key: string): any {
+  const branches = key.split('.');
+  let current: any = obj;
+  let branch: string | undefined;
+  while ((branch = branches.shift())) {
+    if (!(branch in current)) {
+      return undefined;
+    }
+    current = current[branch];
+  }
+  return current;
+}

--- a/packages/prebuild-config/src/plugins/unversioned/expo-system-ui/withIosUserInterfaceStyle.ts
+++ b/packages/prebuild-config/src/plugins/unversioned/expo-system-ui/withIosUserInterfaceStyle.ts
@@ -1,12 +1,16 @@
-import { ConfigPlugin, InfoPlist, withInfoPlist } from '@expo/config-plugins';
+import { InfoPlist } from '@expo/config-plugins';
+import { createInfoPlistPluginWithPropertyGuard } from '@expo/config-plugins/build/plugins/ios-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
-export const withIosUserInterfaceStyle: ConfigPlugin = config => {
-  return withInfoPlist(config, config => {
-    config.modResults = setUserInterfaceStyle(config, config.modResults);
-    return config;
-  });
-};
+export const withIosUserInterfaceStyle = createInfoPlistPluginWithPropertyGuard(
+  setUserInterfaceStyle,
+  {
+    infoPlistProperty: 'UIUserInterfaceStyle',
+    expoConfigProperty: 'userInterfaceStyle | ios.userInterfaceStyle',
+    expoPropertyGetter: getUserInterfaceStyle,
+  },
+  'withIosUserInterfaceStyle'
+);
 
 export function getUserInterfaceStyle(
   config: Pick<ExpoConfig, 'ios' | 'userInterfaceStyle'>


### PR DESCRIPTION
# Why

- [User request](https://twitter.com/nightstomp/status/1526478440773427201).

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Save the original config and pass it around in mods under `modRawConfig`. Mods can observe this config to determine if the user had manually defined the Info.plist key that they would have otherwise modified. If the abstract field is defined (i.e. there's a conflict) then a warning will be thrown.
- We mostly only need this part of the spec for internal use since other plugins run in user space and can be modified.

# Test Plan

- Added tests.