### PR TITLE
fix(webpack): add webpack-dev-server as a dependency of webpack-config

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -61,6 +61,7 @@
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.0",
     "webpack": "^5.64.4",
+    "webpack-dev-server": "^4.11.1",
     "webpack-manifest-plugin": "^4.1.1"
   },
   "devDependencies": {

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -93,7 +93,7 @@
     "url-join": "4.0.0",
     "uuid": "^8.0.0",
     "webpack": "^5.64.4",
-    "webpack-dev-server": "^4.7.3",
+    "webpack-dev-server": "^4.11.1",
     "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18072,7 +18072,7 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@*, webpack-dev-server@^4.7.3:
+webpack-dev-server@*, webpack-dev-server@^4.11.1:
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz#ae07f0d71ca0438cf88446f09029b92ce81380b5"
   integrity sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==


### PR DESCRIPTION
# Why

Makes versioned CLI usage a bit easier, also bumps the version to latest.