### PR TITLE
[config] Include automatically EAS Build config plugin

### DIFF
--- a/packages/config/src/plugins/withConfigPlugins.ts
+++ b/packages/config/src/plugins/withConfigPlugins.ts
@@ -9,7 +9,14 @@ import { serializeAfterStaticPlugins } from '../Serialize';
  * @param projectRoot
  */
 export const withConfigPlugins: ConfigPlugin<boolean> = (config, skipPlugins) => {
-  // @ts-ignore: plugins not on config type yet -- TODO
+  if (process.env.EAS_BUILD_CONFIG_PLUGIN_PATH) {
+    const easPlugin = process.env.EAS_BUILD_CONFIG_PLUGIN_PATH;
+    if (!Array.isArray(config.plugins) || !config.plugins?.length) {
+      config.plugins = [easPlugin];
+    } else {
+      config.plugins.push(easPlugin);
+    }
+  }
   if (!Array.isArray(config.plugins) || !config.plugins?.length) {
     return config;
   }


### PR DESCRIPTION
# Why

General case: Sometimes we might want to modify(or maybe just read) manifest values when building on eas
Specific case: Specific issue we want to resolve here is to allow us to override android.versionCode and ios.buildNumber. To support autoincrementing versions we need a way to update versions in the project, if someone is using app.conifg.js we can't modify the file, but if we use the config plugin we can handle all cases.

# How

If EAS_BUILD_CONFIG_PLUGIN_PATH is set add value of that env as location of the plugin you want to inject

# Test Plan

`expo config` with example plugin