### PR TITLE
chore(babel-preset-cli): update snapshot failure

### DIFF
--- a/packages/babel-preset-cli/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-preset-cli/__tests__/__snapshots__/index-test.js.snap
@@ -4,6 +4,7 @@ exports[`class-properties 1`] = `
 Object {
   Symbol(jest-snapshot-serializer-raw): "\\"use strict\\";
 
+var _class;
 function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 function _toPropertyKey(arg) { var key = _toPrimitive(arg, \\"string\\"); return typeof key === \\"symbol\\" ? key : String(key); }
 function _toPrimitive(input, hint) { if (typeof input !== \\"object\\" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || \\"default\\"); if (typeof res !== \\"object\\") return res; throw new TypeError(\\"@@toPrimitive must return a primitive value.\\"); } return (hint === \\"string\\" ? String : Number)(input); }
@@ -16,10 +17,11 @@ class Bork {
     });
   }
 }
+_class = Bork;
 //Static class properties
 _defineProperty(Bork, \\"staticProperty\\", \\"babelIsCool\\");
 _defineProperty(Bork, \\"staticFunction\\", function () {
-  return Bork.staticProperty;
+  return _class.staticProperty;
 });",
 }
 `;


### PR DESCRIPTION
# Why

Let's bring the CI back to life.

# How

- Ran `yarn test -u` in **./packages/babel-preset-cli**
- Snapshot update seems ok, just an additional var being used without changing meaning of code.

# Test Plan

See CI
