### PR TITLE
feature(create-expo-app): add `--example` flag to initialize from example

### DIFF
--- a/packages/create-expo-app/package.json
+++ b/packages/create-expo-app/package.json
@@ -51,7 +51,7 @@
     "node-fetch": "^2.6.7",
     "ora": "3.4.0",
     "prompts": "^2.4.2",
-    "tar": "^6.1.11",
+    "tar": "^6.1.13",
     "update-check": "^1.5.4"
   },
   "publishConfig": {

--- a/packages/create-expo-app/src/Examples.ts
+++ b/packages/create-expo-app/src/Examples.ts
@@ -1,0 +1,138 @@
+import JsonFile from '@expo/json-file';
+import chalk from 'chalk';
+import fs from 'fs';
+import fetch from 'node-fetch';
+import path from 'path';
+import prompts from 'prompts';
+import { Stream } from 'stream';
+import tar from 'tar';
+import { promisify } from 'util';
+
+import { sanitizeTemplateAsync } from './Template';
+import { createEntryResolver, createFileTransform } from './createFileTransform';
+import { env } from './utils/env';
+
+const debug = require('debug')('expo:init:template') as typeof console.log;
+const pipeline = promisify(Stream.pipeline);
+
+/**
+ * The partial GitHub content type, used to filter out examples.
+ * @see https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28
+ */
+export type GithubContent = {
+  name: string;
+  path: string;
+  type: 'file' | 'dir';
+};
+
+/** List all existing examples directory from https://github.com/expo/examples. */
+async function listExamplesAsync() {
+  const response = await fetch('https://api.github.com/repos/expo/examples/contents');
+  if (!response.ok) {
+    throw new Error('Unexpected GitHub API response: https://github.com/expo/examples');
+  }
+
+  const data: GithubContent[] = await response.json();
+  return data.filter(item => item.type === 'dir' && !item.name.startsWith('.'));
+}
+
+/** Determine if an example exists, using only its name */
+async function hasExampleAsync(name: string) {
+  const response = await fetch(
+    `https://api.github.com/repos/expo/examples/contents/${encodeURIComponent(name)}/package.json`
+  );
+
+  // Either ok or 404 responses are expected
+  if (response.status === 404 || response.ok) {
+    return response.ok;
+  }
+
+  throw new Error(`Unexpected GitHub API response: ${response.status} - ${response.statusText}`);
+}
+
+export async function ensureExampleExists(name: string) {
+  if (!(await hasExampleAsync(name))) {
+    throw new Error(`Example "${name}" does not exist, see https://github.com/expo/examples`);
+  }
+}
+
+/** Ask the user which example to create */
+export async function promptExamplesAsync() {
+  if (env.CI) {
+    throw new Error('Cannot prompt for examples in CI');
+  }
+
+  const examples = await listExamplesAsync();
+  const { answer } = await prompts({
+    type: 'select',
+    name: 'answer',
+    message: 'Choose an example:',
+    choices: examples.map(example => ({
+      title: example.name,
+      value: example.path,
+    })),
+  });
+
+  if (!answer) {
+    console.log();
+    console.log(chalk`Please specify the example, example: {cyan --example with-router}`);
+    console.log();
+    process.exit(1);
+  }
+
+  return answer;
+}
+
+/** Download and move the selected example from https://github.com/expo/examples. */
+export async function downloadAndExtractExampleAsync(root: string, name: string) {
+  const projectName = path.basename(root);
+  const response = await fetch('https://codeload.github.com/expo/examples/tar.gz/master');
+  if (!response.ok) {
+    debug(`Failed to fetch the examples code, received status "${response.status}"`);
+    throw new Error('Failed to fetch the examples code from https://github.com/expo/examples');
+  }
+
+  await pipeline(
+    response.body,
+    tar.extract(
+      {
+        cwd: root,
+        transform: createFileTransform(projectName),
+        onentry: createEntryResolver(projectName),
+        strip: 2,
+      },
+      [`examples-master/${name}`]
+    )
+  );
+
+  await sanitizeTemplateAsync(root);
+  await sanitizeScriptsAsync(root);
+}
+
+function exampleHasNativeCode(root: string): boolean {
+  return [path.join(root, 'android'), path.join(root, 'ios')].some(folder => fs.existsSync(folder));
+}
+
+export async function sanitizeScriptsAsync(root: string) {
+  const defaultScripts = exampleHasNativeCode(root)
+    ? {
+        start: 'expo start --dev-client',
+        android: 'expo run:android',
+        ios: 'expo run:ios',
+        web: 'expo start --web',
+      }
+    : {
+        start: 'expo start',
+        android: 'expo start --android',
+        ios: 'expo start --ios',
+        web: 'expo start --web',
+      };
+
+  const packageFile = new JsonFile(path.join(root, 'package.json'));
+  const packageJson = await packageFile.readAsync();
+
+  const scripts = (packageJson.scripts ?? {}) as Record<string, string>;
+  packageJson.scripts = { ...defaultScripts, ...scripts };
+
+  await packageFile.writeAsync(packageJson);
+}

--- a/packages/create-expo-app/src/Template.ts
+++ b/packages/create-expo-app/src/Template.ts
@@ -1,6 +1,7 @@
 import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
 import chalk from 'chalk';
+import fs from 'fs';
 import ora from 'ora';
 import path from 'path';
 
@@ -83,6 +84,25 @@ export async function extractAndPrepareTemplateAppAsync(
     disableCache: type === 'file',
   });
 
