### PR TITLE
[cli] add deprecated commands to helpgroup

### DIFF
--- a/packages/expo-cli/src/commands/fetch/index.ts
+++ b/packages/expo-cli/src/commands/fetch/index.ts
@@ -11,7 +11,7 @@ export default function (program: Command) {
       .longDescription(
         `Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.`
       )
-      .helpGroup('credentials'),
+      .helpGroup('deprecated'),
     () => import('./fetchIosCertsAsync')
   );
 
@@ -22,7 +22,7 @@ export default function (program: Command) {
       .longDescription(
         "Fetch this project's Android Keystore. Writes Keystore to PROJECT_DIR/PROJECT_NAME.jks and prints passwords to stdout."
       )
-      .helpGroup('credentials'),
+      .helpGroup('deprecated'),
     () => import('./fetchAndroidKeystoreAsync')
   );
 
@@ -33,7 +33,7 @@ export default function (program: Command) {
       .longDescription(
         "Fetch this project's Android key hashes needed to set up Google/Facebook authentication. Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console."
       )
-      .helpGroup('credentials'),
+      .helpGroup('deprecated'),
     () => import('./fetchAndroidHashesAsync')
   );
 
@@ -44,7 +44,7 @@ export default function (program: Command) {
       .longDescription(
         "Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate"
       )
-      .helpGroup('credentials'),
+      .helpGroup('deprecated'),
     () => import('./fetchAndroidUploadCertAsync')
   );
 }

--- a/packages/expo-cli/src/commands/publish/publish.ts
+++ b/packages/expo-cli/src/commands/publish/publish.ts
@@ -9,7 +9,7 @@ export default function (program: Command) {
       .command('publish [path]')
       .alias('p')
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update`} in eas-cli`)
-      .helpGroup('publish')
+      .helpGroup('deprecated')
       .option('-q, --quiet', 'Suppress verbose output from the Metro bundler.')
       .option('-s, --send-to [dest]', 'A phone number or email address to send a link to')
       .option('-c, --clear', 'Clear the Metro bundler cache')
@@ -32,7 +32,7 @@ export default function (program: Command) {
       .command('publish:set [path]')
       .alias('ps')
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update:republish`} in eas-cli`)
-      .helpGroup('publish')
+      .helpGroup('deprecated')
       .option(
         '-c, --release-channel <name>',
         'The channel to set the published release. (Required)'
@@ -50,7 +50,7 @@ export default function (program: Command) {
       .command('publish:rollback [path]')
       .alias('pr')
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update:republish`} in eas-cli`)
-      .helpGroup('publish')
+      .helpGroup('deprecated')
       .option('--channel-id <channel-id>', 'This flag is deprecated.')
       .option('-c, --release-channel <name>', 'The channel to rollback from. (Required)')
       .option('-s, --sdk-version <version>', 'The sdk version to rollback. (Required)')
@@ -64,7 +64,7 @@ export default function (program: Command) {
       .command('publish:history [path]')
       .alias('ph')
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update:list`} in eas-cli`)
-      .helpGroup('publish')
+      .helpGroup('deprecated')
       .option(
         '-c, --release-channel <name>',
         'Filter by release channel. If this flag is not included, the most recent publications will be shown.'
@@ -89,7 +89,7 @@ export default function (program: Command) {
       .command('publish:details [path]')
       .alias('pd')
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas update:view`} in eas-cli`)
-      .helpGroup('publish')
+      .helpGroup('deprecated')
       .option('--publish-id <publish-id>', 'Publication id. (Required)')
       .option('-r, --raw', 'Produce some raw output.'),
     () => import('./publishDetailsAsync'),

--- a/packages/expo-cli/src/commands/push.ts
+++ b/packages/expo-cli/src/commands/push.ts
@@ -8,7 +8,7 @@ export default function (program: Command) {
     program
       .command('push:android:upload [path]')
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
-      .helpGroup('notifications')
+      .helpGroup('deprecated')
       .option('--api-key [api-key]', 'Server API key for FCM.'),
     () => import('./push/pushAndroidUploadAsync')
   );
@@ -17,7 +17,7 @@ export default function (program: Command) {
     program
       .command('push:android:show [path]')
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
-      .helpGroup('notifications'),
+      .helpGroup('deprecated'),
     () => import('./push/pushAndroidShowAsync')
   );
 
@@ -25,7 +25,7 @@ export default function (program: Command) {
     program
       .command('push:android:clear [path]')
       .description(`${chalk.yellow`Superseded`} by ${chalk.bold`eas credentials`} in eas-cli`)
-      .helpGroup('notifications'),
+      .helpGroup('deprecated'),
     () => import('./push/pushAndroidClearAsync')
   );
 }


### PR DESCRIPTION
# Why

feedback from https://github.com/expo/expo-cli/pull/4693#issuecomment-1518429839

add commands to deprecated helpgroup


