### PR TITLE
[doctor] Validate that projects do not include illegal packages

### DIFF
--- a/packages/expo-cli/src/commands/info/doctor/depedencies/explain.ts
+++ b/packages/expo-cli/src/commands/info/doctor/depedencies/explain.ts
@@ -111,7 +111,7 @@ export async function printExplanationsAsync(
     printInvalidPackages(pkg, { explanations: invalid });
     return false;
   } else {
-    Log.log(chalk`All copies of {bold ${pkg.name}} satisfy {green ${pkg.version}}`);
+    Log.debug(chalk`All copies of {bold ${pkg.name}} satisfy {green ${pkg.version}}`);
     return true;
   }
 }

--- a/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
+++ b/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
@@ -32,7 +32,23 @@ async function validateSupportPackagesAsync(sdkVersion: string): Promise<boolean
       }
     }
   }
+
+  // None of these packages should exist in any modern project
+  const illegalPackages = [
+    '@unimodules/core',
+    '@unimodules/react-native-adapter',
+    'react-native-unimodules',
+  ];
+
+  for (const pkg of illegalPackages) {
+    const isPackageAbsent = await warnAboutDeepDependenciesAsync({ name: pkg });
+    if (!isPackageAbsent) {
+      allPackagesValid = false;
+    }
+  }
+
   Log.newLine();
+
   return allPackagesValid;
 }
 

--- a/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
+++ b/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
@@ -32,24 +32,27 @@ async function validateSupportPackagesAsync(sdkVersion: string): Promise<boolean
       }
     }
   }
+  return allPackagesValid;
+}
 
-  // None of these packages should exist in any modern project
+// Ensures that a set of packages
+async function validateIllegalPackagesAsync(): Promise<boolean> {
   const illegalPackages = [
     '@unimodules/core',
     '@unimodules/react-native-adapter',
     'react-native-unimodules',
   ];
 
+  let allPackagesLegal = true;
+
   for (const pkg of illegalPackages) {
     const isPackageAbsent = await warnAboutDeepDependenciesAsync({ name: pkg });
     if (!isPackageAbsent) {
-      allPackagesValid = false;
+      allPackagesLegal = false;
     }
   }
 
-  Log.newLine();
-
-  return allPackagesValid;
+  return allPackagesLegal;
 }
 
 export async function actionAsync(projectRoot: string, options: Options) {
@@ -61,6 +64,12 @@ export async function actionAsync(projectRoot: string, options: Options) {
   // Only use the new validation on SDK +45.
   if (Versions.gteSdkVersion(exp, '45.0.0')) {
     if (!(await validateSupportPackagesAsync(exp.sdkVersion!))) {
+      foundSomeIssues = true;
+    }
+  }
+
+  if (Versions.gteSdkVersion(exp, '44.0.0')) {
+    if (!(await validateIllegalPackagesAsync())) {
       foundSomeIssues = true;
     }
   }


### PR DESCRIPTION
# Why

Any SDK 45+ project that includes `@unimodules/core`, `@unimodules/react-native-adapter`, and `react-native-unimodules` is likely not going to build. We should let people know about this and `doctor` is a good spot.

# How

I adapted our existing checks for deep dependencies to let us check for the existence of a package that should not exist. I changed the output slightly for this to make sense and to remove some (I think) unnecessary logs. See below for some examples.

# Test Plan

https://user-images.githubusercontent.com/90494/176566254-808fa54d-c983-4f7b-aa6c-d4649ce706e6.mov

https://user-images.githubusercontent.com/90494/176566264-f4766dff-000d-4ab3-a0fd-e5ef80331fb0.mov

https://user-images.githubusercontent.com/90494/176566279-0f0bc8b9-debf-4e07-bc79-1b2cfeb2d4e7.mov