### PR TITLE
[webpack-config] remove explicit @expo/config dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to Expo CLI and related packages.
 
 ### 🧹 Chores
 
+- [webpack-config] Remove explicit `@expo/config` dependency ([#4512](https://github.com/expo/expo-cli/pull/4512))
+
 ### 🐛 Bug fixes
 
 ## [Thu, 11 Aug 2022 17:55:34 -0700](https://github.com/expo/expo-cli/commit/8012304c978ae6f943b95210534536577418cb86)

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@babel/core": "7.9.0",
-    "@expo/config": "6.0.24",
     "babel-loader": "8.1.0",
     "chalk": "^4.0.0",
     "clean-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
# Why

Remove `@expo/config` dependency that is causing nested dependency version conflicts, and instead have it pulled it via the `expo` devDependency.

Fixes #4511.

# How

Updated package.json

# Test Plan

🙏🏻