### PR TITLE
[doctor] Move dependencies to devDependencies

### DIFF
--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-doctor",
   "version": "1.0.6",
+  "main": "build/index.js",
   "keywords": [
     "expo",
     "ios",
@@ -33,12 +34,13 @@
   "engines": {
     "node": "^14.13.1 || >=16.0.0"
   },
-  "dependencies": {
+  "devDependencies": {
     "@expo/config": "6.0.24",
     "@expo/json-file": "~8.2.37",
     "@expo/schemer": "1.4.5",
     "@expo/spawn-async": "^1.7.0",
     "chalk": "^4.0.0",
-    "semver": "7.3.2"
+    "semver": "7.3.2",
+    "ora": "3.4.0"
   }
 }

--- a/packages/expo-doctor/tsconfig.json
+++ b/packages/expo-doctor/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "src",
     "declaration": false,
     "composite": false,
-    "module": "es2020"
+    "module": "es2020",
+    "allowSyntheticDefaultImports": true
   },
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }


### PR DESCRIPTION
# Why
Optimize for NCC, hopefully resulting in quicker start times when first installing (e.g., on EAS Build)

# How
- Moved all dependencies to `devDependencies`
- Added `ora` dep because it's used in the app but wasn't in package.json
- Set `allowSyntheticDefaultImports` to true due to import TS errors after clearing node_modules and starting over. I could have fixed the references, but some were using a combination of the default export and other exports, and it wasn't clear on how to fix them all.

# Test Plan
- [x] Doctor works when running against test project
