### PR TITLE
Fix crash when device doesn't have udid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This is the log of notable changes to Expo CLI and related packages.
 ### 🐛 Bug fixes
 
 - fix(image-utils): make jimp export buffers as png like sharp ([#4576](https://github.com/expo/expo-cli/issues/4576))
+- fix(cli): fix crash when a device doesn't have a udid defined
 
 ### 📦 Packages updated
 

--- a/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
+++ b/packages/expo-cli/src/commands/run/ios/resolveDeviceAsync.ts
@@ -98,7 +98,7 @@ export async function resolveDeviceAsync(
   }
   const searchValue = device.toLowerCase();
   const resolved = devices.find(device => {
-    return device.udid.toLowerCase() === searchValue || device.name.toLowerCase() === searchValue;
+    return device.udid?.toLowerCase() === searchValue || device.name.toLowerCase() === searchValue;
   });
 
   if (!resolved) {


### PR DESCRIPTION

# Why
Cli crashes when a device doesn't have a defined `udid`.

OS: Ventura 13.0 (M1 Pro)

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at /Users/user/project_dir/node_modules/@expo/cli/build/src/run/ios/options/resolveDevice.js:76:56
    at Array.find (<anonymous>)
    at findDeviceFromSearchValue (/Users/user/project_dir/node_modules/@expo/cli/build/src/run/ios/options/resolveDevice.js:76:29)
    at Object.resolveDeviceAsync (/Users/user/project_dir/node_modules/@expo/cli/build/src/run/ios/options/resolveDevice.js:67:94)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.resolveOptionsAsync (/Users/user/project_dir/node_modules/@expo/cli/build/src/run/ios/options/resolveOptions.js:19:20)
    at async runIosAsync (/Users/user/project_dir/node_modules/@expo/cli/build/src/run/ios/runIosAsync.js:54:19)

```



<!-- 

!! NOTICE !! The global Expo CLI (`packages/expo-cli`) is deprecated in favor of the new versioned CLI `npx expo`:

Open Expo CLI changes here -> https://github.com/expo/expo/tree/main/packages/@expo/cli

...

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How
Some iOS devices connected via wifi (eg. iPad) show up in the devices list but might not have an `udid` defined. It still tries to match by name if it can't find a `udid`, which works.


# Test Plan
 - connect iPad to mac with a cable
 - in Finder window for the iPad, select "Show this device on wifi"
<img width=300 src=https://user-images.githubusercontent.com/1693287/200449635-ffc05584-1eb6-4d20-aa63-d59ef795c339.jpg>

 - disconnect iPad
 - check that iPad is showing still in Finder under "Locations"
 - in an Expo project, run `expo run:ios -d 'iPhone 14 Pro'`
 - this fails with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`


