### PR TITLE
[install-expo-modules] support to update AGP version for Expo SDK 48

### DIFF
--- a/packages/install-expo-modules/src/plugins/android/withAndroidGradles.ts
+++ b/packages/install-expo-modules/src/plugins/android/withAndroidGradles.ts
@@ -1,0 +1,59 @@
+import { ConfigPlugin, withProjectBuildGradle } from '@expo/config-plugins';
+import fs from 'fs';
+import path from 'path';
+import semver from 'semver';
+
+// Because regexp //g is stateful, to use it multiple times, we should create a new one.
+function createAgpRegExp() {
+  return /^(\s*classpath[(\s]["']com\.android\.tools\.build:gradle:)(\d+\.\d+\.\d+)(["'][)\s]\s*)$/gm;
+}
+
+export async function shouldUpdateAgpVersionAsync(projectRoot: string, targetVersion: string) {
+  const gradlePath = path.join(projectRoot, 'android', 'build.gradle');
+  const content = await fs.promises.readFile(gradlePath, 'utf-8');
+  const matchResult = createAgpRegExp().exec(content);
+  if (!matchResult) {
+    console.warn(
+      'Unrecognized `android/build.gradle` content, will skip the process to update AGP version.'
+    );
+    return false;
+  }
+
+  const version = matchResult[2];
+  if (!version) {
+    console.warn(
+      'Unrecognized `android/build.gradle` content, will skip the process to update AGP version.'
+    );
+    return false;
+  }
+
+  return semver.lt(toSemVer(version), toSemVer(targetVersion));
+}
+
+export const withAndroidGradlePluginVersion: ConfigPlugin<{ androidAgpVersion: string }> = (
+  config,
+  prop
+) => {
+  return withProjectBuildGradle(config, config => {
+    if (config.modResults.language !== 'groovy') {
+      throw new Error('Cannot setup kotlin because the build.gradle is not groovy');
+    }
+    const matchResult = createAgpRegExp().exec(config.modResults.contents);
+    if (matchResult) {
+      const version = matchResult[2];
+      if (version && semver.lt(toSemVer(version), toSemVer(prop.androidAgpVersion))) {
+        config.modResults.contents = config.modResults.contents.replace(
+          createAgpRegExp(),
+          (match, prefix, versionPart, suffix) => {
+            return `${prefix}${prop.androidAgpVersion}${suffix}`;
+          }
+        );
+      }
+    }
+    return config;
+  });
+};
+
+function toSemVer(version: string): semver.SemVer {
+  return semver.coerce(version) ?? new semver.SemVer('0.0.0');
+}

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -5,6 +5,7 @@ export interface VersionInfo {
   expoSdkVersion: string;
   iosDeploymentTarget: string;
   reactNativeVersionRange: string;
+  androidAgpVersion?: string;
 }
 
 export const ExpoVersionMappings: VersionInfo[] = [
@@ -13,6 +14,7 @@ export const ExpoVersionMappings: VersionInfo[] = [
     expoSdkVersion: '48.0.0',
     iosDeploymentTarget: '13.0',
     reactNativeVersionRange: '>= 0.71.0',
+    androidAgpVersion: '7.4.1',
   },
   {
     expoSdkVersion: '47.0.0',


### PR DESCRIPTION
# Why

since sdk 48 requires AGP 7.4.1, we should help this migration in the install-expo-modules tool

# How

prompt and update agp version

# Test Plan

```sh
$ npx react-native init RN071 --version 0.71
$ cd RN071
$ /path/to/install-expo-modules/build/index.js
# check the agp version in android/build.gradle
```
