### PR TITLE
[xdl] include version number in package info cache

### DIFF
--- a/packages/xdl/src/tools/ModuleVersion.ts
+++ b/packages/xdl/src/tools/ModuleVersion.ts
@@ -15,7 +15,7 @@ function createModuleVersionChecker(name: string, currentVersion: string) {
         deprecated: pkgJson.deprecated,
       };
     },
-    `${name}-updates.json`,
+    `${name}-${currentVersion}-updates.json`,
     24 * 60 * 60 * 1000 // one day
   );
 


### PR DESCRIPTION
# Why

Because `xdl` caches package information by name only, it will not refresh the information if a new version of the package is available. This leads to issues like #4483.

# How

Include the provided `currentVersion` in the filename

# Test Plan

There's no test coverage in `xdl` for it, and it's not worth adding it, as the method is already deprecated.

Also hard to test because `xdl` is a dependency of `expo-cli`, but it should be testable by:
- Installing `expo-cli` 5.5.2 or 5.6.0 (which are deprecated)
- Run `expo start`, or another command to trigger the version check
- Upgrade `expo-cli` to a version with the new `xdl`
- Run `expo start` again, and see that a separate file is created in cache for the new version, and the deprecation warning isn't shown.