### PR TITLE
[install-expo-modules] add sdk 49 support

### DIFF
--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -11,6 +11,11 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
+    expoSdkVersion: '49.0.0',
+    iosDeploymentTarget: '13.0',
+    reactNativeVersionRange: '>= 0.72.0',
+  },
+  {
     expoSdkVersion: '48.0.0',
     iosDeploymentTarget: '13.0',
     reactNativeVersionRange: '>= 0.71.0',


### PR DESCRIPTION
# Why

add instal-expo-modules support for sdk 49

# How

sdk 49 doesn't come new changes to templates (in expo-modules point of view). this pr just adds the version mapping.

# Test Plan

```sh
$  npx react-native init RN072 --version 0.72
$ cd RN072
$ /path/to/install-expo-modules/build/index.js
$ yarn android
$ yarn ios
```