+  await sanitizeTemplateAsync(projectRoot);
+
+  return projectRoot;
+}
+
+/**
+ * Sanitize a template (or example) with expected `package.json` properties and files.
+ */
+export async function sanitizeTemplateAsync(projectRoot: string) {
+  const projectName = path.basename(projectRoot);
+
+  debug(`Sanitizing template or example app (projectName: ${projectName})`);
+
+  const templatePath = path.join(__dirname, '../template/gitignore');
+  const ignorePath = path.join(projectRoot, '.gitignore');
+  if (!fs.existsSync(ignorePath)) {
+    await fs.promises.copyFile(templatePath, ignorePath);
+  }
+
   const config: Record<string, any> = {
     expo: {
       name: projectName,
@@ -112,8 +132,6 @@ export async function extractAndPrepareTemplateAppAsync(
   delete packageJson.repository;
 
   await packageFile.writeAsync(packageJson);
-
-  return projectRoot;
 }
 
 export function validateName(name?: string): string | true {

--- a/packages/create-expo-app/src/__mocks__/fs.ts
+++ b/packages/create-expo-app/src/__mocks__/fs.ts
@@ -1,0 +1,3 @@
+import { fs } from 'memfs';
+
+module.exports = fs;

--- a/packages/create-expo-app/src/__mocks__/ora.ts
+++ b/packages/create-expo-app/src/__mocks__/ora.ts
@@ -1,0 +1,13 @@
+const ora = jest.fn(() => {
+  return {
+    start: jest.fn(() => {
+      return { stop: jest.fn(), succeed: jest.fn(), fail: jest.fn() };
+    }),
+    stop: jest.fn(),
+    stopAndPersist: jest.fn(),
+    succeed: jest.fn(),
+    fail: jest.fn(),
+  };
+});
+
+module.exports = ora;

--- a/packages/create-expo-app/src/__tests__/Examples.test.ts
+++ b/packages/create-expo-app/src/__tests__/Examples.test.ts
@@ -1,0 +1,131 @@
+import { vol } from 'memfs';
+import typedFetch from 'node-fetch';
+import typedPrompts from 'prompts';
+
+import {
+  ensureExampleExists,
+  GithubContent,
+  promptExamplesAsync,
+  sanitizeScriptsAsync,
+} from '../Examples';
+import { env } from '../utils/env';
+
+jest.mock('fs');
+jest.mock('node-fetch');
+jest.mock('prompts');
+
+const fetch = typedFetch as jest.MockedFunction<typeof typedFetch>;
+const prompts = typedPrompts as jest.MockedFunction<typeof typedPrompts>;
+
+describe(ensureExampleExists, () => {
+  it('resolves when example exists', async () => {
+    fetch.mockResolvedValue({ ok: true, status: 200 } as any);
+    await expect(ensureExampleExists('test')).resolves.not.toThrow();
+  });
+
+  it('rejects when example does note exists', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 404 } as any);
+    await expect(() => ensureExampleExists('test')).rejects.toThrow(/example.*does not exist/i);
+  });
+
+  it('throws when running into rate limits', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 403 } as any);
+    await expect(() => ensureExampleExists('test')).rejects.toThrow(
+      /unexpected GitHub API response/i
+    );
+  });
+});
+
+describe(promptExamplesAsync, () => {
+  it('throws when in CI mode', async () => {
+    const spy = jest.spyOn(env, 'CI', 'get').mockReturnValue(true);
+    await expect(() => promptExamplesAsync()).rejects.toThrowError(/cannot prompt/i);
+    spy.mockRestore();
+  });
+
+  it('prompts examples and return selected example', async () => {
+    const examples: GithubContent[] = [
+      { name: 'test-1', path: 'test-1', type: 'dir' },
+      { name: 'test-2', path: 'test-2', type: 'dir' },
+    ];
+
+    fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(examples) } as any);
+    prompts.mockResolvedValue({ answer: 'test-1' });
+
+    await expect(promptExamplesAsync()).resolves.toBe('test-1');
+    expect(prompts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        choices: expect.arrayContaining([
+          { title: 'test-1', value: 'test-1' },
+          { title: 'test-2', value: 'test-2' },
+        ]),
+      })
+    );
+  });
+});
+
+describe(sanitizeScriptsAsync, () => {
+  afterEach(() => vol.reset());
+
+  it('adds default scripts for managed apps', async () => {
+    vol.fromJSON({
+      '/project/package.json': JSON.stringify({
+        name: 'project',
+        version: '0.0.0',
+      }),
+    });
+
+    await sanitizeScriptsAsync('/project');
+    const packageJson = JSON.parse(String(vol.readFileSync('/project/package.json')));
+
+    expect(packageJson.scripts).toMatchObject({
+      start: 'expo start',
+      android: 'expo start --android',
+      ios: 'expo start --ios',
+      web: 'expo start --web',
+    });
+  });
+
+  it('adds default scripts for bare apps', async () => {
+    vol.fromJSON({
+      '/project/android/build.gradle': 'fake-gradle',
+      '/project/ios/Podfile': 'fake-podfile',
+      '/project/package.json': JSON.stringify({
+        name: 'project',
+        version: '0.0.0',
+      }),
+    });
+
+    await sanitizeScriptsAsync('/project');
+    const packageJson = JSON.parse(String(vol.readFileSync('/project/package.json')));
+
+    expect(packageJson.scripts).toMatchObject({
+      start: 'expo start --dev-client',
+      android: 'expo run:android',
+      ios: 'expo run:ios',
+      web: 'expo start --web',
+    });
+  });
+
+  it('does not overwrite existing scripts', async () => {
+    vol.fromJSON({
+      '/project/package.json': JSON.stringify({
+        name: 'project',
+        version: '0.0.0',
+        scripts: {
+          start: 'node start.js',
+        },
+      }),
+    });
+
+    await sanitizeScriptsAsync('/project');
+    const packageJson = JSON.parse(String(vol.readFileSync('/project/package.json')));
+
+    expect(packageJson.scripts).toMatchObject({
+      start: 'node start.js',
+      android: 'expo start --android',
+      ios: 'expo start --ios',
+      web: 'expo start --web',
+    });
+  });
+});

