### PR TITLE
[install-expo-modules] Fix RCTRootView for react-native 0.68 or above

### DIFF
--- a/packages/install-expo-modules/package.json
+++ b/packages/install-expo-modules/package.json
@@ -47,7 +47,8 @@
     "glob": "7.1.6",
     "prompts": "^2.3.2",
     "resolve-from": "^5.0.0",
-    "semver": "7.3.2"
+    "semver": "7.3.2",
+    "xcparse": "^0.0.3"
   },
   "devDependencies": {
     "@types/prompts": "^2.0.6",

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -12,6 +12,7 @@ import {
   withIosDeploymentTarget,
 } from './plugins/ios/withIosDeploymentTarget';
 import { withIosModules } from './plugins/ios/withIosModules';
+import { withXCParseXcodeProjectBaseMod } from './plugins/ios/withXCParseXcodeProject';
 import { getDefaultSdkVersion, getVersionInfo, VersionInfo } from './utils/expoVersionMappings';
 import { installExpoPackageAsync, installPodsAsync } from './utils/packageInstaller';
 import { normalizeProjectRoot } from './utils/projectRoot';
@@ -90,6 +91,9 @@ async function runAsync(programName: string) {
   config = withIosDeploymentTarget(config, {
     deploymentTarget: iosDeploymentTarget,
   });
+
+  // Keeps the base mods last
+  config = withXCParseXcodeProjectBaseMod(config);
 
   console.log('\u203A Updating your project...');
   await compileModsAsync(config, {

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn068-updated.mm
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn068-updated.mm
@@ -41,7 +41,7 @@
   bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 #endif
 
-  UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"HelloWorld", nil);
+  UIView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"HelloWorld" initialProperties:nil];
 
   if (@available(iOS 13.0, *)) {
     rootView.backgroundColor = [UIColor systemBackgroundColor];

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
@@ -93,6 +93,10 @@ export function updateModulesAppDelegateObjcImpl(
       /\[\[RCTRootView alloc\] initWithBridge:/g,
       '[self.reactDelegate createRootViewWithBridge:'
     );
+    contents = contents.replace(/\bRCTAppSetupDefaultRootView\((.+)\)/g, (match, group) => {
+      const [bridge, moduleName, initProps] = group.split(',').map((s: string) => s.trim());
+      return `[self.reactDelegate createRootViewWithBridge:${bridge} moduleName:${moduleName} initialProperties:${initProps}]`;
+    });
     contents = contents.replace(
       /\[UIViewController new\]/g,
       '[self.reactDelegate createRootViewController]'

--- a/packages/install-expo-modules/src/plugins/ios/withXCParseXcodeProject.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withXCParseXcodeProject.ts
@@ -1,0 +1,62 @@
+import { BaseMods, ConfigPlugin, IOSConfig, Mod, withMod } from '@expo/config-plugins';
+import fs from 'fs';
+import { ISA, build as xcbuild, parse as xcparse } from 'xcparse';
+import type { BuildSettings, XCBuildConfiguration, XcodeProject } from 'xcparse';
+
+export type XCParseXcodeProject = Partial<XcodeProject>;
+
+export interface BuildSettingsExtended extends BuildSettings {
+  SWIFT_OBJC_BRIDGING_HEADER?: string;
+}
+
+const MOD_NAME = 'xcparseXcodeproj';
+
+export const withXCParseXcodeProjectBaseMod: ConfigPlugin = config => {
+  return BaseMods.withGeneratedBaseMods(config, {
+    platform: 'ios',
+    skipEmptyMod: false,
+    providers: {
+      [MOD_NAME]: BaseMods.provider<XCParseXcodeProject>({
+        getFilePath({ modRequest: { projectRoot } }) {
+          return IOSConfig.Paths.getPBXProjectPath(projectRoot);
+        },
+        async read(filePath) {
+          const content = await fs.promises.readFile(filePath, 'utf8');
+          const pbxproj = xcparse(content);
+          return pbxproj;
+        },
+        async write(filePath: string, { modResults }) {
+          const content = xcbuild(modResults);
+          await fs.promises.writeFile(filePath, content);
+        },
+      }),
+    },
+  });
+};
+
+export const withXCParseXcodeProject: ConfigPlugin<Mod<XCParseXcodeProject>> = (config, action) => {
+  return withMod(config, {
+    platform: 'ios',
+    mod: MOD_NAME,
+    action,
+  });
+};
+
+export function getDesignatedSwiftBridgingHeaderFileReference(
+  pbxproj: XCParseXcodeProject
+): string | null {
+  for (const section of Object.values(pbxproj.objects ?? {})) {
+    if (section.isa === ISA.XCBuildConfiguration) {
+      const buildConfigSection = section as XCBuildConfiguration;
+      const buildSettings = buildConfigSection.buildSettings as BuildSettingsExtended;
+      if (
+        typeof buildSettings.PRODUCT_NAME !== 'undefined' &&
+        typeof buildSettings.SWIFT_OBJC_BRIDGING_HEADER === 'string' &&
+        buildSettings.SWIFT_OBJC_BRIDGING_HEADER
+      ) {
+        return buildSettings.SWIFT_OBJC_BRIDGING_HEADER;
+      }
+    }
+  }
+  return null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19010,6 +19010,11 @@ xcode@^3.0.1:
     simple-plist "^1.1.0"
     uuid "^7.0.3"
 
+xcparse@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/xcparse/-/xcparse-0.0.3.tgz#abc2dbe07e0550c14c1b670c41d05dcbe3cfd10b"
+  integrity sha512-/HgjZ1o81gudtNHt5a/EGEyMa991WZjZqu8ryPWJ1UtG4NRJyQ2AthR8MaqD6nN7UnCe7IcFShMm5oEA/S9nEQ==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"


### PR DESCRIPTION
# Why

react-native 0.68 introduced a `RCTAppSetupDefaultRootView` to create the RCTRootView in AppDelegate.mm. i missed the pattern update in install-expo-modules. this pr will fix https://github.com/expo/expo/issues/19179.

# How

migrate `RCTAppSetupDefaultRootView`

# Test Plan

- ✅ unit test for AppDelegate-rn068