### PR TITLE
[image-utils] Silence sharp related warnings by default

### DIFF
--- a/packages/image-utils/src/Image.ts
+++ b/packages/image-utils/src/Image.ts
@@ -5,6 +5,7 @@ import * as Cache from './Cache';
 import * as Download from './Download';
 import * as Ico from './Ico';
 import { ImageOptions } from './Image.types';
+import { env } from './env';
 import * as Jimp from './jimp';
 import * as Sharp from './sharp';
 
@@ -73,8 +74,8 @@ async function resizeAsync(imageOptions: ImageOptions): Promise<Buffer> {
 
     if (imageOptions.borderRadius) {
       const mask = Buffer.from(
-        `<svg><rect x="0" y="0" width="${width}" height="${height}" 
-        rx="${imageOptions.borderRadius}" ry="${imageOptions.borderRadius}" 
+        `<svg><rect x="0" y="0" width="${width}" height="${height}"
+        rx="${imageOptions.borderRadius}" ry="${imageOptions.borderRadius}"
         fill="${
           backgroundColor && backgroundColor !== 'transparent' ? backgroundColor : 'none'
         }" /></svg>`
@@ -105,7 +106,7 @@ function getDimensionsId(imageOptions: Pick<ImageOptions, 'width' | 'height'>): 
 
 async function maybeWarnAboutInstallingSharpAsync() {
   // Putting the warning here will prevent the warning from showing if all images were reused from the cache
-  if (!hasWarned && !(await Sharp.isAvailableAsync())) {
+  if (env.EXPO_IMAGE_UTILS_DEBUG && !hasWarned && !(await Sharp.isAvailableAsync())) {
     hasWarned = true;
     console.warn(
       chalk.yellow(

--- a/packages/image-utils/src/env.ts
+++ b/packages/image-utils/src/env.ts
@@ -1,0 +1,15 @@
+import { boolish } from 'getenv';
+
+class Env {
+  /** Enable image utils related debugging messages */
+  get EXPO_IMAGE_UTILS_DEBUG() {
+    return boolish('EXPO_IMAGE_UTILS_DEBUG', false);
+  }
+
+  /** Disable all Sharp related functionality. */
+  get EXPO_IMAGE_UTILS_NO_SHARP() {
+    return boolish('EXPO_IMAGE_UTILS_NO_SHARP', false);
+  }
+}
+
+export const env = new Env();

--- a/packages/image-utils/src/sharp.ts
+++ b/packages/image-utils/src/sharp.ts
@@ -1,9 +1,9 @@
 import spawnAsync from '@expo/spawn-async';
-import { boolish } from 'getenv';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
+import { env } from './env';
 import { Options, SharpCommandOptions, SharpGlobalOptions } from './sharp.types';
 
 const SHARP_HELP_PATTERN = /\n\nSpecify --help for available options/g;
@@ -28,14 +28,12 @@ export async function resizeBufferAsync(buffer: Buffer, sizes: number[]): Promis
   return resizedBuffers;
 }
 
-const isSharpDisabled = boolish('EXPO_IMAGE_UTILS_NO_SHARP', false);
-
 /**
  * Returns `true` if a global sharp instance can be found.
  * This functionality can be overridden with `process.env.EXPO_IMAGE_UTILS_NO_SHARP=1`.
  */
 export async function isAvailableAsync(): Promise<boolean> {
-  if (isSharpDisabled) {
+  if (env.EXPO_IMAGE_UTILS_NO_SHARP) {
     return false;
   }
   try {
@@ -144,7 +142,7 @@ async function findSharpBinAsync(): Promise<string> {
  * This method will throw errors if the `sharp` instance cannot be found, these errors can be circumvented by ensuring `isAvailableAsync()` resolves to `true`.
  */
 export async function findSharpInstanceAsync(): Promise<any | null> {
-  if (isSharpDisabled) {
+  if (env.EXPO_IMAGE_UTILS_NO_SHARP) {
     throw new Error(
       'Global instance of sharp-cli cannot be retrieved because sharp-cli has been disabled with the environment variable `EXPO_IMAGE_UTILS_NO_SHARP`'
     );


### PR DESCRIPTION
# Why

Fixes ENG-2724

# How

This warning doesn't make a lot of sense when building your app. For new people, it's pretty hard to know you have to install this library before building your app. And once you are building it, you probably won't cancel the build to restart for a minor speed improvement compared to node image optimizations.

That being said, it can still be helpful to know which one of the image libraries is being used. So, instead of entirely dropping the message, it's now behind `EXPO_IMAGE_UTILS_DEBUG`. When setting this to true, it will output the warnings again.

# Test Plan

Run a build with this version of image utils.