### PR TITLE
[doctor] Specify schemer version to eliminate 'NOT SUPPORTED' warning

### DIFF
--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@expo/config": "6.0.24",
     "@expo/json-file": "~8.2.37",
+    "@expo/schemer": "1.4.5",
     "@expo/spawn-async": "^1.7.0",
     "chalk": "^4.0.0",
     "semver": "7.3.2"


### PR DESCRIPTION
# Why
After this[ latest publish of Doctor](https://github.com/expo/expo-cli/commit/680639dc7b923fde9002d7288bb17168654091c9), pretty much everyone started seeing this warning:
<img width="615" alt="image" src="https://user-images.githubusercontent.com/8053974/232825788-58cf1d14-c4b4-4784-89bc-a0c21b88b29b.png">
It comes from `ajv` by way of `schemer`

My guess is that this is due to some machine-specific difference in what version of schemer was used on publish, because the dependency wasn't specified in package.json. I'm guessing a bit because I can't tell from changelogs what versions of `ajv` would or would not cause this warning, and it's murky to me when I crawl through the NPX install folders exactly what version of `schemer`/ `ajv` is being used, other than that it is old/ wrong. But what I do know is that there's no warning in my local dev environment, where it's clearly using the latest `schemer` with `ajv@8.x.x`.

# How
Added `schemer` with latest version to **package.json**.

# Test Plan
Ran doctor locally, no warning!