### PR TITLE
feat: detect bun package manager

### DIFF
--- a/packages/create-expo-app/README.md
+++ b/packages/create-expo-app/README.md
@@ -40,6 +40,9 @@ yarn create expo-app
 
 # With pnpm
 pnpm create expo-app
+
+# With Bun
+bunx create-expo-app
 ```
 
 Once you're up and running with Create Expo App, visit [this tutorial](https://docs.expo.dev/tutorial/planning/) for more information on building mobile apps with React.

--- a/packages/create-expo-app/e2e/__tests__/index-test.js
+++ b/packages/create-expo-app/e2e/__tests__/index-test.js
@@ -144,6 +144,27 @@ describe('yes', () => {
     extendedTimeout
   );
   it(
+    'uses Bun',
+    async () => {
+      const projectName = 'uses-bun';
+      const results = await execute([projectName, '--no-install'], {
+        // Run: DEBUG=create-expo-app:* bunx create-expo-app
+        npm_config_user_agent: `bun`,
+      });
+
+      // Test that the user was warned about deps
+      expect(results.stdout).toMatch(/make sure you have modules installed/);
+      expect(results.stdout).toMatch(/bun install/);
+
+      expect(fileExists(projectName, 'package.json')).toBeTruthy();
+      expect(fileExists(projectName, 'App.js')).toBeTruthy();
+      expect(fileExists(projectName, '.gitignore')).toBeTruthy();
+      // Check if it skipped install
+      expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
+    },
+    extendedTimeout
+  );
+  it(
     'uses npm',
     async () => {
       const projectName = 'uses-npm';

--- a/packages/create-expo-app/src/cli.ts
+++ b/packages/create-expo-app/src/cli.ts
@@ -59,6 +59,7 @@ async function run() {
     {bold  npm:} {cyan npm create expo-app}
     {bold yarn:} {cyan yarn create expo-app}
     {bold pnpm:} {cyan pnpm create expo-app}
+    {bold  bun:} {cyan bunx create-expo-app}
     `
     );
   }

--- a/packages/create-expo-app/src/resolvePackageManager.ts
+++ b/packages/create-expo-app/src/resolvePackageManager.ts
@@ -3,19 +3,21 @@ import { execSync } from 'child_process';
 
 import { CLI_NAME } from './cmd';
 
-export type PackageManagerName = 'npm' | 'pnpm' | 'yarn';
+export type PackageManagerName = 'npm' | 'pnpm' | 'yarn' | 'bun';
 
 const debug = require('debug')('expo:init:resolvePackageManager') as typeof console.log;
 
 /** Determine which package manager to use for installing dependencies based on how the process was started. */
 export function resolvePackageManager(): PackageManagerName {
-  // Attempt to detect if the user started the command using `yarn` or `pnpm`
+  // Attempt to detect if the user started the command using `yarn` or `pnpm` or `bun`
   const userAgent = process.env.npm_config_user_agent;
   debug('npm_config_user_agent:', userAgent);
   if (userAgent?.startsWith('yarn')) {
     return 'yarn';
   } else if (userAgent?.startsWith('pnpm')) {
     return 'pnpm';
+  } else if (userAgent?.startsWith('bun')) {
+    return 'bun';
   } else if (userAgent?.startsWith('npm')) {
     return 'npm';
   }
@@ -25,6 +27,8 @@ export function resolvePackageManager(): PackageManagerName {
     return 'yarn';
   } else if (isPackageManagerAvailable('pnpm')) {
     return 'pnpm';
+  } else if (isPackageManagerAvailable('bun')) {
+    return 'bun';
   }
 
   return 'npm';
@@ -44,6 +48,8 @@ export function formatRunCommand(packageManager: PackageManagerName, cmd: string
       return `pnpm run ${cmd}`;
     case 'yarn':
       return `yarn ${cmd}`;
+    case 'bun':
+      return `bun run ${cmd}`;
     case 'npm':
     default:
       return `npm run ${cmd}`;
@@ -55,6 +61,8 @@ export function formatSelfCommand() {
   switch (packageManager) {
     case 'pnpm':
       return `pnpx ${CLI_NAME}`;
+    case 'bun':
+      return `bunx ${CLI_NAME}`;
     case 'yarn':
     case 'npm':
     default:
@@ -72,6 +80,8 @@ export async function installDependenciesAsync(
     await new PackageManager.YarnPackageManager(options).installAsync();
   } else if (packageManager === 'pnpm') {
     await new PackageManager.PnpmPackageManager(options).installAsync();
+  } else if (packageManager === 'bun') {
+    await new PackageManager.BunPackageManager(options).installAsync();
   } else {
     await new PackageManager.NpmPackageManager(options).installAsync();
   }


### PR DESCRIPTION
Depends on https://github.com/expo/expo/pull/24168

# Why

Detect bun package manager in `create-expo-app`

# How

- Checks `npm_config_user_agent` for `bun`

# Test Plan
Tests have been addeed to `resolvePackageManager.test.ts`