### PR TITLE
[xdl] Add feature gates

### DIFF
--- a/packages/xdl/src/ApiV2.ts
+++ b/packages/xdl/src/ApiV2.ts
@@ -3,7 +3,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import concat from 'concat-stream';
 import FormData from 'form-data';
 import merge from 'lodash/merge';
-import QueryString from 'querystring';
+import QueryString, { ParsedUrlQueryInput } from 'querystring';
 
 import { Config, ConnectionStatus } from './internal';
 
@@ -55,7 +55,7 @@ type UploadOptions = {
   data: any;
 };
 
-type QueryParameters = { [key: string]: string | number | boolean | null | undefined };
+type QueryParameters = ParsedUrlQueryInput;
 
 type APIV2ClientOptions = {
   sessionSecret?: string;

--- a/packages/xdl/src/Env.ts
+++ b/packages/xdl/src/Env.ts
@@ -15,6 +15,13 @@ export function isLocal(): boolean {
   return getenv.boolish('EXPO_LOCAL', false);
 }
 
+export function getFeatureGateOverrides(): { enable: string[]; disable: string[] } {
+  return {
+    enable: getenv.array('EXPO_FG_ENABLE'),
+    disable: getenv.array('EXPO_FG_DISABLE'),
+  };
+}
+
 // TODO: remove this function once all related PRs have landed and there's no chance for conflict
 export function isInterstitiaLPageEnabled(): boolean {
   return true;

--- a/packages/xdl/src/User.ts
+++ b/packages/xdl/src/User.ts
@@ -7,6 +7,8 @@ import {
   Analytics,
   ApiV2 as ApiV2Client,
   ConnectionStatus,
+  FeatureGateEnvOverrides,
+  FeatureGating,
   Logger,
   Semaphore,
   UnifiedAnalytics,
@@ -411,6 +413,13 @@ export class UserManagerInstance {
 
     // Delete saved auth info
     await UserSettings.deleteKeyAsync('auth');
+  }
+
+  async getFeatureGatingAsync(): Promise<FeatureGating> {
+    const user = await this.ensureLoggedInAsync();
+    const api = ApiV2Client.clientForUser(user);
+    const { featureGates } = await api.getAsync('auth/user-feature-gates');
+    return new FeatureGating(featureGates, new FeatureGateEnvOverrides());
   }
 
   /**

--- a/packages/xdl/src/gating/FeatureGateEnvOverrides.ts
+++ b/packages/xdl/src/gating/FeatureGateEnvOverrides.ts
@@ -1,0 +1,31 @@
+import nullthrows from 'nullthrows';
+
+import { Env, FeatureGateKey } from '../internal';
+
+export default class FeatureGateEnvOverrides {
+  private readonly map = new Map<string, boolean>();
+
+  constructor() {
+    const { enable, disable } = Env.getFeatureGateOverrides();
+    const overrideEnableGateKeys = new Set(enable);
+    const overrideDisableGateKeys = new Set(disable);
+
+    for (const overrideEnableKey of overrideEnableGateKeys) {
+      if (overrideDisableGateKeys.has(overrideEnableKey)) {
+        continue;
+      }
+      this.map.set(overrideEnableKey, true);
+    }
+    for (const overrideDisableGateKey of overrideDisableGateKeys) {
+      this.map.set(overrideDisableGateKey, false);
+    }
+  }
+
+  public isOverridden(key: FeatureGateKey): boolean {
+    return this.map.has(key) ?? false;
+  }
+
+  public getOverride(key: FeatureGateKey): boolean {
+    return nullthrows(this.map.get(key));
+  }
+}

--- a/packages/xdl/src/gating/FeatureGateKey.ts
+++ b/packages/xdl/src/gating/FeatureGateKey.ts
@@ -1,0 +1,8 @@
+export enum FeatureGateKey {
+  // for tests
+  TEST = 'test',
+}
+
+export const featureGateDefaultValueWhenNoServerValue: Record<FeatureGateKey, boolean> = {
+  [FeatureGateKey.TEST]: true,
+};

--- a/packages/xdl/src/gating/FeatureGateTestOverrides.ts
+++ b/packages/xdl/src/gating/FeatureGateTestOverrides.ts
@@ -1,0 +1,15 @@
+import { FeatureGateKey } from '../internal';
+
+export const setOverride = (_key: FeatureGateKey, _enabled: boolean): void => {
+  throw new Error('Must use mocked FeatureGateTestOverrides');
+};
+
+export const removeOverride = (_key: FeatureGateKey): void => {
+  throw new Error('Must use mocked FeatureGateTestOverrides');
+};
+
+export const isOverridden = (_key: FeatureGateKey): boolean => false;
+
+export const getOverride = (_key: FeatureGateKey): boolean => {
+  throw new Error('Must use mocked FeatureGateTestOverrides');
+};

--- a/packages/xdl/src/gating/FeatureGating.ts
+++ b/packages/xdl/src/gating/FeatureGating.ts
@@ -1,0 +1,72 @@
+import {
+  featureGateDefaultValueWhenNoServerValue,
+  FeatureGateEnvOverrides,
+  FeatureGateKey,
+  FeatureGateTestOverrides,
+} from '../internal';
+
+export default class FeatureGating {
+  constructor(
+    private readonly serverValues: { [key: string]: boolean },
+    private readonly envOverrides: FeatureGateEnvOverrides
+  ) {}
+
+  public isEnabled(experimentKey: FeatureGateKey): boolean {
+    if (process.env.NODE_ENV === 'test' && FeatureGateTestOverrides.isOverridden(experimentKey)) {
+      return FeatureGateTestOverrides.getOverride(experimentKey);
+    }
+
+    if (this.envOverrides.isOverridden(experimentKey)) {
+      return this.envOverrides.getOverride(experimentKey);
+    }
+
+    if (experimentKey in this.serverValues) {
+      return this.serverValues[experimentKey];
+    }
+
+    return featureGateDefaultValueWhenNoServerValue[experimentKey];
+  }
+
+  /**
+   * Test gate override methods
+   */
+
+  public static overrideKeyForScope(
+    key: FeatureGateKey,
+    enabled: boolean,
+    scope: () => void
+  ): void {
+    if (process.env.NODE_ENV !== 'test') {
+      throw new Error(`Cannot overrideKeyForScope outside of test environment`);
+    }
+
+    FeatureGateTestOverrides.setOverride(key, enabled);
+    try {
+      scope();
+    } finally {
+      FeatureGateTestOverrides.removeOverride(key);
+    }
+  }
+
+  public static async overrideKeyForScopeAsync(
+    key: FeatureGateKey,
+    enabled: boolean,
+    scope: () => Promise<void>
+  ): Promise<void> {
+    if (process.env.NODE_ENV !== 'test') {
+      throw new Error(`Cannot overrideKeyForScopeAsync outside of test environment`);
+    }
+
+    FeatureGateTestOverrides.setOverride(key, enabled);
+    try {
+      await scope();
+    } finally {
+      FeatureGateTestOverrides.removeOverride(key);
+    }
+  }
+
+  public static overrideKeyForEachInTest(key: FeatureGateKey, enabled: boolean): void {
+    beforeEach(() => FeatureGateTestOverrides.setOverride(key, enabled));
+    afterEach(() => FeatureGateTestOverrides.removeOverride(key));
+  }
+}

--- a/packages/xdl/src/gating/__mocks__/FeatureGateTestOverrides.ts
+++ b/packages/xdl/src/gating/__mocks__/FeatureGateTestOverrides.ts
@@ -1,0 +1,20 @@
+import { FeatureGateKey } from '../../internal';
+
+const map = new Map();
+
+export const setOverride = (key: FeatureGateKey, enabled: boolean): void => {
+  map.set(key, enabled);
+};
+
+export const removeOverride = (key: FeatureGateKey): void => {
+  map.delete(key);
+};
+
+export const isOverridden = (key: FeatureGateKey): boolean => map.has(key);
+
+export const getOverride = (key: FeatureGateKey): boolean => {
+  if (map.has(key)) {
+    return map.get(key);
+  }
+  throw new Error(`Key ${key} not overridden`);
+};

--- a/packages/xdl/src/gating/__tests__/FeatureGate-test.ts
+++ b/packages/xdl/src/gating/__tests__/FeatureGate-test.ts
@@ -1,0 +1,106 @@
+import { Env, FeatureGateEnvOverrides, FeatureGateKey, FeatureGating } from '../../internal';
+
+jest.mock('../FeatureGateTestOverrides');
+jest.mock('../../Env', () => ({
+  getFeatureGateOverrides: jest.fn(() => ({ enable: [], disable: [] })),
+}));
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  (Env.getFeatureGateOverrides as jest.MockedFunction<
+    typeof Env.getFeatureGateOverrides
+  >).mockReturnValue({
+    enable: [],
+    disable: [],
+  });
+});
+
+describe(FeatureGating, () => {
+  it('supports scoped overriding', () => {
+    const featureGating = new FeatureGating({}, new FeatureGateEnvOverrides());
+    FeatureGating.overrideKeyForScope(FeatureGateKey.TEST, false, () => {
+      expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(false);
+    });
+
+    expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(true);
+  });
+
+  it('supports async scoped overriding', async () => {
+    const featureGating = new FeatureGating({}, new FeatureGateEnvOverrides());
+    await FeatureGating.overrideKeyForScopeAsync(FeatureGateKey.TEST, false, async () => {
+      expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(false);
+    });
+
+    expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(true);
+  });
+
+  it('uses value from the server, falls back to defined value', () => {
+    const featureGating = new FeatureGating(
+      { [FeatureGateKey.TEST]: true },
+      new FeatureGateEnvOverrides()
+    );
+    expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(true);
+
+    const featureGating2 = new FeatureGating(
+      { [FeatureGateKey.TEST]: false },
+      new FeatureGateEnvOverrides()
+    );
+    expect(featureGating2.isEnabled(FeatureGateKey.TEST)).toBe(false);
+
+    const featureGating3 = new FeatureGating({}, new FeatureGateEnvOverrides());
+    expect(featureGating3.isEnabled(FeatureGateKey.TEST)).toBe(true);
+  });
+
+  describe('environment variable overriding', () => {
+    it('supports env overrides affirmative', () => {
+      (Env.getFeatureGateOverrides as jest.MockedFunction<
+        typeof Env.getFeatureGateOverrides
+      >).mockReturnValue({
+        enable: [FeatureGateKey.TEST],
+        disable: [],
+      });
+      const featureGating = new FeatureGating(
+        { [FeatureGateKey.TEST]: false },
+        new FeatureGateEnvOverrides()
+      );
+      expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(true);
+    });
+
+    it('supports env overrides negative', () => {
+      (Env.getFeatureGateOverrides as jest.MockedFunction<
+        typeof Env.getFeatureGateOverrides
+      >).mockReturnValue({
+        enable: [],
+        disable: [FeatureGateKey.TEST],
+      });
+      const featureGating = new FeatureGating(
+        { [FeatureGateKey.TEST]: true },
+        new FeatureGateEnvOverrides()
+      );
+      expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(false);
+    });
+  });
+});
+
+describe('jest scoped overriding', () => {
+  FeatureGating.overrideKeyForEachInTest(FeatureGateKey.TEST, false);
+
+  it('supports jest scoped overriding', () => {
+    const featureGating = new FeatureGating(
+      { [FeatureGateKey.TEST]: true },
+      new FeatureGateEnvOverrides()
+    );
+    expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(false);
+  });
+});
+
+describe('removal of jest scoped overriding', () => {
+  it('jest scoped overriding is only for describe scope above', () => {
+    const featureGating = new FeatureGating(
+      { [FeatureGateKey.TEST]: true },
+      new FeatureGateEnvOverrides()
+    );
+    expect(featureGating.isEnabled(FeatureGateKey.TEST)).toBe(true);
+  });
+});

--- a/packages/xdl/src/internal.ts
+++ b/packages/xdl/src/internal.ts
@@ -11,6 +11,10 @@
 */
 export { Semaphore } from './utils/Semaphore';
 export * as Env from './Env';
+export { default as FeatureGating } from './gating/FeatureGating';
+export { default as FeatureGateEnvOverrides } from './gating/FeatureGateEnvOverrides';
+export { FeatureGateKey, featureGateDefaultValueWhenNoServerValue } from './gating/FeatureGateKey';
+export * as FeatureGateTestOverrides from './gating/FeatureGateTestOverrides';
 export * as CoreSimulator from './apple/CoreSimulator';
 export * as AppleDevice from './apple/AppleDevice';
 export { default as Config } from './Config';


### PR DESCRIPTION
# Why

This is the legacy CLI equivalent of https://github.com/expo/eas-cli/pull/1475. This uses the new www API to fetch the feature gates since there isn't a graphql client available in this CLI.

This will be used to roll out features to encourage users to move to EAS update before the deadline.

# How

Add similar code, update to be in the style of this repo and with the `internal` module stuff.

# Test Plan

Run test.