### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,6 @@
-<!-- Title -->
+# Assorted Expo Dev Tools
 
-<p align="center">
-  <a href="https://expo.dev/">
-    <img alt="expo cli" src="./.gh-assets/banner.svg">
-  </a>
-</p>
-
-<p align="center">Tools for creating, running, and deploying Universal Expo and React Native apps</p>
-
-<p align="center">
-
-  <a aria-label="Join our Discord" href="https://discord.gg/4gtbPAdpaE" target="_blank">
-    <img alt="Discord" src="https://img.shields.io/discord/695411232856997968.svg?style=flat-square&labelColor=000000&color=000000&logo=discord&logoColor=FFFFFF&label=" />
-  </a>
-  <a aria-label="expo-cli downloads" href="http://www.npmtrends.com/expo-cli" target="_blank">
-    <img alt="Downloads" src="https://img.shields.io/npm/dm/expo-cli.svg?style=flat-square&labelColor=000&color=000000&label=Downloads" />
-</a>
-  <a aria-label="Join our forums" href="https://forums.expo.dev" target="_blank">
-    <img alt="" src="https://img.shields.io/badge/Ask%20Questions%20-000.svg?style=flat-square&logo=discourse&logoWidth=15&labelColor=000000&color=000000">
-  </a>
-
-</p>
-
-<p align="center">
-  <a aria-label="expo documentation" href="https://docs.expo.dev/workflow/expo-cli/">📚 Read the Documentation</a>
-  |
-  <a aria-label="contribute to expo cli" href="https://github.com/expo/expo-cli/blob/main/CONTRIBUTING.md"><b>Contributing to Expo CLI</b></a>
-</p>
+Packages used in Expo CLI and related tooling. Contains source for the legacy global Expo CLI. The new [local Expo CLI](https://blog.expo.dev/the-new-expo-cli-f4250d8e3421) lives in the [**`expo/expo`**](https://github.com/expo/expo/blob/main/packages/%40expo/cli) repo.
 
 <p>
   <a aria-label="Follow @expo on Twitter" href="https://twitter.com/intent/follow?screen_name=expo" target="_blank">
@@ -39,13 +13,7 @@
 
 ---
 
-<a align="right" href="#">
-  <img align="right" width="130" alt="expo cli" src="./.gh-assets/float-box.svg">
-</a>
-
-- [📚 Documentation](#-documentation)
 - [🗺 Project Layout](#-project-layout)
-- [🏅 Badges](#-badges)
 - [👏 Contributing](#-contributing)
 - [❓ FAQ](#-faq)
 - [💙 The Team](#-the-team)
@@ -55,7 +23,7 @@
 
 <p>Learn about building and deploying universal apps <a aria-label="expo documentation" href="https://docs.expo.dev">in our official docs!</a></p>
 
-- [Using the CLI](https://docs.expo.dev/workflow/expo-cli/)
+- [Using Expo CLI](https://docs.expo.dev/workflow/expo-cli/)
 - [App.json Configuration](https://docs.expo.dev/workflow/configuration/)
 - [Building and Deploying apps](https://docs.expo.dev/introduction/walkthrough/#building-and-deploying)
 
@@ -74,7 +42,6 @@
 | [**`@expo/json-file`**](./packages/json-file)               | [![badges](https://img.shields.io/npm/v/@expo/json-file?color=32cd32&style=flat-square)](https://www.npmjs.com/package/@expo/json-file)               |
 | [**`@expo/next-adapter`**](./packages/next-adapter)         | [![badges](https://img.shields.io/npm/v/@expo/next-adapter?color=32cd32&style=flat-square)](https://www.npmjs.com/package/@expo/next-adapter)         |
 | [**`@expo/osascript`**](./packages/osascript)               | [![badges](https://img.shields.io/npm/v/@expo/osascript?color=32cd32&style=flat-square)](https://www.npmjs.com/package/@expo/osascript)               |
-| [**`@expo/package-manager`**](./packages/package-manager)   | [![badges](https://img.shields.io/npm/v/@expo/package-manager?color=32cd32&style=flat-square)](https://www.npmjs.com/package/@expo/package-manager)   |
 | [**`@expo/pkcs12`**](./packages/pkcs12)                     | [![badges](https://img.shields.io/npm/v/@expo/pkcs12?color=32cd32&style=flat-square)](https://www.npmjs.com/package/@expo/pkcs12)                     |
 | [**`@expo/plist`**](./packages/plist)                       | [![badges](https://img.shields.io/npm/v/@expo/plist?color=32cd32&style=flat-square)](https://www.npmjs.com/package/@expo/plist)                       |
 | [**`pod-install`**](./packages/pod-install)                 | [![badges](https://img.shields.io/npm/v/pod-install?color=32cd32&style=flat-square)](https://www.npmjs.com/package/pod-install)                       |
@@ -83,23 +50,6 @@
 | [**`uri-scheme`**](./packages/uri-scheme)                   | [![badges](https://img.shields.io/npm/v/uri-scheme?color=32cd32&style=flat-square)](https://www.npmjs.com/package/uri-scheme)                         |
 | [**`@expo/webpack-config`**](./packages/webpack-config)     | [![badges](https://img.shields.io/npm/v/@expo/webpack-config?color=32cd32&style=flat-square)](https://www.npmjs.com/package/@expo/webpack-config)     |
 | [**`xdl`**](./packages/xdl)                                 | [![badges](https://img.shields.io/npm/v/xdl?color=32cd32&style=flat-square)](https://www.npmjs.com/package/xdl)                                       |
-
-<!-- Generated with $ node scripts/build-packages-toc.js -->
-
-## 🏅 Badges
-
-Let everyone know your app can be run instantly in the _Expo Go_ app!
-<br/>
-
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
-
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
-
-```md
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
-
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
-```
 
 ## 👏 Contributing
 


### PR DESCRIPTION
# Why

Make it clear that this repo is no longer the home of the latest Expo CLI, redirect traffic to the new location.

- Demo https://github.com/expo/expo-cli/blob/@evanbacon/readme/redirect/README.md
