### PR TITLE
Remove Node.js limitations on the legacy CLI

### DIFF
--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -1,40 +1,20 @@
 #!/usr/bin/env node
 
-function red(text) {
-  return '\u001b[31m' + text + '\u001b[39m';
-}
 function yellow(text) {
   return '\u001b[33m' + text + '\u001b[39m';
 }
 
 const match = /v(\d+)\.(\d+)/.exec(process.version);
 const major = parseInt(match[1], 10);
-const minor = parseInt(match[2], 10);
-
-const supportedVersions =
-  'expo-cli supports following Node.js versions:\n' +
-  '* >=12.13.0 <15.0.0 (Maintenance LTS)\n' +
-  '* >=16.0.0 <17.0.0 (Active LTS)\n';
 
 // If newer than the current release
 if (major > 16) {
   // eslint-disable-next-line no-console
   console.warn(
     yellow(
-      'WARNING: expo-cli has not yet been tested against Node.js ' +
-        process.version +
-        '.\n' +
-        'If you encounter any issues, please report them to https://github.com/expo/expo-cli/issues\n' +
-        '\n' +
-        supportedVersions
+      'WARNING: The legacy expo-cli does not support Node +17. Migrate to the versioned Expo CLI (npx expo).'
     )
   );
-} else if (!((major === 12 && minor >= 13) || major === 14 || major === 15 || major === 16)) {
-  // eslint-disable-next-line no-console
-  console.error(
-    red('ERROR: Node.js ' + process.version + ' is no longer supported.\n\n' + supportedVersions)
-  );
-  process.exit(1);
 }
 
 require('../build/exp.js').run('expo');

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -38,9 +38,6 @@
     "url": "https://github.com/expo/expo-cli/issues"
   },
   "homepage": "https://github.com/expo/expo-cli/tree/main/packages/expo-cli#readme",
-  "engines": {
-    "node": ">=12 <=16"
-  },
   "volta": {
     "extends": "../../package.json"
   },


### PR DESCRIPTION
# Why

- `expo-cli` is deprecated in favor of `npx expo`, any existing use cases are unstable and subject to breakage.
