### PR TITLE
[dev-server] Fix js inspector broken from websocket address transform

### DIFF
--- a/packages/dev-server/src/JsInspector.ts
+++ b/packages/dev-server/src/JsInspector.ts
@@ -29,7 +29,7 @@ export function openJsInspector(app: MetroInspectorProxyApp) {
   const devtoolsFrontendRev = 'e3cd97fc771b893b7fd1879196d1215b622c2bed'; // Chrome 90.0.4430.212
 
   const urlBase = `https://chrome-devtools-frontend.appspot.com/serve_rev/@${devtoolsFrontendRev}/inspector.html`;
-  const ws = app.webSocketDebuggerUrl.replace('ws://[::]:', 'localhost:');
+  const ws = app.webSocketDebuggerUrl.replace(/^ws:\/\//, '');
   const url = `${urlBase}?panel=sources&v8only=true&ws=${encodeURIComponent(ws)}`;
   launchChromiumAsync(url);
 }


### PR DESCRIPTION
# Why

the hermes inspector is broken on expo sdk 45 (or maybe just my setup) where the metro server was listening at `[::]` (all addresses), but now it's `[::1]` (loopback address)

# How

not transforming the websocket address but only to remove the `ws://` scheme. so it would also support other addresses like a ipv4 address. browsers and `chrome-devtools-frontend.appspot.com` should support all of these formats. 

# Test Plan

on an expo sdk 45 project with jsEngine: hermes, press 'j' to open the inspector.