### PR TITLE
[CEA] Prevent Forbidden/ Conflicting app names

### DIFF
--- a/packages/create-expo-app/src/Template.ts
+++ b/packages/create-expo-app/src/Template.ts
@@ -18,6 +18,12 @@ const debug = require('debug')('expo:init:template') as typeof console.log;
 
 const isMacOS = process.platform === 'darwin';
 
+const FORBIDDEN_NAMES = ['react-native', 'react', 'react-dom', 'react-native-web', 'expo'];
+
+export function isFolderNameForbidden(folderName: string): boolean {
+  return FORBIDDEN_NAMES.includes(folderName);
+}
+
 function deepMerge(target: any, source: any) {
   if (typeof target !== 'object') {
     return source;

--- a/packages/create-expo-app/src/resolveProjectRoot.ts
+++ b/packages/create-expo-app/src/resolveProjectRoot.ts
@@ -13,6 +13,11 @@ export function assertValidName(folderName: string) {
   if (typeof validation === 'string') {
     Log.exit(chalk`{red Cannot create an app named {bold "${folderName}"}. ${validation}}`, 1);
   }
+  
+  const isFolderNameForbidden = Template.isFolderNameForbidden(folderName);
+  if (isFolderNameForbidden) {
+    Log.exit(chalk`{red Cannot create an app named {bold "${folderName}"} because it would conflict with a dependency of the same name.}`, 1);
+  }
 }
 
 export function assertFolderEmpty(projectRoot: string, folderName: string) {

--- a/packages/create-expo-app/src/resolveProjectRoot.ts
+++ b/packages/create-expo-app/src/resolveProjectRoot.ts
@@ -13,10 +13,12 @@ export function assertValidName(folderName: string) {
   if (typeof validation === 'string') {
     Log.exit(chalk`{red Cannot create an app named {bold "${folderName}"}. ${validation}}`, 1);
   }
-  
   const isFolderNameForbidden = Template.isFolderNameForbidden(folderName);
   if (isFolderNameForbidden) {
-    Log.exit(chalk`{red Cannot create an app named {bold "${folderName}"} because it would conflict with a dependency of the same name.}`, 1);
+    Log.exit(
+      chalk`{red Cannot create an app named {bold "${folderName}"} because it would conflict with a dependency of the same name.}`,
+      1
+    );
   }
 }
 


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
This PR solves the following issue: #4533 

If ```create-expo-app``` is used with app names such as expo or react-native it leads to the app being correctly initialized however crashing upon starting up because it would conflict with a dependency of the same name. ```expo-cli```already prevents this. This should be handled in create-expo-app too.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->
Upon init, projectName will be checked if it's present in a list of Forbidden project names. If yes, log error and exit.

# Test Plan

Build the changes and run ```node index expo``` from the build path and the error should pop up.