### PR TITLE
fix(package-manager): should not use yarn when npm lockfile exists

### DIFF
--- a/packages/package-manager/src/NodePackageManagers.ts
+++ b/packages/package-manager/src/NodePackageManagers.ts
@@ -11,7 +11,7 @@ import { Transform } from 'stream';
 import { Logger, PackageManager } from './PackageManager';
 import { PnpmPackageManager } from './PnpmPackageManager';
 import isYarnOfflineAsync from './utils/isYarnOfflineAsync';
-import { findWorkspaceRoot, resolvePackageManager } from './utils/nodeWorkspaces';
+import { findWorkspaceRoot, isUsingYarn, resolvePackageManager } from './utils/nodeWorkspaces';
 
 export type NodePackageManager = 'yarn' | 'npm' | 'pnpm';
 
@@ -30,19 +30,6 @@ const yarnPeerDependencyWarningPattern = new RegExp(
   `${ansi}warning${ansi} "[^"]+" has (?:unmet|incorrect) peer dependency "[^"]+"\\.\n`,
   'g'
 );
-
-/**
- * Returns true if the project is using yarn, false if the project is using npm.
- *
- * @param projectRoot
- */
-export function isUsingYarn(projectRoot: string): boolean {
-  const workspaceRoot = findWorkspaceRoot(projectRoot);
-  if (workspaceRoot) {
-    return existsSync(path.join(workspaceRoot, 'yarn.lock'));
-  }
-  return existsSync(path.join(projectRoot, 'yarn.lock'));
-}
 
 class NpmStderrTransform extends Transform {
   _transform(

--- a/packages/package-manager/src/utils/__tests__/shouldUseYarn-test.ts
+++ b/packages/package-manager/src/utils/__tests__/shouldUseYarn-test.ts
@@ -1,6 +1,12 @@
+import { isUsingNpm } from '../nodeWorkspaces';
 import shouldUseYarn from '../shouldUseYarn';
 
+export const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+
 beforeAll(() => {
+  jest.mock('../nodeWorkspaces', () => ({ isUsingNpm: jest.fn() }));
+
   jest.mock('child_process', () => {
     return {
       execSync: () => {
@@ -8,13 +14,6 @@ beforeAll(() => {
           throw new Error('failed');
         }
         return 'something';
-      },
-    };
-  });
-  jest.mock('../nodeWorkspaces', () => {
-    return {
-      isUsingNpm: () => {
-        return !!process.env.TEST_NPM_LOCKFILE_EXISTS;
       },
     };
   });
@@ -44,6 +43,6 @@ it(`returns false if yarn -v throws an error`, () => {
 
 it(`returns false if npm lockfile exists`, () => {
   // Use project with npm lockfile
-  process.env.TEST_NPM_LOCKFILE_EXISTS = 'true';
+  asMock(isUsingNpm).mockClear().mockReturnValueOnce(true);
   expect(shouldUseYarn()).toBe(false);
 });

--- a/packages/package-manager/src/utils/__tests__/shouldUseYarn-test.ts
+++ b/packages/package-manager/src/utils/__tests__/shouldUseYarn-test.ts
@@ -11,6 +11,13 @@ beforeAll(() => {
       },
     };
   });
+  jest.mock('fs-extra', () => {
+    return {
+      existsSync: () => {
+        return !!process.env.TEST_NPM_LOCKFILE_EXISTS;
+      },
+    };
+  });
 });
 beforeEach(() => {
   delete process.env.CAN_USE_YARN_TEST_VALUE_SHOULD_THROW;
@@ -32,5 +39,10 @@ it(`uses env variable instead of yarn -v`, () => {
 it(`returns false if yarn -v throws an error`, () => {
   // Ensure yarn -v doesn't work
   process.env.CAN_USE_YARN_TEST_VALUE_SHOULD_THROW = 'true';
+  expect(shouldUseYarn()).toBe(false);
+});
+
+it(`returns false if NPM lockfile exists`, () => {
+  process.env.TEST_NPM_LOCKFILE_EXISTS = 'true';
   expect(shouldUseYarn()).toBe(false);
 });

--- a/packages/package-manager/src/utils/__tests__/shouldUseYarn-test.ts
+++ b/packages/package-manager/src/utils/__tests__/shouldUseYarn-test.ts
@@ -13,8 +13,8 @@ beforeAll(() => {
   });
   jest.mock('../nodeWorkspaces', () => {
     return {
-      resolvePackageManager: () => {
-        return process.env.TEST_NPM_LOCKFILE_EXISTS ? 'npm' : null;
+      isUsingNpm: () => {
+        return !!process.env.TEST_NPM_LOCKFILE_EXISTS;
       },
     };
   });

--- a/packages/package-manager/src/utils/__tests__/shouldUseYarn-test.ts
+++ b/packages/package-manager/src/utils/__tests__/shouldUseYarn-test.ts
@@ -11,10 +11,10 @@ beforeAll(() => {
       },
     };
   });
-  jest.mock('fs-extra', () => {
+  jest.mock('../nodeWorkspaces', () => {
     return {
-      existsSync: () => {
-        return !!process.env.TEST_NPM_LOCKFILE_EXISTS;
+      resolvePackageManager: () => {
+        return process.env.TEST_NPM_LOCKFILE_EXISTS ? 'npm' : null;
       },
     };
   });
@@ -42,7 +42,8 @@ it(`returns false if yarn -v throws an error`, () => {
   expect(shouldUseYarn()).toBe(false);
 });
 
-it(`returns false if NPM lockfile exists`, () => {
+it(`returns false if npm lockfile exists`, () => {
+  // Use project with npm lockfile
   process.env.TEST_NPM_LOCKFILE_EXISTS = 'true';
   expect(shouldUseYarn()).toBe(false);
 });

--- a/packages/package-manager/src/utils/nodeWorkspaces.ts
+++ b/packages/package-manager/src/utils/nodeWorkspaces.ts
@@ -111,3 +111,21 @@ export function resolvePackageManager(
 
   return null;
 }
+
+/**
+ * Returns true if the project is using yarn, false if the project is using another package manager.
+ *
+ * @param projectRoot
+ */
+export function isUsingYarn(projectRoot: string): boolean {
+  return !!resolvePackageManager(projectRoot, 'yarn');
+}
+
+/**
+ * Returns true if the project is using npm, false if the project is using another package manager.
+ *
+ * @param projectRoot
+ */
+export function isUsingNpm(projectRoot: string): boolean {
+  return !!resolvePackageManager(projectRoot, 'npm');
+}

--- a/packages/package-manager/src/utils/nodeWorkspaces.ts
+++ b/packages/package-manager/src/utils/nodeWorkspaces.ts
@@ -114,8 +114,6 @@ export function resolvePackageManager(
 
 /**
  * Returns true if the project is using yarn, false if the project is using another package manager.
- *
- * @param projectRoot
  */
 export function isUsingYarn(projectRoot: string): boolean {
   return !!resolvePackageManager(projectRoot, 'yarn');
@@ -123,8 +121,6 @@ export function isUsingYarn(projectRoot: string): boolean {
 
 /**
  * Returns true if the project is using npm, false if the project is using another package manager.
- *
- * @param projectRoot
  */
 export function isUsingNpm(projectRoot: string): boolean {
   return !!resolvePackageManager(projectRoot, 'npm');

--- a/packages/package-manager/src/utils/shouldUseYarn.ts
+++ b/packages/package-manager/src/utils/shouldUseYarn.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
-import fs from 'fs-extra';
-import path from 'path';
+
+import { resolvePackageManager } from './nodeWorkspaces';
 
 export default function shouldUseYarn(): boolean {
   try {
@@ -8,17 +8,17 @@ export default function shouldUseYarn(): boolean {
       return true;
     }
 
-    if (npmLockfileExists()) {
-      return false;
-    }
-
     execSync('yarnpkg --version', { stdio: 'ignore' });
-    return true;
+
+    return isNotUsingNpm();
   } catch {
     return false;
   }
 }
 
-function npmLockfileExists(): boolean {
-  return fs.existsSync(path.join(process.cwd(), 'package-lock.json'));
+/**
+ * Returns true if the project does not have an npm lockfile, false otherwise.
+ */
+function isNotUsingNpm(): boolean {
+  return resolvePackageManager(process.cwd(), 'npm') === null;
 }

--- a/packages/package-manager/src/utils/shouldUseYarn.ts
+++ b/packages/package-manager/src/utils/shouldUseYarn.ts
@@ -1,13 +1,24 @@
 import { execSync } from 'child_process';
+import fs from 'fs-extra';
+import path from 'path';
 
 export default function shouldUseYarn(): boolean {
   try {
     if (process.env.npm_config_user_agent?.startsWith('yarn')) {
       return true;
     }
+
+    if (npmLockfileExists()) {
+      return false;
+    }
+
     execSync('yarnpkg --version', { stdio: 'ignore' });
     return true;
   } catch {
     return false;
   }
+}
+
+function npmLockfileExists(): boolean {
+  return fs.existsSync(path.join(process.cwd(), 'package-lock.json'));
 }

--- a/packages/package-manager/src/utils/shouldUseYarn.ts
+++ b/packages/package-manager/src/utils/shouldUseYarn.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 
-import { resolvePackageManager } from './nodeWorkspaces';
+import { isUsingNpm } from './nodeWorkspaces';
 
 export default function shouldUseYarn(): boolean {
   try {
@@ -10,15 +10,12 @@ export default function shouldUseYarn(): boolean {
 
     execSync('yarnpkg --version', { stdio: 'ignore' });
 
-    return isNotUsingNpm();
+    if (isUsingNpm(process.cwd())) {
+      return false;
+    }
+
+    return true;
   } catch {
     return false;
   }
-}
-
-/**
- * Returns true if the project does not have an npm lockfile, false otherwise.
- */
-function isNotUsingNpm(): boolean {
-  return resolvePackageManager(process.cwd(), 'npm') === null;
 }

--- a/packages/package-manager/src/utils/shouldUseYarn.ts
+++ b/packages/package-manager/src/utils/shouldUseYarn.ts
@@ -3,17 +3,16 @@ import { execSync } from 'child_process';
 import { isUsingNpm } from './nodeWorkspaces';
 
 export default function shouldUseYarn(): boolean {
+  if (process.env.npm_config_user_agent?.startsWith('yarn')) {
+    return true;
+  }
+
+  if (isUsingNpm(process.cwd())) {
+    return false;
+  }
+
   try {
-    if (process.env.npm_config_user_agent?.startsWith('yarn')) {
-      return true;
-    }
-
     execSync('yarnpkg --version', { stdio: 'ignore' });
-
-    if (isUsingNpm(process.cwd())) {
-      return false;
-    }
-
     return true;
   } catch {
     return false;


### PR DESCRIPTION
# Why

- This fixes [#4355](https://github.com/expo/expo-cli/issues/4355#issue-1229575049)

As Brent says [here](https://forums.expo.dev/t/android-failure-for-managed-workflows-due-to-npm/63576/8?u=wodin):

>it appears that the default logic when running expo run:android defaults to using yarn if you have it installed, rather than checking for lockfile as it should

# How

So now Yarn is still favored over NPM, but if there's already a `package-lock.json` in the project root, NPM will be used.

# Test Plan

- See tests