### PR TITLE
[doctor] check if global cli is installed in project

### DIFF
--- a/packages/expo-doctor/src/checks/GlobalPackageInstalledCheck.ts
+++ b/packages/expo-doctor/src/checks/GlobalPackageInstalledCheck.ts
@@ -1,0 +1,27 @@
+import { getDeepDependenciesWarningAsync } from '../utils/explainDependencies';
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+export class GlobalPackageInstalledCheck implements DoctorCheck {
+  description = 'Checking for conflicting global packages in project';
+
+  sdkVersionRange = '>=46.0.0';
+
+  async runAsync({ projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+    const advice: string[] = [];
+
+    const warning = await getDeepDependenciesWarningAsync({ name: 'expo-cli' }, projectRoot);
+    if (warning) {
+      issues.push(
+        `Expo CLI is now part of the expo package. Having expo-cli in your project dependencies may cause issues, such as “error: unknown option --fix” when running npx expo install --fix`
+      );
+      advice.push(`Remove expo-cli from your project dependencies.`);
+    }
+
+    return {
+      isSuccessful: !issues.length,
+      issues,
+      advice,
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/__tests__/GlobalPackageInstalledCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/GlobalPackageInstalledCheck.test.ts
@@ -1,0 +1,48 @@
+import { asMock } from '../../__tests__/asMock';
+import { getDeepDependenciesWarningAsync } from '../../utils/explainDependencies';
+import { GlobalPackageInstalledCheck } from '../GlobalPackageInstalledCheck';
+
+jest.mock('../../utils/explainDependencies');
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  pkg: {},
+};
+
+describe(GlobalPackageInstalledCheck, () => {
+  describe('runAsync', () => {
+    it('returns result with isSuccessful = true if check passes', async () => {
+      asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce(null);
+      const check = new GlobalPackageInstalledCheck();
+      const result = await check.runAsync({
+        projectRoot: '/path/to/project',
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeTruthy();
+    });
+
+    it('returns result with isSuccessful = false if check fails', async () => {
+      asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
+      const check = new GlobalPackageInstalledCheck();
+      const result = await check.runAsync({
+        projectRoot: '/path/to/project',
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeFalsy();
+    });
+
+    it('returns result with advice to remove expo-cli if check fails', async () => {
+      asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
+      const check = new GlobalPackageInstalledCheck();
+      const result = await check.runAsync({
+        projectRoot: '/path/to/project',
+        ...additionalProjectProps,
+      });
+      expect(result.advice).toEqual(['Remove expo-cli from your project dependencies.']);
+    });
+  });
+});

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import semver from 'semver';
 
 import { ExpoConfigSchemaCheck } from './checks/ExpoConfigSchemaCheck';
+import { GlobalPackageInstalledCheck } from './checks/GlobalPackageInstalledCheck';
 import { GlobalPrereqsVersionCheck } from './checks/GlobalPrereqsVersionCheck';
 import { IllegalPackageCheck } from './checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from './checks/InstalledDependencyVersionCheck';
@@ -86,6 +87,7 @@ export async function actionAsync(projectRoot: string) {
   const checks = [
     new GlobalPrereqsVersionCheck(),
     new IllegalPackageCheck(),
+    new GlobalPackageInstalledCheck(),
     new SupportPackageVersionCheck(),
     new InstalledDependencyVersionCheck(),
     new ExpoConfigSchemaCheck(),


### PR DESCRIPTION
# Why
We now recommend users upgrade by using `npx expo install --fix`, but some have `expo-cli` installed in project for legacy reasons, and that can break the `--fix` flag with `error: unknown option --fix’`.

# How

Added a check, much like the other illegal package checks.

NOTE: I think we'll end up with many illegal package checks, so will likely eventually refactor to reduce that to adding package name and customized advice without so much ceremony, just not yet.

# Test Plan
- Add `expo-cli` to a project, get warning.
- Remove from project, no more warning.
