### PR TITLE
Typo: Update index.ts

### DIFF
--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -105,7 +105,7 @@ async function promptUpgradeIosDeployTargetAsync(projectRoot: string, iosDeploym
  */
 async function promptCliIntegrationAsync() {
   const message = `This tool can install Expo CLI integration for your project.
-Using Expo CLI has some some benefits over the the default CLI in bare React Native projects:
+Using Expo CLI has some benefits over the the default CLI in bare React Native projects:
   - Built-in JavaScript debugger and React Devtools.
   - Support for Continuous Native Generation (CNG) with \`npx expo prebuild\` for easy upgrades.
   - Automatic web support with Metro.


### PR DESCRIPTION
I fixed a typo by removing the extra "some" from the promptCliIntegrationAsync function prompt

# Why

I noticed this typo while integrating Expo into my React Native application

# How

I fixed it by removing a word

# Test Plan

Not necessary