--- a/packages/create-expo-app/src/__tests__/Examples.test.ts
+++ b/packages/create-expo-app/src/__tests__/Examples.test.ts
@@ -44,6 +44,8 @@ describe(promptExamplesAsync, () => {
   });
 
   it('prompts examples and return selected example', async () => {
+    // Make this test run in CI
+    const spy = jest.spyOn(env, 'CI', 'get').mockReturnValue(false);
     const examples: GithubContent[] = [
       { name: 'test-1', path: 'test-1', type: 'dir' },
       { name: 'test-2', path: 'test-2', type: 'dir' },
@@ -61,6 +63,8 @@ describe(promptExamplesAsync, () => {
         ]),
       })
     );
+
+    spy.mockRestore();
   });
 });
 

--- a/packages/create-expo-app/src/cli.ts
+++ b/packages/create-expo-app/src/cli.ts
@@ -36,19 +36,25 @@ async function run() {
       chalk`npx create-expo-app {cyan <path>} [options]`,
       [
         `-y, --yes             Use the default options for creating a project`,
-        `--no-install          Skip installing npm packages or CocoaPods`,
+        `    --no-install      Skip installing npm packages or CocoaPods`,
         chalk`-t, --template {gray [pkg]}  NPM template to use: blank, tabs, bare-minimum. Default: blank`,
+        chalk`-e, --example {gray [name]}  Example name from {underline https://github.com/expo/examples}.`,
         `-v, --version         Version number`,
         `-h, --help            Usage info`,
       ].join('\n'),
       chalk`
     {gray To choose a template pass in the {bold --template} arg:}
-    
+
     {gray $} npm create expo-app {cyan --template}
+
+    {gray To choose an Expo example pass in the {bold --example} arg:}
+
+    {gray $} npm create expo-app {cyan --example}
+    {gray $} npm create expo-app {cyan --example with-router}
 
     {gray The package manager used for installing}
     {gray node modules is based on how you invoke the CLI:}
-    
+
     {bold  npm:} {cyan npm create expo-app}
     {bold yarn:} {cyan yarn create expo-app}
     {bold pnpm:} {cyan pnpm create expo-app}
@@ -62,7 +68,9 @@ async function run() {
   try {
     const parsed = await resolveStringOrBooleanArgsAsync(argv, rawArgsMap, {
       '--template': Boolean,
+      '--example': Boolean,
       '-t': '--template',
+      '-e': '--example',
     });
 
     debug(`Default args:\n%O`, args);
@@ -72,6 +80,7 @@ async function run() {
     await createAsync(parsed.projectRoot, {
       yes: !!args['--yes'],
       template: parsed.args['--template'],
+      example: parsed.args['--example'],
       install: !args['--no-install'],
     });
 

--- a/packages/create-expo-app/src/createAsync.ts
+++ b/packages/create-expo-app/src/createAsync.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
+import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 
+import {
+  downloadAndExtractExampleAsync,
+  ensureExampleExists,
+  promptExamplesAsync,
+} from './Examples';
 import * as Template from './Template';
 import { promptTemplateAsync } from './legacyTemplates';
 import { Log } from './log';
@@ -19,10 +25,12 @@ import {
   track,
 } from './telemetry';
 import { initGitRepoAsync } from './utils/git';
+import { withSectionLog } from './utils/log';
 
 export type Options = {
   install: boolean;
   template?: string | true;
+  example?: string | true;
   yes: boolean;
 };
 
@@ -40,21 +48,6 @@ async function resolveProjectRootArgAsync(
     return projectRoot;
   } else {
     return await resolveProjectRootAsync(inputPath);
-  }
-}
-
-async function cloneTemplateAsync(projectRoot: string, template: string | null) {
-  const extractTemplateStep = Template.logNewSection(`Locating project files.`);
-  try {
-    await Template.extractAndPrepareTemplateAppAsync(projectRoot, {
-      npmPackage: template,
-    });
-    extractTemplateStep.succeed('Downloaded and extracted project files.');
-  } catch (error: any) {
-    extractTemplateStep.fail(
-      'Something went wrong in downloading and extracting the project files: ' + error.message
-    );
-    Log.exit(`Error cloning template: ` + error);
   }
 }
 
@@ -78,7 +71,15 @@ async function setupDependenciesAsync(projectRoot: string, props: Pick<Options, 
   }
 }
 
-export async function createAsync(inputPath: string, props: Options): Promise<void> {
+export async function createAsync(inputPath: string, options: Options): Promise<void> {
+  if (options.example) {
+    return await createExampleAsync(inputPath, options);
+  }
+
+  return await createTemplateAsync(inputPath, options);
+}
+
+async function createTemplateAsync(inputPath: string, props: Options): Promise<void> {
   let resolvedTemplate: string | null = null;
   // @ts-ignore: This guards against someone passing --template without a name after it.
   if (props.template === true) {
@@ -97,10 +98,65 @@ export async function createAsync(inputPath: string, props: Options): Promise<vo
   identify();
   track({
     event: AnalyticsEventTypes.CREATE_EXPO_APP,
-    properties: { phase: AnalyticsEventPhases.ATTEMPT },
+    properties: { phase: AnalyticsEventPhases.ATTEMPT, template: resolvedTemplate },
   });
 
-  await cloneTemplateAsync(projectRoot, resolvedTemplate);
+  await withSectionLog(
+    () => Template.extractAndPrepareTemplateAppAsync(projectRoot, { npmPackage: resolvedTemplate }),
+    {
+      pending: chalk.bold('Locating project files.'),
+      success: 'Downloaded and extracted project files.',
+      error: error =>
+        `Something went wrong in downloading and extracting the project files: ${error.message}`,
+    }
+  );
+
+  await setupDependenciesAsync(projectRoot, props);
+
+  // for now, we will just init a git repo if they have git installed and the
+  // project is not inside an existing git tree, and do it silently. we should
+  // at some point check if git is installed and actually bail out if not, because
+  // npm install will fail with a confusing error if so.
+  try {
+    // check if git is installed
+    // check if inside git repo
+    await initGitRepoAsync(projectRoot);
+  } catch (error) {
+    debug(`Error initializing git: %O`, error);
+    // todo: check if git is installed, bail out
+  }
+}
+
+async function createExampleAsync(inputPath: string, props: Options): Promise<void> {
+  let resolvedExample = '';
+  if (props.example === true) {
+    resolvedExample = await promptExamplesAsync();
+  } else if (props.example) {
+    resolvedExample = props.example;
+  }
+
+  await ensureExampleExists(resolvedExample);
+
+  const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
+  await fs.promises.mkdir(projectRoot, { recursive: true });
+
+  // Setup telemetry attempt after a reasonable point.
+  // Telemetry is used to ensure safe feature deprecation since the command is unversioned.
+  // All telemetry can be disabled across Expo tooling by using the env var $EXPO_NO_TELEMETRY.
+  await initializeAnalyticsIdentityAsync();
+  identify();
+  track({
+    event: AnalyticsEventTypes.CREATE_EXPO_APP,
+    properties: { phase: AnalyticsEventPhases.ATTEMPT, example: resolvedExample },
+  });
+
+  await withSectionLog(() => downloadAndExtractExampleAsync(projectRoot, resolvedExample), {
+    pending: chalk.bold('Locating example files...'),
+    success: 'Downloaded and extracted example files.',
+    error: error =>
+      `Something went wrong in downloading and extracting the example files: ${error.message}`,
+  });
+
   await setupDependenciesAsync(projectRoot, props);
 
   // for now, we will just init a git repo if they have git installed and the

--- a/packages/create-expo-app/src/createAsync.ts
+++ b/packages/create-expo-app/src/createAsync.ts
@@ -72,6 +72,10 @@ async function setupDependenciesAsync(projectRoot: string, props: Pick<Options, 
 }
 
 export async function createAsync(inputPath: string, options: Options): Promise<void> {
+  if (options.example && options.template) {
+    throw new Error('Cannot use both --example and --template');
+  }
+
   if (options.example) {
     return await createExampleAsync(inputPath, options);
   }

--- a/packages/create-expo-app/src/utils/__tests__/log.test.ts
+++ b/packages/create-expo-app/src/utils/__tests__/log.test.ts
@@ -1,0 +1,99 @@
+import ora from 'ora';
+
+import { env } from '../env';
+import { withSectionLog } from '../log';
+
+jest.mock('ora');
+
+describe(withSectionLog, () => {
+  it('it disables the spinner when in CI mode', async () => {
+    jest.spyOn(env, 'CI', 'get').mockReturnValue(true);
+
+    await withSectionLog(() => Promise.resolve(), {
+      pending: 'pending',
+      success: 'success',
+      error: () => 'error',
+    });
+
+    expect(ora).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isEnabled: false,
+      })
+    );
+  });
+
+  it('it uses stdout when in CI mode', async () => {
+    jest.spyOn(env, 'CI', 'get').mockReturnValue(true);
+
+    await withSectionLog(() => Promise.resolve(), {
+      pending: 'pending',
+      success: 'success',
+      error: () => 'error',
+    });
+
+    expect(ora).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: process.stdout,
+      })
+    );
+  });
+
+  it('it returns the result of the action', async () => {
+    const result = await withSectionLog(() => Promise.resolve('hello world'), {
+      pending: 'pending',
+      success: 'success',
+      error: () => 'error',
+    });
+
+    expect(result).toBe('hello world');
+  });
+
+  it('it sets pending message', async () => {
+    await withSectionLog(() => Promise.resolve(), {
+      pending: 'pending',
+      success: 'success',
+      error: () => 'error',
+    });
+
+    expect(ora).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'pending',
+      })
+    );
+  });
+
+  it('it sets success message', async () => {
+    const spinner = await withSectionLog(ora => Promise.resolve(ora), {
+      pending: 'pending',
+      success: 'success',
+      error: () => 'error',
+    });
+
+    expect(spinner.succeed).toHaveBeenCalledWith('success');
+  });
+
+  it('it throws the encountered error', async () => {
+    const error = new Error('error');
+
+    try {
+      await withSectionLog(() => Promise.reject(error), {
+        pending: 'pending',
+        success: 'success',
+        error: () => 'error',
+      });
+      expect(true).toBe('Should not be reached');
+    } catch (thrown) {
+      expect(thrown).toBe(error);
+    }
+  });
+
+  it('it sets error message', async () => {
+    const spinner = await withSectionLog(ora => Promise.reject(ora), {
+      pending: 'pending',
+      success: 'success',
+      error: () => 'error',
+    }).catch(ora => ora);
+
+    expect(spinner.fail).toHaveBeenCalledWith('error');
+  });
+});

--- a/packages/create-expo-app/src/utils/log.ts
+++ b/packages/create-expo-app/src/utils/log.ts
@@ -1,0 +1,34 @@
+import ora, { Ora } from 'ora';
+
+import { env } from './env';
+
+export function withSectionLog<T>(
+  action: (spinner: Ora) => Promise<T>,
+  message: {
+    pending: string;
+    success: string;
+    error: (errror: Error) => string;
+  }
+) {
+  const disabled = env.CI || env.EXPO_DEBUG;
+  const spinner = ora({
+    text: message.pending,
+    // Ensure our non-interactive mode emulates CI mode.
+    isEnabled: !disabled,
+    // In non-interactive mode, send the stream to stdout so it prevents looking like an error.
+    stream: disabled ? process.stdout : process.stderr,
+  });
+
+  spinner.start();
+
+  return action(spinner).then(
+    result => {
+      spinner.succeed(message.success);
+      return result;
+    },
+    error => {
+      spinner.fail(message.error(error));
+      throw error;
+    }
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12816,6 +12816,11 @@ minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.0.2.tgz#26fc3364d5ea6cb971c6e5259eac67a0887510d1"
+  integrity sha512-4Hbzei7ZyBp+1aw0874YWpKOubZd/jc53/XU+gkYry1QV+VvrbO8icLM5CUtm4F0hyXn85DXYKEMIS26gitD3A==
+
 minizlib@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
@@ -17029,7 +17034,7 @@ tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-tar@^6.0.2, tar@^6.0.5, tar@^6.1.11:
+tar@^6.0.2, tar@^6.0.5:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
@@ -17037,6 +17042,18 @@ tar@^6.0.2, tar@^6.0.5, tar@^6.1.11:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
     minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tar@^6.1.13:
+  version "6.1.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.13.tgz#46e22529000f612180601a6fe0680e7da508847b"
+  integrity sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^4.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"


### PR DESCRIPTION
# Why

Fixes ENG-7493

# How

- Based on the code from [`create-react-native-app`](https://github.com/expo/create-react-native-app/blob/main/src/Examples.ts), but adopted to this repository

> **Warning**
> I ran into the "premature close" error when testing this: https://github.com/isaacs/node-tar/issues/321. I upgraded `tar@6.1.11` to `tar@6.1.13` to avoid this.

# Test Plan

See tests and help info:

```bash
$ yarn create expo-app --help

# Show list of examples to create from
$ yarn create expo-app --example
# Or create a new example by name
$ yarn create expo-app --example with-router
```
