### PR TITLE
fix(cli): 'expo not installed' error message

### DIFF
--- a/packages/expo-cli/src/commands/start/startAsync.ts
+++ b/packages/expo-cli/src/commands/start/startAsync.ts
@@ -33,7 +33,7 @@ export async function actionAsync(projectRoot: string, options: NormalizedOption
     const hasExpoInstalled = resolveFrom.silent(projectRoot, 'expo');
     if (!hasExpoInstalled) {
       throw new ConfigError(
-        `Unable to find expo in this project - have you run yarn / npm install yet?`,
+        `Unable to find expo in this project - have you installed it yet? (run yarn add expo / npm install expo)`,
         'MODULE_NOT_FOUND'
       );
     }


### PR DESCRIPTION
For beginners like me, this error message would save an extra google search.