### PR TITLE
[expo-cli] Advise to use new doctor on SDK 46+

### DIFF
--- a/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
+++ b/packages/expo-cli/src/commands/info/doctor/doctorAsync.ts
@@ -59,6 +59,15 @@ export async function actionAsync(projectRoot: string, options: Options) {
   await warnUponCmdExe();
 
   const { exp, pkg } = profileMethod(getConfig)(projectRoot);
+
+  if (Versions.gteSdkVersion(exp, '46.0.0')) {
+    Log.error(
+      `'expo-cli doctor' is not supported for SDK 46 and higher. Use 'npx expo-doctor' instead.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   let foundSomeIssues = false;
 
   // Only use the new validation on SDK +45.


### PR DESCRIPTION
# Why
Fulfills https://linear.app/expo/issue/CX-223/in-global-expo-cli-tell-people-about-new-doctor-when-they-run-old

# How
Added an error log and exited when SDK Version >= 46

# Test Plan
Tested on SDK 46+, errored out:
<img width="626" alt="image" src="https://user-images.githubusercontent.com/8053974/233122773-8f165459-3b14-45d4-ae6a-21e9290ccd53.png">

Proceeded as before when SDK 45 is installed.

