### PR TITLE
[BREAKING][cli] remove deprecated command functionality

### DIFF
--- a/packages/expo-cli/src/commands/credentialsManagerAsync.ts
+++ b/packages/expo-cli/src/commands/credentialsManagerAsync.ts
@@ -1,9 +1,4 @@
-import { Context, runCredentialsManagerStandalone } from '../credentials';
-import {
-  SelectAndroidExperience,
-  SelectIosExperience,
-  SelectPlatform,
-} from '../credentials/views/Select';
+import Log from '../log';
 
 type Options = {
   platform?: 'android' | 'ios';
@@ -12,18 +7,6 @@ type Options = {
   };
 };
 
-export async function actionAsync(projectRoot: string, options: Options) {
-  const context = new Context();
-  await context.init(projectRoot, {
-    nonInteractive: options.parent?.nonInteractive,
-  });
-  let mainpage;
-  if (options.platform === 'android') {
-    mainpage = new SelectAndroidExperience();
-  } else if (options.platform === 'ios') {
-    mainpage = new SelectIosExperience();
-  } else {
-    mainpage = new SelectPlatform();
-  }
-  await runCredentialsManagerStandalone(context, mainpage);
+export async function actionAsync(_projectRoot: string, _options: Options) {
+  Log.warn('expo credentials:manager no longer exists. Migrate to eas credentials.');
 }

--- a/packages/expo-cli/src/commands/fetch/index.ts
+++ b/packages/expo-cli/src/commands/fetch/index.ts
@@ -12,7 +12,7 @@ export default function (program: Command) {
         `Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.`
       )
       .helpGroup('deprecated'),
-    () => import('./fetchIosCertsAsync')
+    () => import('./removalNotice')
   );
 
   applyAsyncActionProjectDir(
@@ -23,7 +23,7 @@ export default function (program: Command) {
         "Fetch this project's Android Keystore. Writes Keystore to PROJECT_DIR/PROJECT_NAME.jks and prints passwords to stdout."
       )
       .helpGroup('deprecated'),
-    () => import('./fetchAndroidKeystoreAsync')
+    () => import('./removalNotice')
   );
 
   applyAsyncActionProjectDir(
@@ -34,7 +34,7 @@ export default function (program: Command) {
         "Fetch this project's Android key hashes needed to set up Google/Facebook authentication. Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console."
       )
       .helpGroup('deprecated'),
-    () => import('./fetchAndroidHashesAsync')
+    () => import('./removalNotice')
   );
 
   applyAsyncActionProjectDir(
@@ -45,6 +45,6 @@ export default function (program: Command) {
         "Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate"
       )
       .helpGroup('deprecated'),
-    () => import('./fetchAndroidUploadCertAsync')
+    () => import('./removalNotice')
   );
 }

--- a/packages/expo-cli/src/commands/fetch/removalNotice.ts
+++ b/packages/expo-cli/src/commands/fetch/removalNotice.ts
@@ -1,0 +1,5 @@
+import Log from '../../log';
+
+export async function actionAsync(): Promise<void> {
+  Log.error(`expo fetch:* no longer exists. Migrate to eas credentials.`);
+}

--- a/packages/expo-cli/src/commands/push.ts
+++ b/packages/expo-cli/src/commands/push.ts
@@ -10,22 +10,22 @@ export default function (program: Command) {
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
       .helpGroup('deprecated')
       .option('--api-key [api-key]', 'Server API key for FCM.'),
-    () => import('./push/pushAndroidUploadAsync')
+    () => import('./push/removalNotice')
   );
 
   applyAsyncActionProjectDir(
     program
       .command('push:android:show [path]')
-      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
+      .description('Log the value currently in use for FCM notifications for this project')
       .helpGroup('deprecated'),
-    () => import('./push/pushAndroidShowAsync')
+    () => import('./push/removalNotice')
   );
 
   applyAsyncActionProjectDir(
     program
       .command('push:android:clear [path]')
-      .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
+      .description('Delete a previously uploaded FCM credential')
       .helpGroup('deprecated'),
-    () => import('./push/pushAndroidClearAsync')
+    () => import('./push/removalNotice')
   );
 }

--- a/packages/expo-cli/src/commands/push/removalNotice.ts
+++ b/packages/expo-cli/src/commands/push/removalNotice.ts
@@ -1,0 +1,5 @@
+import Log from '../../log';
+
+export async function actionAsync(): Promise<void> {
+  Log.error(`expo push:* no longer exists. Migrate to eas credentials.`);
+}


### PR DESCRIPTION
# Why

Applying feedback from https://github.com/expo/expo-cli/pull/4686#pullrequestreview-1391116636

This PR removes deprecated command functionality. These changes should be made into a new major version release .

# Test Plan

- [ ] current test still passes
