### PR TITLE
[doctor] remove watchman check

### DIFF
--- a/packages/expo-doctor/__mocks__/child_process.ts
+++ b/packages/expo-doctor/__mocks__/child_process.ts
@@ -1,0 +1,3 @@
+const execSync = jest.fn();
+
+export { execSync };

--- a/packages/expo-doctor/src/checks/GlobalPrereqsVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/GlobalPrereqsVersionCheck.ts
@@ -7,7 +7,6 @@ import semver from 'semver';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
-const MIN_WATCHMAN_VERSION = '4.6.0';
 const MIN_NPM_VERSION = '3.0.0';
 const CORRECT_NPM_VERSION = 'latest';
 const WARN_NPM_VERSION_RANGES = ['>= 5.0.0 < 5.7.0'];
@@ -43,50 +42,6 @@ async function checkNpmVersionAsync(): Promise<string | null> {
   return null;
 }
 
-async function checkWatchmanVersionAsync(): Promise<string | null> {
-  const homebrewInstallNote = `\n\nIf you are using homebrew, try:\nbrew uninstall watchman; brew install watchman`;
-
-  let watchmanVersion;
-  // There's no point in checking any of this stuff if watchman isn't supported on this platform
-  if (process.platform !== 'darwin') {
-    return null;
-  }
-
-  // all checks going forward assume macOS, which should have watchman
-
-  const cannotDetectWatchmanInstallationMessage =
-    'Cannot detect watchman installation.' + homebrewInstallNote;
-
-  try {
-    watchmanVersion = JSON.parse((await spawnAsync('watchman', ['version'])).stdout.trim()).version;
-  } catch (e: any) {
-    return cannotDetectWatchmanInstallationMessage;
-  }
-
-  if (!watchmanVersion) {
-    // watchman is probably just not installed
-    return cannotDetectWatchmanInstallationMessage;
-  }
-
-  // Watchman versioning through homebrew is changed from semver to date since "2021.05.31.00"
-  // see: https://github.com/Homebrew/homebrew-core/commit/d299c2867503cb6ad8d90792343993c80e745071
-  const validSemver =
-    !!semver.valid(watchmanVersion) && semver.gte(watchmanVersion, MIN_WATCHMAN_VERSION);
-
-  // This new format is used later than the MIN_WATCHMAN_VERSION, we assume/estimate if the version is correct here.
-  const validNewVersion =
-    !validSemver && /[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]{2}/.test(watchmanVersion);
-
-  if (!validSemver && !validNewVersion) {
-    return (
-      `Warning: You are using an old version of watchman (v${watchmanVersion}).\n\nIt is recommend to always use the latest version, or at least v${MIN_WATCHMAN_VERSION}.` +
-      homebrewInstallNote
-    );
-  }
-
-  return null;
-}
-
 export class GlobalPrereqsVersionCheck implements DoctorCheck {
   description = 'Validating global prerequisites versions';
 
@@ -95,15 +50,11 @@ export class GlobalPrereqsVersionCheck implements DoctorCheck {
   async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
     const issues: string[] = [];
 
-    const checkResults = await Promise.all([
-      await checkWatchmanVersionAsync(),
-      await checkNpmVersionAsync(),
-    ]);
-    checkResults.forEach(result => {
-      if (result) {
-        issues.push(result);
-      }
-    });
+    const checkResult = await checkNpmVersionAsync();
+
+    if (checkResult) {
+      issues.push(checkResult);
+    }
 
     // Should we check for node LTS? Maybe warn if 18+ but configured for web?
 

--- a/packages/expo-doctor/src/checks/__tests__/GlobalPackageInstalledCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/GlobalPackageInstalledCheck.test.ts
@@ -13,36 +13,34 @@ const additionalProjectProps = {
   pkg: {},
 };
 
-describe(GlobalPackageInstalledCheck, () => {
-  describe('runAsync', () => {
-    it('returns result with isSuccessful = true if check passes', async () => {
-      asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce(null);
-      const check = new GlobalPackageInstalledCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeTruthy();
+describe('runAsync', () => {
+  it('returns result with isSuccessful = true if check passes', async () => {
+    asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce(null);
+    const check = new GlobalPackageInstalledCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeTruthy();
+  });
 
-    it('returns result with isSuccessful = false if check fails', async () => {
-      asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
-      const check = new GlobalPackageInstalledCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeFalsy();
+  it('returns result with isSuccessful = false if check fails', async () => {
+    asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
+    const check = new GlobalPackageInstalledCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeFalsy();
+  });
 
-    it('returns result with advice to remove expo-cli if check fails', async () => {
-      asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
-      const check = new GlobalPackageInstalledCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.advice).toEqual(['Remove expo-cli from your project dependencies.']);
+  it('returns result with advice to remove expo-cli if check fails', async () => {
+    asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
+    const check = new GlobalPackageInstalledCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
     });
+    expect(result.advice).toEqual(['Remove expo-cli from your project dependencies.']);
   });
 });

--- a/packages/expo-doctor/src/checks/__tests__/GlobalPrereqsVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/GlobalPrereqsVersionCheck.test.ts
@@ -1,0 +1,60 @@
+import spawnAsync from '@expo/spawn-async';
+import { execSync } from 'child_process';
+
+import { asMock } from '../../__tests__/asMock';
+import { GlobalPrereqsVersionCheck } from '../GlobalPrereqsVersionCheck';
+
+jest.mock('child_process');
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  pkg: {},
+};
+
+describe(GlobalPrereqsVersionCheck, () => {
+  describe('runAsync', () => {
+    it('returns result with isSuccessful = true if yarnpkg is installed', async () => {
+      asMock(spawnAsync).mockResolvedValueOnce({
+        status: 0,
+      } as any);
+      const check = new GlobalPrereqsVersionCheck();
+      const result = await check.runAsync({
+        projectRoot: '/path/to/project',
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeTruthy();
+    });
+
+    it('returns result with isSuccessful = true if yarnpkg is not installed and npm version is in acceptable range', async () => {
+      asMock(spawnAsync).mockResolvedValueOnce({
+        status: 1,
+      } as any);
+
+      asMock(execSync).mockReturnValueOnce('8.19.3');
+      const check = new GlobalPrereqsVersionCheck();
+      const result = await check.runAsync({
+        projectRoot: '/path/to/project',
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeTruthy();
+    });
+
+    it('returns result with isSuccessful = false if yarnpkg is not installed and npm version is not in acceptable range', async () => {
+      asMock(spawnAsync).mockResolvedValueOnce({
+        status: 1,
+      } as any);
+
+      asMock(execSync).mockReturnValueOnce('5.0.0');
+      const check = new GlobalPrereqsVersionCheck();
+      const result = await check.runAsync({
+        projectRoot: '/path/to/project',
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeFalsy();
+    });
+  });
+});

--- a/packages/expo-doctor/src/checks/__tests__/GlobalPrereqsVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/GlobalPrereqsVersionCheck.test.ts
@@ -15,46 +15,44 @@ const additionalProjectProps = {
   pkg: {},
 };
 
-describe(GlobalPrereqsVersionCheck, () => {
-  describe('runAsync', () => {
-    it('returns result with isSuccessful = true if yarnpkg is installed', async () => {
-      asMock(spawnAsync).mockResolvedValueOnce({
-        status: 0,
-      } as any);
-      const check = new GlobalPrereqsVersionCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeTruthy();
+describe('runAsync', () => {
+  it('returns result with isSuccessful = true if yarnpkg is installed', async () => {
+    asMock(spawnAsync).mockResolvedValueOnce({
+      status: 0,
+    } as any);
+    const check = new GlobalPrereqsVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeTruthy();
+  });
 
-    it('returns result with isSuccessful = true if yarnpkg is not installed and npm version is in acceptable range', async () => {
-      asMock(spawnAsync).mockResolvedValueOnce({
-        status: 1,
-      } as any);
+  it('returns result with isSuccessful = true if yarnpkg is not installed and npm version is in acceptable range', async () => {
+    asMock(spawnAsync).mockResolvedValueOnce({
+      status: 1,
+    } as any);
 
-      asMock(execSync).mockReturnValueOnce('8.19.3');
-      const check = new GlobalPrereqsVersionCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeTruthy();
+    asMock(execSync).mockReturnValueOnce('8.19.3');
+    const check = new GlobalPrereqsVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeTruthy();
+  });
 
-    it('returns result with isSuccessful = false if yarnpkg is not installed and npm version is not in acceptable range', async () => {
-      asMock(spawnAsync).mockResolvedValueOnce({
-        status: 1,
-      } as any);
+  it('returns result with isSuccessful = false if yarnpkg is not installed and npm version is not in acceptable range', async () => {
+    asMock(spawnAsync).mockResolvedValueOnce({
+      status: 1,
+    } as any);
 
-      asMock(execSync).mockReturnValueOnce('5.0.0');
-      const check = new GlobalPrereqsVersionCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeFalsy();
+    asMock(execSync).mockReturnValueOnce('5.0.0');
+    const check = new GlobalPrereqsVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeFalsy();
   });
 });

--- a/packages/expo-doctor/src/checks/__tests__/InstalledDependencyVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/InstalledDependencyVersionCheck.test.ts
@@ -12,63 +12,58 @@ const additionalProjectProps = {
   pkg: {},
 };
 
-describe(InstalledDependencyVersionCheck, () => {
-  describe('runAsync', () => {
-    it('returns result with isSuccessful = true if check passes', async () => {
-      asMock(spawnAsync).mockResolvedValueOnce({
-        stdout: '',
-      } as any);
-      const check = new InstalledDependencyVersionCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeTruthy();
+describe('runAsync', () => {
+  it('returns result with isSuccessful = true if check passes', async () => {
+    asMock(spawnAsync).mockResolvedValueOnce({
+      stdout: '',
+    } as any);
+    const check = new InstalledDependencyVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeTruthy();
+  });
 
-    it('calls npx expo install --check', async () => {
-      const mockSpawnAsync = asMock(spawnAsync).mockResolvedValueOnce({
-        stdout: '',
-      } as any);
-      const check = new InstalledDependencyVersionCheck();
-      await check.runAsync({ projectRoot: '/path/to/project', ...additionalProjectProps });
-      expect(mockSpawnAsync.mock.calls[0][0]).toBe('sh');
-      expect(mockSpawnAsync.mock.calls[0][1]).toEqual([
-        '-c',
-        'echo "n" | npx expo install --check',
-      ]);
-    });
+  it('calls npx expo install --check', async () => {
+    const mockSpawnAsync = asMock(spawnAsync).mockResolvedValueOnce({
+      stdout: '',
+    } as any);
+    const check = new InstalledDependencyVersionCheck();
+    await check.runAsync({ projectRoot: '/path/to/project', ...additionalProjectProps });
+    expect(mockSpawnAsync.mock.calls[0][0]).toBe('sh');
+    expect(mockSpawnAsync.mock.calls[0][1]).toEqual(['-c', 'echo "n" | npx expo install --check']);
+  });
 
-    it('returns result with isSuccessful = false if check fails', async () => {
-      asMock(spawnAsync).mockImplementationOnce(() => {
-        const error: any = new Error();
-        error.stderr = 'error';
-        error.stdout = '';
-        error.status = 1;
-        throw error;
-      });
-      const check = new InstalledDependencyVersionCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeFalsy();
+  it('returns result with isSuccessful = false if check fails', async () => {
+    asMock(spawnAsync).mockImplementationOnce(() => {
+      const error: any = new Error();
+      error.stderr = 'error';
+      error.stdout = '';
+      error.status = 1;
+      throw error;
     });
+    const check = new InstalledDependencyVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
 
-    it('pushes npx expo install --check stderr to issues list', async () => {
-      asMock(spawnAsync).mockImplementationOnce(() => {
-        const error: any = new Error();
-        error.stderr = 'error';
-        error.stdout = '';
-        error.status = 1;
-        throw error;
-      });
-      const check = new InstalledDependencyVersionCheck();
-      const result = await check.runAsync({
-        projectRoot: '/path/to/project',
-        ...additionalProjectProps,
-      });
-      expect(result.issues).toEqual(['error']);
+  it('pushes npx expo install --check stderr to issues list', async () => {
+    asMock(spawnAsync).mockImplementationOnce(() => {
+      const error: any = new Error();
+      error.stderr = 'error';
+      error.stdout = '';
+      error.status = 1;
+      throw error;
     });
+    const check = new InstalledDependencyVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.issues).toEqual(['error']);
   });
 });


### PR DESCRIPTION
# Why

Resolves https://linear.app/expo/issue/ENG-7606/doctor-dont-require-watchman. Expo works fine without watchman on macOS, so let's not warn about it.

# How

Removed the check

# Test Plan

Tried without watchman installed; no warning
