### PR TITLE
fix(create-expo-app): allow scoped template package names

### DIFF
--- a/packages/create-expo-app/src/utils/npm.ts
+++ b/packages/create-expo-app/src/utils/npm.ts
@@ -173,6 +173,12 @@ async function npmPackAsync(
 
   try {
     const json = JSON.parse(results);
+    const filename = json[0].filename as string;
+    // Transform filename for scoped packages.
+    // See issue https://github.com/npm/cli/issues/3405
+    if (filename?.startsWith('@') && packageName.startsWith('@')) {
+      json[0].filename = filename.replace(/^@/, '').replace(/\//, '-');
+    }
     if (Array.isArray(json) && json.every(isNpmPackageInfo)) {
       return json;
     } else {

--- a/packages/create-expo-app/src/utils/npm.ts
+++ b/packages/create-expo-app/src/utils/npm.ts
@@ -174,7 +174,7 @@ async function npmPackAsync(
   try {
     const json = JSON.parse(results);
     if (Array.isArray(json) && json.every(isNpmPackageInfo)) {
-      return json.map(santizeNpmPackageFilename);
+      return json.map(sanitizeNpmPackageFilename);
     } else {
       throw new Error(`Invalid response from npm: ${results}`);
     }
@@ -239,7 +239,7 @@ function isNpmPackageInfo(item: any): item is NpmPackageInfo {
  *
  * @see https://github.com/npm/cli/issues/3405
  */
-function santizeNpmPackageFilename(item: NpmPackageInfo): NpmPackageInfo {
+function sanitizeNpmPackageFilename(item: NpmPackageInfo): NpmPackageInfo {
   if (item.filename.startsWith('@') && item.name.startsWith('@')) {
     item.filename = item.filename.replace(/^@/, '').replace(/\//, '-')
   }

--- a/packages/create-expo-app/src/utils/npm.ts
+++ b/packages/create-expo-app/src/utils/npm.ts
@@ -241,7 +241,7 @@ function isNpmPackageInfo(item: any): item is NpmPackageInfo {
  */
 function sanitizeNpmPackageFilename(item: NpmPackageInfo): NpmPackageInfo {
   if (item.filename.startsWith('@') && item.name.startsWith('@')) {
-    item.filename = item.filename.replace(/^@/, '').replace(/\//, '-')
+    item.filename = item.filename.replace(/^@/, '').replace(/\//, '-');
   }
 
   return item;


### PR DESCRIPTION
# Why

Realm has a scoped package for its expo template.  This was not working with `expo-create-app`.

Fixes #4749 

# How
This change detects a scoped package name for templates and correctly determines its location. 

# Test Plan

Tested with `@realm/expo-template`

```
node build/index.js --template @realm/expo-template testProj
```

