### PR TITLE
fix(image-utils): make jimp export buffers as png like sharp

### DIFF
--- a/packages/image-utils/src/Image.ts
+++ b/packages/image-utils/src/Image.ts
@@ -40,8 +40,8 @@ async function resizeAsync(imageOptions: ImageOptions): Promise<Buffer> {
       await Jimp.circleAsync(jimp);
     }
 
-    const imgBuffer = await jimp.getBufferAsync(jimp.getMIME());
-    return imgBuffer;
+    // Convert to png buffer
+    return jimp.getBufferAsync('image/png');
   }
   try {
     let sharpBuffer = sharp(imageOptions.src)


### PR DESCRIPTION
# Why

When using Jimp instead of sharp for image generation, the images are modified and exported in the original format. This proposed change will always export as PNG (same as Sharp).

Related to https://github.com/expo/eas-cli/pull/1477

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- `expo.android.adaptiveIcon.foregroundImage` set to a jpg
- `yarn expo run:android --variant release` should not fail
