### PR TITLE
chore(configure-splash-screen): add deprecation warning

### DIFF
--- a/unlinked-packages/configure-splash-screen/README.md
+++ b/unlinked-packages/configure-splash-screen/README.md
@@ -1,5 +1,8 @@
 # @expo/configure-splash-screen
 
+> **Warning**
+> This package is deprecated in favor of Expo config options. [Learn more](https://docs.expo.dev/versions/latest/sdk/splash-screen/)
+
 This package provides CLI command that helps you configure [`expo-splash-screen`](https://github.com/expo/expo/tree/master/packages/expo-splash-screen) module.
 You can use it to configure your native iOS and Android project according to your needs without opening Xcode or Android Studio.
 


### PR DESCRIPTION
# Why

Part of ENG-6837

This marks the tool as deprecated.

> **Warning**
> Because this is still installed when installing `expo-splash-screen`, we can't mark it as deprecated on npm yet. We need to wait until SDK 48 is no longer supported before we can do that.

# How

- Added note in readme

# Test Plan

Docs change only