### PR TITLE
feat(create-expo-app): adds analytics

### DIFF
--- a/packages/create-expo-app/src/__tests__/telemetry.test.ts
+++ b/packages/create-expo-app/src/__tests__/telemetry.test.ts
@@ -1,0 +1,221 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import fetch from 'node-fetch';
+
+import { dotExpoHomeDirectory, getStateJsonPath } from '../paths';
+import {
+  _resetGlobals,
+  AnalyticsEventPhases,
+  AnalyticsEventTypes,
+  flushAsync,
+  identify,
+  initializeAnalyticsIdentityAsync,
+  track,
+} from '../telemetry';
+
+jest.mock('node-fetch');
+const fetchAsMock = (fetch as any) as jest.Mock;
+
+function clearGlobals() {
+  fetchAsMock.mockClear();
+  if (!fs.existsSync(dotExpoHomeDirectory())) {
+    fs.mkdirSync(dotExpoHomeDirectory(), { recursive: true });
+  }
+
+  if (fs.existsSync(getStateJsonPath())) {
+    fs.unlinkSync(getStateJsonPath());
+  }
+  _resetGlobals();
+}
+
+describe('telemetry', () => {
+  describe('with no pre-existing state', () => {
+    beforeEach(() => {
+      clearGlobals();
+    });
+
+    it('can enqueue events and send them to the proper endpoint with the proper shape', async () => {
+      await initializeAnalyticsIdentityAsync();
+      identify();
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.ATTEMPT },
+      });
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.SUCCESS },
+      });
+      await flushAsync();
+      expect(fetchAsMock.mock.calls.length).toEqual(1);
+      const [fetchRequestArgs] = fetchAsMock.mock.calls;
+      const [url, request] = fetchRequestArgs;
+      expect(url).toEqual('https://cdp.expo.dev/v1/batch');
+      const { body } = request;
+      expect(request).toEqual(
+        expect.objectContaining({
+          headers: {
+            accept: 'application/json, text/plain, */*',
+            authorization: expect.stringContaining('Basic '),
+            'content-type': 'application/json;charset=utf-8',
+            'user-agent': expect.any(String),
+          },
+          method: 'POST',
+        })
+      );
+      const bodyAsjson = JSON.parse(body);
+      const { batch, sentAt }: { batch: any[]; sentAt: string } = bodyAsjson;
+      expect(Number.isNaN(Date.parse(sentAt))).toBeFalsy();
+      expect(batch.length).toEqual(3);
+      expect(batch[0]).toEqual(
+        expect.objectContaining({
+          type: 'identify',
+          sentAt: expect.any(String),
+          originalTimestamp: expect.any(String),
+          messageId: expect.any(String),
+          traits: expect.any(Object),
+          anonymousId: expect.any(String),
+        })
+      );
+      expect(batch[1]).toEqual(
+        expect.objectContaining({
+          type: 'track',
+          sentAt: expect.any(String),
+          originalTimestamp: expect.any(String),
+          messageId: expect.any(String),
+          event: AnalyticsEventTypes.CREATE_EXPO_APP,
+          properties: {
+            phase: AnalyticsEventPhases.ATTEMPT,
+          },
+          anonymousId: expect.any(String),
+        })
+      );
+      expect(batch[2]).toEqual(
+        expect.objectContaining({
+          type: 'track',
+          sentAt: expect.any(String),
+          originalTimestamp: expect.any(String),
+          messageId: expect.any(String),
+          event: AnalyticsEventTypes.CREATE_EXPO_APP,
+          properties: {
+            phase: AnalyticsEventPhases.SUCCESS,
+          },
+          anonymousId: expect.any(String),
+        })
+      );
+    });
+
+    it('does not enqueue events if not initialized', async () => {
+      identify();
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.ATTEMPT },
+      });
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.SUCCESS },
+      });
+      await flushAsync();
+      expect(fetchAsMock.mock.calls.length).toEqual(0);
+    });
+  });
+
+  describe('with pre-existing state', () => {
+    const existingAnonymousId = (crypto as any).randomUUID();
+    const existingUserId = (crypto as any).randomUUID();
+
+    beforeEach(() => {
+      clearGlobals();
+      fs.writeFileSync(
+        getStateJsonPath(),
+        JSON.stringify({ analyticsDeviceId: existingAnonymousId, auth: { userId: existingUserId } })
+      );
+    });
+
+    it('can enqueue events and send them to the proper endpoint with the proper shape', async () => {
+      await initializeAnalyticsIdentityAsync();
+      identify();
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.ATTEMPT },
+      });
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.SUCCESS },
+      });
+      await flushAsync();
+      expect(fetchAsMock.mock.calls.length).toEqual(1);
+      const [fetchRequestArgs] = fetchAsMock.mock.calls;
+      const [url, request] = fetchRequestArgs;
+      expect(url).toEqual('https://cdp.expo.dev/v1/batch');
+      const { body } = request;
+      expect(request).toEqual(
+        expect.objectContaining({
+          headers: {
+            accept: 'application/json, text/plain, */*',
+            authorization: expect.stringContaining('Basic '),
+            'content-type': 'application/json;charset=utf-8',
+            'user-agent': expect.any(String),
+          },
+          method: 'POST',
+        })
+      );
+      const bodyAsjson = JSON.parse(body);
+      const { batch, sentAt }: { batch: any[]; sentAt: string } = bodyAsjson;
+      expect(Number.isNaN(Date.parse(sentAt))).toBeFalsy();
+      expect(batch.length).toEqual(3);
+      expect(batch[0]).toEqual(
+        expect.objectContaining({
+          type: 'identify',
+          sentAt: expect.any(String),
+          originalTimestamp: expect.any(String),
+          messageId: expect.any(String),
+          traits: expect.any(Object),
+          anonymousId: existingAnonymousId,
+          userId: existingUserId,
+        })
+      );
+      expect(batch[1]).toEqual(
+        expect.objectContaining({
+          type: 'track',
+          sentAt: expect.any(String),
+          originalTimestamp: expect.any(String),
+          messageId: expect.any(String),
+          event: AnalyticsEventTypes.CREATE_EXPO_APP,
+          properties: {
+            phase: AnalyticsEventPhases.ATTEMPT,
+          },
+          anonymousId: existingAnonymousId,
+          userId: existingUserId,
+        })
+      );
+      expect(batch[2]).toEqual(
+        expect.objectContaining({
+          type: 'track',
+          sentAt: expect.any(String),
+          originalTimestamp: expect.any(String),
+          messageId: expect.any(String),
+          event: AnalyticsEventTypes.CREATE_EXPO_APP,
+          properties: {
+            phase: AnalyticsEventPhases.SUCCESS,
+          },
+          anonymousId: existingAnonymousId,
+          userId: existingUserId,
+        })
+      );
+    });
+
+    it('does not enqueue events if not initialized', async () => {
+      identify();
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.ATTEMPT },
+      });
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.SUCCESS },
+      });
+      await flushAsync();
+      expect(fetchAsMock.mock.calls.length).toEqual(0);
+    });
+  });
+});

