### PR TITLE
[doctor] remove sh command from dep check for Windows compat

### DIFF
--- a/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
@@ -18,9 +18,10 @@ export class InstalledDependencyVersionCheck implements DoctorCheck {
     try {
       // only way to check dependencies without automatically fixing them is to use interactive prompt
       // In the future, we should add JSON output to npx expo install, check for support, and use that instead
-      await spawnAsync('sh', ['-c', 'echo "n" | npx expo install --check'], {
+      await spawnAsync('npx', ['expo', 'install', '--check'], {
         stdio: 'pipe',
         cwd: projectRoot,
+        env: { ...process.env, CI: '1' },
       });
     } catch (error: any) {
       if (isSpawnResult(error)) {

--- a/packages/expo-doctor/src/checks/__tests__/InstalledDependencyVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/InstalledDependencyVersionCheck.test.ts
@@ -25,14 +25,16 @@ describe('runAsync', () => {
     expect(result.isSuccessful).toBeTruthy();
   });
 
-  it('calls npx expo install --check', async () => {
+  // CI=1 is required to prevent interactive prompt asking to fix the dependencies
+  it('calls npx expo install --check with CI=1 env variable', async () => {
     const mockSpawnAsync = asMock(spawnAsync).mockResolvedValueOnce({
       stdout: '',
     } as any);
     const check = new InstalledDependencyVersionCheck();
     await check.runAsync({ projectRoot: '/path/to/project', ...additionalProjectProps });
-    expect(mockSpawnAsync.mock.calls[0][0]).toBe('sh');
-    expect(mockSpawnAsync.mock.calls[0][1]).toEqual(['-c', 'echo "n" | npx expo install --check']);
+    expect(mockSpawnAsync.mock.calls[0][0]).toBe('npx');
+    expect(mockSpawnAsync.mock.calls[0][1]).toEqual(['expo', 'install', '--check']);
+    expect(mockSpawnAsync.mock.calls[0][2]).toMatchObject({ env: { CI: '1' } });
   });
 
   it('returns result with isSuccessful = false if check fails', async () => {


### PR DESCRIPTION
# Why
Expo Doctor's dependency version check isn't working at all on Windows right now (other than in WSL) 🙈 .

When calling npx expo install --check, we had to pipe a "y" into the command so it would finish, [necessitating this technique for calling a child process](https://stackoverflow.com/a/39482554). Since this uses sh, it doesn't work in Windows.

Fortunately, there's a WAY easier way to do this

# How
Use the `CI=1` environment variable, which causes the versioned CLI to disable the interactive prompt on `npx expo install --check`.

# Test Plan
- [x] works the same on macOS (same output, etc.)
- [ ] works on Windows (no PC available until next week for me to check this, though I can't imagine it works worse than it does now)
