### PR TITLE
[ci/cd] Add node 16 testing and drop node 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14']
+        node: ['14', '16']
     name: Build with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['12', '14']
+        node: ['14', '16']
         package:
           [
             create-expo-app,

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node: ['12', '14']
+        node: ['14', '16']
     name: Build with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['12', '14']
+        node: ['14', '16']
         package:
           [
             dev-tools,


### PR DESCRIPTION
# Why

We're dropping node 12 support and adding node 16 support.

# How

Updated the workflow settings.

# Test Plan

All tests should pass.