### PR TITLE
fix: Create <meta name="description" /> tag in index.html from web.description app config

### DIFF
--- a/packages/pwa/src/Manifest.ts
+++ b/packages/pwa/src/Manifest.ts
@@ -56,7 +56,8 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): PWAConfig {
   const buildOutputPath = getWebOutputPath(appJSON);
   const publicPath = sanitizePublicPath(webManifest.publicPath);
   const primaryColor = appManifest.primaryColor;
-  const description = webManifest.description || appManifest.description;
+  const description = appManifest.description;
+  const webDescription = webManifest.description || description;
   // The theme_color sets the color of the tool bar, and may be reflected in the app's preview in task switchers.
   const webThemeColor = webManifest.themeColor || primaryColor;
   const dir = webManifest.dir;
@@ -125,7 +126,7 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): PWAConfig {
       dangerous: webDangerous,
       scope,
       crossorigin,
-      description,
+      description: webDescription,
       preferRelatedApplications,
       relatedApplications,
       startUrl,

--- a/packages/pwa/src/Manifest.ts
+++ b/packages/pwa/src/Manifest.ts
@@ -56,7 +56,7 @@ function applyWebDefaults(appJSON: AppJSONConfig | ExpoConfig): PWAConfig {
   const buildOutputPath = getWebOutputPath(appJSON);
   const publicPath = sanitizePublicPath(webManifest.publicPath);
   const primaryColor = appManifest.primaryColor;
-  const description = appManifest.description;
+  const description = webManifest.description || appManifest.description;
   // The theme_color sets the color of the tool bar, and may be reflected in the app's preview in task switchers.
   const webThemeColor = webManifest.themeColor || primaryColor;
   const dir = webManifest.dir;


### PR DESCRIPTION
# Why

According to table  here https://docs.expo.dev/guides/progressive-web-apps/#usage `<meta name="description" />` should be populated with value of `web.description` or `description` fields in `app.config.js`.

Currently, providing only `web.description` does not create meta tag, because value is read only from top-level `description` field.

# How

Read `web.description` first as it should take precedence in case of PWA manifest generation

# Test Plan

1. Create expo web project
2. Fill only `web.description` in `app.config.js`
3. Export web, check that `<meta name="description" />` is present in `index.html` and filled with value from `web.description` in `app.config.js`