### PR TITLE
[cli] remove credentials:manager functionality

### DIFF
--- a/packages/expo-cli/src/commands/credentials.ts
+++ b/packages/expo-cli/src/commands/credentials.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type { Command } from 'commander';
 
 import { applyAsyncActionProjectDir } from './utils/applyAsyncAction';
@@ -6,7 +7,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('credentials:manager [path]')
-      .description('Manage your credentials')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .helpGroup('credentials')
       .option('-p --platform <android|ios>', 'Platform: [android|ios]', /^(android|ios)$/i),
     () => import('./credentialsManagerAsync'),

--- a/packages/expo-cli/src/commands/credentialsManagerAsync.ts
+++ b/packages/expo-cli/src/commands/credentialsManagerAsync.ts
@@ -1,9 +1,4 @@
-import { Context, runCredentialsManagerStandalone } from '../credentials';
-import {
-  SelectAndroidExperience,
-  SelectIosExperience,
-  SelectPlatform,
-} from '../credentials/views/Select';
+import Log from '../log';
 
 type Options = {
   platform?: 'android' | 'ios';
@@ -12,18 +7,6 @@ type Options = {
   };
 };
 
-export async function actionAsync(projectRoot: string, options: Options) {
-  const context = new Context();
-  await context.init(projectRoot, {
-    nonInteractive: options.parent?.nonInteractive,
-  });
-  let mainpage;
-  if (options.platform === 'android') {
-    mainpage = new SelectAndroidExperience();
-  } else if (options.platform === 'ios') {
-    mainpage = new SelectIosExperience();
-  } else {
-    mainpage = new SelectPlatform();
-  }
-  await runCredentialsManagerStandalone(context, mainpage);
+export async function actionAsync(_projectRoot: string, _options: Options) {
+  Log.warn('expo credentials:manager is deprecated. Migrate to eas credentials.');
 }

--- a/packages/expo-cli/src/commands/credentialsManagerAsync.ts
+++ b/packages/expo-cli/src/commands/credentialsManagerAsync.ts
@@ -8,5 +8,5 @@ type Options = {
 };
 
 export async function actionAsync(_projectRoot: string, _options: Options) {
-  Log.warn('expo credentials:manager is deprecated. Migrate to eas credentials.');
+  Log.warn('expo credentials:manager no longer exists. Migrate to eas credentials.');
 }


### PR DESCRIPTION
# Why

Since the planned last date expo build will work is January 4, 2023, we don't have any more use for credentials manager. Adding deprecation notice and removing functionality to discourage people from using it.

# How

- add deprecation notice to command description and print it when run

# Test Plan

<img width="1246" alt="Screenshot 2023-04-17 at 11 52 43 PM" src="https://user-images.githubusercontent.com/6380927/232695326-c95e4bb0-1831-4f0c-bc29-6f5a6983df8c.png">