--- a/packages/create-expo-app/src/analytics.ts
+++ b/packages/create-expo-app/src/analytics.ts
@@ -1,0 +1,189 @@
+import JsonFile from '@expo/json-file';
+import crypto from 'crypto';
+import fs from 'fs';
+import fetch from 'node-fetch';
+import os from 'os';
+
+import { getStateJsonPath } from './paths';
+import { getSession } from './sessionStorage';
+
+const packageJSON = require('../package.json');
+
+const xdlWriteKey = '1wabJGd5IiuF9Q8SGlcI90v8WTs';
+const analyticsEndpoint = 'https://cdp.expo.dev/v1/batch';
+const version = '1.0.0';
+const library = 'create-expo-app';
+
+//#region mostly copied from @expo/rudder-sdk-node https://github.com/expo/rudder-sdk-node/blob/main/index.ts
+// some changes include:
+// - the identity being injected inside of the enqueue method, rather than as a function argument.
+// - a global event queue that gets cleared after each flush
+// - using node's crypto library for hashing and uuidv4
+type AnalyticsPayload = {
+  messageId: string;
+  _metadata: any;
+  context: any;
+  type: string;
+  originalTimestamp: Date;
+  [key: string]: any;
+};
+type AnalyticsMessage = {
+  context?: {
+    [key: string]: unknown;
+  };
+  integrations?: {
+    [destination: string]: boolean;
+  };
+  properties?: {
+    [key: string]: unknown;
+  };
+  timestamp?: Date;
+  [key: string]: unknown;
+};
+type AnalyticsIdentity =
+  | {
+      userId: string;
+    }
+  | {
+      userId?: string;
+      anonymousId: string;
+    };
+
+const messageBatch = [] as AnalyticsPayload[];
+
+let analyticsIdentity: AnalyticsIdentity | null = null;
+
+// call before tracking any analytics events.
+// if track/identify are called before this method they will be dropped
+export async function initializeAnalyticsIdentityAsync() {
+  if (analyticsIdentity) {
+    return;
+  }
+  analyticsIdentity = await getAnalyticsIdentityAsync();
+}
+
+export function identify() {
+  enqueue('identify', {});
+}
+
+export function track(
+  message: AnalyticsMessage & {
+    event: string;
+  }
+) {
+  enqueue('track', { ...message, context: getAnalyticsContext() });
+}
+
+function enqueue(type: 'identify' | 'track', message: any) {
+  if (!analyticsIdentity) {
+    // do not send messages without identities to our backend
+    return;
+  }
+
+  message = { ...message, ...analyticsIdentity };
+  message.type = type;
+
+  if (message.type === 'identify') {
+    message.traits ??= {};
+    message.context ??= {};
+    message.context.traits = message.traits;
+  }
+
+  message.context = {
+    library: {
+      name: `@expo/expo-cli/${library}`,
+      version,
+    },
+    ...message.context,
+  };
+
+  message._metadata = {
+    nodeVersion: process.versions.node,
+    ...message._metadata,
+  };
+
+  if (!message.originalTimestamp) {
+    message.originalTimestamp = new Date();
+  }
+
+  if (!message.messageId) {
+    // We md5 the messaage to add more randomness. This is primarily meant
+    // for use in the browser where the uuid package falls back to Math.random()
+    // which is not a great source of randomness.
+    // Borrowed from analytics.js (https://github.com/segment-integrations/analytics.js-integration-segmentio/blob/a20d2a2d222aeb3ab2a8c7e72280f1df2618440e/lib/index.js#L255-L256).
+    message.messageId = `node-${crypto
+      .createHash('md5')
+      .update(JSON.stringify(message))
+      .digest('hex')}-${uuidv4()}`;
+  }
+  messageBatch.unshift(message);
+}
+
+export async function flushAsync() {
+  if (!messageBatch.length) {
+    return;
+  }
+
+  const request = {
+    method: 'POST',
+    headers: {
+      accept: 'application/json, text/plain, */*',
+      'content-type': 'application/json;charset=utf-8',
+      'user-agent': `expo-expo-cli-${library}/${version}`,
+      authorization: 'Basic ' + Buffer.from(`${xdlWriteKey}:`).toString('base64'),
+    },
+    body: JSON.stringify({
+      batch: messageBatch.map(message => ({ ...message, sentAt: new Date() })),
+      sentAt: new Date(),
+    }),
+  };
+  await fetch(analyticsEndpoint, request);
+  // clear array so we don't resend events in subsequent flushes
+  messageBatch.splice(0, messageBatch.length);
+}
+//#endregion
+
+//#region copied from eas cli https://github.com/expo/eas-cli/blob/f0c958e58bc7aa90ee8f822e075d40703563708e/packages/eas-cli/src/analytics/rudderstackClient.ts#L9-L13
+const PLATFORM_TO_ANALYTICS_PLATFORM: { [platform: string]: string } = {
+  darwin: 'Mac',
+  win32: 'Windows',
+  linux: 'Linux',
+};
+
+function getAnalyticsContext(): Record<string, any> {
+  const platform = PLATFORM_TO_ANALYTICS_PLATFORM[os.platform()] || os.platform();
+  return {
+    os: { name: platform, version: os.release() },
+    device: { type: platform, model: platform },
+    app: { name: 'create expo app', version: packageJSON.version },
+  };
+}
+//#endregion
+
+function uuidv4() {
+  // https://github.com/denoland/deno/issues/12754
+  return (crypto as any).randomUUID();
+}
+
+export enum AnalyticsEventTypes {
+  CREATE_EXPO_APP = 'create expo app',
+}
+
+export enum AnalyticsEventPhases {
+  ATTEMPT = 'attempt',
+  SUCCESS = 'success',
+  FAIL = 'fail',
+}
+
+async function getAnalyticsIdentityAsync(): Promise<AnalyticsIdentity> {
+  if (!fs.existsSync(getStateJsonPath())) {
+    fs.writeFileSync(getStateJsonPath(), JSON.stringify({}));
+  }
+  const savedDeviceId = await JsonFile.getAsync(getStateJsonPath(), 'analyticsDeviceId', null);
+  const deviceId = savedDeviceId ?? uuidv4();
+  if (!savedDeviceId) {
+    await JsonFile.setAsync(getStateJsonPath(), 'analyticsDeviceId', deviceId);
+  }
+  const userId = getSession()?.userId ?? null;
+  return userId ? { anonymousId: deviceId, userId } : { anonymousId: deviceId };
+}

