### PR TITLE
[prebuild-config] Remove the dependency on expo-modules-autolinking

### DIFF
--- a/packages/prebuild-config/package.json
+++ b/packages/prebuild-config/package.json
@@ -46,6 +46,9 @@
     "semver": "7.3.2",
     "xml2js": "0.4.23"
   },
+  "peerDependencies": {
+    "expo-modules-autolinking": ">=0.8.1"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/prebuild-config/package.json
+++ b/packages/prebuild-config/package.json
@@ -41,7 +41,6 @@
     "@expo/image-utils": "0.3.20",
     "@expo/json-file": "8.2.36",
     "debug": "^4.3.1",
-    "expo-modules-autolinking": "0.8.1",
     "fs-extra": "^9.0.0",
     "resolve-from": "^5.0.0",
     "semver": "7.3.2",

--- a/packages/prebuild-config/src/getAutolinkedPackages.ts
+++ b/packages/prebuild-config/src/getAutolinkedPackages.ts
@@ -1,6 +1,8 @@
 import { ModPlatform, StaticPlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
+import { importExpoModulesAutolinking } from './importExpoModulesAutolinking';
+
 /**
  * Returns a list of packages that are autolinked to a project.
  *
@@ -60,20 +62,4 @@ export function shouldSkipAutoPlugin(
     }
   }
   return false;
-}
-
-/**
- * Imports the `expo-modules-autolinking` package installed in the project at the given path.
- */
-function importExpoModulesAutolinking(projectRoot: string) {
-  try {
-    const resolvedAutolinkingPath = require.resolve('expo-modules-autolinking/build/autolinking', {
-      paths: [projectRoot],
-    });
-    return require(resolvedAutolinkingPath);
-  } catch (error) {
-    throw new Error(
-      "Cannot find 'expo-modules-autolinking' package in your project, make sure that you have 'expo' package installed"
-    );
-  }
 }

--- a/packages/prebuild-config/src/importExpoModulesAutolinking.ts
+++ b/packages/prebuild-config/src/importExpoModulesAutolinking.ts
@@ -1,0 +1,47 @@
+// NOTE: Keep these types in-sync with expo-modules-autolinking
+
+export type SearchResults = {
+  [moduleName: string]: object;
+};
+
+export type SearchOptions = {
+  searchPaths: string[];
+  platform: 'ios' | 'android' | 'web';
+  silent?: boolean;
+};
+
+export type AutolinkingModule = {
+  resolveSearchPathsAsync(searchPaths: string[] | null, cwd: string): Promise<string[]>;
+  findModulesAsync(providedOptions: SearchOptions): Promise<SearchResults>;
+};
+
+/**
+ * Imports the `expo-modules-autolinking` package installed in the project at the given path.
+ */
+export function importExpoModulesAutolinking(projectRoot: string): AutolinkingModule {
+  const autolinking = tryRequireExpoModulesAutolinking(projectRoot);
+  assertAutolinkingCompatibility(autolinking);
+  return autolinking;
+}
+
+function tryRequireExpoModulesAutolinking(projectRoot: string): AutolinkingModule {
+  try {
+    const resolvedAutolinkingPath = require.resolve('expo-modules-autolinking/build/autolinking', {
+      paths: [projectRoot],
+    });
+    return require(resolvedAutolinkingPath);
+  } catch {
+    throw new Error(
+      "Cannot find 'expo-modules-autolinking' package in your project, make sure that you have 'expo' package installed"
+    );
+  }
+}
+
+function assertAutolinkingCompatibility(autolinking: AutolinkingModule): void {
+  if ('resolveSearchPathsAsync' in autolinking && 'findModulesAsync' in autolinking) {
+    return;
+  }
+  throw new Error(
+    "The 'expo-modules-autolinking' package has been found, but it seems to be incompatible with '@expo/prebuild-config'"
+  );
+}


### PR DESCRIPTION
# Why

`expo-modules-autolinking` being a dependency of `@expo/prebuild-config` is the most common reason of duplicated versions of the autolinking installed in the project. To avoid such issues the `expo` package must be the only one that depends on `expo-modules-autolinking`.

# How

- Instead of importing the autolinking statically, I use Node's resolution to find the path to `expo-modules-autolinking` that is installed in the project where the prebuild command is run
- Removed `expo-modules-autolinking` from the dependencies

# Test Plan

- Tested `dexpo prebuild` on a fresh project and confirmed that the results are the same as before (`searchPaths` and `platformPaths`)
- Ensured that `require.resolve` and especially `paths` option is available in all versions of Node that we support (it's available as of v8.9.0 so yes)