### PR TITLE
Upgrade @xmldom/xmldom to 0.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "dependencies": {
     "@babel/cli": "^7.8.4",
     "@expo/spawn-async": "^1.5.0",
+    "@tsconfig/node12": "^1.0.7",
     "@types/jest": "^26.0.8",
     "@types/node": "^12",
-    "@tsconfig/node12": "^1.0.7",
     "@vercel/ncc": "^0.33.4",
     "codecov": "^3.6.5",
     "eslint": "^8.13.0",
@@ -41,9 +41,9 @@
     "jest-watch-typeahead": "^1.0.0",
     "lerna": "3.22.1",
     "lint-staged": "^8.0.4",
+    "memfs": "^2.15.5",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
-    "memfs": "^2.15.5",
     "typescript": "4.6.3",
     "yarn-deduplicate": "^3.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1857,7 +1857,7 @@
   resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.18.tgz#9abcde78df703a88f6d9fa1a557ee2f045d178b0"
   integrity sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==
   dependencies:
-    "@xmldom/xmldom" "~0.7.0"
+    "@xmldom/xmldom" "~0.7.7"
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
 
@@ -4447,7 +4447,12 @@
   dependencies:
     tslib "^1.9.3"
 
-"@xmldom/xmldom@~0.7.0", "@xmldom/xmldom@~0.7.7":
+"@xmldom/xmldom@0.7.7":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.7.tgz#16bd8a4e5c953018b8168e5d0a7d26b117cd7fa9"
+  integrity sha512-RwEdIYho2kjbSZ7fpvhkHy5wk1Y3x0O6e/EHL3/SoiAfFWH+yhV2/XZQvsBoAeGRNFwgScJS/gRZv+uIwoj7yA==
+
+"@xmldom/xmldom@^0.7.7", "@xmldom/xmldom@~0.7.0":
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.8.tgz#a8d0a0067c9554c187b0d04e86ad1845053c0e06"
   integrity sha512-PrJx38EfpitFhwmILRl37jAdBlsww6AZ6rRVK4QS7T7RHLhX7mSs647sTmgr9GIxe3qjXdesmomEgbgaokrVFg==


### PR DESCRIPTION
# Why
- Security, [xmldom allows multiple root nodes in a DOM](https://github.com/advisories/GHSA-crh6-fp67-6883)
<!-- 

!! NOTICE !! The global Expo CLI (`packages/expo-cli`) is deprecated in favor of the new versioned CLI `npx expo`:

Open Expo CLI changes here -> https://github.com/expo/expo/tree/main/packages/@expo/cli

...

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How
- `yarn add @xmldom/xmldom@7.7.0` inside of root and `packages/plist`

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan
- `yarn build`
- `yarn list --pattern @xmldom`

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
