### PR TITLE
chore(webpack-config): fix import name

### DIFF
--- a/packages/webpack-config/src/env/paths.ts
+++ b/packages/webpack-config/src/env/paths.ts
@@ -1,5 +1,5 @@
 /* eslint-env node */
-import { ExpoConfig, getConfig, getPackageJson, getWebOutputPath } from 'expo/config';
+import { ExpoConfig, getConfig, getPackageJson, getWebOutputPath } from '@expo/config';
 import findWorkspaceRoot from 'find-yarn-workspace-root';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
# Why

Looks like a typo... We ran into an issue trying builder.io beta RN build that depends on @expo/webpack-config

<!-- 

!! NOTICE !! The global Expo CLI (`packages/expo-cli`) is deprecated in favor of the new versioned CLI `npx expo`:

Open Expo CLI changes here -> https://github.com/expo/expo/tree/main/packages/@expo/cli

...

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Trying to build https://github.com/BuilderIO/builder/blob/main/examples/react-native and following their README instructions. Failing when running expo web resolving `expo/config`. It seems fixed with the changed line.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Should run against existing tests.... and fix
https://github.com/expo/expo-cli/actions/runs/5083949369/jobs/9135598475#step:5:99