### PR TITLE
[doctor] Gracefully handle not being able to run dependency tree validation on older Node/npm versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+[doctor] Gracefully handle not being able to run dependency tree validation on older Node/npm versions.
+
 ## [Wed, 1 Jun 2022 14:18:31 -0700](https://github.com/expo/expo-cli/commit/7873fefa2f73a5c8df08d20376d0ff374a19e96d)
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
-[doctor] Gracefully handle not being able to run dependency tree validation on older Node/npm versions. ([#4413](https://github.com/expo/expo-cli/pull/4413))
+- [doctor] Gracefully handle not being able to run dependency tree validation on older Node/npm versions. ([#4413](https://github.com/expo/expo-cli/pull/4413))
 
 ## [Wed, 1 Jun 2022 14:18:31 -0700](https://github.com/expo/expo-cli/commit/7873fefa2f73a5c8df08d20376d0ff374a19e96d)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
-[doctor] Gracefully handle not being able to run dependency tree validation on older Node/npm versions.
+[doctor] Gracefully handle not being able to run dependency tree validation on older Node/npm versions. ([#4413](https://github.com/expo/expo-cli/pull/4413))
 
 ## [Wed, 1 Jun 2022 14:18:31 -0700](https://github.com/expo/expo-cli/commit/7873fefa2f73a5c8df08d20376d0ff374a19e96d)
 

--- a/packages/expo-cli/src/commands/info/doctor/depedencies/explain.ts
+++ b/packages/expo-cli/src/commands/info/doctor/depedencies/explain.ts
@@ -33,6 +33,14 @@ export async function explainAsync(
         ora.succeed();
         return null;
       }
+      if (error.stdout.match(/Usage: npm <command>/)) {
+        ora.fail(
+          `Dependency tree validation for ${chalk.underline(
+            packageName
+          )} failed. This validation is only available on Node 16+ / npm 8.`
+        );
+        return null;
+      }
     }
     ora.fail(`Failed to find dependency tree for ${packageName}: ` + error.message);
     throw error;

--- a/packages/expo-cli/src/commands/info/doctor/depedencies/explain.ts
+++ b/packages/expo-cli/src/commands/info/doctor/depedencies/explain.ts
@@ -32,8 +32,7 @@ export async function explainAsync(
       if (error.stderr.match(/npm ERR! No dependencies found matching/)) {
         ora.succeed();
         return null;
-      }
-      if (error.stdout.match(/Usage: npm <command>/)) {
+      } else if (error.stdout.match(/Usage: npm <command>/)) {
         ora.fail(
           `Dependency tree validation for ${chalk.underline(
             packageName


### PR DESCRIPTION
# Why

`expo doctor` crashes on Node 14/npm 6 because `npm why is not available.

# How

Detect the standard npm output for running an unknown npm command, and log.

# Test Plan
- Run `expo doctor` on Node 14/npm 6
![WindowsTerminal_SGweChyIim](https://user-images.githubusercontent.com/852069/172049526-4ba04fd5-93d7-4e8e-af77-314d7b4b3f10.png)

