### PR TITLE
Fix showstopper in next-adapter/document.js

### DIFF
--- a/packages/next-adapter/document.js
+++ b/packages/next-adapter/document.js
@@ -47,7 +47,7 @@ body {
 export async function getInitialProps({ renderPage }) {
   AppRegistry.registerComponent('Main', () => Main);
   const { getStyleElement } = AppRegistry.getApplication('Main');
-  const page = renderPage();
+  const page = await renderPage();
   const styles = [<style dangerouslySetInnerHTML={{ __html: style }} />, getStyleElement()];
   return { ...page, styles: React.Children.toArray(styles) };
 }


### PR DESCRIPTION
`renderPage` is now async. Otherwise this error shows even after adding expo to a barebone next app

<img width="596" alt="image" src="https://user-images.githubusercontent.com/696842/178016917-d49330ef-7b93-42f8-ae9a-35e59175fba1.png">
