### PR TITLE
test(create-expo-app): bun desc from copy/paste

### DIFF
--- a/packages/create-expo-app/src/__tests__/resolvePackageManager.test.ts
+++ b/packages/create-expo-app/src/__tests__/resolvePackageManager.test.ts
@@ -25,7 +25,7 @@ describe(resolvePackageManager, () => {
     process.env.npm_config_user_agent = 'pnpm';
     expect(resolvePackageManager()).toBe('pnpm');
   });
-  it('should use pnpm due to the user agent', () => {
+  it('should use bun due to the user agent', () => {
     process.env.npm_config_user_agent = 'bun';
     expect(resolvePackageManager()).toBe('bun');
   });


### PR DESCRIPTION
# Why

<!-- 

!! NOTICE !! The global Expo CLI (`packages/expo-cli`) is deprecated in favor of the new versioned CLI `npx expo`:

Open Expo CLI changes here -> https://github.com/expo/expo/tree/main/packages/@expo/cli

...

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Just updating a copy/paste typo for in the `resolvePackageManager.test.ts` test description for new `bun` package manager.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Fixed the typo

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Tests all the same, change for readability and maintainability
