### PR TITLE
Handle multiple query parameters in Android URIs

### DIFF
--- a/packages/uri-scheme/src/Android.ts
+++ b/packages/uri-scheme/src/Android.ts
@@ -137,7 +137,7 @@ export async function openAsync({
   uri,
   androidPackage,
 }: Pick<Options, 'uri'> & { androidPackage?: string }): Promise<string> {
-  return await openUrlAsync(uri, androidPackage ?? null);
+  return await openUrlAsync(uri.replace(/&/g, String.raw`\&`), androidPackage ?? null);
 }
 
 export async function getAsync({


### PR DESCRIPTION
# Why

Currently, `npx uri-scheme open --android "myscheme://test?varA=1&varB=2"` launch the app with a deeplink `myscheme://test?varA=1` instead of `myscheme://test?varA=1&varB=2`

# How

Apparently adb expects the character `&` to be escaped.

# Test Plan

Tested with the current version and `npx uri-scheme open --android "myscheme://test?varA=1\&varB=2"`