### PR TITLE
fix(doctor): replace commander-based interactivity check with tty/ci check

### DIFF
--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -1,6 +1,11 @@
 import { boolish } from 'getenv';
 
 class Env {
+  /** Is running in non-interactive CI mode */
+  get CI() {
+    return boolish('CI', false);
+  }
+
   /** Enable debug logging */
   get EXPO_DEBUG() {
     return boolish('EXPO_DEBUG', false);

--- a/packages/expo-doctor/src/utils/interactive.ts
+++ b/packages/expo-doctor/src/utils/interactive.ts
@@ -1,0 +1,6 @@
+import { env } from './env';
+
+/** Determine if the current process is interactive, and can receive user input */
+export function isInteractive(): boolean {
+  return !env.CI && process.stdout.isTTY;
+}

--- a/packages/expo-doctor/src/utils/ora.ts
+++ b/packages/expo-doctor/src/utils/ora.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk';
-import program from 'commander';
 import oraReal, { Ora } from 'ora';
+
+import { env } from './env';
+import { isInteractive } from './interactive';
 
 // eslint-disable-next-line no-console
 const logReal = console.log;
@@ -19,7 +21,7 @@ const errorReal = console.error;
  */
 export function ora(options?: oraReal.Options | string): oraReal.Ora {
   const inputOptions = typeof options === 'string' ? { text: options } : options || {};
-  const disabled = program.nonInteractive;
+  const disabled = !isInteractive() || env.EXPO_DEBUG;
   const spinner = oraReal({
     // Ensure our non-interactive mode emulates CI mode.
     isEnabled: !disabled,


### PR DESCRIPTION
# Why

Doctor had 2 different parts from legacy and newer code.

- **Legacy**: the `nonInteractive` flag on `commander`'s `program` singleton
- **Newer**: uses `args` instead of `commander`

# How

- Added `isInteractive()` function in **./utils/interactive.ts**
- Added `CI` environment variable in **./utils/env.ts**
- Refactored Ora's `disabled` check to use `isInteractive() || env.EXPO_DEBUG`

# Test Plan

Ora should now be disabled in non-interactive environments.