### PR TITLE
[readme] Highlight the modern local CLI over everything else

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+**The modern [local Expo CLI](https://blog.expo.dev/the-new-expo-cli-f4250d8e3421) is included with the `expo` package and does not need to be installed separately. Run it with `npx expo`. Its source code lives in the [`expo/expo`](https://github.com/expo/expo/blob/main/packages/%40expo/cli) repo.**
+
+---
+
 # Assorted Expo Dev Tools
 
-Packages used in Expo CLI and related tooling. Contains source for the legacy global Expo CLI. The new [local Expo CLI](https://blog.expo.dev/the-new-expo-cli-f4250d8e3421) lives in the [**`expo/expo`**](https://github.com/expo/expo/blob/main/packages/%40expo/cli) repo.
+This repo consists of packages used in the legacy global Expo CLI and related tooling.
 
 <p>
   <a aria-label="Follow @expo on Twitter" href="https://twitter.com/intent/follow?screen_name=expo" target="_blank">


### PR DESCRIPTION
Why: the local CLI is the only maintained CLI aside from critical security fixes for now. Everyone looking at this repo should be aware that Expo CLI has moved repos.

How: added a bold section above everything else in the README.

# Why

<!-- 

!! NOTICE !! The global Expo CLI (`packages/expo-cli`) is deprecated in favor of the new versioned CLI `npx expo`:

Open Expo CLI changes here -> https://github.com/expo/expo/tree/main/packages/@expo/cli

...

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
