### PR TITLE
[doctor] clean up check names

### DIFF
--- a/packages/expo-doctor/src/checks/ExpoConfigSchemaCheck.ts
+++ b/packages/expo-doctor/src/checks/ExpoConfigSchemaCheck.ts
@@ -5,7 +5,7 @@ import { validateWithSchemaAsync } from '../utils/schema';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 export class ExpoConfigSchemaCheck implements DoctorCheck {
-  description = 'Validate Expo Config';
+  description = 'Check Expo config (app.json/ app.config.js)';
 
   sdkVersionRange = '*';
 

--- a/packages/expo-doctor/src/checks/GlobalPackageInstalledCheck.ts
+++ b/packages/expo-doctor/src/checks/GlobalPackageInstalledCheck.ts
@@ -2,7 +2,7 @@ import { getDeepDependenciesWarningAsync } from '../utils/explainDependencies';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 export class GlobalPackageInstalledCheck implements DoctorCheck {
-  description = 'Check for conflicting global packages in project';
+  description = 'Check for legacy global CLI installed locally';
 
   sdkVersionRange = '>=46.0.0';
 

--- a/packages/expo-doctor/src/checks/GlobalPrereqsVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/GlobalPrereqsVersionCheck.ts
@@ -43,7 +43,7 @@ async function checkNpmVersionAsync(): Promise<string | null> {
 }
 
 export class GlobalPrereqsVersionCheck implements DoctorCheck {
-  description = 'Validate global prerequisites versions';
+  description = 'Check npm/ yarn versions';
 
   sdkVersionRange = '*';
 

--- a/packages/expo-doctor/src/checks/IllegalPackageCheck.ts
+++ b/packages/expo-doctor/src/checks/IllegalPackageCheck.ts
@@ -3,7 +3,7 @@ import { getDeepDependenciesWarningAsync } from '../utils/explainDependencies';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 export class IllegalPackageCheck implements DoctorCheck {
-  description = 'Check for incompatible packages';
+  description = 'Check that native modules do not use incompatible support packages';
 
   sdkVersionRange = '>=44.0.0';
 

--- a/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
@@ -7,7 +7,7 @@ function isSpawnResult(result: any): result is SpawnResult {
 }
 
 export class InstalledDependencyVersionCheck implements DoctorCheck {
-  description = 'Check compatible dependency versions for the installed Expo SDK';
+  description = 'Check that packages match versions required by installed Expo SDK';
 
   sdkVersionRange = '>=46.0.0';
 

--- a/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
@@ -3,7 +3,8 @@ import { getRemoteVersionsForSdkAsync } from '../utils/getRemoteVersionsForSdkAs
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 export class SupportPackageVersionCheck implements DoctorCheck {
-  description = 'Verify prebuild support package versions are compatible';
+  description =
+    'Check that native modules use compatible support package versions for installed Expo SDK';
 
   sdkVersionRange = '>=45.0.0';
 


### PR DESCRIPTION
# Why

Fulfills https://linear.app/expo/issue/ENG-8979/unify-expo-doctor-test-descriptions

# How

Changed the check names as suggested, trying to explain a little more specifically/ plainly what they were doing.

In the long run, I kind of want to get away from these descriptions entirely. They were originally an attempt to componentize things that were tested together, but now they result in sometimes having to worry about how the technical category (e.g., a deep dependency check) matches or doesn't match with the logical category of the check (e.g., support package version check vs. checking for unimodules, various categories of things that could all be considered "package.json checks", etc.).

# Test Plan
<img width="669" alt="image" src="https://github.com/expo/expo-cli/assets/8053974/d6948dc9-90d9-4de9-aa2f-630b017b2862">
