### PR TITLE
Removed @expo/config dependency

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.20.2",
-    "@expo/config": "6.0.20",
     "babel-loader": "^8.3.0",
     "chalk": "^4.0.0",
     "clean-webpack-plugin": "^4.0.0",


### PR DESCRIPTION
# Why

Removed @expo/config dependency that is causing nested dependency version conflicts, and instead have it pulled it via the expo devDependency.


Fixes #4688 


Same PR as #4512 (Which fixed #4511) - This issue has regressed from commit https://github.com/expo/expo-cli/commit/3052b9d0c719de7362d77c78b15d6a459eb11e80 from https://github.com/expo/expo-cli/pull/3763.

# How

Updated package.json

# Test Plan

Tested
