### PR TITLE
[doctor] @expo/metro-config deep dependency check

### DIFF
--- a/packages/expo-doctor/src/api/getSchemaAsync.ts
+++ b/packages/expo-doctor/src/api/getSchemaAsync.ts
@@ -2,8 +2,19 @@ import fetch from 'node-fetch';
 
 export async function getSchemaAsync(sdkVersion: string): Promise<any> {
   const result = await fetch(
-    `https://exp.host/--/api/v2/project/configuration/schema/${sdkVersion}`
+    new URL(
+      `/--/api/v2/project/configuration/schema/${sdkVersion}`,
+      getExpoHostApiBaseUrl()
+    ).toString()
   );
   const resultJson = await result.json();
   return resultJson.data.schema;
+}
+
+function getExpoHostApiBaseUrl(): string {
+  if (process.env.EXPO_STAGING) {
+    return `https://staging.exp.host`;
+  } else {
+    return `https://exp.host`;
+  }
 }

--- a/packages/expo-doctor/src/api/getVersionsAsync.ts
+++ b/packages/expo-doctor/src/api/getVersionsAsync.ts
@@ -20,7 +20,17 @@ export type Versions = {
 
 /** Get versions from remote endpoint. */
 export async function getVersionsAsync(): Promise<Versions> {
-  const results = await fetch(`https://api.expo.dev/v2/versions/latest`);
+  const results = await fetch(new URL(`/v2/versions/latest`, getExpoApiBaseUrl()).toString());
   const json = await results.json();
   return json.data;
+}
+
+function getExpoApiBaseUrl(): string {
+  if (process.env.EXPO_STAGING) {
+    return `https://staging-api.expo.dev`;
+  } else if (process.env.EXPO_LOCAL) {
+    return `http://127.0.0.1:3000`;
+  } else {
+    return `https://api.expo.dev`;
+  }
 }

--- a/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
@@ -18,6 +18,7 @@ export class SupportPackageVersionCheck implements DoctorCheck {
       'expo-modules-autolinking',
       '@expo/config-plugins',
       '@expo/prebuild-config',
+      '@expo/metro-config',
     ].filter(pkg => versionsForSdk[pkg]);
 
     // check that a specific semver is installed for each package

--- a/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
@@ -22,6 +22,7 @@ describe('runAsync', () => {
       'expo-modules-autolinking': '1.0.0',
       '@expo/config-plugins': '1.0.0',
       '@expo/prebuild-config': '1.0.0',
+      '@expo/metro-config': '1.0.0',
     });
     asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce(null);
     const check = new SupportPackageVersionCheck();
@@ -37,6 +38,7 @@ describe('runAsync', () => {
       'expo-modules-autolinking': '1.0.0',
       '@expo/config-plugins': '1.0.0',
       '@expo/prebuild-config': '1.0.0',
+      '@expo/metro-config': '1.0.0',
     });
     asMock(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
     const check = new SupportPackageVersionCheck();

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -2,8 +2,8 @@ import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 import semver from 'semver';
 
-import { ExpoConfigCommonIssueCheck } from './checks/ExpoConfigCommonIssueCheck';
 import { DirectPackageInstallCheck } from './checks/DirectPackageInstallCheck';
+import { ExpoConfigCommonIssueCheck } from './checks/ExpoConfigCommonIssueCheck';
 import { ExpoConfigSchemaCheck } from './checks/ExpoConfigSchemaCheck';
 import { GlobalPackageInstalledCheck } from './checks/GlobalPackageInstalledCheck';
 import { GlobalPrereqsVersionCheck } from './checks/GlobalPrereqsVersionCheck';

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -10,6 +10,11 @@ class Env {
   get EXPO_DEBUG() {
     return boolish('EXPO_DEBUG', false);
   }
+
+  /** Enable staging API environment */
+  get EXPO_STAGING() {
+    return boolish('EXPO_STAGING', false);
+  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why
Based on an i[ssue faced by a user](https://exponent-internal.slack.com/archives/C1QP38NQ5/p1688747375186529?thread_ts=1688726115.843029&cid=C1QP38NQ5), it was suggested we include `@expo/metro-config` in deep dependency version checking, to check any case where this package is the wrong version, not just direct installs.

# How
1. Added `@expo/metro-config` to the staging API with `et update-versions -k 'relatedPackages.@expo/metro-config' -v '~0.10.0'`.
2. Updated Doctor to respect `EXPO_STAGING=1` for API calls, so then we could test the additional related package in the API.
3. Added `@expo/metro-config` to the existing list of deep dependency version checks

# Follow-up after merge
- Update release documentation to note that we should update the `@expo/metro-config` version [here](https://github.com/expo/expo/blob/main/guides/releasing/Release%20Workflow.md#52-add-related-packages-to-versions-endpoint).
- Update the endpoint on production

# Test Plan
Not a perfect check, because installing `@expo/metro-config` already results in the warning from `npx expo install --check`, but you can see here now it also triggers the deep dependency check:
<img width="689" alt="image" src="https://github.com/expo/expo-cli/assets/8053974/7579deb7-e176-43da-a550-174913321c52">

