### PR TITLE
commit version bumps after publish

### DIFF
--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/dev-tools",
-  "version": "0.13.181",
+  "version": "0.13.182",
   "main": "build/server/index.js",
   "scripts": {
     "dev": "cross-env NODE_ENV=development ts-node -T ./server/dev-server",
@@ -64,7 +64,7 @@
     "slugify": "^1.0.2",
     "ts-node": "^9.1.1",
     "velocity-react": "^1.4.1",
-    "xdl": "60.0.6"
+    "xdl": "60.0.7"
   },
   "license": "MIT",
   "repository": {

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-cli",
-  "version": "6.3.4",
+  "version": "6.3.5",
   "description": "The command-line tool for creating and publishing Expo apps",
   "preferGlobal": true,
   "main": "build/exp.js",
@@ -119,6 +119,6 @@
     "url-join": "4.0.0",
     "uuid": "^8.0.0",
     "wrap-ansi": "^7.0.0",
-    "xdl": "60.0.6"
+    "xdl": "60.0.7"
   }
 }

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-doctor",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "keywords": [
     "expo",
     "ios",

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/webpack-config",
-  "version": "18.0.2",
+  "version": "18.0.3",
   "description": "A Webpack configuration used to bundle Expo websites with Expo CLI.",
   "main": "webpack.config.js",
   "types": "webpack.config.d.ts",

--- a/packages/xdl/package.json
+++ b/packages/xdl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdl",
-  "version": "60.0.6",
+  "version": "60.0.7",
   "description": "The Expo Development Library",
   "main": "build/index.js",
   "files": [
@@ -45,7 +45,7 @@
     "@expo/schemer": "1.4.5",
     "@expo/sdk-runtime-versions": "^1.0.0",
     "@expo/spawn-async": "1.5.0",
-    "@expo/webpack-config": "18.0.2",
+    "@expo/webpack-config": "18.0.3",
     "axios": "0.21.1",
     "better-opn": "^3.0.1",
     "boxen": "^5.0.1",


### PR DESCRIPTION
 - @expo/dev-tools@0.13.182
 - expo-cli@6.3.5
 - expo-doctor@1.0.4
 - @expo/webpack-config@18.0.3
 - xdl@60.0.7

# Why

<!-- 

!! NOTICE !! The global Expo CLI (`packages/expo-cli`) is deprecated in favor of the new versioned CLI `npx expo`:

Open Expo CLI changes here -> https://github.com/expo/expo/tree/main/packages/@expo/cli

...

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
