### PR TITLE
Make Metro start with IPv4 address

### DIFF
--- a/packages/dev-server/src/MetroDevServer.ts
+++ b/packages/dev-server/src/MetroDevServer.ts
@@ -111,6 +111,8 @@ export async function runMetroDevServerAsync(
   const server = await Metro.runServer(metroConfig, {
     hmrEnabled: true,
     websocketEndpoints,
+    // Ensure Metro starts with an IPv4 address for maximum interoperability.
+    host: "0.0.0.0",
   });
 
   if (attachToServer) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/17843

# How

Starting Metro with an IPv4 address ensures that when it generates a websocket URL, it is also IPv4. E.g., helpful in containerized environments.

# Test Plan

Load `http://localhost:8081/json` when Metro is running and `webSocketDebuggerUrl` should be `ws://localhost...`