### PR TITLE
[doctor] added basic package.json sanity checks

### DIFF
--- a/packages/expo-doctor/__mocks__/fs.js
+++ b/packages/expo-doctor/__mocks__/fs.js
@@ -1,5 +1,2 @@
-import { fs, promises } from 'memfs';
-
-const constants = jest.requireActual('fs').constants;
-
-export { fs, promises, constants };
+import { fs } from 'memfs';
+module.exports = fs;

--- a/packages/expo-doctor/src/checks/PackageJsonCheck.ts
+++ b/packages/expo-doctor/src/checks/PackageJsonCheck.ts
@@ -7,11 +7,6 @@ function getDirectPackageInstallErrorMessage(pkg: string): string {
   return `The package "${pkg}" should not be installed directly in your project. It is a dependency of other Expo packages and should be installed automatically.`;
 }
 
-// find if any one of several values is in an array
-const findOne = (haystack: [string], needles: [string]) => {
-  return needles.some(v => haystack.includes(v));
-};
-
 export class PackageJsonCheck implements DoctorCheck {
   description = 'Checking package.json for common issues';
 

--- a/packages/expo-doctor/src/checks/PackageJsonCheck.ts
+++ b/packages/expo-doctor/src/checks/PackageJsonCheck.ts
@@ -1,0 +1,52 @@
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+function getDirectPackageInstallErrorMessage(pkg: string): string {
+  return `The package "${pkg}" should not be installed directly in your project. It is a dependency of other Expo packages and should be installed automatically.`;
+}
+
+export class PackageJsonCheck implements DoctorCheck {
+  description = 'Checking package.json for common issues';
+
+  sdkVersionRange = '*';
+
+  async runAsync({ pkg }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const advice: string[] = [];
+    const issues: string[] = [];
+
+    // check for "expo" in scripts
+    if (pkg.scripts?.['expo']) {
+      issues.push(
+        'The script "expo" is defined in package.json. This will cause conflicts with the Expo CLI and likely lead to build failures.'
+      );
+    }
+
+    // check for dependencies that should only be transitive
+    if (pkg.dependencies?.['expo-modules-core'] || pkg.devDependencies?.['expo-modules-core']) {
+      issues.push(getDirectPackageInstallErrorMessage('expo-modules-core'));
+    }
+
+    if (
+      pkg.dependencies?.['expo-modules-autolinking'] ||
+      pkg.devDependencies?.['expo-modules-autolinking']
+    ) {
+      issues.push(getDirectPackageInstallErrorMessage('expo-modules-autolinking'));
+    }
+
+    // check for conflicts between package name and installed packages
+    const installedPackages = Object.keys(pkg.dependencies ?? {}).concat(
+      Object.keys(pkg.devDependencies ?? {})
+    );
+
+    if (installedPackages.includes(pkg.name)) {
+      issues.push(
+        `The name in your package.json is set to "${pkg.name}", which conflicts with a dependency of the same name.`
+      );
+    }
+
+    return {
+      isSuccessful: issues.length === 0,
+      issues,
+      advice,
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
@@ -1,4 +1,10 @@
+import { vol } from 'memfs';
+
 import { PackageJsonCheck } from '../PackageJsonCheck';
+
+jest.mock('fs');
+
+const projectRoot = '/tmp/project';
 
 // required by runAsync
 const additionalProjectProps = {
@@ -6,113 +12,139 @@ const additionalProjectProps = {
     name: 'name',
     slug: 'slug',
   },
-  projectRoot: '/path/to/project',
+  projectRoot,
 };
 
-describe(PackageJsonCheck, () => {
-  describe('runAsync', () => {
-    it('returns result with isSuccessful = true if empty dependencies, devDependencies, scripts', async () => {
+describe('runAsync', () => {
+  beforeEach(() => {
+    vol.fromJSON({
+      [projectRoot + '/node_modules/.bin/expo']: 'test',
+    });
+  });
+
+  it('returns result with isSuccessful = true if empty dependencies, devDependencies, scripts', async () => {
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  // bin/ expo script conflict sub-check
+
+  it('returns result with isSuccessful = true if scripts does not contain expo', async () => {
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0', scripts: { start: 'start' } },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if scripts contain expo', async () => {
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0', scripts: { expo: 'start' } },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = false if scripts contain another bin', async () => {
+    vol.fromJSON({
+      [projectRoot + '/node_modules/.bin/otherbin']: 'test',
+    });
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0', scripts: { otherbin: 'start' } },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = false if no node_modules/.bin present, but expo script is', async () => {
+    vol.fromJSON({});
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0', scripts: { expo: 'start' } },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  // transitive-only dependencies sub-check
+
+  const dependencyLocations = ['dependencies', 'devDependencies'];
+
+  const transitiveOnlyDependencies = ['expo-modules-core', 'expo-modules-autolinking'];
+
+  dependencyLocations.forEach(dependencyLocation => {
+    it(`returns result with isSuccessful = true if ${dependencyLocation} does not contain expo-modules-core/ expo-modules-autolinking`, async () => {
       const check = new PackageJsonCheck();
       const result = await check.runAsync({
-        pkg: { name: 'name', version: '1.0.0' },
+        pkg: { name: 'name', version: '1.0.0', [dependencyLocation]: { somethingjs: '17.0.1' } },
         ...additionalProjectProps,
       });
       expect(result.isSuccessful).toBeTruthy();
     });
 
-    // expo script sub-check
-
-    it('returns result with isSuccessful = true if scripts does not contain expo', async () => {
-      const check = new PackageJsonCheck();
-      const result = await check.runAsync({
-        pkg: { name: 'name', version: '1.0.0', scripts: { start: 'start' } },
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeTruthy();
-    });
-
-    it('returns result with isSuccessful = false if scripts contain expo', async () => {
-      const check = new PackageJsonCheck();
-      const result = await check.runAsync({
-        pkg: { name: 'name', version: '1.0.0', scripts: { expo: 'start' } },
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeFalsy();
-    });
-
-    // transitive-only dependencies sub-check
-
-    const dependencyLocations = ['dependencies', 'devDependencies'];
-
-    const transitiveOnlyDependencies = ['expo-modules-core', 'expo-modules-autolinking'];
-
-    dependencyLocations.forEach(dependencyLocation => {
-      it(`returns result with isSuccessful = true if ${dependencyLocation} does not contain expo-modules-core/ expo-modules-autolinking`, async () => {
+    transitiveOnlyDependencies.forEach(transitiveOnlyDependency => {
+      it(`returns result with isSuccessful = false if ${dependencyLocation} contains ${transitiveOnlyDependency}`, async () => {
         const check = new PackageJsonCheck();
         const result = await check.runAsync({
-          pkg: { name: 'name', version: '1.0.0', [dependencyLocation]: { somethingjs: '17.0.1' } },
+          pkg: {
+            name: 'name',
+            version: '1.0.0',
+            [dependencyLocation]: { [transitiveOnlyDependency]: '1.0.0' },
+          },
           ...additionalProjectProps,
         });
-        expect(result.isSuccessful).toBeTruthy();
-      });
-
-      transitiveOnlyDependencies.forEach(transitiveOnlyDependency => {
-        it(`returns result with isSuccessful = false if ${dependencyLocation} contains ${transitiveOnlyDependency}`, async () => {
-          const check = new PackageJsonCheck();
-          const result = await check.runAsync({
-            pkg: {
-              name: 'name',
-              version: '1.0.0',
-              [dependencyLocation]: { [transitiveOnlyDependency]: '1.0.0' },
-            },
-            ...additionalProjectProps,
-          });
-          expect(result.isSuccessful).toBeFalsy();
-        });
+        expect(result.isSuccessful).toBeFalsy();
       });
     });
+  });
 
-    // package name conflicts with installed packages sub-check
-    it('returns result with isSuccessful = true if package name does not match dependency', async () => {
-      const check = new PackageJsonCheck();
-      const result = await check.runAsync({
-        pkg: {
-          name: 'package-name',
-          version: '1.0.0',
-          dependencies: { 'something-js': '17.0.1' },
-          devDependencies: { 'something-else-js': '17.0.1' },
-        },
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeTruthy();
+  // package name conflicts with installed packages sub-check
+  it('returns result with isSuccessful = true if package name does not match dependency', async () => {
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'package-name',
+        version: '1.0.0',
+        dependencies: { 'something-js': '17.0.1' },
+        devDependencies: { 'something-else-js': '17.0.1' },
+      },
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeTruthy();
+  });
 
-    it('returns result with isSuccessful = false if package name matches dependency', async () => {
-      const check = new PackageJsonCheck();
-      const result = await check.runAsync({
-        pkg: {
-          name: 'something-js',
-          version: '1.0.0',
-          dependencies: { 'something-js': '17.0.1' },
-          devDependencies: { 'something-else-js': '17.0.1' },
-        },
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeFalsy();
+  it('returns result with isSuccessful = false if package name matches dependency', async () => {
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'something-js',
+        version: '1.0.0',
+        dependencies: { 'something-js': '17.0.1' },
+        devDependencies: { 'something-else-js': '17.0.1' },
+      },
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeFalsy();
+  });
 
-    it('returns result with isSuccessful = false if package name matches dev dependency', async () => {
-      const check = new PackageJsonCheck();
-      const result = await check.runAsync({
-        pkg: {
-          name: 'something-else-js',
-          version: '1.0.0',
-          dependencies: { 'something-js': '17.0.1' },
-          devDependencies: { 'something-else-js': '17.0.1' },
-        },
-        ...additionalProjectProps,
-      });
-      expect(result.isSuccessful).toBeFalsy();
+  it('returns result with isSuccessful = false if package name matches dev dependency', async () => {
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'something-else-js',
+        version: '1.0.0',
+        dependencies: { 'something-js': '17.0.1' },
+        devDependencies: { 'something-else-js': '17.0.1' },
+      },
+      ...additionalProjectProps,
     });
+    expect(result.isSuccessful).toBeFalsy();
   });
 });

--- a/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
@@ -1,0 +1,118 @@
+import { PackageJsonCheck } from '../PackageJsonCheck';
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  projectRoot: '/path/to/project',
+};
+
+describe(PackageJsonCheck, () => {
+  describe('runAsync', () => {
+    it('returns result with isSuccessful = true if empty dependencies, devDependencies, scripts', async () => {
+      const check = new PackageJsonCheck();
+      const result = await check.runAsync({
+        pkg: { name: 'name', version: '1.0.0' },
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeTruthy();
+    });
+
+    // expo script sub-check
+
+    it('returns result with isSuccessful = true if scripts does not contain expo', async () => {
+      const check = new PackageJsonCheck();
+      const result = await check.runAsync({
+        pkg: { name: 'name', version: '1.0.0', scripts: { start: 'start' } },
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeTruthy();
+    });
+
+    it('returns result with isSuccessful = false if scripts contain expo', async () => {
+      const check = new PackageJsonCheck();
+      const result = await check.runAsync({
+        pkg: { name: 'name', version: '1.0.0', scripts: { expo: 'start' } },
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeFalsy();
+    });
+
+    // transitive-only dependencies sub-check
+
+    const dependencyLocations = ['dependencies', 'devDependencies'];
+
+    const transitiveOnlyDependencies = ['expo-modules-core', 'expo-modules-autolinking'];
+
+    dependencyLocations.forEach(dependencyLocation => {
+      it(`returns result with isSuccessful = true if ${dependencyLocation} does not contain expo-modules-core/ expo-modules-autolinking`, async () => {
+        const check = new PackageJsonCheck();
+        const result = await check.runAsync({
+          pkg: { name: 'name', version: '1.0.0', [dependencyLocation]: { somethingjs: '17.0.1' } },
+          ...additionalProjectProps,
+        });
+        expect(result.isSuccessful).toBeTruthy();
+      });
+
+      transitiveOnlyDependencies.forEach(transitiveOnlyDependency => {
+        it(`returns result with isSuccessful = false if ${dependencyLocation} contains ${transitiveOnlyDependency}`, async () => {
+          const check = new PackageJsonCheck();
+          const result = await check.runAsync({
+            pkg: {
+              name: 'name',
+              version: '1.0.0',
+              [dependencyLocation]: { [transitiveOnlyDependency]: '1.0.0' },
+            },
+            ...additionalProjectProps,
+          });
+          expect(result.isSuccessful).toBeFalsy();
+        });
+      });
+    });
+
+    // package name conflicts with installed packages sub-check
+    it('returns result with isSuccessful = true if package name does not match dependency', async () => {
+      const check = new PackageJsonCheck();
+      const result = await check.runAsync({
+        pkg: {
+          name: 'package-name',
+          version: '1.0.0',
+          dependencies: { 'something-js': '17.0.1' },
+          devDependencies: { 'something-else-js': '17.0.1' },
+        },
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeTruthy();
+    });
+
+    it('returns result with isSuccessful = false if package name matches dependency', async () => {
+      const check = new PackageJsonCheck();
+      const result = await check.runAsync({
+        pkg: {
+          name: 'something-js',
+          version: '1.0.0',
+          dependencies: { 'something-js': '17.0.1' },
+          devDependencies: { 'something-else-js': '17.0.1' },
+        },
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeFalsy();
+    });
+
+    it('returns result with isSuccessful = false if package name matches dev dependency', async () => {
+      const check = new PackageJsonCheck();
+      const result = await check.runAsync({
+        pkg: {
+          name: 'something-else-js',
+          version: '1.0.0',
+          dependencies: { 'something-js': '17.0.1' },
+          devDependencies: { 'something-else-js': '17.0.1' },
+        },
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBeFalsy();
+    });
+  });
+});

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -86,12 +86,12 @@ export async function actionAsync(projectRoot: string) {
 
   // add additional checks here
   const checks = [
-    new GlobalPrereqsVersionCheck(),
-    new IllegalPackageCheck(),
-    new GlobalPackageInstalledCheck(),
-    new SupportPackageVersionCheck(),
-    new InstalledDependencyVersionCheck(),
-    new ExpoConfigSchemaCheck(),
+    // new GlobalPrereqsVersionCheck(),
+    // new IllegalPackageCheck(),
+    // new GlobalPackageInstalledCheck(),
+    // new SupportPackageVersionCheck(),
+    // new InstalledDependencyVersionCheck(),
+    // new ExpoConfigSchemaCheck(),
     new PackageJsonCheck(),
   ];
 

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -7,6 +7,7 @@ import { GlobalPackageInstalledCheck } from './checks/GlobalPackageInstalledChec
 import { GlobalPrereqsVersionCheck } from './checks/GlobalPrereqsVersionCheck';
 import { IllegalPackageCheck } from './checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from './checks/InstalledDependencyVersionCheck';
+import { PackageJsonCheck } from './checks/PackageJsonCheck';
 import { SupportPackageVersionCheck } from './checks/SupportPackageVersionCheck';
 import { DoctorCheck, DoctorCheckParams } from './checks/checks.types';
 import { Log } from './utils/log';
@@ -91,6 +92,7 @@ export async function actionAsync(projectRoot: string) {
     new SupportPackageVersionCheck(),
     new InstalledDependencyVersionCheck(),
     new ExpoConfigSchemaCheck(),
+    new PackageJsonCheck(),
   ];
 
   let hasIssues = false;

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -86,12 +86,12 @@ export async function actionAsync(projectRoot: string) {
 
   // add additional checks here
   const checks = [
-    // new GlobalPrereqsVersionCheck(),
-    // new IllegalPackageCheck(),
-    // new GlobalPackageInstalledCheck(),
-    // new SupportPackageVersionCheck(),
-    // new InstalledDependencyVersionCheck(),
-    // new ExpoConfigSchemaCheck(),
+    new GlobalPrereqsVersionCheck(),
+    new IllegalPackageCheck(),
+    new GlobalPackageInstalledCheck(),
+    new SupportPackageVersionCheck(),
+    new InstalledDependencyVersionCheck(),
+    new ExpoConfigSchemaCheck(),
     new PackageJsonCheck(),
   ];
 


### PR DESCRIPTION
# Why

Check package.json for scenarios [identified here](https://www.notion.so/expo/Expo-Doctor-Roadmap-Q1-Q2-2023-32343debd75549d38dd282a249e3cb52):
- check for direct inclusion of expo-modules/ autolinking
- no scripts should be named "expo"
- package name shouldn't match a project dependency

# How

Added a check class and unit tests.

# Test Plan
Ran doctor against a project with and without the following changes:
- added expo-modules to project
- named a script "expo"
- named a package after a direct dependency (question: should we be checking deep dependencies for this, too?)
