### PR TITLE
[install-expo-modules] Add react-native 0.71 support

### DIFF
--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071-updated.java
@@ -1,0 +1,36 @@
+package com.helloworld;
+import expo.modules.ReactActivityDelegateWrapper;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactActivityDelegate;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  /**
+   * Returns the instance of the {@link ReactActivityDelegate}. Here we use a util class {@link
+   * DefaultReactActivityDelegate} which allows you to easily enable Fabric and Concurrent React
+   * (aka React 18) with two boolean flags.
+   */
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, new DefaultReactActivityDelegate(
+        this,
+        getMainComponentName(),
+        // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+        DefaultNewArchitectureEntryPoint.getFabricEnabled(), // fabricEnabled
+        // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
+        DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
+        ));
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071-updated.kt
@@ -1,0 +1,32 @@
+package com.helloworld
+import expo.modules.ReactActivityDelegateWrapper
+
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.concurrentReactEnabled
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String? {
+    return "HelloWorld"
+  }
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. Here we use a util class [ ] which allows you to easily enable Fabric and Concurrent React
+   * (aka React 18) with two boolean flags.
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, DefaultReactActivityDelegate(
+            this,
+            mainComponentName!!,  // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+            fabricEnabled,  // fabricEnabled
+            // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
+            concurrentReactEnabled // concurrentRootEnabled
+    ))
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071.java
@@ -1,0 +1,35 @@
+package com.helloworld;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactActivityDelegate;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "HelloWorld";
+  }
+
+  /**
+   * Returns the instance of the {@link ReactActivityDelegate}. Here we use a util class {@link
+   * DefaultReactActivityDelegate} which allows you to easily enable Fabric and Concurrent React
+   * (aka React 18) with two boolean flags.
+   */
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new DefaultReactActivityDelegate(
+        this,
+        getMainComponentName(),
+        // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+        DefaultNewArchitectureEntryPoint.getFabricEnabled(), // fabricEnabled
+        // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
+        DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
+        );
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn071.kt
@@ -1,0 +1,31 @@
+package com.helloworld
+
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.concurrentReactEnabled
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String? {
+    return "HelloWorld"
+  }
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. Here we use a util class [ ] which allows you to easily enable Fabric and Concurrent React
+   * (aka React 18) with two boolean flags.
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate {
+    return DefaultReactActivityDelegate(
+            this,
+            mainComponentName!!,  // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+            fabricEnabled,  // fabricEnabled
+            // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
+            concurrentReactEnabled // concurrentRootEnabled
+    )
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn071-updated.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn071-updated.java
@@ -1,0 +1,72 @@
+package com.helloworld;
+import android.content.res.Configuration;
+import expo.modules.ApplicationLifecycleDispatcher;
+import expo.modules.ReactNativeHostWrapper;
+
+import android.app.Application;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactNativeHost;
+import com.facebook.soloader.SoLoader;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHostWrapper(this, new DefaultReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+
+        @Override
+        protected boolean isNewArchEnabled() {
+          return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+        }
+
+        @Override
+        protected Boolean isHermesEnabled() {
+          return BuildConfig.IS_HERMES_ENABLED;
+        }
+      });
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      DefaultNewArchitectureEntryPoint.load();
+    }
+    ReactNativeFlipper.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+    ApplicationLifecycleDispatcher.onApplicationCreate(this);
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig);
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn071.java
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn071.java
@@ -1,0 +1,62 @@
+package com.helloworld;
+
+import android.app.Application;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactNativeHost;
+import com.facebook.soloader.SoLoader;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new DefaultReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+
+        @Override
+        protected boolean isNewArchEnabled() {
+          return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+        }
+
+        @Override
+        protected Boolean isHermesEnabled() {
+          return BuildConfig.IS_HERMES_ENABLED;
+        }
+      };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      DefaultNewArchitectureEntryPoint.load();
+    }
+    ReactNativeFlipper.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
@@ -35,6 +35,32 @@ describe(setModulesMainActivity, () => {
     expect(nextContents).toEqual(expectContents);
   });
 
