### PR TITLE
[expo-cli] return non-zero exit code if package versions are incorrect

### DIFF
--- a/packages/expo-cli/src/commands/info/doctor/depedencies/explain.ts
+++ b/packages/expo-cli/src/commands/info/doctor/depedencies/explain.ts
@@ -45,15 +45,18 @@ export async function explainAsync(
     throw error;
   }
 }
-
-export async function warnAboutDeepDependenciesAsync(pkg: TargetPackage) {
+/**
+ * @param pkg
+ * @returns true if all versions of the package satisfy the constraints
+ */
+export async function warnAboutDeepDependenciesAsync(pkg: TargetPackage): Promise<boolean> {
   const explanations = await explainAsync(pkg.name);
 
   if (!explanations) {
     Log.debug(`No dependencies found for ${pkg.name}`);
-    return;
+    return true;
   }
-  printExplanationsAsync(pkg, explanations);
+  return printExplanationsAsync(pkg, explanations);
 }
 
 export function organizeExplanations(
@@ -87,7 +90,15 @@ export function organizeExplanations(
   return { valid, invalid };
 }
 
-export async function printExplanationsAsync(pkg: TargetPackage, explanations: RootNodePackage[]) {
+/**
+ * @param pkg
+ * @param explanations
+ * @returns true if all versions of the package satisfy the constraints
+ */
+export async function printExplanationsAsync(
+  pkg: TargetPackage,
+  explanations: RootNodePackage[]
+): Promise<boolean> {
   const { invalid } = organizeExplanations(pkg, {
     explanations,
     isValid(otherPkg) {
@@ -97,8 +108,10 @@ export async function printExplanationsAsync(pkg: TargetPackage, explanations: R
 
   if (invalid.length > 0) {
     printInvalidPackages(pkg, { explanations: invalid });
+    return false;
   } else {
     Log.log(chalk`  All copies of {bold ${pkg.name}} satisfy {green ${pkg.version}}`);
+    return true;
   }
 }
 

--- a/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
+++ b/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
@@ -13,7 +13,7 @@ type Options = {
   fixDependencies?: boolean;
 };
 
-async function validateSupportPackagesAsync(sdkVersion: string) {
+async function validateSupportPackagesAsync(sdkVersion: string): Promise<boolean> {
   const versionsForSdk = await getRemoteVersionsForSdk(sdkVersion);
 
   const supportPackagesToValidate = [
@@ -22,38 +22,54 @@ async function validateSupportPackagesAsync(sdkVersion: string) {
     '@expo/prebuild-config',
   ];
 
+  let allPackagesValid = true;
   for (const pkg of supportPackagesToValidate) {
     const version = versionsForSdk[pkg];
     if (version) {
-      await warnAboutDeepDependenciesAsync({ name: pkg, version });
+      const isVersionValid = await warnAboutDeepDependenciesAsync({ name: pkg, version });
+      if (!isVersionValid) {
+        allPackagesValid = false;
+      }
     }
   }
   Log.newLine();
+  return allPackagesValid;
 }
 
 export async function actionAsync(projectRoot: string, options: Options) {
   await warnUponCmdExe();
 
   const { exp, pkg } = profileMethod(getConfig)(projectRoot);
+  let foundSomeIssues = false;
 
   // Only use the new validation on SDK +45.
   if (Versions.gteSdkVersion(exp, '45.0.0')) {
-    await validateSupportPackagesAsync(exp.sdkVersion!);
+    if (!(await validateSupportPackagesAsync(exp.sdkVersion!))) {
+      foundSomeIssues = true;
+    }
   }
 
-  const areDepsValid = await profileMethod(validateDependenciesVersionsAsync)(
-    projectRoot,
-    exp,
-    pkg,
-    options.fixDependencies
-  );
+  if (
+    !(await profileMethod(validateDependenciesVersionsAsync)(
+      projectRoot,
+      exp,
+      pkg,
+      options.fixDependencies
+    ))
+  ) {
+    foundSomeIssues = true;
+  }
 
   // note: this currently only warns when something isn't right, it doesn't fail
   await Doctor.validateExpoServersAsync(projectRoot);
 
-  if ((await Doctor.validateWithNetworkAsync(projectRoot)) === Doctor.NO_ISSUES && areDepsValid) {
-    Log.log(chalk.green(`🎉 Didn't find any issues with the project!`));
-  } else {
+  if ((await Doctor.validateWithNetworkAsync(projectRoot)) !== Doctor.NO_ISSUES) {
+    foundSomeIssues = true;
+  }
+
+  if (foundSomeIssues) {
     process.exitCode = 1;
+  } else {
+    Log.log(chalk.green(`🎉 Didn't find any issues with the project!`));
   }
 }


### PR DESCRIPTION
# Why

If there is wrong version of autolinking installed or config plugins, `expo dotor` still states that there are no issues with the project plus exit code is zero


# How

return boolean form functions that are doing the validation and if there were any issues exit with non-zero exit code

# Test Plan

before (exit code zero)
![20220615_15h00m14s_grim](https://user-images.githubusercontent.com/9753141/173833032-1a80a312-9921-4929-8ece-f45293bfe7b6.png)

after (exit code 1)
![20220615_15h00m20s_grim](https://user-images.githubusercontent.com/9753141/173833091-ab178a1e-176a-45ca-a645-351edaa26544.png)
