### PR TITLE
[xdl] fix failing unit test

### DIFF
--- a/packages/xdl/src/project/__tests__/createBundlesAsync-test.ts
+++ b/packages/xdl/src/project/__tests__/createBundlesAsync-test.ts
@@ -42,7 +42,6 @@ describe(createBundlesAsync, () => {
       '/',
       expoConfig,
       {
-        target: 'managed',
         resetCache: false,
         quiet: true,
         logger: mockLogger,


### PR DESCRIPTION
# Why

Wanted tests to pass. UPDATE: didn't notice others were failing; oh, well, a little closer I suppose!

# How

Per [this commit](https://github.com/expo/expo-cli/commit/5ce6893721da5af1b54ebcf9ff9c2529341d8bf3), it looks like `target` should no longer be passed, so removed it from the check.

# Test Plan

XDL unit tests pass!