--- a/packages/create-expo-app/src/index.ts
+++ b/packages/create-expo-app/src/index.ts
@@ -6,6 +6,14 @@ import path from 'path';
 
 import * as Template from './Template';
 import shouldUpdate from './Update';
+import {
+  AnalyticsEventPhases,
+  AnalyticsEventTypes,
+  flushAsync,
+  identify,
+  initializeAnalyticsIdentityAsync,
+  track,
+} from './analytics';
 import { initGitRepoAsync } from './git';
 import { promptTemplateAsync } from './legacyTemplates';
 import {
@@ -60,7 +68,15 @@ async function runAsync(): Promise<void> {
       projectRoot = await resolveProjectRootAsync(inputPath);
     }
 
-    await fs.promises.mkdir(projectRoot, { recursive: true });
+    await Promise.all([
+      fs.promises.mkdir(projectRoot, { recursive: true }),
+      initializeAnalyticsIdentityAsync(),
+    ]);
+    identify();
+    track({
+      event: AnalyticsEventTypes.CREATE_EXPO_APP,
+      properties: { phase: AnalyticsEventPhases.ATTEMPT },
+    });
     const extractTemplateStep = Template.logNewSection(`Locating project files.`);
     try {
       await Template.extractAndPrepareTemplateAppAsync(projectRoot, {
@@ -71,6 +87,11 @@ async function runAsync(): Promise<void> {
       extractTemplateStep.fail(
         'Something went wrong in downloading and extracting the project files: ' + e.message
       );
+      track({
+        event: AnalyticsEventTypes.CREATE_EXPO_APP,
+        properties: { phase: AnalyticsEventPhases.FAIL, message: e.message },
+      });
+      await flushAsync();
       process.exit(1);
     }
     // Install dependencies
@@ -104,10 +125,18 @@ async function runAsync(): Promise<void> {
     } catch {
       // todo: check if git is installed, bail out
     }
-  } catch (error) {
-    await commandDidThrowAsync(error);
+  } catch (error: any) {
+    track({
+      event: AnalyticsEventTypes.CREATE_EXPO_APP,
+      properties: { phase: AnalyticsEventPhases.FAIL, message: error.message },
+    });
+    await Promise.all([commandDidThrowAsync(error), flushAsync()]);
   }
-  await shouldUpdate();
+  track({
+    event: AnalyticsEventTypes.CREATE_EXPO_APP,
+    properties: { phase: AnalyticsEventPhases.SUCCESS },
+  });
+  await Promise.all([shouldUpdate(), flushAsync()]);
   process.exit(0);
 }
 

--- a/packages/create-expo-app/src/index.ts
+++ b/packages/create-expo-app/src/index.ts
@@ -6,14 +6,6 @@ import path from 'path';
 
 import * as Template from './Template';
 import shouldUpdate from './Update';
-import {
-  AnalyticsEventPhases,
-  AnalyticsEventTypes,
-  flushAsync,
-  identify,
-  initializeAnalyticsIdentityAsync,
-  track,
-} from './analytics';
 import { initGitRepoAsync } from './git';
 import { promptTemplateAsync } from './legacyTemplates';
 import {
@@ -22,6 +14,14 @@ import {
   resolvePackageManager,
 } from './resolvePackageManager';
 import { assertFolderEmpty, assertValidName, resolveProjectRootAsync } from './resolveProjectRoot';
+import {
+  AnalyticsEventPhases,
+  AnalyticsEventTypes,
+  flushAsync,
+  identify,
+  initializeAnalyticsIdentityAsync,
+  track,
+} from './telemetry';
 
 const packageJSON = require('../package.json');
 

--- a/packages/create-expo-app/src/paths.ts
+++ b/packages/create-expo-app/src/paths.ts
@@ -1,12 +1,10 @@
-import { homedir } from 'os';
-import * as path from 'path';
-
-// copied from https://github.com/expo/eas-cli/blob/f0c958e58bc7aa90ee8f822e075d40703563708e/packages/eas-cli/src/utils/paths.ts
+import os from 'os';
+import path from 'path';
 
 // The ~/.expo directory is used to store authentication sessions,
 // which are shared between EAS CLI and Expo CLI.
-function dotExpoHomeDirectory(): string {
-  const home = homedir();
+export function dotExpoHomeDirectory(): string {
+  const home = os.homedir();
   if (!home) {
     throw new Error(
       "Can't determine your home directory; make sure your $HOME environment variable is set."
@@ -24,6 +22,4 @@ function dotExpoHomeDirectory(): string {
   return dirPath;
 }
 
-const getStateJsonPath = (): string => path.join(dotExpoHomeDirectory(), 'state.json');
-
-export { getStateJsonPath };
+export const getStateJsonPath = (): string => path.join(dotExpoHomeDirectory(), 'state.json');

--- a/packages/create-expo-app/src/paths.ts
+++ b/packages/create-expo-app/src/paths.ts
@@ -1,0 +1,29 @@
+import { homedir } from 'os';
+import * as path from 'path';
+
+// copied from https://github.com/expo/eas-cli/blob/f0c958e58bc7aa90ee8f822e075d40703563708e/packages/eas-cli/src/utils/paths.ts
+
+// The ~/.expo directory is used to store authentication sessions,
+// which are shared between EAS CLI and Expo CLI.
+function dotExpoHomeDirectory(): string {
+  const home = homedir();
+  if (!home) {
+    throw new Error(
+      "Can't determine your home directory; make sure your $HOME environment variable is set."
+    );
+  }
+
+  let dirPath;
+  if (process.env.EXPO_STAGING) {
+    dirPath = path.join(home, '.expo-staging');
+  } else if (process.env.EXPO_LOCAL) {
+    dirPath = path.join(home, '.expo-local');
+  } else {
+    dirPath = path.join(home, '.expo');
+  }
+  return dirPath;
+}
+
+const getStateJsonPath = (): string => path.join(dotExpoHomeDirectory(), 'state.json');
+
+export { getStateJsonPath };

--- a/packages/create-expo-app/src/sessionStorage.ts
+++ b/packages/create-expo-app/src/sessionStorage.ts
@@ -1,0 +1,29 @@
+import JsonFile from '@expo/json-file';
+
+import { getStateJsonPath } from './paths';
+
+// copied from https://github.com/expo/eas-cli/blob/f0c958e58bc7aa90ee8f822e075d40703563708e/packages/eas-cli/src/user/sessionStorage.ts
+
+type UserSettingsData = {
+  auth?: SessionData;
+};
+
+type SessionData = {
+  sessionSecret: string;
+
+  // These fields are potentially used by Expo CLI.
+  userId: string;
+  username: string;
+  currentConnection: 'Username-Password-Authentication';
+};
+
+export function getSession(): SessionData | null {
+  try {
+    return JsonFile.read<UserSettingsData>(getStateJsonPath())?.auth ?? null;
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
# Why

We'd like to ensure package health and understand developer usage.

# How

- adds analytics methods such as identify, track, and flush
- adds paths and sessionStorage from eas-cli for reading and writing
  device + user-id to ~/.expo/state.json
- adds analytics event tracking to create expo app

# Test Plan

- build the package (preferably with a test writekey -- the 'rudderstack-sandbox' one)
- create a new expo app
- ensure the events make it to the backend when
  - the initialization finishes successfully
  - the command fails partway through
- delete your local ~/.expo/state.json file 
  - ensure the above still works
  - run eas build with the new state file, ensure the other properties get filled in and the cli does not crash

Using `ls -hl (build output path)`:
Old bundle size: 1.3M
New bundle size: 1.3M