### PR TITLE
Revert "fix(webpack-config): fix sourcemap bug with expo camera"

### DIFF
--- a/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
+++ b/packages/webpack-config/src/__tests__/__snapshots__/webpack.config-test.js.snap
@@ -74,14 +74,7 @@ Object {
           "fullySpecified": false,
         },
         "test": /\\\\\\.\\(js\\|mjs\\|jsx\\|ts\\|tsx\\|css\\)\\$/,
-        "use": Array [
-          Object {
-            "loader": "node_modules/source-map-loader/dist/cjs.js",
-            "options": Object {
-              "filterSourceMappingUrl": [Function],
-            },
-          },
-        ],
+        "use": "node_modules/source-map-loader/dist/cjs.js",
       },
       Object {
         "oneOf": Array [
@@ -277,14 +270,7 @@ Object {
           "fullySpecified": false,
         },
         "test": /\\\\\\.\\(js\\|mjs\\|jsx\\|ts\\|tsx\\|css\\)\\$/,
-        "use": Array [
-          Object {
-            "loader": "node_modules/source-map-loader/dist/cjs.js",
-            "options": Object {
-              "filterSourceMappingUrl": [Function],
-            },
-          },
-        ],
+        "use": "node_modules/source-map-loader/dist/cjs.js",
       },
       Object {
         "oneOf": Array [

--- a/packages/webpack-config/src/webpack.config.ts
+++ b/packages/webpack-config/src/webpack.config.ts
@@ -429,21 +429,7 @@ export default async function (env: Environment, argv: Arguments = {}): Promise<
           enforce: 'pre',
           exclude: /@babel(?:\/|\\{1,2})runtime/,
           test: /\.(js|mjs|jsx|ts|tsx|css)$/,
-          use: [
-            {
-              loader: require.resolve('source-map-loader'),
-              options: {
-                filterSourceMappingUrl(url: string, resourcePath: string) {
-                  // https://github.com/alewin/useWorker/issues/138
-                  if (resourcePath.match(/@koale\/useworker/)) {
-                    return 'remove';
-                  }
-                  return true;
-                },
-              },
-            },
-          ],
-
+          use: require.resolve('source-map-loader'),
           resolve: {
             fullySpecified: false,
           },


### PR DESCRIPTION
Reverts expo/expo-cli#4735

We are removing `@koale/useworker`  so these rules can be moved 

https://github.com/expo/expo/pull/23967