### PR TITLE
[dev-server] Support prebuilt hermes in react-native 0.69

### DIFF
--- a/packages/dev-server/src/metro/importMetroFromProject.ts
+++ b/packages/dev-server/src/metro/importMetroFromProject.ts
@@ -65,7 +65,28 @@ export function importExpoMetroConfigFromProject(
 
 export function importHermesCommandFromProject(projectRoot: string): string {
   const platformExecutable = getHermesCommandPlatform();
-  return resolveFromProject(projectRoot, `hermes-engine/${platformExecutable}`);
+  const hermescLocations = [
+    // Override hermesc dir by environment variables
+    process.env['REACT_NATIVE_OVERRIDE_HERMES_DIR']
+      ? `${process.env['REACT_NATIVE_OVERRIDE_HERMES_DIR']}/build/bin/hermesc`
+      : '',
+
+    // Building hermes from source
+    'react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc',
+
+    // Prebuilt hermesc in official react-native 0.69+
+    `react-native/sdks/hermesc/${platformExecutable}`,
+
+    // Legacy hermes-engine package
+    `hermes-engine/${platformExecutable}`,
+  ];
+
+  for (const location of hermescLocations) {
+    try {
+      return resolveFromProject(projectRoot, location);
+    } catch (e: any) {}
+  }
+  throw new Error('Cannot find the hermesc executable.');
 }
 
 function getHermesCommandPlatform(): string {


### PR DESCRIPTION
# Why

we used the `hermesc` from [the hermes-engine node dependency to compile hermes bundle](https://github.com/expo/expo-cli/blob/eda8fe6eafde912a9a37eaa3197e7fb48aa50f42/packages/dev-server/src/metro/importMetroFromProject.ts#L66-L82).  the hermes-engine dependency in react-native 0.69 is outdated, instead we should use the hermesc bundled in react-native 0.69.
close ENG-5677

# How

tries to resolve hermesc from multiple locations:
 - `${process.env['REACT_NATIVE_OVERRIDE_HERMES_DIR']}/build/bin/hermesc` - building hermes from source with override dir
 - `node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc` - building hermes from source
 - `node_modules/react-native/sdks/hermesc/...` - the one bundled in react-native npm package
 - `node_modules/hermes-engine/...` - support legacy hermes-engine for react-native <= 0.68

the logic is referenced from [react.gradle](https://github.com/facebook/react-native/blob/64fe67695be3c038414c5ed3e02d487c449702b6/react.gradle#L105-L124)

# Test Plan

```sh
$ expo init -t blank@46 sdk46
$ cd sdk46
# add `"jsEngine": "hermes"` to app.json
$ expo export --platform ios -p https://www.example.org/
$ file dist/bundles/*
# the hermes bytecode version should be 85 (hermes bundled in react-native 0.69) not 84 (hermes-engine for react-native 0.68)
```