### PR TITLE
add better warning when prebuilding in non-interactive mode

### DIFF
--- a/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
+++ b/packages/expo-cli/src/commands/eject/clearNativeFolder.ts
@@ -104,6 +104,9 @@ export async function promptToClearMalformedNativeProjectsAsync(
       initial: true,
     }))
   ) {
+    if (isNonInteractive()) {
+      Log.warn(`${message}, project files will be cleared and reinitialized.`);
+    }
     await clearNativeFolder(projectRoot, platforms);
   } else {
     // Warn the user that the process may fail.


### PR DESCRIPTION
# Why

currently, if someone has a managed project with an ios directory, or is writing eas secrets to ios directory e.g.

```
echo "$IOS_GOOGLE_SERVICES_BASE64" | base64 -d > ios/GoogleService-Info.plist
```
then only warning they are getting that ios directory is deleted is log

```
- Clearing ios
✔ Cleared ios code
```

# How

print working when rebuilding in non-interactive mode

# Test Plan
