### PR TITLE
[install-expo-modules] add sdk 48 support

### DIFF
--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -10,6 +10,11 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
+    expoSdkVersion: '48.0.0',
+    iosDeploymentTarget: '13.0',
+    reactNativeVersionRange: '>= 0.71.0',
+  },
+  {
     expoSdkVersion: '47.0.0',
     iosDeploymentTarget: '13.0',
     reactNativeVersionRange: '>= 0.70.0',


### PR DESCRIPTION
# Why

officially add sdk 48 support for install-expo-modules

# How

add sdk 48 to the version mappings

# Test Plan

```sh
$ npx react-native init RN071 --version 0.71
$ cd RN071
$ /path/to/expo/expo-cli/packages/install-expo-modules/build/index.js
```
