### PR TITLE
chore(create-expo-app): possibly fix windows bug for relative paths

### DIFF
--- a/packages/create-expo-app/src/Template.ts
+++ b/packages/create-expo-app/src/Template.ts
@@ -44,10 +44,10 @@ export function resolvePackageModuleId(moduleId: string) {
     moduleId?.startsWith(path.sep)
   ) {
     if (moduleId?.startsWith('file:')) {
-      moduleId = moduleId.substring('file:'.length);
+      moduleId = moduleId.substring(5);
     }
     debug(`Resolved moduleId to file path:`, moduleId);
-    return { type: 'file', uri: moduleId };
+    return { type: 'file', uri: path.resolve(moduleId) };
   } else {
     debug(`Resolved moduleId to NPM package:`, moduleId);
     return { type: 'npm', uri: moduleId };

--- a/packages/create-expo-app/src/__tests__/Template.test.ts
+++ b/packages/create-expo-app/src/__tests__/Template.test.ts
@@ -1,22 +1,26 @@
+import path from 'path';
+
 import { resolvePackageModuleId } from '../Template';
 
 describe(resolvePackageModuleId, () => {
   it(`resolves 'file:' path`, () => {
-    expect(resolvePackageModuleId('file:./path/to/template.tgz')).toEqual({
+    const result = resolvePackageModuleId('file:./path/to/template.tgz');
+    expect(result).toEqual({
       type: 'file',
-      uri: './path/to/template.tgz',
+      uri: expect.stringMatching('./path/to/template.tgz'),
     });
+    expect(path.isAbsolute(result.uri)).toBe(true);
   });
   it(`resolves darwin local path`, () => {
     expect(resolvePackageModuleId('./path/to/template.tgz')).toEqual({
       type: 'file',
-      uri: './path/to/template.tgz',
+      uri: expect.stringMatching('./path/to/template.tgz'),
     });
   });
   it(`resolves windows local path`, () => {
     expect(resolvePackageModuleId('.\\path\\to\\template.tgz')).toEqual({
       type: 'file',
-      uri: '.\\path\\to\\template.tgz',
+      uri: expect.stringMatching(/template\.tgz$/),
     });
   });
   it(`resolves module ID`, () => {

--- a/packages/create-expo-app/src/createAsync.ts
+++ b/packages/create-expo-app/src/createAsync.ts
@@ -55,7 +55,7 @@ async function cloneTemplateAsync(projectRoot: string, template: string | null) 
     extractTemplateStep.fail(
       'Something went wrong in downloading and extracting the project files: ' + error.message
     );
-    Log.exit(`Error cloning template: %O`, error);
+    Log.exit(`Error cloning template: ` + error);
   }
 }
 


### PR DESCRIPTION
# Why

- improve failure error.
- reduce complexity file path resolution.
- resolve more file paths to attempt to fix relative path bugs on windows -- appears NPM on windows doesn't resolve paths manually.
