### PR TITLE
[cli] fix ignored existing plugins on expo install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [cli] Fix ignored existing plugins on `expo install`. ([#4429]([https://github.com/expo/expo/pull/17936](https://github.com/expo/expo-cli/pull/4429))
+
 ## [Wed, 15 Jun 2022 20:47:15 -0700](https://github.com/expo/expo-cli/commit/2c8188fd3e0dbbc9f545ce4c59ea543d676f97eb)
 
 ### 🧹 Chores

--- a/packages/expo-cli/src/commands/installAsync.ts
+++ b/packages/expo-cli/src/commands/installAsync.ts
@@ -141,7 +141,7 @@ export async function actionAsync(
   await packageManager.addWithParametersAsync(versionedPackages, parameters);
 
   try {
-    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true, skipPlugins: true }).exp;
+    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true, skipPlugins: false }).exp;
 
     // Only auto add plugins if the plugins array is defined or if the project is using SDK +42.
     await autoAddConfigPluginsAsync(

--- a/packages/expo-cli/src/commands/installAsync.ts
+++ b/packages/expo-cli/src/commands/installAsync.ts
@@ -141,7 +141,7 @@ export async function actionAsync(
   await packageManager.addWithParametersAsync(versionedPackages, parameters);
 
   try {
-    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true, skipPlugins: false }).exp;
+    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp;
 
     // Only auto add plugins if the plugins array is defined or if the project is using SDK +42.
     await autoAddConfigPluginsAsync(


### PR DESCRIPTION
# Why

Existing plugins were ignored retrieving the config for `expo install`.

# How

No longer skip resolving plugins. I'm not sure if the behavior of `skipPlugins` for `getConfig` in @expo/config has changed, but this makes it work here as intented.

Update: this comes down to this line: https://github.com/expo/expo-cli/blob/391f8faae3b3d497b4472bc9bd8c8b989f20ad11/packages/config/src/plugins/withConfigPlugins.ts#L22 where the plugins array is deleted from config when `skipPlugins` is `true`.

# Test Plan

- Initialize a blank project
- expo install expo-camera
- Add expo-camera plugin to app.json: "plugins": ["expo-camera"]
- Run expo install sentry-expo
- Notice that both plugins exists in the plugins array

Will look into automated testing, but suggestions are welcome.