### PR TITLE
chore: add deprecated banner to dev tools UI

### DIFF
--- a/packages/dev-tools/components/DeprecatedBanner.js
+++ b/packages/dev-tools/components/DeprecatedBanner.js
@@ -1,0 +1,29 @@
+import * as Constants from 'app/common/constants';
+import React from 'react';
+import { css } from 'react-emotion';
+
+const STYLES_BANNER = css`
+  padding: 16px;
+  width: 100%;
+  background-color: ${Constants.colors.red};
+`;
+const STYLES_INDICATOR = css`
+  font-family: ${Constants.fontFamilies.mono};
+  color: ${Constants.colors.white};
+  font-size: 12px;
+  padding-top: 2px;
+`;
+
+export default function DeprecatedBanner() {
+  return (
+    <div className={STYLES_BANNER}>
+      <span className={STYLES_INDICATOR}>
+        This Development UI is deprecated, please use the Terminal UI instead.{' '}
+        <a style={{ color: 'white' }} href="#">
+          Learn more
+        </a>
+        .
+      </span>
+    </div>
+  );
+}

--- a/packages/dev-tools/components/ProjectManagerLayout.js
+++ b/packages/dev-tools/components/ProjectManagerLayout.js
@@ -1,5 +1,6 @@
 import * as Constants from 'app/common/constants';
 import ProjectManagerSection from 'app/components/ProjectManagerSection';
+import DeprecatedBanner from 'app/components/DeprecatedBanner';
 import * as React from 'react';
 import { css } from 'react-emotion';
 
@@ -251,6 +252,7 @@ export default class ProjectManagerLayout extends React.Component {
 
     return (
       <section className={STYLES_MAIN_SECTION}>
+        <DeprecatedBanner />
         {navigationSection}
         {alertSection}
         <div className={STYLES_CONTAINER}>
@@ -263,6 +265,7 @@ export default class ProjectManagerLayout extends React.Component {
               {this.props.headerSection ? (
                 <div className={STYLES_CONTAINER_MIDDLE_TOP_HEADER}>{headerSection}</div>
               ) : null}
+
               <div className={STYLES_CONTAINER_MIDDLE_TOP_ACTIONS}>{toolbarSection}</div>
             </div>
             {sectionElements}


### PR DESCRIPTION
# Why

- We don't have the capacity to maintain this part of the CLI. It hasn't had updates in a very long time.
- The UI doesn't add value outside of the terminal, now that [Flipper is moving to the same model](https://fbflipper.com/blog/2022/05/20/preparing-for-headless-flipper/), we may be able to leverage that instead.
- Due to the large increase in bundle size and net dependency overhead it would be pretty impractical to bring this feature into the [new versioned CLI](https://blog.expo.dev/new-versioned-expo-cli-cf6e10632656) which is installed in every project.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Add a banner to the top of the UI which links to more info about the deprecation -- pending @brentvatne releasing article.

![localhost_3333_ (1)](https://user-images.githubusercontent.com/9664363/176909815-b5a3b0de-dbee-4518-93ea-c8047b6ab897.png)


<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `yarn start ../path/to/project`

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->