### PR TITLE
[Doc] [Bug Fix]: fixes 404 issue on click with some cli's

### DIFF
--- a/packages/expo-cli/bin/expo.js
+++ b/packages/expo-cli/bin/expo.js
@@ -12,7 +12,7 @@ if (major > 16) {
   // eslint-disable-next-line no-console
   console.warn(
     yellow(
-      'WARNING: The legacy expo-cli does not support Node +17. Migrate to the new local Expo CLI: https://blog.expo.dev/the-new-expo-cli-f4250d8e3421.'
+      'WARNING: The legacy expo-cli does not support Node +17. Migrate to the new local Expo CLI: https://blog.expo.dev/the-new-expo-cli-f4250d8e3421'
     )
   );
 }

--- a/packages/expo-cli/src/exp.ts
+++ b/packages/expo-cli/src/exp.ts
@@ -762,7 +762,7 @@ async function checkCliVersionAsync() {
           'The global expo-cli package has been deprecated.'
         )}\n\nThe new Expo CLI is now bundled in your project in the ${chalk.bold(
           'expo'
-        )} package.\nLearn more: https://blog.expo.dev/the-new-expo-cli-f4250d8e3421.\n\nTo use the local CLI instead (recommended in SDK 46 and higher), run:\n\u203A ${chalk.bold(
+        )} package.\nLearn more: https://blog.expo.dev/the-new-expo-cli-f4250d8e3421\n\nTo use the local CLI instead (recommended in SDK 46 and higher), run:\n\u203A ${chalk.bold(
           `npx expo <command>`
         )}`
       ),


### PR DESCRIPTION
# Why

Error messages that point to the [new Expo CLI medium post](https://blog.expo.dev/the-new-expo-cli-f4250d8e3421)

With the way it was, it was including the period (with some CLI GUIs), this fixes that.

<img width="1255" alt="Screenshot 2023-07-06 at 12 16 30 PM" src="https://github.com/expo/expo-cli/assets/1774589/29430207-7e76-4419-964a-064f834685b5">


# How

Just removed the period so no matter what CLI the user is using, it doesn't 404 when they click on the url.

# Test Plan

N/A
