### PR TITLE
ci: disable codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,20 +68,20 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Test ${{ matrix.package }}
-        # run: cd packages/${{ matrix.package }} && yarn test
-        run: cd packages/${{ matrix.package }} && yarn test --coverage
+        run: cd packages/${{ matrix.package }} && yarn test
+        # run: cd packages/${{ matrix.package }} && yarn test --coverage
         env:
           CI: true
           EXPO_DEBUG: true
-      - name: Get Test Flag Name
-        id: cov-flag-name
-        run: echo "::set-output name=flag::$(echo ${{ matrix.package }} | perl -pe 's/[^a-z]+([a-z])/\U\1/gi;s/^([A-Z])/\l\1/')"
-      - uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          file: ./packages/${{ matrix.package }}/coverage/clover.xml # optional
-          flags: ${{ steps.cov-flag-name.outputs.flag }} # optional
-          fail_ci_if_error: false # optional (default = false)
+      # - name: Get Test Flag Name
+      #   id: cov-flag-name
+      #   run: echo "::set-output name=flag::$(echo ${{ matrix.package }} | perl -pe 's/[^a-z]+([a-z])/\U\1/gi;s/^([A-Z])/\l\1/')"
+      # - uses: codecov/codecov-action@v2
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+      #     file: ./packages/${{ matrix.package }}/coverage/clover.xml # optional
+      #     flags: ${{ steps.cov-flag-name.outputs.flag }} # optional
+      #     fail_ci_if_error: false # optional (default = false)
 
   puppeteer:
     runs-on: ubuntu-latest


### PR DESCRIPTION

# Why

codecov is throwing too many false positives in PRs. When CI fails consistently and constantly then it reduces confidence in the review cycle.

We won't be drastically improving the testing of this repo since it is pretty much in maintenance mode until the versioned CLI migration is complete.

# How

Revert change to enable the feature.
