### PR TITLE
fix(webpack-config): add optional chain to app entrypoint

### DIFF
--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -519,7 +519,7 @@ export default async function (
               }
               return manifest;
             }, seed);
-            const entrypointFiles = entrypoints.app.filter(fileName => !fileName.endsWith('.map'));
+            const entrypointFiles = entrypoints.app?.filter(fileName => !fileName.endsWith('.map'));
 
             return {
               files: manifestFiles,


### PR DESCRIPTION
# Why

When using [Cypress component testing](https://docs.cypress.io/guides/component-testing/overview), the `app` entrypoint is not available in the webpack-manifest-plugin, and only the `main` entrypoint exists. This results in the following error:
```bash
✖ ｢wdm｣: TypeError: Cannot read properties of undefined (reading 'filter')
    at Object.generate (/Users/danadajian/WebstormProjects/LastDram/webpack-config/webpack/webpack.config.js:418:65)
    at ManifestPlugin.<anonymous> (/Users/danadajian/WebstormProjects/LastDram/node_modules/webpack-manifest-plugin/lib/plugin.js:199:28)
    at _next2 (eval at create (/Users/danadajian/WebstormProjects/LastDram/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:10:1)
    at eval (eval at create (/Users/danadajian/WebstormProjects/LastDram/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
```

# How

I added an optional chain to the `entrypoint.app` so the app can still compile even if the `app` entrypoint does not exist.

# Test Plan

I tested this by making this change in a local instance of the `@expo/webpack-config` package in my react-native app.
