### PR TITLE
Run some deep dependency checks in parallel

### DIFF
--- a/packages/expo-doctor/src/checks/IllegalPackageCheck.ts
+++ b/packages/expo-doctor/src/checks/IllegalPackageCheck.ts
@@ -17,12 +17,16 @@ export class IllegalPackageCheck implements DoctorCheck {
       'react-native-unimodules',
     ];
 
-    for (const pkg of illegalPackages) {
-      const warning = await getDeepDependenciesWarningAsync({ name: pkg }, projectRoot);
-      if (warning) {
-        issues.push(warning);
+    // warn if these packages are installed at all
+    const possibleWarnings = await Promise.all(
+      illegalPackages.map(pkg => getDeepDependenciesWarningAsync({ name: pkg }, projectRoot))
+    );
+
+    possibleWarnings.forEach(possibleWarning => {
+      if (possibleWarning) {
+        issues.push(possibleWarning);
       }
-    }
+    });
 
     if (issues.length) {
       advice.push(

--- a/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
@@ -13,20 +13,26 @@ export class SupportPackageVersionCheck implements DoctorCheck {
 
     const versionsForSdk = await getRemoteVersionsForSdkAsync(exp.sdkVersion);
 
+    // only check for packages that have a required semver for the current SDK version
     const supportPackagesToValidate = [
       'expo-modules-autolinking',
       '@expo/config-plugins',
       '@expo/prebuild-config',
-    ];
-    for (const pkg of supportPackagesToValidate) {
-      const version = versionsForSdk[pkg];
-      if (version) {
-        const warning = await getDeepDependenciesWarningAsync({ name: pkg, version }, projectRoot);
-        if (warning) {
-          issues.push(warning);
-        }
+    ].filter(pkg => versionsForSdk[pkg]);
+
+    // check that a specific semver is installed for each package
+    const possibleWarnings = await Promise.all(
+      supportPackagesToValidate.map(pkg =>
+        getDeepDependenciesWarningAsync({ name: pkg, version: versionsForSdk[pkg] }, projectRoot)
+      )
+    );
+
+    possibleWarnings.forEach(possibleWarning => {
+      if (possibleWarning) {
+        issues.push(possibleWarning);
       }
-    }
+    });
+
     if (issues.length) {
       advice.push(`Upgrade dependencies that are using the invalid package versions.`);
     }

--- a/packages/expo-doctor/src/checks/__tests__/IllegalPackageCheck.js
+++ b/packages/expo-doctor/src/checks/__tests__/IllegalPackageCheck.js
@@ -1,0 +1,36 @@
+import { asMock } from '../../__tests__/asMock';
+import { getDeepDependenciesWarningAsync } from '../../utils/explainDependencies';
+import { IllegalPackageCheck } from '../IllegalPackageCheck';
+
+jest.mock('../../utils/explainDependencies');
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  pkg: {},
+};
+
+describe('runAsync', () => {
+  it('returns result with isSuccessful = true if check passes', async () => {
+    asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce(null);
+    const check = new IllegalPackageCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if check fails', async () => {
+    asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
+    const check = new IllegalPackageCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+});

--- a/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
@@ -1,0 +1,49 @@
+import { asMock } from '../../__tests__/asMock';
+import { getDeepDependenciesWarningAsync } from '../../utils/explainDependencies';
+import { getRemoteVersionsForSdkAsync } from '../../utils/getRemoteVersionsForSdkAsync';
+import { SupportPackageVersionCheck } from '../SupportPackageVersionCheck';
+
+jest.mock('../../utils/explainDependencies');
+
+jest.mock('../../utils/getRemoteVersionsForSdkAsync');
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  pkg: {},
+};
+
+describe('runAsync', () => {
+  it('returns result with isSuccessful = true if check passes', async () => {
+    asMock(getRemoteVersionsForSdkAsync).mockResolvedValueOnce({
+      'expo-modules-autolinking': '1.0.0',
+      '@expo/config-plugins': '1.0.0',
+      '@expo/prebuild-config': '1.0.0',
+    });
+    asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce(null);
+    const check = new SupportPackageVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if check fails', async () => {
+    asMock(getRemoteVersionsForSdkAsync).mockResolvedValueOnce({
+      'expo-modules-autolinking': '1.0.0',
+      '@expo/config-plugins': '1.0.0',
+      '@expo/prebuild-config': '1.0.0',
+    });
+    asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
+    const check = new SupportPackageVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+});


### PR DESCRIPTION
# Why
[Per these early results from Doctor running on EAS Build](https://exponent-internal.slack.com/archives/C5ERY0TAR/p1680180597751169?thread_ts=1679999034.565819&cid=C5ERY0TAR), looks like we could shave some time off on these deep dependency checks.

# How
I just parallelized the deep dependency checks within each test that had more than one. This was something I could do quickly without changing any structure outside of the individual tests in order to see some fast feedback.

Next up, I would want to extract/ parallelize the network requests, and then run all of the deep dependency checks in parallel.

# Test Plan
Tested on a project, made sure both checks caught the same stuff as before
