### PR TITLE
fix: fix auto TypeScript version check

### DIFF
--- a/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
+++ b/packages/expo-cli/src/commands/utils/typescript/resolveModules.ts
@@ -12,8 +12,8 @@ const requiredPackages = [
   // use typescript/package.json to skip node module cache issues when the user installs
   // the package and attempts to resolve the module in the same process.
   { file: 'typescript/package.json', pkg: 'typescript' },
-  { file: '@types/react/index.d.ts', pkg: '@types/react' },
-  { file: '@types/react-native/index.d.ts', pkg: '@types/react-native' },
+  { file: '@types/react/package.json', pkg: '@types/react' },
+  { file: '@types/react-native/package.json', pkg: '@types/react-native' },
 ];
 
 export const baseTSConfigName = 'expo/tsconfig.base';


### PR DESCRIPTION
# Why

Ensure we check against the package.json for versions.