### PR TITLE
[install-expo-modules] Add SDK 46 support

### DIFF
--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.java
@@ -17,7 +17,7 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this,
+    return new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
       new ReactActivityDelegate(this, getMainComponentName())
     );
   }

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-no-delegate-updated.kt
@@ -15,7 +15,7 @@ class MainActivity : ReactActivity() {
   }
 
   override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this,
+    return ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
       ReactActivityDelegate(this, getMainComponentName())
     );
   }

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.java
@@ -19,7 +19,7 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(this, new MainActivityDelegate(this, getMainComponentName()));
+    return new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, new MainActivityDelegate(this, getMainComponentName()));
   }
 
   public static class MainActivityDelegate extends ReactActivityDelegate {

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn068-updated.kt
@@ -16,7 +16,7 @@ class MainActivity : ReactActivity() {
   }
 
   override fun createReactActivityDelegate(): ReactActivityDelegate {
-    return ReactActivityDelegateWrapper(this, MainActivityDelegate(this, mainComponentName))
+    return ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, MainActivityDelegate(this, mainComponentName))
   }
 
   class MainActivityDelegate(activity: ReactActivity?, mainComponentName: String?)

--- a/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainActivity.ts
+++ b/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainActivity.ts
@@ -36,14 +36,14 @@ export function setModulesMainActivity(mainActivity: string, language: 'java' | 
       ? [
           '\n  @Override',
           '  protected ReactActivityDelegate createReactActivityDelegate() {',
-          '    return new ReactActivityDelegateWrapper(this,',
+          '    return new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,',
           '      new ReactActivityDelegate(this, getMainComponentName())',
           '    );',
           '  }\n',
         ]
       : [
           '\n  override fun createReactActivityDelegate(): ReactActivityDelegate {',
-          '    return ReactActivityDelegateWrapper(this,',
+          '    return ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,',
           '      ReactActivityDelegate(this, getMainComponentName())',
           '    );',
           '  }\n',
@@ -73,8 +73,8 @@ export function setModulesMainActivity(mainActivity: string, language: 'java' | 
     }
 
     const replacement = isJava
-      ? `new ReactActivityDelegateWrapper(this, ${newInstanceCodeBlock.code})`
-      : `ReactActivityDelegateWrapper(this, ${newInstanceCodeBlock.code})`;
+      ? `new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, ${newInstanceCodeBlock.code})`
+      : `ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, ${newInstanceCodeBlock.code})`;
     mainActivity = replaceContentsWithOffset(
       mainActivity,
       replacement,

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosDeploymentTarget-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosDeploymentTarget-test.ts
@@ -1,4 +1,11 @@
-import { updateDeploymentTargetPodfile } from '../withIosDeploymentTarget';
+import fs from 'fs';
+
+import {
+  shouldUpdateDeployTargetPodfileAsync,
+  updateDeploymentTargetPodfile,
+} from '../withIosDeploymentTarget';
+
+jest.mock('fs', () => ({ promises: { readFile: jest.fn() } }));
 
 describe(updateDeploymentTargetPodfile, () => {
   it('should update deployment target in Podfile', () => {
@@ -71,5 +78,35 @@ end
 `;
 
     expect(updateDeploymentTargetPodfile(contents, '12.0')).toEqual(contents);
+  });
+});
+
+describe(shouldUpdateDeployTargetPodfileAsync, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should returns true when target version is higher than current version', async () => {
+    const podfileContent = `platform :ios, '11.0'`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValue(podfileContent);
+
+    const result = await shouldUpdateDeployTargetPodfileAsync('/app', '13.0');
+    expect(result).toBe(true);
+  });
+
+  it('should returns false when target version is equal to current version', async () => {
+    const podfileContent = `platform :ios, '12.4'`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValue(podfileContent);
+
+    const result = await shouldUpdateDeployTargetPodfileAsync('/app', '12.4');
+    expect(result).toBe(false);
+  });
+
+  it('should show a warning when the Podfile content is not supported', async () => {
+    const podfileContent = `platform :ios, something || '14.0'`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValue(podfileContent);
+    const spy = jest.spyOn(console, 'warn');
+    await shouldUpdateDeployTargetPodfileAsync('/app', '13.0');
+    expect(spy).toBeCalled();
   });
 });

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -10,6 +10,11 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
+    expoSdkVersion: '46.0.0',
+    iosDeploymentTarget: '12.4',
+    reactNativeVersionRange: '>= 0.69.0',
+  },
+  {
     expoSdkVersion: '45.0.0',
     iosDeploymentTarget: '12.0',
     reactNativeVersionRange: '>= 0.65.0',


### PR DESCRIPTION
# Why

close ENG-5724

# How

- add react-native 0.69 with sdk 46 version info
- add missing `BuildConfig.IS_NEW_ARCHITECTURE_ENABLED` migration in MainActivity. this is also available from sdk 45. it's just me forgot to add it from template.
- skip the prompt for ios deployment target update if the requirement is already meet.

# Test Plan

- ci  and unit tests passed
- `npx install-expo-modules` on a react-native 0.68 project
- `npx install-expo-modules` on a react-native 0.69 project