### PR TITLE
Update CLI description to mention expo-router

### DIFF
--- a/packages/create-expo-app/src/legacyTemplates.ts
+++ b/packages/create-expo-app/src/legacyTemplates.ts
@@ -18,7 +18,7 @@ export const LEGACY_TEMPLATES = [
   {
     title: 'Navigation (TypeScript)',
     value: 'expo-template-tabs',
-    description: 'several example screens and tabs using react-navigation and TypeScript',
+    description: 'several example screens and tabs using expo-router and TypeScript',
   },
 
   {

--- a/packages/expo-cli/src/commands/initAsync.ts
+++ b/packages/expo-cli/src/commands/initAsync.ts
@@ -44,7 +44,7 @@ const FEATURED_TEMPLATES = [
   {
     shortName: 'tabs (TypeScript)',
     name: 'expo-template-tabs',
-    description: 'several example screens and tabs using react-navigation and TypeScript',
+    description: 'several example screens and tabs using expo-router and TypeScript',
   },
   '----- Bare workflow -----',
   {


### PR DESCRIPTION
# Why

<!-- 

!! NOTICE !! The global Expo CLI (`packages/expo-cli`) is deprecated in favor of the new versioned CLI `npx expo`:

Open Expo CLI changes here -> https://github.com/expo/expo/tree/main/packages/@expo/cli

...

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

CLI still mentions `react-navigation` when in reality `expo-router` is being used

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

I've updated the description
