### PR TITLE
fix(xdl): remove unused import from `createBundlesAsync`

### DIFF
--- a/packages/xdl/src/project/createBundlesAsync.ts
+++ b/packages/xdl/src/project/createBundlesAsync.ts
@@ -1,4 +1,4 @@
-import { getConfig, isLegacyImportsEnabled, Platform } from '@expo/config';
+import { getConfig, Platform } from '@expo/config';
 import { bundleAsync, BundleOutput } from '@expo/dev-server';
 import axios from 'axios';
 import chalk from 'chalk';


### PR DESCRIPTION
# Why

CI is currently failing on all PRs due to an eslint issue

# How

Fixed that eslint issue

# Test Plan

See if CI passes