### PR TITLE
[cli] replace deprecated commands with superceded ones

### DIFF
--- a/packages/expo-cli/src/commands/credentials.ts
+++ b/packages/expo-cli/src/commands/credentials.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type { Command } from 'commander';
 
 import { applyAsyncActionProjectDir } from './utils/applyAsyncAction';
@@ -6,7 +7,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('credentials:manager [path]')
-      .description('Manage your credentials')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .helpGroup('credentials')
       .option('-p --platform <android|ios>', 'Platform: [android|ios]', /^(android|ios)$/i),
     () => import('./credentialsManagerAsync'),

--- a/packages/expo-cli/src/commands/fetch/index.ts
+++ b/packages/expo-cli/src/commands/fetch/index.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type { Command } from 'commander';
 
 import { applyAsyncActionProjectDir } from '../utils/applyAsyncAction';
@@ -6,7 +7,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('fetch:ios:certs [path]')
-      .description(`Download the project's iOS standalone app signing credentials`)
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .longDescription(
         `Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.`
       )
@@ -17,7 +18,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('fetch:android:keystore [path]')
-      .description("Download the project's Android keystore")
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .longDescription(
         "Fetch this project's Android Keystore. Writes Keystore to PROJECT_DIR/PROJECT_NAME.jks and prints passwords to stdout."
       )
@@ -28,7 +29,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('fetch:android:hashes [path]')
-      .description("Compute and log the project's Android key hashes")
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .longDescription(
         "Fetch this project's Android key hashes needed to set up Google/Facebook authentication. Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console."
       )
@@ -39,7 +40,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('fetch:android:upload-cert [path]')
-      .description("Download the project's Android keystore")
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .longDescription(
         "Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate"
       )

--- a/packages/expo-cli/src/commands/push.ts
+++ b/packages/expo-cli/src/commands/push.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type { Command } from 'commander';
 
 import { applyAsyncActionProjectDir } from './utils/applyAsyncAction';
@@ -6,7 +7,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('push:android:upload [path]')
-      .description('Upload an FCM key for Android push notifications')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .helpGroup('notifications')
       .option('--api-key [api-key]', 'Server API key for FCM.'),
     () => import('./push/pushAndroidUploadAsync')
@@ -15,7 +16,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('push:android:show [path]')
-      .description('Log the value currently in use for FCM notifications for this project')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .helpGroup('notifications'),
     () => import('./push/pushAndroidShowAsync')
   );
@@ -23,7 +24,7 @@ export default function (program: Command) {
   applyAsyncActionProjectDir(
     program
       .command('push:android:clear [path]')
-      .description('Delete a previously uploaded FCM credential')
+      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .helpGroup('notifications'),
     () => import('./push/pushAndroidClearAsync')
   );


### PR DESCRIPTION
# Why

Applying feedback from https://github.com/expo/expo-cli/pull/4686#pullrequestreview-1391116636

This PR replaces the description of deprecated commands and provides information about their superceded commands.  These changes should be made into a patch release for the last major/minor version with all the cli functionality

# Test Plan

- [ ] tests still pass
