### PR TITLE
[webpack] fix error for not specifying full extension

### DIFF
--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -70,6 +70,9 @@ Object {
       Object {
         "enforce": "pre",
         "exclude": /@babel\\(\\?:\\\\/\\|\\\\\\\\\\{1,2\\}\\)runtime/,
+        "resolve": Object {
+          "fullySpecified": false,
+        },
         "test": /\\\\\\.\\(js\\|mjs\\|jsx\\|ts\\|tsx\\|css\\)\\$/,
         "use": "node_modules/source-map-loader/dist/cjs.js",
       },
@@ -104,6 +107,9 @@ Object {
           },
           Object {
             "include": [Function],
+            "resolve": Object {
+              "fullySpecified": false,
+            },
             "test": /\\\\\\.\\(js\\|mjs\\|jsx\\|ts\\|tsx\\)\\$/,
             "use": Object {
               "loader": "node_modules/babel-loader/lib/index.js",
@@ -260,6 +266,9 @@ Object {
       Object {
         "enforce": "pre",
         "exclude": /@babel\\(\\?:\\\\/\\|\\\\\\\\\\{1,2\\}\\)runtime/,
+        "resolve": Object {
+          "fullySpecified": false,
+        },
         "test": /\\\\\\.\\(js\\|mjs\\|jsx\\|ts\\|tsx\\|css\\)\\$/,
         "use": "node_modules/source-map-loader/dist/cjs.js",
       },
@@ -294,6 +303,9 @@ Object {
           },
           Object {
             "include": [Function],
+            "resolve": Object {
+              "fullySpecified": false,
+            },
             "test": /\\\\\\.\\(js\\|mjs\\|jsx\\|ts\\|tsx\\)\\$/,
             "use": Object {
               "loader": "node_modules/babel-loader/lib/index.js",

--- a/packages/webpack-config/src/loaders/createBabelLoader.ts
+++ b/packages/webpack-config/src/loaders/createBabelLoader.ts
@@ -239,5 +239,8 @@ export default function createBabelLoader({
       loader: require.resolve('babel-loader'),
       options: presetOptions,
     },
+    resolve: {
+      fullySpecified: false,
+    },
   };
 }

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -430,6 +430,9 @@ export default async function (env: Environment, argv: Arguments = {}): Promise<
           exclude: /@babel(?:\/|\\{1,2})runtime/,
           test: /\.(js|mjs|jsx|ts|tsx|css)$/,
           use: require.resolve('source-map-loader'),
+          resolve: {
+            fullySpecified: false,
+          },
         },
         {
           oneOf: allLoaders,


### PR DESCRIPTION
# Why

a regression from webpack 5 upgrade where it should explicitly specify full js extension like `import './foo.js';`. this breaks metro assumption and existing code in [expo-noifications](https://github.com/expo/expo/blob/1120c716f35cb28d88800e8f5d963d2b2ac94705/packages/expo-notifications/src/DevicePushTokenAutoRegistration.fx.ts#L1)

fixes https://github.com/expo/expo/issues/22064
close ENG-8248

# How

add `resolve.fullySpecified=false` as webpack doc mentioned: https://webpack.js.org/configuration/module/#resolvefullyspecified

# Test Plan

based on https://github.com/viveksc1994/expo-48-web and apply the patch
**patches/@expo+webpack-config+18.0.3.patch**

```diff
diff --git a/node_modules/@expo/webpack-config/webpack/loaders/createBabelLoader.js b/node_modules/@expo/webpack-config/webpack/loaders/createBabelLoader.js
index d19e849..beba961 100644
--- a/node_modules/@expo/webpack-config/webpack/loaders/createBabelLoader.js
+++ b/node_modules/@expo/webpack-config/webpack/loaders/createBabelLoader.js
@@ -202,6 +202,9 @@ mode, projectRoot: inputProjectRoot, babelProjectRoot, include = [], verbose, pl
             loader: require.resolve('babel-loader'),
             options: presetOptions,
         },
+        resolve: {
+          fullySpecified: false,
+        },
     };
 }
 exports.default = createBabelLoader;
diff --git a/node_modules/@expo/webpack-config/webpack/webpack.config.js b/node_modules/@expo/webpack-config/webpack/webpack.config.js
index 413918a..fb2f565 100644
--- a/node_modules/@expo/webpack-config/webpack/webpack.config.js
+++ b/node_modules/@expo/webpack-config/webpack/webpack.config.js
@@ -328,6 +328,9 @@ async function default_1(env, argv = {}) {
                     exclude: /@babel(?:\/|\\{1,2})runtime/,
                     test: /\.(js|mjs|jsx|ts|tsx|css)$/,
                     use: require.resolve('source-map-loader'),
+                    resolve: {
+                      fullySpecified: false,
+                    }
                 },
                 {
                     oneOf: allLoaders,
```
