### PR TITLE
feat: add support for EXPO_BETA flag

### DIFF
--- a/packages/create-expo-app/src/Template.ts
+++ b/packages/create-expo-app/src/Template.ts
@@ -8,6 +8,7 @@ import { Log } from './log';
 import { formatRunCommand, PackageManagerName } from './resolvePackageManager';
 import { env } from './utils/env';
 import {
+  applyBetaTag,
   applyKnownNpmPackageNameRules,
   downloadAndExtractNpmModuleAsync,
   getResolvedTemplateName,
@@ -68,7 +69,7 @@ export async function extractAndPrepareTemplateAppAsync(
 
   const { type, uri } = resolvePackageModuleId(npmPackage || 'expo-template-blank');
 
-  const resolvedUri = type === 'file' ? uri : getResolvedTemplateName(uri);
+  const resolvedUri = type === 'file' ? uri : getResolvedTemplateName(applyBetaTag(uri));
 
   await downloadAndExtractNpmModuleAsync(resolvedUri, {
     cwd: projectRoot,

--- a/packages/create-expo-app/src/utils/npm.ts
+++ b/packages/create-expo-app/src/utils/npm.ts
@@ -33,6 +33,7 @@ export function applyBetaTag(npmPackageName: string): string {
   let [name, tag] = splitNpmNameAndTag(npmPackageName);
 
   if (!tag && env.EXPO_BETA) {
+    debug('Using beta tag for', name);
     tag = 'beta';
   }
 


### PR DESCRIPTION
# Why

Running EXPO_BETA should use the beta templates in create-expo-app
