### PR TITLE
fix(webpack-config): fix sourcemap bug with expo camera

### DIFF
--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -74,7 +74,14 @@ Object {
           "fullySpecified": false,
         },
         "test": /\\\\\\.\\(js\\|mjs\\|jsx\\|ts\\|tsx\\|css\\)\\$/,
-        "use": "node_modules/source-map-loader/dist/cjs.js",
+        "use": Array [
+          Object {
+            "loader": "node_modules/source-map-loader/dist/cjs.js",
+            "options": Object {
+              "filterSourceMappingUrl": [Function],
+            },
+          },
+        ],
       },
       Object {
         "oneOf": Array [
@@ -270,7 +277,14 @@ Object {
           "fullySpecified": false,
         },
         "test": /\\\\\\.\\(js\\|mjs\\|jsx\\|ts\\|tsx\\|css\\)\\$/,
-        "use": "node_modules/source-map-loader/dist/cjs.js",
+        "use": Array [
+          Object {
+            "loader": "node_modules/source-map-loader/dist/cjs.js",
+            "options": Object {
+              "filterSourceMappingUrl": [Function],
+            },
+          },
+        ],
       },
       Object {
         "oneOf": Array [

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -436,7 +436,7 @@ export default async function (env: Environment, argv: Arguments = {}): Promise<
                 filterSourceMappingUrl(url: string, resourcePath: string) {
                   // https://github.com/alewin/useWorker/issues/138
                   if (resourcePath.match(/@koale\/useworker/)) {
-                    return 'skip';
+                    return 'remove';
                   }
                   return true;
                 },

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -429,7 +429,21 @@ export default async function (env: Environment, argv: Arguments = {}): Promise<
           enforce: 'pre',
           exclude: /@babel(?:\/|\\{1,2})runtime/,
           test: /\.(js|mjs|jsx|ts|tsx|css)$/,
-          use: require.resolve('source-map-loader'),
+          use: [
+            {
+              loader: require.resolve('source-map-loader'),
+              options: {
+                filterSourceMappingUrl(url: string, resourcePath: string) {
+                  // https://github.com/alewin/useWorker/issues/138
+                  if (resourcePath.match(/@koale\/useworker/)) {
+                    return 'skip';
+                  }
+                  return true;
+                },
+              },
+            },
+          ],
+
           resolve: {
             fullySpecified: false,
           },


### PR DESCRIPTION
# Why

- Fix https://github.com/expo/expo/issues/23296
- Related https://github.com/alewin/useWorker/issues/138

# How

Filter out sourcemaps from useWorker.
<!-- 
How did you build this feature or fix this bug and why? 
-->
