### PR TITLE
fix(create-expo-app): skip creating a git repo when inside existing repo

### DIFF
--- a/packages/create-expo-app/src/utils/git.ts
+++ b/packages/create-expo-app/src/utils/git.ts
@@ -8,6 +8,7 @@ export async function initGitRepoAsync(root: string) {
   try {
     await spawnAsync('git', ['rev-parse', '--is-inside-work-tree'], { stdio: 'ignore', cwd: root });
     debug(chalk.dim('New project is already inside of a Git repo, skipping git init.'));
+    return false;
   } catch (e: any) {
     if (e.errno === 'ENOENT') {
       debug(chalk.dim('Unable to initialize Git repo. `git` not in $PATH.'));


### PR DESCRIPTION
# Why

Part of ENG-7078

When already inside a Git repo, we shouldn't be creating a new one.

# How

Added `return false;` to stop creating a new repo.

# Test Plan

- `$ git clone git@github.com:bycedric/expo-monorepo-example.git ./test`
- `$ npx create-expo-app ./test/apps/new-without-subrepo`
- `$ cd ./test/apps/new-without-subrepo` should not have `.git`
