### PR TITLE
[install-expo-modules] add sdk 47 support

### DIFF
--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -10,6 +10,11 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
+    expoSdkVersion: '47.0.0',
+    iosDeploymentTarget: '13.0',
+    reactNativeVersionRange: '>= 0.70.0',
+  },
+  {
     expoSdkVersion: '46.0.0',
     iosDeploymentTarget: '12.4',
     reactNativeVersionRange: '>= 0.69.0',


### PR DESCRIPTION
# Why

add sdk 47 (react-native 0.70) support
close ENG-6698

# How

react-native 0.70 didn't introduce template breaking changes. we don't have to change in install-expo-modules. just the minimum ios deployment target as 13.0 for expo sdk 47.

# Test Plan

- unit test passed
- integration test from react-native 0.70 project