### PR TITLE
Warn if expo-dev-launcher / expo-dev-menu are installed

### DIFF
--- a/packages/expo-doctor/src/checks/PackageJsonCheck.ts
+++ b/packages/expo-doctor/src/checks/PackageJsonCheck.ts
@@ -15,7 +15,7 @@ function checkForInvalidDirectInstallPackage(
   packageName: string
 ): string | null {
   if (pkg.dependencies?.[packageName] || pkg.devDependencies?.[packageName]) {
-    return `The package "${packageName}" should not be installed directly in your project. It is a dependency of other Expo packages and should be installed automatically.`;
+    return `The package "${packageName}" should not be installed directly in your project. It is a dependency of other Expo packages, which will install it automatically as needed.`;
   }
   return null;
 }

--- a/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
@@ -77,10 +77,15 @@ describe('runAsync', () => {
 
   const dependencyLocations = ['dependencies', 'devDependencies'];
 
-  const transitiveOnlyDependencies = ['expo-modules-core', 'expo-modules-autolinking'];
+  const transitiveOnlyDependencies = [
+    'expo-modules-core',
+    'expo-modules-autolinking',
+    'expo-dev-launcher',
+    'expo-dev-menu',
+  ];
 
   dependencyLocations.forEach(dependencyLocation => {
-    it(`returns result with isSuccessful = true if ${dependencyLocation} does not contain expo-modules-core/ expo-modules-autolinking`, async () => {
+    it(`returns result with isSuccessful = true if ${dependencyLocation} does not contain a dependency that should only be installed by another Expo package`, async () => {
       const check = new PackageJsonCheck();
       const result = await check.runAsync({
         pkg: { name: 'name', version: '1.0.0', [dependencyLocation]: { somethingjs: '17.0.1' } },


### PR DESCRIPTION
# Why

(At least partially) fulfills https://linear.app/expo/issue/ENG-9160/[cli]-expo-doctor-and-expo-install-should-warn-on-dev-launcher-in

# How

Add these packages to the existing transitive-only package checks

# Test Plan

- [x] Updated unit tests
- [x] Tested against project (warns on new packages being directly installed)
