### PR TITLE
[xdl] Enhance `expo start --tunnel` with Ngrok tunnel customization options via env.

### DIFF
--- a/packages/xdl/src/start/ngrok.ts
+++ b/packages/xdl/src/start/ngrok.ts
@@ -54,6 +54,10 @@ async function connectToNgrokAsync(
   try {
     dotenv.config();
     const configPath = getNgrokConfigPath();
+    if (process.env.EXPO_TUNNEL_SKIP_CONNECT && process.env.NGROK_HOSTNAME) {
+      const protocol = process.env.EXPO_TUNNEL_USE_HTTPS ? 'https' : 'http';
+      return `${protocol}://${process.env.NGROK_HOSTNAME}`;
+    }
     const hostname = await hostnameAsync();
     const url = await ngrok.connect({
       configPath,

--- a/packages/xdl/src/start/ngrok.ts
+++ b/packages/xdl/src/start/ngrok.ts
@@ -1,4 +1,5 @@
 import { readExpRcAsync } from '@expo/config';
+import * as dotenv from 'dotenv';
 import * as path from 'path';
 
 import {
@@ -51,13 +52,16 @@ async function connectToNgrokAsync(
   attempts: number = 0
 ): Promise<string> {
   try {
+    dotenv.config();
     const configPath = getNgrokConfigPath();
     const hostname = await hostnameAsync();
     const url = await ngrok.connect({
-      hostname,
       configPath,
+      hostname: process.env.NGROK_HOSTNAME || hostname,
       onStatusChange: handleStatusChange.bind(null, projectRoot),
       ...args,
+      authtoken:
+        process.env.NGROK_AUTHTOKEN || args.authtoken || NGROK_CONFIG.authToken || undefined,
     });
     return url;
   } catch (e: any) {

--- a/packages/xdl/src/start/ngrok.ts
+++ b/packages/xdl/src/start/ngrok.ts
@@ -66,6 +66,7 @@ async function connectToNgrokAsync(
       ...args,
       authtoken:
         process.env.NGROK_AUTHTOKEN || args.authtoken || NGROK_CONFIG.authToken || undefined,
+      port: process.env.NGROK_PORT || args.port || undefined,
     });
     return url;
   } catch (e: any) {

--- a/packages/xdl/src/start/ngrok.ts
+++ b/packages/xdl/src/start/ngrok.ts
@@ -52,12 +52,11 @@ async function connectToNgrokAsync(
   attempts: number = 0
 ): Promise<string> {
   try {
-    dotenv.config();
-    const configPath = getNgrokConfigPath();
     if (process.env.EXPO_TUNNEL_SKIP_CONNECT && process.env.NGROK_HOSTNAME) {
       const protocol = process.env.EXPO_TUNNEL_USE_HTTPS ? 'https' : 'http';
       return `${protocol}://${process.env.NGROK_HOSTNAME}`;
     }
+    const configPath = getNgrokConfigPath();
     const hostname = await hostnameAsync();
     const url = await ngrok.connect({
       configPath,
@@ -109,6 +108,7 @@ export async function startTunnelsAsync(
   projectRoot: string,
   options: { autoInstall?: boolean } = {}
 ): Promise<void> {
+  dotenv.config();
   const ngrok = await resolveNgrokAsync(projectRoot, options);
   const username = (await UserManager.getCurrentUsernameAsync()) || ANONYMOUS_USERNAME;
   assertValidProjectRoot(projectRoot);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9576,10 +9576,10 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@*, form-data@^3.0.0, form-data@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+form-data@*, form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -9594,10 +9594,10 @@ form-data@^2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+form-data@^3.0.0, form-data@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
# Why

This pull request enhances the `expo start --tunnel` experience by introducing new environment variables and conditional logic for more control over the Ngrok tunnel setup. Specifically, it allows skipping the creation of a tunnel if the `EXPO_TUNNEL_SKIP_CONNECT` environment variable is set (EXPO_TUNNEL_USE_HTTPS must be set if that tunnel uses https protocol). Additionally, it provides the flexibility to use a custom Ngrok domain via the `NGROK_HOSTNAME`, `NGROK_AUTHTOKEN`, and `NGROK_PORT` environment variables.

# Changes Made

1. Added conditionals to check for the `EXPO_TUNNEL_SKIP_CONNECT` and `NGROK_HOSTNAME` environment variables.
2. Introduced the `EXPO_TUNNEL_USE_HTTPS` environment variable for specifying HTTPS protocol usage.
3. Modified the `connectToNgrokInternalAsync` method to incorporate these changes.

# New Environment Variables

- `EXPO_TUNNEL_SKIP_CONNECT`: If set, the tunnel creation process is skipped.
- `EXPO_TUNNEL_USE_HTTPS`: must be set if existing tunnel is using https protocol.

- `NGROK_HOSTNAME`: Allows specifying a custom Ngrok domain.
- `NGROK_AUTHTOKEN`: Ngrok auth token.
- `NGROK_PORT`: Allows specifying a custom port for the tunnel.

## Usage Examples

1. To skip tunnel creation and use an existing tunnel (e.g., when using cloudflared):
```bash
EXPO_TUNNEL_SKIP_CONNECT=true expo start --tunnel

# If existing tunnel is using https
EXPO_TUNNEL_SKIP_CONNECT=1 EXPO_TUNNEL_USE_HTTPS=1 expo start --tunnel
```

2. To create a tunnel on a custom ngrok domain
```bash
NGROK_HOSTNAME=my-custom-domain.com NGROK_AUTHTOKEN=xxxxxxx NGROK_PORT=8181 expo start --tunnel
```

# Test Plan

I have been using these changes as `patches` for some time. I had to ensure that my app works as expected outside of my homelab. I set up a test HTTPS tunnel and needed this changes for Expo Go to work properly.

P.S.
Simply running `npx expo start` with a specified port (e.g., 8181) did not yield the desired results. This issue arose when attempting to scan a QR code, as Expo Go was attempting to download an update from a URL structured as http://example.com:8181/...

Examples for testing are listed above. Sorry if I did sth wrong.
Example output
```bash
NGROK_HOSTNAME=expo.example.dev EXPO_TUNNEL_SKIP_CONNECT=1 EXPO_TUNNEL_USE_HTTPS=1 npx expo start --tunnel
Starting project at /home/lightsoul/github/Lightsoul-Development/BB-native
Starting Metro Bundler
Tunnel ready
› Metro waiting on exp://expo.example.dev
Logs for your project will appear below. Press Ctrl+C to exit.
...
```