### PR TITLE
[doctor] Add warning when explicitly using `androidStatusBar.translucent`

### DIFF
--- a/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
+++ b/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
@@ -37,8 +37,9 @@ async function validateSupportPackagesAsync(sdkVersion: string): Promise<boolean
 
 function validateAndroidExpoConfig(exp: ExpoConfig) {
   if (
-    exp.android?.softwareKeyboardLayoutMode === 'resize' &&
-    exp.androidStatusBar?.translucent === true
+    exp.androidStatusBar?.translucent === true &&
+    (!exp.android?.softwareKeyboardLayoutMode ||
+      exp.android?.softwareKeyboardLayoutMode === 'resize')
   ) {
     Log.warn(
       'Explicitly setting `androidStatusBar.translucent` to `true` in `app.json` with `softwareKeyboardLayoutMode` `resize` may result in unexpected keyboard behavior on Android and you will have to use a KeyboardAvoidingView to manage the keyboard layout.'

--- a/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
+++ b/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
@@ -1,4 +1,4 @@
-import { getConfig } from '@expo/config';
+import { ExpoConfig, getConfig } from '@expo/config';
 import chalk from 'chalk';
 import { Doctor, Versions } from 'xdl';
 
@@ -33,6 +33,20 @@ async function validateSupportPackagesAsync(sdkVersion: string): Promise<boolean
     }
   }
   return allPackagesValid;
+}
+
+function validateAndroidExpoConfig(exp: ExpoConfig) {
+  if (
+    exp.android?.softwareKeyboardLayoutMode === 'resize' &&
+    exp.androidStatusBar?.translucent === true
+  ) {
+    Log.warn(
+      'Explicitly setting `androidStatusBar.translucent` to `true` in `app.json` with `softwareKeyboardLayoutMode` `resize` may result in unexpected keyboard behavior on Android and you will have to use a KeyboardAvoidingView to manage the keyboard layout.'
+    );
+    return false;
+  }
+
+  return true;
 }
 
 // Ensures that a set of packages
@@ -82,6 +96,10 @@ export async function actionAsync(projectRoot: string, options: Options) {
       options.fixDependencies
     ))
   ) {
+    foundSomeIssues = true;
+  }
+
+  if (!validateAndroidExpoConfig(exp)) {
     foundSomeIssues = true;
   }
 


### PR DESCRIPTION
# Why

When explicitly adding `androidStatusBar.translucent` `true` inside `app.json` EAS builds add `<item name="android:windowTranslucentStatus">true</item>` to `android/app/src/main/res/values/styles.xml` which when used with `softwareKeyboardLayoutMode` `resize` don't combine to the expected keyboard behavior.

 
<details>
   <summary>Example</summary>
<table>
    <tr><th>With explicit translucent `true`</th><th>Without translucent</th></tr>
    <tr>
        <td><video src="https://user-images.githubusercontent.com/11707729/213022005-68cacde6-6c16-44b4-b674-4e14058a978b.mp4"></td>
        <td><video src="https://user-images.githubusercontent.com/11707729/213021976-73254bd9-0dd9-40b3-98c0-d8e397c8643c.mp4"></td>
    </tr> 
</table>    
</details>

 
Unfortunately, this is a platform quirk and there isn't much we can do about it, but given that we let people set both of these values directly in `app.json` we can detect if they are set to incompatible values and warn people about the need of using a KeyboardAvoidingView in such cases


Closes ENG-4613
 
# How

Check ExpoConfig values to detect if they are set to incompatible values and if so show a warning

# Test Plan

Running `expod doctor` in a project with `"softwareKeyboardLayoutMode": "resize"` and `"androidStatusBar"."translucent": true`

![image](https://user-images.githubusercontent.com/11707729/213013497-049fc411-2ed0-499f-8dac-211ecd4ec641.png)

Running `expod doctor` in a project without `"androidStatusBar"."translucent": true` or  `"softwareKeyboardLayoutMode": "resize"

![image](https://user-images.githubusercontent.com/11707729/213025295-2659359e-5eea-45d1-a0d8-5cd4919a4eec.png)

