### PR TITLE
[doctor] multiple lock file, unintentionally-bare detection

### DIFF
--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -13,7 +13,7 @@ export class ProjectSetupCheck implements DoctorCheck {
     // ** possibly-unintentionally-bare check **
 
     if (
-      (fs.existsSync(`${projectRoot}/ios`) || fs.existsSync(`${projectRoot}/android`)) &&
+      (fs.existsSync(path.join(projectRoot, 'ios')) || fs.existsSync(path.join(projectRoot', 'android'))) &&
       exp.plugins?.length
     ) {
       issues.push(

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
@@ -13,7 +14,8 @@ export class ProjectSetupCheck implements DoctorCheck {
     // ** possibly-unintentionally-bare check **
 
     if (
-      (fs.existsSync(path.join(projectRoot, 'ios')) || fs.existsSync(path.join(projectRoot', 'android'))) &&
+      (fs.existsSync(path.join(projectRoot, 'ios')) ||
+        fs.existsSync(path.join(projectRoot, 'android'))) &&
       exp.plugins?.length
     ) {
       issues.push(

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+export class ProjectSetupCheck implements DoctorCheck {
+  description = 'Check for common project setup issues';
+
+  sdkVersionRange = '*';
+
+  async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+
+    // ** possibly-unintentionally-bare check **
+
+    if (
+      (fs.existsSync(`${projectRoot}/ios`) || fs.existsSync(`${projectRoot}/android`)) &&
+      exp.plugins?.length
+    ) {
+      issues.push(
+        'This project has native project folders but is also configured to use Prebuild. EAS Build will not sync your native configuration if the ios or android folders are present. Gitignore these folders intend to use Prebuild (aka "managed" workflow).'
+      );
+    }
+
+    // ** multiple lock file check **
+
+    const lockfileCheckResults = await Promise.all(
+      ['pnpm-lock.yaml', 'yarn.lock', 'package-lock.json'].map(lockfile => {
+        return { lockfile, exists: fs.existsSync(`${projectRoot}/${lockfile}`) };
+      })
+    );
+
+    const lockfiles = lockfileCheckResults
+      .filter(result => result.exists)
+      .map(result => result.lockfile);
+
+    if (lockfiles.length > 1) {
+      issues.push(
+        `This project has multiple package manager lock files (${lockfiles.join(
+          ', '
+        )}). This may cause EAS build to restore dependencies with a different package manager from what you use in other environments.`
+      );
+    }
+
+    return {
+      isSuccessful: issues.length === 0,
+      issues,
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -17,7 +17,7 @@ export class ProjectSetupCheck implements DoctorCheck {
       exp.plugins?.length
     ) {
       issues.push(
-        'This project has native project folders but is also configured to use Prebuild. EAS Build will not sync your native configuration if the ios or android folders are present. Gitignore these folders intend to use Prebuild (aka "managed" workflow).'
+        'This project has native project folders but is also configured to use Prebuild. EAS Build will not sync your native configuration if the ios or android folders are present. Add these folders to your .gitignore file if you intend to use prebuild (aka "managed" workflow).'
       );
     }
 

--- a/packages/expo-doctor/src/checks/__tests__/ProjectSetupCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/ProjectSetupCheck.test.ts
@@ -1,0 +1,96 @@
+import { vol } from 'memfs';
+
+import { ProjectSetupCheck } from '../ProjectSetupCheck';
+
+jest.mock('fs');
+
+const projectRoot = '/tmp/project';
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  projectRoot,
+};
+
+describe('runAsync', () => {
+  // unintentionally bare check
+  it('returns result with isSuccessful = true if no ios/ android folders and no config plugins', async () => {
+    const check = new ProjectSetupCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = true if ios/ android folders but no config plugins', async () => {
+    vol.fromJSON({
+      [projectRoot + '/ios/something.pbxproj']: 'test',
+    });
+    const check = new ProjectSetupCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false ios/ android folders and config plugins', async () => {
+    vol.fromJSON({
+      [projectRoot + '/ios/something.pbxproj']: 'test',
+    });
+    const check = new ProjectSetupCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+      exp: {
+        name: 'name',
+        slug: 'slug',
+        plugins: ['expo-something'],
+      },
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  // multiple lock files
+  it('returns result with isSuccessful = true if just one lock file', async () => {
+    vol.fromJSON({
+      [projectRoot + '/yarn.lock']: 'test',
+    });
+    const check = new ProjectSetupCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if more than one lockfile (yarn + npm)', async () => {
+    vol.fromJSON({
+      [projectRoot + '/yarn.lock']: 'test',
+      [projectRoot + '/package-lock.json']: 'test',
+    });
+    const check = new ProjectSetupCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = false if more than one lockfile (yarn + pnpm)', async () => {
+    vol.fromJSON({
+      [projectRoot + '/yarn.lock']: 'test',
+      [projectRoot + '/pnpm-lock.yaml']: 'test',
+    });
+    const check = new ProjectSetupCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+});

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -8,6 +8,7 @@ import { GlobalPrereqsVersionCheck } from './checks/GlobalPrereqsVersionCheck';
 import { IllegalPackageCheck } from './checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from './checks/InstalledDependencyVersionCheck';
 import { PackageJsonCheck } from './checks/PackageJsonCheck';
+import { ProjectSetupCheck } from './checks/ProjectSetupCheck';
 import { SupportPackageVersionCheck } from './checks/SupportPackageVersionCheck';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/checks.types';
 import { env } from './utils/env';
@@ -139,6 +140,7 @@ export async function actionAsync(projectRoot: string) {
     new InstalledDependencyVersionCheck(),
     new ExpoConfigSchemaCheck(),
     new PackageJsonCheck(),
+    new ProjectSetupCheck(),
   ];
 
   const checkParams = { exp, pkg, projectRoot };


### PR DESCRIPTION
# Why
Multiple "project structure" tests in here (to avoid chicken-and-egg-esque merge mayhem):
- Warn on multiple lock files
- Warn if possibly-unintentionally bare

# How
For the lockfile check, just checking for the existence of more than one lockfile.

For the bare check, right now I'm checking if you have config plugins and ios/ android folders. I know that's not the only situation where you could be unintentionally bare (and you could be intentionally bare and just have left those lines in your Expo config), but not sure of a better way to detect this, and I would really like to detect it, as misunderstanding prebuild and what it means to "use" it comes up pretty regularly in support requests.

## Note on structure
One of the pain points with adding individual checks to doctor right now is that you either have to a) figure out what `Check` class, aka "category" a check goes in, possibly mixing unlike things together, or b) create a new `Check` class. My plan is to address this once we are checking more things, with a pattern like what is [described here](https://github.com/expo/expo-cli/pull/4731), recategorizing by how the check is performed and reworking the UI to not over-explain things.

In the meantime, the "categories" will expand a bit (like they did here). 

# Test Plan
Lockfile check:
<img width="935" alt="image" src="https://github.com/expo/expo-cli/assets/8053974/f0cd0f1c-80e5-45db-8e9b-9feefbdb8fa8">

Bare detection:
<img width="938" alt="image" src="https://github.com/expo/expo-cli/assets/8053974/ba9f2529-4e61-418c-86d0-34661deba672">
