### PR TITLE
Update @expo/next-adapter/babel - useTransformReactJSXExperimental

### DIFF
--- a/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
+++ b/packages/expo-cli/e2e/__tests__/__snapshots__/export-test.ts.snap
@@ -6,8 +6,8 @@ Array [
   "dist/assetmap.json (size ignored)",
   "dist/assets (dir)",
   "dist/bundles (dir)",
-  "dist/bundles/android-XXX.js (837 kB)",
-  "dist/bundles/ios-XXX.js (835 kB)",
+  "dist/bundles/android-XXX.js (845 kB)",
+  "dist/bundles/ios-XXX.js (844 kB)",
   "dist/ios-index.json (658 B)",
 ]
 `;
@@ -55,8 +55,8 @@ Array [
   "dist/assetmap.json (size ignored)",
   "dist/assets (dir)",
   "dist/bundles (dir)",
-  "dist/bundles/android-XXX.js (837 kB)",
-  "dist/bundles/ios-XXX.js (835 kB)",
+  "dist/bundles/android-XXX.js (845 kB)",
+  "dist/bundles/ios-XXX.js (844 kB)",
   "dist/ios-index.json (658 B)",
 ]
 `;

--- a/packages/next-adapter/src/babel.ts
+++ b/packages/next-adapter/src/babel.ts
@@ -32,7 +32,7 @@ module.exports = function (api: any) {
       [
         require('babel-preset-expo'),
         {
-          web: { useTransformReactJsxExperimental: true },
+          web: { useTransformReactJSXExperimental: true },
           // Disable the `no-anonymous-default-export` plugin in babel-preset-expo
           // so users don't see duplicate warnings.
           'no-anonymous-default-export': false,


### PR DESCRIPTION
Rename `useTransformReactJsxExperimental` to `useTransformReactJSXExperimental`

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/55203625/184532670-9821513b-f4b2-436e-96ae-91eee52f2edb.png">


Playing around with React Native and Next.js. This is my babel file:

```javascript 
module.exports = {
  presets: ['babel-preset-expo', '@expo/next-adapter/babel', 'next/babel'],
  plugins: [
    ['@babel/plugin-transform-flow-strip-types'],
    ['@babel/plugin-proposal-decorators', { legacy: true }],
    ['@babel/plugin-proposal-class-properties', { loose: true }],
    ['@babel/plugin-proposal-private-methods', { loose: true }],
    ['@babel/plugin-proposal-private-property-in-object', { loose: true }]
  ]
};
```
