### PR TITLE
[doctor] check for sdkVersion in Expo config

### DIFF
--- a/packages/expo-doctor/src/checks/ExpoConfigCommonIssueCheck.ts
+++ b/packages/expo-doctor/src/checks/ExpoConfigCommonIssueCheck.ts
@@ -1,0 +1,34 @@
+import JsonFile from '@expo/json-file';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+export class ExpoConfigCommonIssueCheck implements DoctorCheck {
+  description = 'Check Expo config for common issues';
+
+  sdkVersionRange = '*';
+
+  async runAsync({ exp }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+
+    // check if SDK version is in Expo config
+    // exp object derives sdkVersion from expo.sdkVersion or installed version, so it will always be populated.
+    // Therefore, we need to check app.json file itself to see if this value is defined.
+    // Unlikely we can also check a dynamic config unless we change @expo/config.
+    const staticConfigPath = exp?._internal?.staticConfigPath;
+
+    // exp provides an empty object if there is no static config
+    if (staticConfigPath && typeof staticConfigPath === 'string') {
+      const appJson = await JsonFile.readAsync(staticConfigPath);
+      if ((appJson as any).expo?.sdkVersion) {
+        issues.push(
+          'expo.sdkVersion should not be defined in app.json. SDK version is determined by the version of the expo package installed in your project.'
+        );
+      }
+    }
+
+    return {
+      isSuccessful: issues.length === 0,
+      issues,
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/ExpoConfigSchemaCheck.ts
+++ b/packages/expo-doctor/src/checks/ExpoConfigSchemaCheck.ts
@@ -5,7 +5,7 @@ import { validateWithSchemaAsync } from '../utils/schema';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 export class ExpoConfigSchemaCheck implements DoctorCheck {
-  description = 'Check Expo config (app.json/ app.config.js)';
+  description = 'Check Expo config (app.json/ app.config.js) schema';
 
   sdkVersionRange = '*';
 

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -2,6 +2,7 @@ import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 import semver from 'semver';
 
+import { ExpoConfigCommonIssueCheck } from './checks/ExpoConfigCommonIssueCheck';
 import { ExpoConfigSchemaCheck } from './checks/ExpoConfigSchemaCheck';
 import { GlobalPackageInstalledCheck } from './checks/GlobalPackageInstalledCheck';
 import { GlobalPrereqsVersionCheck } from './checks/GlobalPrereqsVersionCheck';
@@ -138,6 +139,7 @@ export async function actionAsync(projectRoot: string) {
     new SupportPackageVersionCheck(),
     new InstalledDependencyVersionCheck(),
     new ExpoConfigSchemaCheck(),
+    new ExpoConfigCommonIssueCheck(),
     new PackageJsonCheck(),
   ];
 


### PR DESCRIPTION
# Why
Detects when someone's upgrade goes awry due to `sdkVersion` in Expo config overriding the actual installed SDK version. (e.g., https://github.com/expo/expo/issues/23351)

# How
We can't use `exp` from `getExpoConfig()` because this always populates `sdkVersion` (either based on installed version or `expo.sdkVersion`). So, we have to read the actual Expo config to see if `sdkVersion` was set. This is really only practical in Doctor for a static config file. We could possibly attempt some comparison between exp's `sdkVersion` and **package.json**, but there'd be limitations to have to tiptoe around there.

One other option would be to actually change `@expo/config` to expose where `sdkVersion` came from. Not sure if it's worth the effort, though.

@brentvatne I can add some unit tests to this, but wanted to first run the concept by you first to see if we should take this approach or go further in one of the directions described above before I spent more time on it.

@brentvatne 

# Test Plan

The message itself:
<img width="1004" alt="image" src="https://github.com/expo/expo-cli/assets/8053974/de19bd9a-a169-4a3f-832d-38bb8ee8d4a4">

When you put in the wrong `sdkVersion`, you get a ton of wrong package versions from the step where it checks against **bundledNativeModules**.
