### PR TITLE
[ENG-8317][cli] deprecate publish:*

### DIFF
--- a/packages/expo-cli/src/commands/publish/deprecationNotice.ts
+++ b/packages/expo-cli/src/commands/publish/deprecationNotice.ts
@@ -1,0 +1,9 @@
+import Log from '../../log';
+import { learnMore } from '../utils/TerminalLink';
+
+export async function printDeprecationNotice(): Promise<void> {
+  Log.warn('The last day to use expo publish is 2024-02-12. Migrate to eas update.');
+  Log.warn(
+    `${learnMore('https://blog.expo.dev/sunsetting-expo-publish-and-classic-updates-6cb9cd295378')}`
+  );
+}

--- a/packages/expo-cli/src/commands/publish/deprecationNotice.ts
+++ b/packages/expo-cli/src/commands/publish/deprecationNotice.ts
@@ -2,7 +2,7 @@ import Log from '../../log';
 import { learnMore } from '../utils/TerminalLink';
 
 export async function printDeprecationNotice(): Promise<void> {
-  Log.warn('The last day to use expo publish is 2024-02-12. Migrate to eas update.');
+  Log.warn('The last day to use expo publish is 2024-02-12 and SDK 49 is the last version to support it. Migrate to eas update.');
   Log.warn(
     `${learnMore('https://blog.expo.dev/sunsetting-expo-publish-and-classic-updates-6cb9cd295378')}`
   );

--- a/packages/expo-cli/src/commands/publish/deprecationNotice.ts
+++ b/packages/expo-cli/src/commands/publish/deprecationNotice.ts
@@ -2,7 +2,9 @@ import Log from '../../log';
 import { learnMore } from '../utils/TerminalLink';
 
 export async function printDeprecationNotice(): Promise<void> {
-  Log.warn('The last day to use expo publish is 2024-02-12 and SDK 49 is the last version to support it. Migrate to eas update.');
+  Log.warn(
+    'The last day to use expo publish is 2024-02-12 and SDK 49 is the last version to support it. Migrate to eas update.'
+  );
   Log.warn(
     `${learnMore('https://blog.expo.dev/sunsetting-expo-publish-and-classic-updates-6cb9cd295378')}`
   );

--- a/packages/expo-cli/src/commands/publish/publish.ts
+++ b/packages/expo-cli/src/commands/publish/publish.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type { Command } from 'commander';
 
 import { applyAsyncActionProjectDir } from '../utils/applyAsyncAction';
@@ -7,7 +8,7 @@ export default function (program: Command) {
     program
       .command('publish [path]')
       .alias('p')
-      .description('Deploy a project to Expo hosting')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update`} in eas-cli`)
       .helpGroup('publish')
       .option('-q, --quiet', 'Suppress verbose output from the Metro bundler.')
       .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')
@@ -30,7 +31,7 @@ export default function (program: Command) {
     program
       .command('publish:set [path]')
       .alias('ps')
-      .description('Specify the channel to serve a published release')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update:republish`} in eas-cli`)
       .helpGroup('publish')
       .option(
         '-c, --release-channel <name>',
@@ -48,7 +49,7 @@ export default function (program: Command) {
     program
       .command('publish:rollback [path]')
       .alias('pr')
-      .description('Undo an update to a channel')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update:republish`} in eas-cli`)
       .helpGroup('publish')
       .option('--channel-id <channel-id>', 'This flag is deprecated.')
       .option('-c, --release-channel <name>', 'The channel to rollback from. (Required)')
@@ -62,7 +63,7 @@ export default function (program: Command) {
     program
       .command('publish:history [path]')
       .alias('ph')
-      .description("Log the project's releases")
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update:list`} in eas-cli`)
       .helpGroup('publish')
       .option(
         '-c, --release-channel <name>',
@@ -87,7 +88,7 @@ export default function (program: Command) {
     program
       .command('publish:details [path]')
       .alias('pd')
-      .description('Log details of a published release')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update:view`} in eas-cli`)
       .helpGroup('publish')
       .option('--publish-id <publish-id>', 'Publication id. (Required)')
       .option('-r, --raw', 'Produce some raw output.'),

--- a/packages/expo-cli/src/commands/publish/publishAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishAsync.ts
@@ -19,6 +19,7 @@ import { confirmAsync } from '../../utils/prompts';
 import * as TerminalLink from '../utils/TerminalLink';
 import { formatNamedWarning } from '../utils/logConfigWarnings';
 import * as sendTo from '../utils/sendTo';
+import { printDeprecationNotice } from './deprecationNotice';
 
 const EAS_UPDATE_URL = 'https://u.expo.dev';
 
@@ -37,6 +38,7 @@ export async function actionAsync(
   projectRoot: string,
   options: Options = {}
 ): Promise<Project.PublishedProjectResult> {
+  printDeprecationNotice();
   assertValidReleaseChannel(options.releaseChannel);
 
   const { exp, pkg } = getConfig(projectRoot, {

--- a/packages/expo-cli/src/commands/publish/publishDetailsAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishDetailsAsync.ts
@@ -5,8 +5,10 @@ import {
   getPublicationDetailAsync,
   printPublicationDetailAsync,
 } from '../utils/PublishUtils';
+import { printDeprecationNotice } from './deprecationNotice';
 
 export async function actionAsync(projectRoot: string, options: DetailOptions) {
+  printDeprecationNotice();
   assert(options.publishId, '--publish-id must be specified.');
 
   const detail = await getPublicationDetailAsync(projectRoot, options);

--- a/packages/expo-cli/src/commands/publish/publishHistoryAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishHistoryAsync.ts
@@ -3,12 +3,14 @@ import dateFormat from 'dateformat';
 import Log from '../../log';
 import { getPublishHistoryAsync, HistoryOptions, Publication } from '../utils/PublishUtils';
 import * as table from '../utils/cli-table';
+import { printDeprecationNotice } from './deprecationNotice';
 
 const HORIZ_CELL_WIDTH_SMALL = 15;
 const HORIZ_CELL_WIDTH_MEDIUM = 20;
 const HORIZ_CELL_WIDTH_BIG = 40;
 
 export async function actionAsync(projectRoot: string, options: HistoryOptions) {
+  printDeprecationNotice();
   const result = await getPublishHistoryAsync(projectRoot, options);
 
   if (options.raw) {

--- a/packages/expo-cli/src/commands/publish/publishRollbackAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishRollbackAsync.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 
 import CommandError from '../../CommandError';
 import { RollbackOptions, rollbackPublicationFromChannelAsync } from '../utils/PublishUtils';
+import { printDeprecationNotice } from './deprecationNotice';
 import { getUsageAsync } from './getUsageAsync';
 
 type Options = {
@@ -12,6 +13,7 @@ type Options = {
 };
 
 export async function actionAsync(projectRoot: string, options: Options) {
+  printDeprecationNotice();
   assert(
     !options.channelId,
     '--channel-id flag is deprecated and does not do anything. Please use --release-channel and --sdk-version instead.'

--- a/packages/expo-cli/src/commands/publish/publishSetAsync.ts
+++ b/packages/expo-cli/src/commands/publish/publishSetAsync.ts
@@ -1,10 +1,12 @@
 import * as table from '../../commands/utils/cli-table';
 import Log from '../../log';
 import { setPublishToChannelAsync } from '../utils/PublishUtils';
+import { printDeprecationNotice } from './deprecationNotice';
 
 type Options = { releaseChannel?: string; publishId?: string };
 
 export async function actionAsync(projectRoot: string, options: Options): Promise<void> {
+  printDeprecationNotice();
   if (!options.releaseChannel) {
     throw new Error('You must specify a release channel.');
   }


### PR DESCRIPTION
# Why

- expo publish:* commands should say they’re deprecated and replaced by eas
- when someone runs one of these commands, print a link to the [sunset blog post](https://blog.expo.dev/sunsetting-expo-publish-and-classic-updates-6cb9cd295378)

# How
- update command description
- print deprecation notice on `expo publish:*`

# Test Plan

<img width="1248" alt="Screenshot 2023-04-17 at 11 32 16 PM" src="https://user-images.githubusercontent.com/6380927/232690951-5240b02a-a4bc-4ba1-b2ed-d15f9a04633a.png">

