### PR TITLE
feat(create-expo-app): drop loading spinner when installing dependencies

### DIFF
--- a/packages/create-expo-app/src/createAsync.ts
+++ b/packages/create-expo-app/src/createAsync.ts
@@ -18,7 +18,6 @@ import {
   initializeAnalyticsIdentityAsync,
   track,
 } from './telemetry';
-import { env } from './utils/env';
 import { initGitRepoAsync } from './utils/git';
 
 export type Options = {

--- a/packages/create-expo-app/src/createAsync.ts
+++ b/packages/create-expo-app/src/createAsync.ts
@@ -130,17 +130,14 @@ async function installNodeDependenciesAsync(
   projectRoot: string,
   packageManager: PackageManagerName
 ): Promise<void> {
-  const installJsDepsStep = Template.logNewSection(
-    `Installing JavaScript dependencies with ${packageManager}.`
-  );
   try {
-    await installDependenciesAsync(projectRoot, packageManager, { silent: !env.EXPO_DEBUG });
-    installJsDepsStep.succeed('Installed JavaScript dependencies.');
-  } catch (error) {
+    await installDependenciesAsync(projectRoot, packageManager, { silent: false });
+  } catch (error: any) {
     debug(`Error installing node modules: %O`, error);
-    installJsDepsStep.fail(
+    Log.error(
       `Something went wrong installing JavaScript dependencies. Check your ${packageManager} logs. Continuing to create the app.`
     );
+    Log.exception(error);
   }
 }
 


### PR DESCRIPTION
# Why

- A spinner should only be used for short-running, indeterminate tasks.
- @gaearon mentioned that the current behavior is not sparking joy: https://twitter.com/dan_abramov/status/1621355168792039426?s=20&t=T-XihEJP2vTJuHT1igMpcg

# How

- Dropping the spinner in favor of the raw logs because we support three different package managers and it's not entirely obvious how we can create a consistent loading bar UI across all three (`yarn install --json` output differs a lot from `npm install --json`)


# Test Plan

- Ran locally
- Unit tests (minimal overlap)

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
