### PR TITLE
chore(create-expo-app): bump node-fetch to latest to prevent deprecation errors

### DIFF
--- a/packages/create-expo-app/package.json
+++ b/packages/create-expo-app/package.json
@@ -53,7 +53,7 @@
     "form-data": "^2.3.2",
     "getenv": "^1.0.0",
     "minipass": "3.1.6",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^3.2.5",
     "ora": "3.4.0",
     "prompts": "^2.3.2",
     "tar": "^6.0.5",

--- a/packages/create-expo-app/src/cache/response.ts
+++ b/packages/create-expo-app/src/cache/response.ts
@@ -24,6 +24,7 @@ export class NFCResponse extends Response {
       statusText: res.statusText,
       headers: res.headers.raw(),
       size: res.size,
+      // @ts-expect-error
       timeout: res.timeout,
       // @ts-ignore
       counter: res[responseInternalSymbol].counter,

--- a/packages/create-expo-app/src/npm.ts
+++ b/packages/create-expo-app/src/npm.ts
@@ -158,9 +158,12 @@ export async function extractNpmTarballFromUrlAsync(
 }
 
 export async function extractNpmTarballAsync(
-  stream: NodeJS.ReadableStream,
+  stream: NodeJS.ReadableStream | null,
   props: ExtractProps
 ): Promise<void> {
+  if (!stream) {
+    throw new Error('Missing stream');
+  }
   const { cwd, strip, name, fileList = [] } = props;
 
   await fs.promises.mkdir(cwd, { recursive: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7392,6 +7392,11 @@ data-uri-to-buffer@3.0.0:
   dependencies:
     buffer-from "^1.1.1"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -9017,6 +9022,14 @@ fbjs@^3.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.30"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.5.tgz#0077bf5f3fcdbd9d75a0b5362f77dbb743489863"
+  integrity sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 fetch-retry@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-4.1.1.tgz#fafe0bb22b54f4d0a9c788dff6dd7f8673ca63f3"
@@ -9315,6 +9328,13 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -13662,6 +13682,11 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch-npm@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz#7258c9046182dca345b4208eda918daf33697ff7"
@@ -13694,6 +13719,15 @@ node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node
   integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.5.tgz#7d31da657804db5185540ddac7ddd516a9a2bd26"
+  integrity sha512-u7zCHdJp8JXBwF09mMfo2CL6kp37TslDl1KP3hRGTlCInBtag+UO3LGVy+NF0VzvnL3PVMpA2hXh1EtECFnyhQ==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@0.10.0:
   version "0.10.0"
@@ -18712,6 +18746,11 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 web-vitals@0.2.4:
   version "0.2.4"


### PR DESCRIPTION
# Why

- #4393 introduces a deprecation error message:

```
(node:52614) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
    at showFlaggedDeprecation (node:buffer:186:11)
    at new Buffer (node:buffer:270:3)
    at utf8PercentDecode (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:38107:17)
    at parseHost (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:38402:18)
    at URLStateMachine.parseHostName (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:38853:18)
    at new URLStateMachine (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:38564:44)
    at Object.module.exports.basicURLParse (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:39260:15)
    at new URLImpl (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:37588:27)
    at Object.setup (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:37966:17)
    at new URL (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:37804:18)
    at parseURL (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:36658:12)
    at new Request (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:36704:17)
    at /Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:36925:19
    at new Promise (<anonymous>)
    at fetch (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:36923:9)
    at flushAsync (/Users/evanbacon/Documents/GitHub/cli/packages/create-expo-app/build/index.js:63409:40)
```

- Couldn't figure out why the new fetch request throws but all the others don't.
- Upgrading is not ideal as it introduces an external file in the bundle, these tend to be problematic across platforms. Will keep an eye out for reports.

# Test Plan

- `create-expo-app` locally no longer throws the deprecation warning.