### PR TITLE
fix: Support scoped package names for initialising projects

### DIFF
--- a/packages/expo-cli/src/commands/utils/npm.ts
+++ b/packages/expo-cli/src/commands/utils/npm.ts
@@ -65,7 +65,16 @@ export async function npmPackAsync(
     return null;
   }
   try {
-    return JSON.parse(results);
+    const parsedResults = JSON.parse(results);
+    const filename = (parsedResults[0] as JSONObject).filename as string;
+
+    // Transform filename for scoped packages.
+    // See issue https://github.com/npm/cli/issues/3405
+    if (filename.startsWith('@') && packageName.startsWith('@')) {
+      parsedResults[0].filename = filename.replace(/^@/, '').replace(/\//, '-');
+    }
+
+    return parsedResults;
   } catch (error: any) {
     throw new Error(
       `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: ${error.message}`

--- a/packages/expo-cli/src/commands/utils/npm.ts
+++ b/packages/expo-cli/src/commands/utils/npm.ts
@@ -70,7 +70,7 @@ export async function npmPackAsync(
 
     // Transform filename for scoped packages.
     // See issue https://github.com/npm/cli/issues/3405
-    if (filename.startsWith('@') && packageName.startsWith('@')) {
+    if (filename?.startsWith('@') && packageName.startsWith('@')) {
       parsedResults[0].filename = filename.replace(/^@/, '').replace(/\//, '-');
     }
 


### PR DESCRIPTION

# Why
The `npm pack` produces a tgz file and shows the path with the `filename` property of the command output.
Unfortunately for scoped package names, this is outputting an incorrect filename.  This is causing initialising
expo projects from a template with a scoped package name to fail.

This is due to a bug in npm (https://github.com/npm/cli/issues/3405)

This PR applies a workaround.

This closes #4416

# How
The fix checks if the package name and the filename from the `npm pack` command start with `@`.  If so, then it removes the `@` and replaces `/` with `-` from the `npm pack` filename output.   It's checking both package name and filename, as it is possible that npm will fix their bug at some time in the future.

# Test Plan
To manually test this, use the following command:
```
expo init RealmJsApp -t @realm/expo-template-js
```