### PR TITLE
[metro-config] Disable symbolicator frame customizations to fix expo/expo#17903

### DIFF
--- a/packages/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/metro-config/src/ExpoMetroConfig.ts
@@ -240,26 +240,26 @@ export function getDefaultConfig(
     server: {
       port: Number(process.env.RCT_METRO_PORT) || 8081,
     },
-    symbolicator: {
-      customizeFrame: frame => {
-        let collapse = Boolean(frame.file && INTERNAL_CALLSITES_REGEX.test(frame.file));
+    // symbolicator: {
+    //   customizeFrame: frame => {
+    //     let collapse = Boolean(frame.file && INTERNAL_CALLSITES_REGEX.test(frame.file));
 
-        if (!collapse) {
-          // This represents the first frame of the stacktrace.
-          // Often this looks like: `__r(0);`.
-          // The URL will also be unactionable in the app and therefore not very useful to the developer.
-          if (
-            frame.column === 3 &&
-            frame.methodName === 'global code' &&
-            frame.file?.match(/^https?:\/\//g)
-          ) {
-            collapse = true;
-          }
-        }
+    //     if (!collapse) {
+    //       // This represents the first frame of the stacktrace.
+    //       // Often this looks like: `__r(0);`.
+    //       // The URL will also be unactionable in the app and therefore not very useful to the developer.
+    //       if (
+    //         frame.column === 3 &&
+    //         frame.methodName === 'global code' &&
+    //         frame.file?.match(/^https?:\/\//g)
+    //       ) {
+    //         collapse = true;
+    //       }
+    //     }
 
-        return { ...(frame || {}), collapse };
-      },
-    },
+    //     return { ...(frame || {}), collapse };
+    //   },
+    // },
     transformer: {
       allowOptionalDependencies: true,
       babelTransformerPath: isExotic


### PR DESCRIPTION
https://github.com/expo/expo/issues/17903 and fixes ENG-5720

# Why

https://github.com/expo/expo/issues/17903 is annoying and quite easy to reproduce.

All you need is an app that uses `@expo/metro-config` and this App.js, and then press the "Press me!" button:

```jsx
import { Button, StyleSheet, Text, View } from 'react-native';

export default function App() {
  return (
    <View style={styles.container}>
      <Button title="Press me!" onPress={() => {
        console.warn('This is a console.warn');
        console.error('This is a console.error');
      }} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

<img width="969" alt="image (3)" src="https://user-images.githubusercontent.com/90494/179120264-ad216866-77c2-4754-80c5-1c8e677fa9ae.png">

# How

I noticed that if we remove the custom `metro.config.js` in a new project, we don't get these errors anymore.

<img width="682" alt="image" src="https://user-images.githubusercontent.com/90494/179120415-c44922aa-08e1-46f7-992f-3c2bebdfeb83.png">

So I added back the `metro.config.js` using `expo/metro-config` and then started modifying the source of a `yarn link`'d `@expo/metro-config` and found that removing the custom symbolicator logic fixed the errors. I propose we move forward with this for SDK 46 and follow up later to see if there is a way for us to add back the functionality the customizations provided without inducing these side effects.

Also, we should probably backport this to SDK 45.

# Test Plan

Described above