### PR TITLE
[pod-install] show alternative message in managed projects

### DIFF
--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -2,8 +2,8 @@ import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 import semver from 'semver';
 
-import { ExpoConfigCommonIssueCheck } from './checks/ExpoConfigCommonIssueCheck';
 import { DirectPackageInstallCheck } from './checks/DirectPackageInstallCheck';
+import { ExpoConfigCommonIssueCheck } from './checks/ExpoConfigCommonIssueCheck';
 import { ExpoConfigSchemaCheck } from './checks/ExpoConfigSchemaCheck';
 import { GlobalPackageInstalledCheck } from './checks/GlobalPackageInstalledCheck';
 import { GlobalPrereqsVersionCheck } from './checks/GlobalPrereqsVersionCheck';

--- a/packages/pod-install/package.json
+++ b/packages/pod-install/package.json
@@ -35,6 +35,7 @@
     "@expo/package-manager": "0.0.56",
     "chalk": "^4.0.0",
     "commander": "2.20.0",
+    "terminal-link": "^2.1.1",
     "update-check": "1.5.3"
   }
 }

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -51,7 +51,11 @@ async function runAsync(): Promise<void> {
       const isManaged = hasExpo && !hasReactNativeUnimodules;
 
       if (isManaged) {
-        info(chalk.yellow('There is no need to run `pod-install` in managed project'));
+        info(
+          chalk.yellow(
+            'In a managed project, `pod-install` will run automatically as part of the EAS Build process. Learn more: https://docs.expo.dev/build-reference/ios-builds/'
+          )
+        );
         return;
       }
     } catch {

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -44,12 +44,12 @@ async function runAsync(): Promise<void> {
 
     if (existsSync(packageJsonPath)) {
       const jsonData = JSON.parse(readFileSync(packageJsonPath).toString());
-      const isManaged = jsonData.dependencies?.hasOwnProperty('expo');
+      const hasExpoPackage = jsonData.dependencies?.hasOwnProperty('expo');
 
-      if (isManaged) {
+      if (hasExpoPackage) {
         info(
           chalk.yellow(
-            `No 'ios' directory found, skipping installing pods. Pods will be automatically installed when the 'ios' directory is generated with 'expo prebuild'.`
+            `No 'ios' directory found, skipping installing pods. Pods will be automatically installed when the 'ios' directory is generated with 'npx expo prebuild' or 'npx expo run:ios'.`
              ${learnMore('https://docs.expo.dev/workflow/prebuild/')}`
           )
         );

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -49,8 +49,8 @@ async function runAsync(): Promise<void> {
       if (isManaged) {
         info(
           chalk.yellow(
-            `In a managed project, 'pod-install' will run automatically as part of the EAS Build process.
-             ${learnMore('https://docs.expo.dev/build-reference/ios-builds/')}`
+            `No 'ios' directory found, skipping installing pods. Pods will be automatically installed when the 'ios' directory is generated with 'expo prebuild'.`
+             ${learnMore('https://docs.expo.dev/workflow/prebuild/')}`
           )
         );
         return;

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -49,8 +49,8 @@ async function runAsync(): Promise<void> {
       if (hasExpoPackage) {
         info(
           chalk.yellow(
-            `No 'ios' directory found, skipping installing pods. Pods will be automatically installed when the 'ios' directory is generated with 'npx expo prebuild' or 'npx expo run:ios'.`
-             ${learnMore('https://docs.expo.dev/workflow/prebuild/')}`
+            `No 'ios' directory found, skipping installing pods. Pods will be automatically installed when the 'ios' directory is generated with 'npx expo prebuild' or 'npx expo run:ios'.`,
+            learnMore('https://docs.expo.dev/workflow/prebuild/')
           )
         );
         return;

--- a/packages/pod-install/src/utils.ts
+++ b/packages/pod-install/src/utils.ts
@@ -1,0 +1,12 @@
+import chalk from 'chalk';
+import terminalLink from 'terminal-link';
+
+/**
+ * When linking isn't available, format the learn more link better.
+ * @param url
+ */
+export function learnMore(url: string): string {
+  return terminalLink(chalk.underline('Learn more.'), url, {
+    fallback: (text, url) => `Learn more: ${chalk.underline(url)}`,
+  });
+}

--- a/packages/pod-install/src/utils.ts
+++ b/packages/pod-install/src/utils.ts
@@ -7,6 +7,6 @@ import terminalLink from 'terminal-link';
  */
 export function learnMore(url: string): string {
   return terminalLink(chalk.underline('Learn more.'), url, {
-    fallback: (text, url) => `Learn more: ${chalk.underline(url)}`,
+    fallback: (_, url) => `Learn more: ${chalk.underline(url)}`,
   });
 }


### PR DESCRIPTION
# Why

Fixes ENG-5760

# How

This small PR adds a check which attempt to determine the workflow used in the current project. 

If it's `managed` an alternative message is being print in the console, to avoid the confusion.

Logic has been inspired by the XDL `ProjectUtils` helpers.

# Test Plan

The changes have been tested by building `pod-install` locally and then running it in various directories.

# Preview

<img width="650" alt="Screenshot 2022-10-06 at 14 00 06" src="https://user-images.githubusercontent.com/719641/194309931-7392e6f3-45bb-45dd-8f8f-6ec5f2780490.png">