### PR TITLE
feat(cli): add migration logs when available

### DIFF
--- a/packages/expo-cli/src/commands/build/buildWebAsync.ts
+++ b/packages/expo-cli/src/commands/build/buildWebAsync.ts
@@ -1,5 +1,7 @@
 import { Webpack } from 'xdl';
 
+import { warnAboutLocalCLI } from '../../utils/migration';
+
 type Options = {
   pwa?: boolean;
   clear?: boolean;
@@ -7,6 +9,8 @@ type Options = {
 };
 
 export async function actionAsync(projectRoot: string, options: Options) {
+  warnAboutLocalCLI(projectRoot, { localCmd: 'export:web' });
+
   return Webpack.bundleAsync(projectRoot, {
     ...options,
     dev: typeof options.dev === 'undefined' ? false : options.dev,

--- a/packages/expo-cli/src/commands/eject/customizeAsync.ts
+++ b/packages/expo-cli/src/commands/eject/customizeAsync.ts
@@ -8,6 +8,7 @@ import prompts from 'prompts';
 import resolveFrom from 'resolve-from';
 
 import Log from '../../log';
+import { warnAboutLocalCLI } from '../../utils/migration';
 
 type Options = { force: boolean };
 
@@ -91,6 +92,7 @@ async function generateFilesAsync({
 }
 
 export async function actionAsync(projectRoot: string = './', options: Options = { force: false }) {
+  warnAboutLocalCLI(projectRoot, { localCmd: 'customize' });
   // Get the static path (defaults to 'web/')
   // Doesn't matter if expo is installed or which mode is used.
   const { exp } = getConfig(projectRoot, {

--- a/packages/expo-cli/src/commands/eject/ejectAsync.ts
+++ b/packages/expo-cli/src/commands/eject/ejectAsync.ts
@@ -3,6 +3,7 @@ import { Versions } from 'xdl';
 
 import CommandError from '../../CommandError';
 import Log from '../../log';
+import { warnAboutLocalCLI } from '../../utils/migration';
 import { confirmAsync } from '../../utils/prompts';
 import { usesOldExpoUpdatesAsync } from '../utils/ProjectUtils';
 import maybeBailOnGitStatusAsync from '../utils/maybeBailOnGitStatusAsync';
@@ -50,6 +51,8 @@ export async function actionAsync(
     platform?: string;
   }
 ) {
+  warnAboutLocalCLI(projectRoot, { localCmd: 'prebuild' });
+
   const { exp } = getConfig(projectRoot);
 
   if (options.npm) {

--- a/packages/expo-cli/src/commands/eject/prebuildAsync.ts
+++ b/packages/expo-cli/src/commands/eject/prebuildAsync.ts
@@ -1,3 +1,4 @@
+import { warnAboutLocalCLI } from '../../utils/migration';
 import maybeBailOnGitStatusAsync from '../utils/maybeBailOnGitStatusAsync';
 import { clearNativeFolder, promptToClearMalformedNativeProjectsAsync } from './clearNativeFolder';
 import { platformsFromPlatform } from './platformOptions';
@@ -17,6 +18,8 @@ export async function actionAsync(
     skipDependencyUpdate?: string;
   }
 ) {
+  warnAboutLocalCLI(projectRoot, { localCmd: 'prebuild' });
+
   if (options.npm) {
     options.packageManager = 'npm';
   }

--- a/packages/expo-cli/src/commands/export/exportAsync.ts
+++ b/packages/expo-cli/src/commands/export/exportAsync.ts
@@ -7,6 +7,7 @@ import { UrlUtils } from 'xdl';
 
 import CommandError from '../../CommandError';
 import Log from '../../log';
+import { warnAboutLocalCLI } from '../../utils/migration';
 import prompt from '../../utils/prompts';
 import { platformsFromPlatform } from '../eject/platformOptions';
 import * as CreateApp from '../utils/CreateApp';
@@ -163,6 +164,8 @@ export async function collectMergeSourceUrlsAsync(
 }
 
 export async function actionAsync(projectRoot: string, options: Options) {
+  warnAboutLocalCLI(projectRoot, { localCmd: 'export' });
+
   if (!options.experimentalBundle) {
     // Ensure URL
     options.publicUrl = await ensurePublicUrlAsync(options.publicUrl, options.dev);

--- a/packages/expo-cli/src/commands/info/config/configAsync.ts
+++ b/packages/expo-cli/src/commands/info/config/configAsync.ts
@@ -4,6 +4,7 @@ import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 
 import CommandError from '../../../CommandError';
 import Log from '../../../log';
+import { warnAboutLocalCLI } from '../../../utils/migration';
 import { logConfig } from '../../eject/configureProjectAsync';
 import { profileMethod } from '../../utils/profileMethod';
 
@@ -14,6 +15,10 @@ type Options = {
 };
 
 export async function actionAsync(projectRoot: string, options: Options) {
+  // Don't break the existing functionality.
+  if (!options.json) {
+    warnAboutLocalCLI(projectRoot, { localCmd: 'config' });
+  }
   let config: ProjectConfig;
 
   if (options.type === 'prebuild') {

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -13,6 +13,7 @@ import { UserManager, Versions } from 'xdl';
 
 import CommandError, { AbortCommandError, SilentError } from '../CommandError';
 import Log from '../log';
+import { warnMigration } from '../utils/migration';
 import { logNewSection } from '../utils/ora';
 import prompts, { selectAsync } from '../utils/prompts';
 import { directoryExistsAsync } from './eject/clearNativeFolder';
@@ -226,6 +227,8 @@ async function resolveTemplateAsync(resolvedTemplate?: string | null) {
 }
 
 export async function actionAsync(incomingProjectRoot: string, command: Partial<Options>) {
+  warnMigration('npx create-expo-app --template');
+
   const options = parseOptions(command);
 
   const deprecatedNameArgument =

--- a/packages/expo-cli/src/commands/installAsync.ts
+++ b/packages/expo-cli/src/commands/installAsync.ts
@@ -8,6 +8,7 @@ import { Versions } from 'xdl';
 import CommandError, { SilentError } from '../CommandError';
 import Log from '../log';
 import { getRemoteVersionsForSdk } from '../utils/getRemoteVersionsForSdk';
+import { warnAboutLocalCLI } from '../utils/migration';
 import { findProjectRootAsync } from './utils/ProjectUtils';
 import { autoAddConfigPluginsAsync } from './utils/autoAddConfigPluginsAsync';
 import { getBundledNativeModulesAsync } from './utils/bundledNativeModules';
@@ -36,6 +37,7 @@ export async function actionAsync(
   options: PackageManager.CreateForProjectOptions
 ) {
   const projectRoot = await resolveExpoProjectRootAsync();
+  warnAboutLocalCLI(projectRoot, { localCmd: 'install' });
 
   const packageManager = PackageManager.createForProject(projectRoot, {
     npm: options.npm,

--- a/packages/expo-cli/src/commands/run/android/runAndroid.ts
+++ b/packages/expo-cli/src/commands/run/android/runAndroid.ts
@@ -9,6 +9,7 @@ import CommandError from '../../../CommandError';
 import StatusEventEmitter from '../../../analytics/StatusEventEmitter';
 import getDevClientProperties from '../../../analytics/getDevClientProperties';
 import Log from '../../../log';
+import { warnAboutLocalCLI } from '../../../utils/migration';
 import { promptToClearMalformedNativeProjectsAsync } from '../../eject/clearNativeFolder';
 import { prebuildAsync } from '../../eject/prebuildAppAsync';
 import { installCustomExitHook } from '../../start/installExitHooks';
@@ -127,6 +128,7 @@ async function resolveOptionsAsync(
 }
 
 export async function actionAsync(projectRoot: string, options: Options) {
+  warnAboutLocalCLI(projectRoot, { localCmd: 'run:android' });
   // If the user has an empty android folder then the project won't build, this can happen when they delete the prebuild files in git.
   // Check to ensure most of the core files are in place, and prompt to remove the folder if they aren't.
   await profileMethod(promptToClearMalformedNativeProjectsAsync)(projectRoot, ['android']);

--- a/packages/expo-cli/src/commands/run/ios/runIos.ts
+++ b/packages/expo-cli/src/commands/run/ios/runIos.ts
@@ -8,6 +8,7 @@ import CommandError from '../../../CommandError';
 import StatusEventEmitter from '../../../analytics/StatusEventEmitter';
 import getDevClientProperties from '../../../analytics/getDevClientProperties';
 import Log from '../../../log';
+import { warnAboutLocalCLI } from '../../../utils/migration';
 import { promptToClearMalformedNativeProjectsAsync } from '../../eject/clearNativeFolder';
 import { EjectAsyncOptions, prebuildAsync } from '../../eject/prebuildAppAsync';
 import { installCustomExitHook } from '../../start/installExitHooks';
@@ -24,6 +25,8 @@ import { Options, resolveOptionsAsync } from './resolveOptionsAsync';
 const isMac = process.platform === 'darwin';
 
 export async function actionAsync(projectRoot: string, options: Options) {
+  warnAboutLocalCLI(projectRoot, { localCmd: 'run:ios' });
+
   // If the user has an empty ios folder then the project won't build, this can happen when they delete the prebuild files in git.
   // Check to ensure most of the core files are in place, and prompt to remove the folder if they aren't.
   await profileMethod(promptToClearMalformedNativeProjectsAsync)(projectRoot, ['ios']);

--- a/packages/expo-cli/src/commands/start/startAsync.ts
+++ b/packages/expo-cli/src/commands/start/startAsync.ts
@@ -7,6 +7,7 @@ import { LoadingPageHandler, Project, UnifiedAnalytics, UrlUtils, Versions } fro
 import StatusEventEmitter from '../../analytics/StatusEventEmitter';
 import getDevClientProperties from '../../analytics/getDevClientProperties';
 import Log from '../../log';
+import { warnAboutLocalCLI } from '../../utils/migration';
 import { assertProjectHasExpoExtensionFilesAsync } from '../utils/deprecatedExtensionWarnings';
 import { profileMethod } from '../utils/profileMethod';
 import * as sendTo from '../utils/sendTo';
@@ -19,6 +20,8 @@ import { installCustomExitHook, installExitHooks } from './installExitHooks';
 import { NormalizedOptions, parseStartOptions } from './parseStartOptions';
 
 export async function actionAsync(projectRoot: string, options: NormalizedOptions): Promise<void> {
+  warnAboutLocalCLI(projectRoot, { localCmd: 'start' });
+
   Log.log(chalk.gray(`Starting project at ${projectRoot}`));
 
   // Add clean up hooks

--- a/packages/expo-cli/src/utils/migration.ts
+++ b/packages/expo-cli/src/utils/migration.ts
@@ -9,7 +9,9 @@ export function warnAboutLocalCLI(projectRoot: string, { localCmd }: { localCmd:
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   const useLocalCLI = boolish('EXPO_USE_LOCAL_CLI', true);
   if (Versions.gteSdkVersion(exp, '46.0.0') && useLocalCLI) {
-    Log.warn(chalk`\n\nMigrate to the local CLI command:\n\u203A {bold npx expo ${localCmd}}\n`);
+    Log.warn(
+      chalk`\nThis command is being executed with the global Expo CLI.\nTo use the local CLI instead (recommended in SDK 46 and higher), run:\n\u203A {bold npx expo ${localCmd}}\n`
+    );
   }
 }
 

--- a/packages/expo-cli/src/utils/migration.ts
+++ b/packages/expo-cli/src/utils/migration.ts
@@ -1,0 +1,18 @@
+import { getConfig } from '@expo/config';
+import chalk from 'chalk';
+import { boolish } from 'getenv';
+import { Versions } from 'xdl';
+
+import Log from '../log';
+
+export function warnAboutLocalCLI(projectRoot: string, { localCmd }: { localCmd: string }) {
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+  const useLocalCLI = boolish('EXPO_USE_LOCAL_CLI', true);
+  if (Versions.gteSdkVersion(exp, '46.0.0') && useLocalCLI) {
+    Log.warn(chalk`\n\nMigrate to the local CLI command:\n\u203A {bold npx expo ${localCmd}}\n`);
+  }
+}
+
+export function warnMigration(toCommand: string) {
+  Log.warn(chalk`\nMigrate to using:\n\u203A {bold ${toCommand}}\n`);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,7 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/compat-data@^7.11.0", "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0", "@babel/compat-data@^7.18.6", "@babel/compat-data@^7.18.8":
+"@babel/compat-data@^7.11.0", "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0", "@babel/compat-data@^7.18.8":
   version "7.18.8"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
   integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
@@ -174,7 +174,7 @@
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-"@babel/generator@^7.18.2", "@babel/generator@^7.18.7", "@babel/generator@^7.18.9", "@babel/generator@^7.5.0", "@babel/generator@^7.7.2", "@babel/generator@^7.7.7", "@babel/generator@^7.9.0":
+"@babel/generator@^7.18.2", "@babel/generator@^7.18.9", "@babel/generator@^7.5.0", "@babel/generator@^7.7.2", "@babel/generator@^7.7.7", "@babel/generator@^7.9.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
   integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
@@ -254,7 +254,7 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-function-name@^7.16.0", "@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.6", "@babel/helper-function-name@^7.18.9":
+"@babel/helper-function-name@^7.16.0", "@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz#940e6084a55dee867d33b4e487da2676365e86b0"
   integrity sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==
@@ -388,7 +388,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.7", "@babel/parser@^7.18.0", "@babel/parser@^7.18.6", "@babel/parser@^7.18.8", "@babel/parser@^7.18.9", "@babel/parser@^7.7.7", "@babel/parser@^7.9.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.7", "@babel/parser@^7.18.0", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9", "@babel/parser@^7.7.7", "@babel/parser@^7.9.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
   integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
@@ -1335,7 +1335,7 @@
     "@babel/parser" "^7.18.6"
     "@babel/types" "^7.18.6"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.18.2", "@babel/traverse@^7.18.6", "@babel/traverse@^7.18.8", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2", "@babel/traverse@^7.7.4", "@babel/traverse@^7.9.0":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.18.2", "@babel/traverse@^7.18.6", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2", "@babel/traverse@^7.7.4", "@babel/traverse@^7.9.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
   integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
@@ -1369,7 +1369,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.11.5", "@babel/types@^7.13.12", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.18.2", "@babel/types@^7.18.6", "@babel/types@^7.18.7", "@babel/types@^7.18.8", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.4", "@babel/types@^7.9.0":
+"@babel/types@^7.0.0", "@babel/types@^7.11.5", "@babel/types@^7.13.12", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.18.2", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.4", "@babel/types@^7.9.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
   integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
@@ -1736,6 +1736,23 @@
     sudo-prompt "^8.2.0"
     tmp "^0.0.33"
     tslib "^1.10.0"
+
+"@expo/image-utils@0.3.21":
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.21.tgz#dabe772135a66671939f87389e11f23e54341e1e"
+  integrity sha512-Ha7pNcpl52RJIeYz3gR1ajOgPPl7WLZWiLqtLi94s9J0a7FvmNBMqd/VKrfHNj8QmtZxXcmXr7y7tPhZbVFg7w==
+  dependencies:
+    "@expo/spawn-async" "1.5.0"
+    chalk "^4.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    jimp-compact "0.16.1"
+    mime "^2.4.4"
+    node-fetch "^2.6.0"
+    parse-png "^2.1.0"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    tempy "0.3.0"
 
 "@expo/metro-config@0.3.18":
   version "0.3.18"


### PR DESCRIPTION
# Why

- resolve ENG-5940


<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- When the user is running a replaced command in an SDK 46 project that doesn't have the local CLI disabled, warn that they should migrate.

<img width="358" alt="Screen Shot 2022-08-09 at 8 20 55 PM" src="https://user-images.githubusercontent.com/9664363/183733120-6c46f7fe-ecd2-40b2-b233-c0043b6cdd35.png">


<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `expod start` in an SDK 46 project -- warning.
- `expod config` in an SDK 44 project -- no warning.
- `expo init` anywhere -- warning.


<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->