### PR TITLE
chore(babel-preset-cli): update snapshot failure

### DIFF
--- a/packages/babel-preset-cli/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-preset-cli/__tests__/__snapshots__/index-test.js.snap
@@ -4,6 +4,7 @@ exports[`class-properties 1`] = `
 Object {
   Symbol(jest-snapshot-serializer-raw): "\\"use strict\\";
 
+var _class;
 function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 function _toPropertyKey(arg) { var key = _toPrimitive(arg, \\"string\\"); return typeof key === \\"symbol\\" ? key : String(key); }
 function _toPrimitive(input, hint) { if (typeof input !== \\"object\\" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || \\"default\\"); if (typeof res !== \\"object\\") return res; throw new TypeError(\\"@@toPrimitive must return a primitive value.\\"); } return (hint === \\"string\\" ? String : Number)(input); }
@@ -16,10 +17,11 @@ class Bork {
     });
   }
 }
+_class = Bork;
 //Static class properties
 _defineProperty(Bork, \\"staticProperty\\", \\"babelIsCool\\");
 _defineProperty(Bork, \\"staticFunction\\", function () {
-  return Bork.staticProperty;
+  return _class.staticProperty;
 });",
 }
 `;

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -39,7 +39,9 @@
     "@expo/json-file": "~8.2.37",
     "@expo/schemer": "1.4.5",
     "@expo/spawn-async": "^1.7.0",
+    "@types/debug": "^4.1.8",
     "chalk": "^4.0.0",
+    "debug": "^4.3.4",
     "ora": "3.4.0",
     "resolve-from": "^5.0.0",
     "semver": "7.3.2"

--- a/packages/image-utils/package.json
+++ b/packages/image-utils/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.1",
     "@types/getenv": "^0.7.0",
+    "@types/node-fetch": "^2.6.5",
     "@types/semver": "^6.0.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,6 +3786,13 @@
   resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-3.0.1.tgz#98d747a2e5e9a56070c6bf14e27bff56204e34cc"
   integrity sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==
 
+"@types/debug@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
+  integrity sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/envinfo@^7.8.1":
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/@types/envinfo/-/envinfo-7.8.1.tgz#1915df82c16d637e92146645c70db9360eb099c6"
@@ -4030,6 +4037,11 @@
   integrity sha512-M2BLHQdEmDmH671h0GIlOQQJrgezd1vNqq7PVj1VOsHZ2uQQb4iPiQIl0SlMdhxZPUsLIfEklmeEHXg8DJRewA==
   dependencies:
     minipass "*"
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/multimatch@^2.1.3":
   version "2.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,6 +4038,14 @@
   dependencies:
     "@types/minimatch" "*"
 
+"@types/node-fetch@^2.6.5":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.5.tgz#972756a9a0fe354b2886bf3defe667ddb4f0d30a"
+  integrity sha512-OZsUlr2nxvkqUFLSaY2ZbA+P1q22q+KrlxWOn/38RX+u5kTkYL2mTujEpzUhGkS+K/QCYp9oagfXG39XOzyySg==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
 "@types/node-forge@^0.9.7":
   version "0.9.7"
   resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-0.9.7.tgz#948f7b52d352a6c4ab22d3328c206f0870672db5"
@@ -9572,6 +9580,15 @@ form-data@^2.3.2:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:


### PR DESCRIPTION
# Why

Let's bring the CI back to life.

# How

- Ran `yarn test -u` in **./packages/babel-preset-cli**
  - Snapshot update seems ok, just an additional var being used without changing meaning of code.
- Added missing `@types/node-fetch` to **./packages/image-utils**
- Added missing `debug` and `@types/debug` to **./packages/expo-doctor**

# Test Plan

See CI