+  it(`should add ReactActivityDelegateWrapper for react-native@>=0.71.0 - java`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn071.java'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn071-updated.java'), 'utf8'),
+    ]);
+
+    const contents = setModulesMainActivity(rawContents, 'java');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainActivity(contents, 'java');
+    expect(nextContents).toEqual(expectContents);
+  });
+
+  it(`should add ReactActivityDelegateWrapper for react-native@>=0.71.0 - kotlin`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn071.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn071-updated.kt'), 'utf8'),
+    ]);
+
+    const contents = setModulesMainActivity(rawContents, 'kt');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainActivity(contents, 'kt');
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it(`should add ReactActivityDelegateWrapper for react-native@>=0.68.0 - java`, async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn068.java'), 'utf8'),

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -6,6 +6,19 @@ import { setModulesMainApplication } from '../withAndroidModulesMainApplication'
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe(setModulesMainApplication, () => {
+  it('should able to update from react-native@>=0.71.0 template', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn071.java'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn071-updated.java'), 'utf8'),
+    ]);
+
+    const contents = setModulesMainApplication(rawContents, 'java');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainApplication(contents, 'java');
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it('should able to update from react-native@>=0.68.0 template', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn068.java'), 'utf8'),

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn071-updated.h
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn071-updated.h
@@ -1,0 +1,7 @@
+#import <RCTAppDelegate.h>
+#import <Expo/Expo.h>
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : EXAppDelegateWrapper
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn071.h
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn071.h
@@ -1,0 +1,6 @@
+#import <RCTAppDelegate.h>
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : RCTAppDelegate
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn071.mm
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn071.mm
@@ -1,0 +1,32 @@
+#import "AppDelegate.h"
+
+#import <React/RCTBundleURLProvider.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  self.moduleName = @"HelloWorld";
+  return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+/// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.
+///
+/// @see: https://reactjs.org/blog/2022/03/29/react-v18.html
+/// @note: This requires to be rendering on Fabric (i.e. on the New Architecture).
+/// @return: `true` if the `concurrentRoot` feature is enabled. Otherwise, it returns `false`.
+- (BOOL)concurrentRootEnabled
+{
+  return true;
+}
+
+@end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-rn071
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-rn071
@@ -1,0 +1,51 @@
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native/scripts/native_modules'
+
+platform :ios, min_ios_version_supported
+prepare_react_native_project!
+
+flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+
+linkage = ENV['USE_FRAMEWORKS']
+if linkage != nil
+  Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
+  use_frameworks! :linkage => linkage.to_sym
+end
+
+target 'HelloWorld' do
+  config = use_native_modules!
+
+  # Flags change depending on the env values.
+  flags = get_default_flags()
+
+  use_react_native!(
+    :path => config[:reactNativePath],
+    # Hermes is now enabled by default. Disable by setting this flag to false.
+    # Upcoming versions of React Native may rely on get_default_flags(), but
+    # we make it explicit here to aid in the React Native upgrade process.
+    :hermes_enabled => flags[:hermes_enabled],
+    :fabric_enabled => flags[:fabric_enabled],
+    # Enables Flipper.
+    #
+    # Note that if you have use_frameworks! enabled, Flipper will not work and
+    # you should disable the next line.
+    :flipper_configuration => flipper_config,
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/.."
+  )
+
+  target 'HelloWorldTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      # Set `mac_catalyst_enabled` to `true` in order to apply patches
+      # necessary for Mac Catalyst builds
+      :mac_catalyst_enabled => false
+    )
+    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+  end
+end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-rn071-updated
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/Podfile-rn071-updated
@@ -1,0 +1,60 @@
+require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native/scripts/native_modules'
+
+platform :ios, min_ios_version_supported
+prepare_react_native_project!
+
+flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+
+linkage = ENV['USE_FRAMEWORKS']
+if linkage != nil
+  Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
+  use_frameworks! :linkage => linkage.to_sym
+end
+
+target 'HelloWorld' do
+  use_expo_modules!
+  post_integrate do |installer|
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end
+  end
+  config = use_native_modules!
+
+  # Flags change depending on the env values.
+  flags = get_default_flags()
+
+  use_react_native!(
+    :path => config[:reactNativePath],
+    # Hermes is now enabled by default. Disable by setting this flag to false.
+    # Upcoming versions of React Native may rely on get_default_flags(), but
+    # we make it explicit here to aid in the React Native upgrade process.
+    :hermes_enabled => flags[:hermes_enabled],
+    :fabric_enabled => flags[:fabric_enabled],
+    # Enables Flipper.
+    #
+    # Note that if you have use_frameworks! enabled, Flipper will not work and
+    # you should disable the next line.
+    :flipper_configuration => flipper_config,
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/.."
+  )
+
+  target 'HelloWorldTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      # Set `mac_catalyst_enabled` to `true` in order to apply patches
+      # necessary for Mac Catalyst builds
+      :mac_catalyst_enabled => false
+    )
+    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+  end
+end

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosDeploymentTarget-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosDeploymentTarget-test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import resolveFrom from 'resolve-from';
 
 import {
   shouldUpdateDeployTargetPodfileAsync,
@@ -6,9 +7,16 @@ import {
 } from '../withIosDeploymentTarget';
 
 jest.mock('fs', () => ({ promises: { readFile: jest.fn() } }));
+jest.mock('resolve-from');
 
 describe(updateDeploymentTargetPodfile, () => {
-  it('should update deployment target in Podfile', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    const mockResolve = resolveFrom.silent as jest.MockedFunction<typeof resolveFrom.silent>;
+    mockResolve.mockReturnValue('/app/node_modules/react-native/scripts/react_native_pods.rb');
+  });
+
+  it('should update deployment target in Podfile', async () => {
     const contents = `\
 platform :ios, '10.0'
 
@@ -28,10 +36,38 @@ target 'HelloWorld' do
   )
 end
 `;
-    expect(updateDeploymentTargetPodfile(contents, '12.0')).toEqual(expectContents);
+    expect(await updateDeploymentTargetPodfile('/app', contents, '12.0')).toEqual(expectContents);
   });
 
-  it('should support multiple deployment targets in Podfile', () => {
+  it(`should replace react-native's min_ios_version_supported if we need higher version`, async () => {
+    const reactNativePodsRubyContent = `\
+def min_ios_version_supported
+  return '12.4'
+end`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValue(reactNativePodsRubyContent);
+    const contents = `\
+platform :ios, min_ios_version_supported
+
+target 'HelloWorld' do
+  use_react_native!(
+    :path => config[:reactNativePath]
+  )
+end
+`;
+
+    const expectContents = `\
+platform :ios, '13.0'
+
+target 'HelloWorld' do
+  use_react_native!(
+    :path => config[:reactNativePath]
+  )
+end
+`;
+    expect(await updateDeploymentTargetPodfile('/app', contents, '13.0')).toEqual(expectContents);
+  });
+
+  it('should support multiple deployment targets in Podfile', async () => {
     const contents = `\
 target 'HelloWorld' do
   platform :ios, '10.0'
@@ -63,10 +99,10 @@ target 'HelloWorld2' do
   )
 end
 `;
-    expect(updateDeploymentTargetPodfile(contents, '12.0')).toEqual(expectContents);
+    expect(await updateDeploymentTargetPodfile('/app', contents, '12.0')).toEqual(expectContents);
   });
 
-  it('should leave unmodified if deployment target meets requirements', () => {
+  it('should leave unmodified if deployment target meets requirements', async () => {
     const contents = `\
 platform :ios, '12.0'
 
@@ -77,13 +113,34 @@ target 'HelloWorld' do
 end
 `;
 
-    expect(updateDeploymentTargetPodfile(contents, '12.0')).toEqual(contents);
+    expect(await updateDeploymentTargetPodfile('/app', contents, '12.0')).toEqual(contents);
+  });
+
+  it(`should leave unmodified if react-native's min_ios_version_supported meets requirement`, async () => {
+    const reactNativePodsRubyContent = `\
+def min_ios_version_supported
+  return '12.4'
+end`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValue(reactNativePodsRubyContent);
+    const contents = `\
+platform :ios, min_ios_version_supported
+
+target 'HelloWorld' do
+  use_react_native!(
+    :path => config[:reactNativePath]
+  )
+end
+`;
+
+    expect(await updateDeploymentTargetPodfile('/app', contents, '12.0')).toEqual(contents);
   });
 });
 
 describe(shouldUpdateDeployTargetPodfileAsync, () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    const mockResolve = resolveFrom.silent as jest.MockedFunction<typeof resolveFrom.silent>;
+    mockResolve.mockReturnValue('/app/node_modules/react-native/scripts/react_native_pods.rb');
   });
 
   it('should returns true when target version is higher than current version', async () => {
@@ -97,6 +154,32 @@ describe(shouldUpdateDeployTargetPodfileAsync, () => {
   it('should returns false when target version is equal to current version', async () => {
     const podfileContent = `platform :ios, '12.4'`;
     (fs.promises.readFile as jest.Mock).mockResolvedValue(podfileContent);
+
+    const result = await shouldUpdateDeployTargetPodfileAsync('/app', '12.4');
+    expect(result).toBe(false);
+  });
+
+  it('should returns true when target version is higher than min_ios_version_supported version', async () => {
+    const podfileContent = `platform :ios, min_ios_version_supported`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(podfileContent);
+    const reactNativePodsRubyContent = `\
+def min_ios_version_supported
+  return '12.4'
+end`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(reactNativePodsRubyContent);
+
+    const result = await shouldUpdateDeployTargetPodfileAsync('/app', '13.0');
+    expect(result).toBe(true);
+  });
+
+  it('should returns false when target version is equal to min_ios_version_supported version', async () => {
+    const podfileContent = `platform :ios, min_ios_version_supported`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(podfileContent);
+    const reactNativePodsRubyContent = `\
+def min_ios_version_supported
+  return '12.4'
+end`;
+    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(reactNativePodsRubyContent);
 
     const result = await shouldUpdateDeployTargetPodfileAsync('/app', '12.4');
     expect(result).toBe(false);

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
@@ -11,6 +11,20 @@ import {
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe(updateModulesAppDelegateObjcHeader, () => {
+  it('should migrate from react-native@>=0.71.0 AppDelegate header', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn071.h'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn071-updated.h'), 'utf8'),
+    ]);
+
+    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const contents = updateModulesAppDelegateObjcHeader(rawContents, sdkVersion);
+    expect(updateModulesAppDelegateObjcHeader(contents, sdkVersion)).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = updateModulesAppDelegateObjcHeader(contents, sdkVersion);
+    expect(updateModulesAppDelegateObjcHeader(nextContents, sdkVersion)).toEqual(expectContents);
+  });
+
   it('should migrate from classic RN AppDelegate header', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate.h'), 'utf8'),

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesPodfile-test.ts
@@ -17,6 +17,16 @@ describe(updatePodfile, () => {
     expect(updatePodfile(rawContents, 'HelloWorld', sdkVersion)).toEqual(expectContents);
   });
 
+  it('should support classic rn 0.71 podfile', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'Podfile-rn071'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'Podfile-rn071-updated'), 'utf8'),
+    ]);
+
+    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    expect(updatePodfile(rawContents, 'HelloWorld', sdkVersion)).toEqual(expectContents);
+  });
+
   it('minimum support for existing post_integrate hook', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'Podfile-with-post-integrate'), 'utf8'),

--- a/packages/install-expo-modules/src/plugins/ios/withIosDeploymentTarget.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosDeploymentTarget.ts
@@ -1,6 +1,7 @@
 import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
 import fs from 'fs';
 import path from 'path';
+import resolveFrom from 'resolve-from';
 import semver from 'semver';
 import { ISA, XCBuildConfiguration } from 'xcparse';
 
@@ -20,7 +21,11 @@ const withIosDeploymentTargetPodfile: IosDeploymentTargetConfigPlugin = (config,
     async config => {
       const podfile = path.join(config.modRequest.platformProjectRoot, 'Podfile');
       let contents = await fs.promises.readFile(podfile, 'utf8');
-      contents = updateDeploymentTargetPodfile(contents, props.deploymentTarget);
+      contents = await updateDeploymentTargetPodfile(
+        config.modRequest.projectRoot,
+        contents,
+        props.deploymentTarget
+      );
 
       await fs.promises.writeFile(podfile, contents);
       return config;
@@ -30,16 +35,34 @@ const withIosDeploymentTargetPodfile: IosDeploymentTargetConfigPlugin = (config,
 
 // Because regexp //g is stateful, to use it multiple times, we should create a new one.
 function createPodfilePlatformRegExp() {
-  return /^(\s*platform :ios, ['"])([\d.]+)(['"])/gm;
+  return /^(\s*platform :ios,\s*)(['"][\d.]+['"]|min_ios_version_supported)/gm;
 }
 
-export function updateDeploymentTargetPodfile(contents: string, deploymentTarget: string): string {
-  return contents.replace(createPodfilePlatformRegExp(), (match, prefix, version, suffix) => {
-    if (semver.lt(toSemVer(version), toSemVer(deploymentTarget))) {
-      return `${prefix}${deploymentTarget}${suffix}`;
+async function parseVersionAsync(projectRoot: string, versionPart: string): Promise<string | null> {
+  let version;
+  if (versionPart === 'min_ios_version_supported') {
+    version = await lookupReactNativeMinIosVersionSupported(projectRoot);
+  } else {
+    version = versionPart.replace(/'"/g, '');
+  }
+  return version;
+}
+
+export async function updateDeploymentTargetPodfile(
+  projectRoot: string,
+  contents: string,
+  deploymentTarget: string
+): Promise<string> {
+  const matchResult = createPodfilePlatformRegExp().exec(contents);
+  if (matchResult) {
+    const version = await parseVersionAsync(projectRoot, matchResult[2]);
+    if (version && semver.lt(toSemVer(version), toSemVer(deploymentTarget))) {
+      return contents.replace(createPodfilePlatformRegExp(), (match, prefix, versionPart) => {
+        return `${prefix}'${deploymentTarget}'`;
+      });
     }
-    return match;
-  });
+  }
+  return contents;
 }
 
 export async function shouldUpdateDeployTargetPodfileAsync(
@@ -55,8 +78,37 @@ export async function shouldUpdateDeployTargetPodfileAsync(
     );
     return false;
   }
-  const [, , version] = matchResult;
+
+  const version = await parseVersionAsync(projectRoot, matchResult[2]);
+  if (!version) {
+    console.warn(
+      'Unrecognized `ios/Podfile` content, will skip the process to update minimum iOS supported version.'
+    );
+    return false;
+  }
+
   return semver.lt(toSemVer(version), toSemVer(targetVersion));
+}
+
+export async function lookupReactNativeMinIosVersionSupported(
+  projectRoot: string
+): Promise<string | null> {
+  const reactNativePodsScript = resolveFrom.silent(
+    projectRoot,
+    'react-native/scripts/react_native_pods.rb'
+  );
+  if (!reactNativePodsScript) {
+    return null;
+  }
+  try {
+    const content = await fs.promises.readFile(reactNativePodsScript, 'utf-8');
+    const matchRepExp = /^def min_ios_version_supported\n\s*return\s*['"]([\d.]+)['"]/gm;
+    const matchResult = matchRepExp.exec(content);
+    if (matchResult) {
+      return matchResult[1];
+    }
+  } catch {}
+  return null;
 }
 
 const withIosDeploymentTargetXcodeProject: IosDeploymentTargetConfigPlugin = (config, props) => {

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
@@ -117,9 +117,14 @@ export function updateModulesAppDelegateObjcHeader(
 
   // Replace parent class if needed
   contents = contents.replace(
+    /^(\s*@interface\s+AppDelegate\s+:\s+)RCTAppDelegate$/m,
+    '$1EXAppDelegateWrapper'
+  ); // react-native@>=0.71.0
+
+  contents = contents.replace(
     /^(\s*@interface\s+AppDelegate\s+:\s+)UIResponder(\s+.+)$/m,
     '$1EXAppDelegateWrapper$2'
-  );
+  ); // react-native@<0.71.0
 
   return contents;
 }


### PR DESCRIPTION
# Why

support react-native 0.71 for sdk 47 in early preview

# How

- [android] nothing particular. original approach works for the new `DefaultReactActivityDelegate` and `DefaultReactNativeHost`
- [ios] for `platform :ios, min_ios_version_supported` to migrate minimal ios version, we should further lookup the `min_ios_version_supported` inside react-native
- [ios] only AppDelegate.h needs migration for the `RCTAppDelegate` for 0.71. original AppDelegate.mm changes will be handled internally in our EXAppDelegateWrapper. see https://github.com/expo/expo/pull/20470 for more details

# Test Plan

- adding unit tests for 0.71
- manual testing on an 0.71 project
